### PR TITLE
Reset stories for `Button`

### DIFF
--- a/packages/react/button/src/Button.stories.tsx
+++ b/packages/react/button/src/Button.stories.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
-import { Button } from './Button';
+import { Button as ButtonPrimitive, styles } from './Button';
 
 export default { title: 'Button' };
 
-export const Basic = () => {
-  return <Button as="div">Hello Button</Button>;
-};
+export const Basic = () => <Button>Button</Button>;
+
+export const InlineStyle = () => (
+  <Button style={{ backgroundColor: 'gainsboro', padding: '5px 10px', borderRadius: '4px' }}>
+    Button
+  </Button>
+);
+
+const Button = (props: React.ComponentProps<typeof ButtonPrimitive>) => (
+  <ButtonPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.
