### PR TITLE
Reset stories for `Header`

### DIFF
--- a/packages/react/header/src/Header.stories.tsx
+++ b/packages/react/header/src/Header.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Header as HeaderPrimitive, styles } from './Header';
+
+export default { title: 'Header' };
+
+export const Basic = () => <Header>Header</Header>;
+
+export const Sticky = () => (
+  <div style={{ height: 9000 }}>
+    <Header isSticky>Header</Header>
+  </div>
+);
+
+export const InlineStyle = () => <Header style={{ backgroundColor: 'gainsboro' }}>Header</Header>;
+
+const Header = (props: React.ComponentProps<typeof HeaderPrimitive>) => (
+  <HeaderPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.