### PR TITLE
Fix `Flex` gap

### DIFF
--- a/packages/react/flex/package.json
+++ b/packages/react/flex/package.json
@@ -17,9 +17,9 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@interop-ui/utils": "1.0.0",
     "@interop-ui/react-utils": "1.0.0",
-    "lodash.pick": "^4.4.0",
+    "@interop-ui/utils": "1.0.0",
+    "lodash.omit": "^4.5.0",
     "tslib": "^2.0.0"
   }
 }

--- a/packages/react/flex/src/Flex.stories.tsx
+++ b/packages/react/flex/src/Flex.stories.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Flex as FlexPrimitive, styles as flexStyles } from './Flex';
+
+export default { title: 'Flex' };
+
+export const Basic = () => (
+  <Flex>
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+  </Flex>
+);
+
+export const Gap = () => (
+  <Flex gap={5}>
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+  </Flex>
+);
+
+export const RowGap = () => (
+  <Flex rowGap={5}>
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+  </Flex>
+);
+
+export const ColumnGap = () => (
+  <Flex columnGap={5}>
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem />
+  </Flex>
+);
+
+export const OffsetGap = () => (
+  <Flex gap={5}>
+    <FlexItem />
+    <FlexItem xOffset={20} />
+    <FlexItem />
+    <FlexItem />
+    <FlexItem yOffset={20} />
+    <FlexItem />
+  </Flex>
+);
+
+const Flex = (props: React.ComponentProps<typeof FlexPrimitive>) => (
+  <FlexPrimitive
+    {...props}
+    style={{
+      ...flexStyles.flex,
+      backgroundColor: 'ghostwhite',
+      flexWrap: 'wrap',
+    }}
+  />
+);
+
+const FlexItem = (props: React.ComponentProps<typeof FlexPrimitive.Item>) => (
+  <FlexPrimitive.Item
+    {...props}
+    style={{
+      ...flexStyles.item,
+      height: 50,
+      minWidth: 200,
+      borderWidth: 2,
+      borderStyle: 'solid',
+      borderColor: 'gainsboro',
+    }}
+  />
+);


### PR DESCRIPTION
Closes #45 
Closes #21 

Changes the API to the following:

```jsx
<Flex (gap|rowGap|columnGap)={5}>
  <Flex.Item yOffset={2} xOffset={2} />
  <Flex.Item />
</Flex>
```

The offset props are to handle additive gaps (`5 + 2`) but I wasn't sure what to name them... it's actually just `topOffset` and `leftOffset`. 

- Any ideas what to name these (considering RTL support)? 
- Do we think we need `rightOffset` and `bottomOffset` too?

Consumers can use the `as` prop to change the `Item` to whatever they want. 

![pr](https://user-images.githubusercontent.com/175330/89939734-52811480-dc10-11ea-8204-f53f5b52afc2.gif)
