### PR TITLE
Reset stories for `Card`

### DIFF
--- a/packages/react/card/src/Card.stories.tsx
+++ b/packages/react/card/src/Card.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Card as CardPrimitive, styles } from './Card';
+
+export default { title: 'Card' };
+
+const Card = (props: React.ComponentProps<typeof CardPrimitive>) => (
+  <CardPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);
+
+export const Basic = () => <Card>Card</Card>;
+
+export const InlineStyle = () => (
+  <Card style={{ border: '2px solid gainsboro', padding: '20px', borderRadius: '4px' }}>Card</Card>
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.

What's the difference between `Box`, `Card` and `Container`? Are we removing this component?