### PR TITLE
Reset stories for `Container`

### DIFF
--- a/packages/react/container/src/Container.stories.tsx
+++ b/packages/react/container/src/Container.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Container as ContainerPrimitive, styles } from './Container';
+
+export default { title: 'Container' };
+
+export const Basic = () => <Container>Container</Container>;
+
+export const InlineStyle = () => (
+  <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <Container style={{ backgroundColor: 'gainsboro' }}>Container</Container>
+  </div>
+);
+
+const Container = (props: React.ComponentProps<typeof ContainerPrimitive>) => (
+  <ContainerPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);

--- a/packages/react/container/src/Container.tsx
+++ b/packages/react/container/src/Container.tsx
@@ -3,7 +3,7 @@ import { cssReset } from '@interop-ui/utils';
 import { forwardRef, createStyleObj } from '@interop-ui/react-utils';
 
 const NAME = 'Container';
-const DEFAULT_TAG = 'span';
+const DEFAULT_TAG = 'div';
 
 type ContainerDOMProps = React.ComponentPropsWithoutRef<typeof DEFAULT_TAG>;
 type ContainerOwnProps = {};


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.

Also: 

- I changed this to a `div` to discuss as I wondered why it was a `span` ?
- What's the difference between `Box`, `Card` and `Container`? Are we removing this component?