### PR TITLE
Reset stories for `Accordion`

### DIFF
--- a/packages/react/accordion/src/Accordion.stories.tsx
+++ b/packages/react/accordion/src/Accordion.stories.tsx
@@ -1,65 +1,101 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { Accordion } from './Accordion';
+import { Accordion as AccordionPrimitive, styles } from './Accordion';
 
 export default { title: 'Accordion' };
 
-export function Basic() {
-  return (
-    <Accordion>
-      <Accordion.Item value="one">
-        <Accordion.Button>One</Accordion.Button>
-        <Accordion.Panel>
-          Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate viverra
-          integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam suscipit
-          habitant sed.
-        </Accordion.Panel>
-      </Accordion.Item>
-      <Accordion.Item value="two">
-        <Accordion.Button>Two</Accordion.Button>
-        <Accordion.Panel>
-          Cursus sed mattis commodo fermentum conubia ipsum pulvinar sagittis, diam eget bibendum
-          porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
-        </Accordion.Panel>
-      </Accordion.Item>
-      <Accordion.Item value="three" disabled>
-        <Accordion.Button>Three</Accordion.Button>
-        <Accordion.Panel>
-          Sociis hac sapien turpis conubia sagittis justo dui, inceptos penatibus feugiat himenaeos
-          euismod magna, nec tempor pulvinar eu etiam mattis.
-        </Accordion.Panel>
-      </Accordion.Item>
-      <Accordion.Item value="four">
-        <Accordion.Button>Four</Accordion.Button>
-        <Accordion.Panel>
-          Odio placerat <a href="#">quisque</a> sapien sagittis non sociis ligula penatibus
-          dignissim vitae, enim vulputate nullam semper potenti etiam volutpat libero.
-          <button>Cool</button>
-        </Accordion.Panel>
-      </Accordion.Item>
-    </Accordion>
-  );
-}
+export const Basic = () => (
+  <Accordion>
+    <AccordionItem value="one">
+      <AccordionButton>One</AccordionButton>
+      <AccordionPanel>
+        Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate viverra
+        integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam suscipit
+        habitant sed.
+      </AccordionPanel>
+    </AccordionItem>
+    <AccordionItem value="two">
+      <AccordionButton>Two</AccordionButton>
+      <AccordionPanel>
+        Cursus sed mattis commodo fermentum conubia ipsum pulvinar sagittis, diam eget bibendum
+        porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
+      </AccordionPanel>
+    </AccordionItem>
+    <AccordionItem value="three" disabled>
+      <AccordionButton>Three (disabled)</AccordionButton>
+      <AccordionPanel>
+        Sociis hac sapien turpis conubia sagittis justo dui, inceptos penatibus feugiat himenaeos
+        euismod magna, nec tempor pulvinar eu etiam mattis.
+      </AccordionPanel>
+    </AccordionItem>
+    <AccordionItem value="four">
+      <AccordionButton>Four</AccordionButton>
+      <AccordionPanel>
+        Odio placerat <a href="#">quisque</a> sapien sagittis non sociis ligula penatibus dignissim
+        vitae, enim vulputate nullam semper potenti etiam volutpat libero.
+        <button>Cool</button>
+      </AccordionPanel>
+    </AccordionItem>
+  </Accordion>
+);
 
-export function Controlled() {
+export const Controlled = () => {
   let [value, setValue] = React.useState('one');
+
   return (
     <Accordion value={value} onChange={setValue}>
-      <Accordion.Item value="one">
-        <Accordion.Button>One</Accordion.Button>
-        <Accordion.Panel>
+      <AccordionItem value="one">
+        <AccordionButton>One</AccordionButton>
+        <AccordionPanel>
           Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate viverra
           integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam suscipit
           habitant sed.
-        </Accordion.Panel>
-      </Accordion.Item>
-      <Accordion.Item value="two">
-        <Accordion.Button>Two</Accordion.Button>
-        <Accordion.Panel>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="two">
+        <AccordionButton>Two</AccordionButton>
+        <AccordionPanel>
           Cursus sed mattis commodo fermentum conubia ipsum pulvinar sagittis, diam eget bibendum
           porta nascetur ac dictum, leo tellus dis integer platea ultrices mi.
-        </Accordion.Panel>
-      </Accordion.Item>
+        </AccordionPanel>
+      </AccordionItem>
     </Accordion>
   );
-}
+};
+
+export const InlineStyle = () => (
+  <Accordion>
+    <AccordionItem value="one" style={{ background: 'ghostwhite', border: '1px solid gainsboro' }}>
+      <AccordionButton style={{ background: 'gainsboro' }}>One</AccordionButton>
+      <AccordionPanel>
+        Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate viverra
+        integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam suscipit
+        habitant sed.
+      </AccordionPanel>
+    </AccordionItem>
+    <AccordionItem value="two" style={{ background: 'ghostwhite', border: '1px solid gainsboro' }}>
+      <AccordionButton style={{ background: 'gainsboro' }}>Two</AccordionButton>
+      <AccordionPanel>
+        Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate viverra
+        integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam suscipit
+        habitant sed.
+      </AccordionPanel>
+    </AccordionItem>
+  </Accordion>
+);
+
+const Accordion = (props: React.ComponentProps<typeof AccordionPrimitive>) => (
+  <AccordionPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);
+
+const AccordionItem = (props: React.ComponentProps<typeof AccordionPrimitive.Item>) => (
+  <AccordionPrimitive.Item {...props} style={{ ...styles.item, ...props.style }} />
+);
+
+const AccordionButton = (props: React.ComponentProps<typeof AccordionPrimitive.Button>) => (
+  <AccordionPrimitive.Button {...props} style={{ ...styles.button, ...props.style }} />
+);
+
+const AccordionPanel = (props: React.ComponentProps<typeof AccordionPrimitive.Panel>) => (
+  <AccordionPrimitive.Panel {...props} style={{ ...styles.panel, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues. 