### PR TITLE
Reset stories for `Collapsible`

### DIFF
--- a/packages/react/collapsible/src/Collapsible.stories.tsx
+++ b/packages/react/collapsible/src/Collapsible.stories.tsx
@@ -1,11 +1,30 @@
 import * as React from 'react';
-import { Collapsible } from './Collapsible';
+import { Collapsible as CollapsiblePrimitive, styles } from './Collapsible';
 
 export default { title: 'Collapsible' };
 
 export const Basic = () => (
   <Collapsible>
-    <Collapsible.Button>Button</Collapsible.Button>
-    <Collapsible.Content>Content 1</Collapsible.Content>
+    <CollapsibleButton>Button</CollapsibleButton>
+    <CollapsibleContent>Content 1</CollapsibleContent>
   </Collapsible>
+);
+
+export const InlineStyle = () => (
+  <Collapsible style={{ background: 'ghostwhite', border: '1px solid gainsboro' }}>
+    <CollapsibleButton style={{ background: 'gainsboro' }}>Button</CollapsibleButton>
+    <CollapsibleContent>Content 1</CollapsibleContent>
+  </Collapsible>
+);
+
+const Collapsible = (props: React.ComponentProps<typeof CollapsiblePrimitive>) => (
+  <CollapsiblePrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);
+
+const CollapsibleButton = (props: React.ComponentProps<typeof CollapsiblePrimitive.Button>) => (
+  <CollapsiblePrimitive.Button {...props} style={{ ...styles.button, ...props.style }} />
+);
+
+const CollapsibleContent = (props: React.ComponentProps<typeof CollapsiblePrimitive.Content>) => (
+  <CollapsiblePrimitive.Content {...props} style={{ ...styles.content, ...props.style }} />
 );


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.