### PR TITLE
Reset stories for `Overlay`

### DIFF
--- a/packages/react/overlay/src/Overlay.stories.tsx
+++ b/packages/react/overlay/src/Overlay.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Overlay as OverlayPrimitive, styles } from './Overlay';
+
+export default { title: 'Overlay' };
+
+export const Basic = () => <Overlay>Overlay</Overlay>;
+
+export const InlineStyle = () => (
+  <Overlay style={{ backgroundColor: 'gainsboro' }}>Overlay</Overlay>
+);
+
+const Overlay = (props: React.ComponentProps<typeof OverlayPrimitive>) => (
+  <OverlayPrimitive {...props} style={{ ...styles.root, ...props.style }} />
+);


### PR DESCRIPTION
Adds basic reset stories. I'll include `styled` and `as` prop stories separately as they currently have type issues.