### PR TITLE
Add interop attributes and default styles to `Toast`

### DIFF
--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -1,14 +1,25 @@
 import * as React from 'react';
+import { cssReset, interopDataAttrObj } from '@interop-ui/utils';
+import { forwardRef, PrimitiveStyles } from '@interop-ui/react-utils';
 
-type ToastDOMProps = React.ComponentProps<'div'>;
+const DEFAULT_TAG = 'div';
+
+type ToastDOMProps = React.ComponentProps<typeof DEFAULT_TAG>;
 type ToastOwnProps = {};
 type ToastProps = ToastDOMProps & ToastOwnProps;
 
-const Toast = React.forwardRef<HTMLDivElement, ToastProps>(function Toast(props, forwardedRef) {
-  return <div ref={forwardedRef} />;
+const Toast = forwardRef<typeof DEFAULT_TAG, ToastProps>(function Toast(props, forwardedRef) {
+  const { as: Comp = DEFAULT_TAG, ...toastProps } = props;
+  return <Comp {...toastProps} {...interopDataAttrObj('Toast')} ref={forwardedRef} />;
 });
 
 Toast.displayName = 'Toast';
 
-export { Toast };
+const styles: PrimitiveStyles = {
+  toast: {
+    ...cssReset(DEFAULT_TAG),
+  },
+};
+
+export { styles, Toast };
 export type { ToastProps };


### PR DESCRIPTION
In preparation for static style extraction. 

- Adds missing interop attributes
- Exports default styles 
