### PR TITLE
Reset stories for `Link`

### DIFF
--- a/packages/react/link/src/Link.stories.tsx
+++ b/packages/react/link/src/Link.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Link as LinkPrimitive, styles } from './Link';
+
+export default { title: 'Link' };
+
+export const Basic = () => <Link href="#">Link</Link>;
+
+export const InlineStyle = () => (
+  <Link href="#" style={{ color: 'dodgerblue', textDecoration: 'underline' }}>
+    Link
+  </Link>
+);
+
+const Link = (props: React.ComponentProps<typeof LinkPrimitive>) => (
+  <LinkPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.