### PR TITLE
Add interop attributes to `AspectRatio`

### DIFF
--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cssReset } from '@interop-ui/utils';
+import { cssReset, interopDataAttrObj } from '@interop-ui/utils';
 import { forwardRef, PrimitiveStyles } from '@interop-ui/react-utils';
 
 const WRAPPER_DEFAULT_TAG = 'div';
@@ -18,6 +18,7 @@ const AspectRatioRoot = forwardRef<typeof WRAPPER_DEFAULT_TAG, AspectRatioProps>
     return (
       <Comp
         {...aspectRatioProps}
+        {...interopDataAttrObj('AspectRatioRoot')}
         ref={forwardedRef}
         style={{
           paddingBottom: `${paddingBottom}%`,
@@ -40,7 +41,7 @@ const AspectRatioInner = forwardRef<typeof INNER_DEFAULT_TAG, AspectRatioInnerPr
   function AspectRatioInner(props, forwardedRef) {
     const { as: Comp = INNER_DEFAULT_TAG, ...innerProps } = props;
 
-    return <Comp ref={forwardedRef} {...innerProps} />;
+    return <Comp ref={forwardedRef} {...innerProps} {...interopDataAttrObj('AspectRatioInner')} />;
   }
 );
 
@@ -54,7 +55,11 @@ const AspectRatio = forwardRef<
   const { children, ...aspectRatioProps } = props;
 
   return (
-    <AspectRatioRoot {...aspectRatioProps} ref={forwardedRef}>
+    <AspectRatioRoot
+      {...aspectRatioProps}
+      {...interopDataAttrObj('AspectRatio')}
+      ref={forwardedRef}
+    >
       <AspectRatioInner>{children}</AspectRatioInner>
     </AspectRatioRoot>
   );


### PR DESCRIPTION
In preparation for static style extraction. 

- Adds missing interop attributes