### PR TITLE
Reset stories for `Blockquote`

### DIFF
--- a/packages/react/blockquote/src/Blockquote.stories.tsx
+++ b/packages/react/blockquote/src/Blockquote.stories.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { Blockquote as BlockquotePrimitive, styles } from './Blockquote';
+
+export default { title: 'Blockquote' };
+
+export const Basic = () => <Blockquote>Blockquote</Blockquote>;
+export const InlineStyle = () => (
+  <Blockquote style={{ borderLeft: '2px solid gainsboro', paddingLeft: 10 }}>Blockquote</Blockquote>
+);
+
+const Blockquote = (props: React.ComponentProps<typeof BlockquotePrimitive>) => (
+  <BlockquotePrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.