### PR TITLE
Reset stories for `AccesibleIcon`

### DIFF
--- a/packages/react/accessible-icon/src/AccessibleIcon.stories.tsx
+++ b/packages/react/accessible-icon/src/AccessibleIcon.stories.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
-import { AccessibleIcon } from './AccessibleIcon';
+import { AccessibleIcon as AccessibleIconPrimitive, styles } from './AccessibleIcon';
 
 export default { title: 'AccessibleIcon' };
 
-export const Basic = () => (
-  <AccessibleIcon label="Close">
+export const Basic = () => <AccessibleIcon label="Close" />;
+export const InlineStyle = () => <AccessibleIcon label="Close" style={{ color: 'gainsboro' }} />;
+
+const AccessibleIcon = (props: React.ComponentProps<typeof AccessibleIconPrimitive>) => (
+  <AccessibleIconPrimitive {...props} style={{ ...styles.root, ...props.style }}>
     <svg viewBox="0 0 32 32" width={24} height={24} fill="none" stroke="currentColor">
       <path d="M2 30 L30 2 M30 30 L2 2" />
     </svg>
-  </AccessibleIcon>
+  </AccessibleIconPrimitive>
 );


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.