### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Add the following users as reviewers on new pull requests
+
+* @benoitgrelard @chancestrickland @jjenzz
+docs/* @peduarte


### PR DESCRIPTION
How do we feel about this? I keep forgetting to add the team manually to PRs.