### PR TITLE
Reset stories for `Avatar`

### DIFF
--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -1,31 +1,39 @@
 import * as React from 'react';
-import { Avatar, styles as avatarStyles } from './Avatar';
+import { Avatar as AvatarPrimitive, styles } from './Avatar';
 
 export default { title: 'Avatar' };
 
-export function Basic() {
-  return (
-    <div>
-      <Avatar.Root alt="John Smith" src="https://picsum.photos/400/400" style={avatarStyles.root}>
-        <Avatar.Image style={avatarStyles.image} />
-        <Avatar.Abbr style={avatarStyles.abbr} />
-      </Avatar.Root>
-    </div>
-  );
-}
+export const WithImage = () => (
+  <Avatar src="https://picsum.photos/id/1005/400/400" alt="John Smith" />
+);
 
-export function BrokenLink() {
-  return (
-    <div>
-      <Avatar.Root
-        alt="John Smith"
-        src="https://broken.link.com/broken-pic.jpg"
-        style={avatarStyles.root}
-        renderLoading={() => <span style={{ color: 'red' }}>Loading lalalala</span>}
-      >
-        <Avatar.Image style={avatarStyles.image} />
-        <Avatar.Abbr style={avatarStyles.abbr} />
-      </Avatar.Root>
-    </div>
-  );
-}
+export const WithoutImage = () => <Avatar alt="Someone else" />;
+
+export const BrokenLink = () => (
+  <Avatar src="https://broken.link.com/broken-pic.jpg" alt="John Smith" />
+);
+
+export const InlineStyle = () => (
+  <Avatar
+    src="https://picsum.photos/id/1005/400/400"
+    alt="John Smith"
+    style={{
+      backgroundColor: 'gainsboro',
+      borderRadius: 50,
+      width: 50,
+      height: 50,
+    }}
+  />
+);
+
+const Avatar = (props: React.ComponentProps<typeof AvatarPrimitive>) => (
+  <AvatarPrimitive.Root
+    {...props}
+    renderLoading={() => <span style={{ color: 'red', fontSize: 11 }}>Loading</span>}
+    style={{ ...styles.root, ...props.style }}
+  >
+    <AvatarPrimitive.Image style={styles.image} />
+    <AvatarPrimitive.Abbr style={styles.abbr} />
+    <AvatarPrimitive.Icon />
+  </AvatarPrimitive.Root>
+);

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -40,7 +40,6 @@ const AvatarRoot = forwardRef<typeof ROOT_DEFAULT_TAG, AvatarProps>(function Ava
     renderFallback,
     renderLoading,
     src,
-    style,
     ...avatarProps
   } = props;
 


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.

### Question

I noticed that I was able to render an `Avatar` without an `src` prop and I ended up with an empty avatar state because I had no `renderFallback` or `Avatar.Icon` as part of my composition. Should the `src` prop be required? 

I feel like this component is a good candidate for a state machine tbh, do we think it's worth creating a task for that? 🤔 