### PR TITLE
Patch babel dev block transform with local definitions

### DIFF
--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -9,3 +9,6 @@ export * from './observeElementRect';
 export * from './typeUtils';
 
 export * from './types';
+
+// TODO: Consider removing this if we can work with the babel plugin as intended
+export const __DEV__ = process.env.NODE_ENV === 'development';

--- a/packages/core/utils/src/logging.ts
+++ b/packages/core/utils/src/logging.ts
@@ -1,3 +1,5 @@
+import { __DEV__ } from './index';
+
 const alreadyWarned: Record<string, boolean> = {};
 
 export function invariant(cond: boolean, message: string): void {

--- a/packages/react/combobox/src/Combobox.tsx
+++ b/packages/react/combobox/src/Combobox.tsx
@@ -10,6 +10,7 @@ import {
   interopDataAttrObj,
   interopSelector,
   cssReset,
+  __DEV__,
 } from '@interop-ui/utils';
 import { useMachine, StateMachine, createMachine } from '@interop-ui/react-use-machine';
 import { findAll } from 'highlight-words-core';
@@ -237,7 +238,7 @@ type ComboboxInputProps = ComboboxInputDOMProps & ComboboxInputOwnProps;
 
 const ComboboxInputImpl = forwardRef<typeof INPUT_DEFAULT_TAG, ComboboxInputProps>(
   function ComboboxInput(props, forwardedRef) {
-    if (process.env.NODE_ENV === 'development') {
+    if (__DEV__) {
       if (typeof (props as any).onChange !== 'undefined') {
         // TODO: Dev warning
         console.warn('');

--- a/packages/react/use-machine/src/use-machine.tsx
+++ b/packages/react/use-machine/src/use-machine.tsx
@@ -11,7 +11,7 @@ import {
   StateMachine,
   Typestate,
 } from '@xstate/fsm';
-import { DistributiveOmit, isString, isFunction } from '@interop-ui/utils';
+import { DistributiveOmit, isString, isFunction, __DEV__ } from '@interop-ui/utils';
 import { useConstant } from '@interop-ui/react-utils';
 
 function getServiceState<


### PR DESCRIPTION
Just a temporary measure to make `__DEV__` expressions work everywhere until we can sort out a better solution for the docs + build babel config.