### PR TITLE
Reset stories for `Divider`

### DIFF
--- a/packages/react/divider/src/Divider.stories.tsx
+++ b/packages/react/divider/src/Divider.stories.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Divider as DividerPrimitive, styles } from './Divider';
+
+export default { title: 'Divider' };
+
+export const Basic = () => <Divider />;
+export const InlineStyle = () => <Divider style={{ height: 2, backgroundColor: 'gainsboro' }} />;
+
+const Divider = (props: React.ComponentProps<typeof DividerPrimitive>) => (
+  <DividerPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.