### PR TITLE
Simplify `useLayoutEffect` usage

### DIFF
--- a/.yarn/versions/59898c4d.yml
+++ b/.yarn/versions/59898c4d.yml
@@ -1,0 +1,36 @@
+releases:
+  "@interop-ui/popper": prerelease
+  "@interop-ui/react-accessible-icon": prerelease
+  "@interop-ui/react-accordion": prerelease
+  "@interop-ui/react-alert-dialog": prerelease
+  "@interop-ui/react-announce": prerelease
+  "@interop-ui/react-arrow": prerelease
+  "@interop-ui/react-aspect-ratio": prerelease
+  "@interop-ui/react-avatar": prerelease
+  "@interop-ui/react-checkbox": prerelease
+  "@interop-ui/react-collapsible": prerelease
+  "@interop-ui/react-collection": prerelease
+  "@interop-ui/react-debug-context": prerelease
+  "@interop-ui/react-dialog": prerelease
+  "@interop-ui/react-label": prerelease
+  "@interop-ui/react-lock": prerelease
+  "@interop-ui/react-lock-modular-temp": prerelease
+  "@interop-ui/react-popover": prerelease
+  "@interop-ui/react-popper": prerelease
+  "@interop-ui/react-portal": prerelease
+  "@interop-ui/react-progress-bar": prerelease
+  "@interop-ui/react-radio": prerelease
+  "@interop-ui/react-separator": prerelease
+  "@interop-ui/react-sheet": prerelease
+  "@interop-ui/react-slider": prerelease
+  "@interop-ui/react-switch": prerelease
+  "@interop-ui/react-tabs": prerelease
+  "@interop-ui/react-toggle-button": prerelease
+  "@interop-ui/react-tooltip": prerelease
+  "@interop-ui/react-use-size": prerelease
+  "@interop-ui/react-utils": prerelease
+  "@interop-ui/react-visually-hidden": prerelease
+
+declined:
+  - interop-ui
+  - "@interop-ui/docs"

--- a/docs/components/QuickNav.tsx
+++ b/docs/components/QuickNav.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Box, Heading, Link, Text } from '@modulz/radix';
-import { useIsomorphicLayoutEffect } from '@interop-ui/react-utils';
+import { useLayoutEffect } from '@interop-ui/react-utils';
 
 type QuickNavItem = {
   label: string;
@@ -45,7 +45,7 @@ function QuickNavItem({
   const label = labelOverride ?? (typeof children === 'string' ? children : '');
   const slug = slugOverride ?? label.toLowerCase().replace(/\s/g, '-');
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     setItems((items) => [...items, { label, slug, level }]);
     return () => setItems((items) => items.filter((item) => item.slug !== slug));
   }, [slug, label, level, setItems]);

--- a/docs/components/ScrollArea.tsx
+++ b/docs/components/ScrollArea.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, Box } from '@modulz/radix';
-import { useIsomorphicLayoutEffect } from '@interop-ui/react-utils';
+import { useLayoutEffect } from '@interop-ui/react-utils';
 
 type Point = {
   x: number;
@@ -26,7 +26,7 @@ export const ScrollArea = (props: ScrollAreaProps) => {
     typeof document === 'undefined' ? '' : document.body.style.pointerEvents
   );
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     const wrapperEl = wrapperRef.current;
     const contentEl = contentRef.current;
     const thumbEl = thumbRef.current;

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -5,7 +5,7 @@ import {
   forwardRef,
   createStyleObj,
   useComposedRefs,
-  useIsomorphicLayoutEffect as useLayoutEffect,
+  useLayoutEffect,
 } from '@interop-ui/react-utils';
 
 type RegionType = 'polite' | 'assertive' | 'off';

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -5,7 +5,7 @@ import {
   forwardRef,
   createStyleObj,
   useCallbackRef,
-  useIsomorphicLayoutEffect,
+  useLayoutEffect,
 } from '@interop-ui/react-utils';
 
 /* -------------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ const AvatarImage = forwardRef<typeof IMAGE_DEFAULT_TAG, AvatarImageProps>(funct
   const imageLoadingStatus = useImageLoadingStatus(src);
   const onLoadingStatusChange = useCallbackRef(onLoadingStatusChangeProp);
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (imageLoadingStatus !== 'idle') {
       onLoadingStatusChange(imageLoadingStatus);
       setImageLoadingStatus(imageLoadingStatus);

--- a/packages/react/collection/src/collection.tsx
+++ b/packages/react/collection/src/collection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createContext, useIsomorphicLayoutEffect } from '@interop-ui/react-utils';
+import { createContext, useLayoutEffect } from '@interop-ui/react-utils';
 
 function createCollection<E extends React.ElementRef<any> = void, S = {}>(name: string) {
   const providerName = name + 'CollectionProvider';
@@ -51,7 +51,7 @@ function createCollection<E extends React.ElementRef<any> = void, S = {}>(name: 
 
     // items are pushed into the `items` array every render, so we reset them
     // everytime the children change.
-    useIsomorphicLayoutEffect(() => {
+    useLayoutEffect(() => {
       setItems([]);
     }, [children]);
 
@@ -98,14 +98,14 @@ function createCollection<E extends React.ElementRef<any> = void, S = {}>(name: 
     ssrSyncUseCollectionItemCountRef.current = ssrSyncUseCollectionItemCountRef.current + 1;
 
     // add item on every render, this is fine because we reset the items in the parent everytime
-    useIsomorphicLayoutEffect(() => {
+    useLayoutEffect(() => {
       addItem(({ ...state, ref } as unknown) as Item);
     });
 
     // only remove on unmount
-    useIsomorphicLayoutEffect(() => {
+    useLayoutEffect(() => {
       return () => removeItem(ref);
-    }, [removeItem]);
+    }, [ref, removeItem]);
 
     return { ref, index };
   }

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -9,7 +9,7 @@ import {
   useRect,
   usePrevious,
   useControlledState,
-  useIsomorphicLayoutEffect,
+  useLayoutEffect,
 } from '@interop-ui/react-utils';
 import { cssReset } from '@interop-ui/utils';
 import { Popper, styles as popperStyles } from '@interop-ui/react-popper';
@@ -92,7 +92,7 @@ const Tooltip: React.FC<TooltipProps> & TooltipStaticProps = function Tooltip(pr
 
   // if we're controlling the component
   // put the state machine in the appropriate state
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (isOpenProp === true) {
       stateMachine.transition('mouseEntered', { id });
     }

--- a/packages/react/utils/src/index.ts
+++ b/packages/react/utils/src/index.ts
@@ -10,7 +10,7 @@ export * from './useConstant';
 export * from './useControlledState';
 export * from './useDocumentRef';
 export * from './useId';
-export * from './useIsomorphicLayoutEffect';
+export * from './useLayoutEffect';
 export * from './usePrevious';
 export * from './useRect';
 export * from './useRovingTabIndex';

--- a/packages/react/utils/src/useDocumentRef.tsx
+++ b/packages/react/utils/src/useDocumentRef.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useIsomorphicLayoutEffect as useLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 
 export function useDocumentRef<T extends Element>(
   forwardedRef: React.RefObject<T | null>

--- a/packages/react/utils/src/useIsomorphicLayoutEffect.tsx
+++ b/packages/react/utils/src/useIsomorphicLayoutEffect.tsx
@@ -1,8 +1,0 @@
-import * as React from 'react';
-import { canUseDOM } from '@interop-ui/utils';
-
-/**
- * A version of `React.useLayoutEffect` which falls back to `React.useEffect`
- * on the server as `React.useLayoutEffect` does nothing on the server.
- */
-export const useIsomorphicLayoutEffect = canUseDOM() ? React.useLayoutEffect : React.useEffect;

--- a/packages/react/utils/src/useLayoutEffect.tsx
+++ b/packages/react/utils/src/useLayoutEffect.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { canUseDOM } from '@interop-ui/utils';
+
+/**
+ * On the server, React emits a warning when calling `useLayoutEffect`.
+ * This is because neither `useLayoutEffect` nor `useEffect` run on the server.
+ * We use this safe version which suppresses the warning by replacing it with a noop on the server.
+ *
+ * See: https://reactjs.org/docs/hooks-reference.html#uselayouteffect
+ */
+export const useLayoutEffect = canUseDOM() ? React.useLayoutEffect : () => {};

--- a/packages/react/utils/src/useRect.tsx
+++ b/packages/react/utils/src/useRect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observeElementRect } from '@interop-ui/utils';
-import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useLayoutEffect } from './useLayoutEffect';
 
 /**
  * Use this custom hook to get access to an element's rect (getBoundingClientRect)
@@ -11,7 +11,7 @@ export function useRect(
   refToObserve: React.RefObject<HTMLElement | SVGElement>
 ) {
   const [rect, setRect] = React.useState<ClientRect>();
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (refToObserve.current) {
       const unobserve = observeElementRect(refToObserve.current, setRect);
       return () => {


### PR DESCRIPTION
This PR brings 2 changes:

- rename `useIsomorphicLayoutEffect` to `useLayoutEffect` to simplify usage and preserve hook effect linting
- simplify implementation of `useLayoutEffect` by returning a noop on the server rather than the misleading `React.useEffect` (inspired by `react-aria`, see [here](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/utils/src/useLayoutEffect.ts))