### PR TITLE
Reset stories for `Arrow`

### DIFF
--- a/packages/react/arrow/src/Arrow.stories.tsx
+++ b/packages/react/arrow/src/Arrow.stories.tsx
@@ -1,52 +1,11 @@
 import * as React from 'react';
-import { Arrow } from './Arrow';
+import { Arrow as ArrowPrimitive, styles } from './Arrow';
 
 export default { title: 'Arrow' };
 
-export function Basic() {
-  return (
-    <blockquote
-      style={{
-        position: 'relative',
-        width: 'max-content',
-        background: 'lemonchiffon',
-        borderRadius: 12,
-        padding: 22,
-      }}
-    >
-      <p style={{ marginTop: 0 }}>You miss 100% of the shots you don't take.</p>
-      <cite>
-        <small>- Wayne Gretzky</small>
-        <br />- Michael Scott
-      </cite>
-      <Arrow
-        aria-hidden
-        style={{
-          fill: 'lemonchiffon',
-          width: 40,
-          height: 20,
-          position: 'absolute',
-          bottom: -20,
-          right: 40,
-        }}
-      />
-    </blockquote>
-  );
-}
+export const Basic = () => <Arrow />;
+export const InlineStyle = () => <Arrow width={20} height={10} style={{ fill: 'gainsboro' }} />;
 
-export function WithFills() {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'center' }}>
-      <Arrow style={{ fill: 'crimson', width: 10, height: 5 }} />
-      <Arrow style={{ fill: 'orangered', width: 20, height: 10 }} />
-      <Arrow style={{ fill: 'goldenrod', width: 40, height: 30 }} />
-      <Arrow style={{ fill: 'yellowgreen', width: 60, height: 60 }} />
-      <Arrow
-        style={{ fill: 'darkturquoise', width: 60, height: 60, transform: 'rotate(180deg)' }}
-      />
-      <Arrow style={{ fill: 'dodgerblue', width: 40, height: 30, transform: 'rotate(180deg)' }} />
-      <Arrow style={{ fill: 'mediumpurple', width: 20, height: 10, transform: 'rotate(180deg)' }} />
-      <Arrow style={{ fill: 'orchid', width: 10, height: 5, transform: 'rotate(180deg)' }} />
-    </div>
-  );
-}
+const Arrow = ({ children, ...props }: React.ComponentProps<typeof ArrowPrimitive>) => (
+  <ArrowPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.

I've had a chat with @colmtuite about this component since doing this and we're thinking it needs to be removed because dropshadow filters will not flow behind it when used in tooltips and popovers etc. 

We're thinking of making the aforementioned components do [some `&::before` trickery](https://github.com/modulz/interop-ui/pull/120) for their arrows instead so that the filter will apply.

I just thought I'd post this regardless to discuss...