### PR TITLE
Add `Alert` component

### DIFF
--- a/packages/react/alert/src/Alert.stories.tsx
+++ b/packages/react/alert/src/Alert.stories.tsx
@@ -8,12 +8,12 @@ export const Basic = () => {
 
   return (
     <>
-      <button onClick={() => setCount((count) => (count > 0 ? count - 1 : count))}>remove</button>
+      {count > 0 && <button onClick={() => setCount((count) => count - 1)}>remove</button>}
       <button onClick={() => setCount((count) => count + 1)}>add</button>
+
       {[...Array(count)].map((_, index) => (
         <Alert key={index} type="assertive">
-          the quick brown fox {index} jumped over the lazy dogs
-          <button onClick={() => alert('test')}>test</button>
+          Message {index}
         </Alert>
       ))}
     </>


### PR DESCRIPTION
Adds an alert that fulfils the following criteria:

- One `aria-live` region per `aria-live` type, (`polite` or `assertive`)
- Each alert instance is appended to the associated live region
- Live region is added when an alert exists
- Live region is removed when no more alerts exist within it

### How it works

When a consumer adds an alert, it will place a component in situ (where they composed it) for visuals but also portal a hidden version of it to an `aria-live` region so that screen readers read the alert aloud.

<h3 id="sr-tests">Screen reader tests (using VoiceOver)</h3>

- [X] One alert rendered during initial load should be read aloud
- [X] Multiple alerts rendered during initial load should **all** be read aloud
- [X] Adding a new alert should be read aloud 
- [ ] Adding a new alert with similar text should be read aloud (**FAIL**)

The failed test seems to be an issue with VoiceOver. If an alert is added with the text "Test 1 alert" it will read the entire message but then if another is added with "Test 10 alert" it will read only "0" because the characters from "Test 1 alert" were all previously read 😕 

The following is the only acknowledgement of the issue that I could find on the web and the fix there is to make sure that the `aria-live` element is emptied before new alerts are added: https://core.trac.wordpress.org/ticket/36853

This doesn't really seem like the right approach to me. Take the second test above for example, it wouldn't read all the messages as it would only allow one at a time. Also, there is an `aria-relevant` attribute that allows screen readers to choose whether to announce removal updates. There doesn't seem to be much SR support for the `removals` type at the moment, but it exists in the spec and tbh, I feel like it should be up to the `Alert` composer to control when an alert is added or removed.

I'm wondering if anyone has any other ideas here?