### PR TITLE
Reset stories for `Grid`

### DIFF
--- a/packages/react/grid/src/Grid.stories.tsx
+++ b/packages/react/grid/src/Grid.stories.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Grid as GridPrimitive, styles } from './Grid';
+
+export default { title: 'Grid' };
+
+export const Basic = () => <Grid>Grid</Grid>;
+export const InlineStyle = () => <Grid style={{ backgroundColor: 'gainsboro' }}>Grid</Grid>;
+
+const Grid = (props: React.ComponentProps<typeof GridPrimitive>) => (
+  <GridPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.

This component doesn't really do much now. Are we going to keep it? 