### PR TITLE
Remove prop runtime from CSS resets

### DIFF
--- a/packages/core/utils/src/cssReset.ts
+++ b/packages/core/utils/src/cssReset.ts
@@ -7,7 +7,7 @@ export type CssResetTagName = keyof ElementTagNameMap;
  * Get css reset for a given tag.
  * We could eventually make this available as a library.
  */
-export function cssResetForTag(tagName: CssResetTagName | null) {
+export function cssReset(tagName: CssResetTagName | null) {
   const sharedResetStyles: CSSObject = {
     boxSizing: 'border-box',
   };
@@ -18,16 +18,6 @@ export function cssResetForTag(tagName: CssResetTagName | null) {
   };
 
   return resetStyles;
-}
-
-/**
- * Top-level util to apply the right reset based on `as` prop or default tag name.
- */
-export function cssReset(defaultTagName: CssResetTagName | null) {
-  return function (props: any) {
-    const tagName: CssResetTagName = props.as || defaultTagName;
-    return cssResetForTag(tagName);
-  };
 }
 
 const RESET_TAG_MAP: { [key in CssResetTagName]?: CSSObject } = {


### PR DESCRIPTION
I noticed that the static style extraction wasn't including the reset styles because the `cssReset` function returns a function.

The function it returns expects to be called with props so it can determine which reset to apply based on the `as` prop. I could manually call this function during extraction with an empty props object however, the prop evaluation wouldn't work with Stitches because it doesn't evaluate CSS at runtime. 

It seems more appropriate to remove the prop stuff given it wouldn't work with our own CSS-in-JS lib and we can think of an alternate approach to switching the resets based on DOM node later.

I'm wondering if we should just export an `interop-normalize.css` file that resets all the DOM elements how we expect. They would import this once if they want our resets and components can render as any DOM node and automatically get the right resets. Trying to apply an abstraction beyond that seems to be overcomplicating things. @colmtuite thoughts on this?