### PR TITLE
Change `StyleObject` type to `{}`

### DIFF
--- a/.yarn/versions/961f3d2a.yml
+++ b/.yarn/versions/961f3d2a.yml
@@ -1,0 +1,36 @@
+releases:
+  "@interop-ui/popper": prerelease
+  "@interop-ui/react-accessible-icon": prerelease
+  "@interop-ui/react-accordion": prerelease
+  "@interop-ui/react-alert-dialog": prerelease
+  "@interop-ui/react-announce": prerelease
+  "@interop-ui/react-arrow": prerelease
+  "@interop-ui/react-aspect-ratio": prerelease
+  "@interop-ui/react-avatar": prerelease
+  "@interop-ui/react-checkbox": prerelease
+  "@interop-ui/react-collapsible": prerelease
+  "@interop-ui/react-collection": prerelease
+  "@interop-ui/react-debug-context": prerelease
+  "@interop-ui/react-dialog": prerelease
+  "@interop-ui/react-label": prerelease
+  "@interop-ui/react-lock": prerelease
+  "@interop-ui/react-lock-modular-temp": prerelease
+  "@interop-ui/react-popover": prerelease
+  "@interop-ui/react-popper": prerelease
+  "@interop-ui/react-portal": prerelease
+  "@interop-ui/react-progress-bar": prerelease
+  "@interop-ui/react-radio-group": prerelease
+  "@interop-ui/react-separator": prerelease
+  "@interop-ui/react-sheet": prerelease
+  "@interop-ui/react-slider": prerelease
+  "@interop-ui/react-switch": prerelease
+  "@interop-ui/react-tabs": prerelease
+  "@interop-ui/react-toggle-button": prerelease
+  "@interop-ui/react-tooltip": prerelease
+  "@interop-ui/react-use-size": prerelease
+  "@interop-ui/react-utils": prerelease
+  "@interop-ui/react-visually-hidden": prerelease
+
+declined:
+  - interop-ui
+  - "@interop-ui/docs"

--- a/packages/react/utils/src/createStyleObj.ts
+++ b/packages/react/utils/src/createStyleObj.ts
@@ -1,6 +1,6 @@
 import { interopDataAttrObj, interopDataAttrSelector } from '@interop-ui/utils';
 
-type StyleObject = any;
+type StyleObject = {};
 type PrimitiveStyles<Part extends string> = {
   root: StyleObject;
 } & Record<Part, StyleObject>;


### PR DESCRIPTION
There was a problem in Stitches where the variant typing wasn't working on components that spread our primitive styles. This is most likely because stitches will be creating an intersection type and intersecting `any` returns `any`.