### PR TITLE
Fix missing types for tabbable

### DIFF
--- a/.yarn/versions/e2069ecf.yml
+++ b/.yarn/versions/e2069ecf.yml
@@ -1,0 +1,10 @@
+releases:
+  "@interop-ui/react-alert-dialog": prerelease
+  "@interop-ui/react-dialog": prerelease
+  "@interop-ui/react-lock": prerelease
+  "@interop-ui/react-popover": prerelease
+  "@interop-ui/react-tooltip": prerelease
+  "@interop-ui/tabbable": prerelease
+
+declined:
+  - interop-ui

--- a/packages/core/tabbable/src/index.ts
+++ b/packages/core/tabbable/src/index.ts
@@ -63,9 +63,6 @@ function tabbable(el: Element, options: TabbableOptions = {}) {
   return tabbableNodes;
 }
 
-tabbable.isTabbable = isTabbable;
-tabbable.isFocusable = isFocusable;
-
 function isNodeMatchingSelectorTabbable(node: Element) {
   if (!isNodeMatchingSelectorFocusable(node) || isNonTabbableRadio(node) || getTabindex(node) < 0) {
     return false;
@@ -73,32 +70,11 @@ function isNodeMatchingSelectorTabbable(node: Element) {
   return true;
 }
 
-function isTabbable(node: Element) {
-  if (!node) {
-    throw new Error('No node provided');
-  }
-  if (matches.call(node, candidateSelector) === false) {
-    return false;
-  }
-  return isNodeMatchingSelectorTabbable(node);
-}
-
 function isNodeMatchingSelectorFocusable(node: Element) {
   if ((node as any).disabled || isHiddenInput(node) || isHidden(node)) {
     return false;
   }
   return true;
-}
-
-const focusableCandidateSelector = candidateSelectors.concat('iframe').join(',');
-function isFocusable(node: Element) {
-  if (!node) {
-    throw new Error('No node provided');
-  }
-  if (matches.call(node, focusableCandidateSelector) === false) {
-    return false;
-  }
-  return isNodeMatchingSelectorFocusable(node);
 }
 
 function getTabindex(node: Element) {
@@ -169,8 +145,8 @@ function isHidden(node: Element) {
   return (node as any).offsetParent === null || getComputedStyle(node).visibility === 'hidden';
 }
 
-export { tabbable };
-
 interface TabbableOptions {
   includeContainer?: boolean;
 }
+
+export { tabbable };


### PR DESCRIPTION
We are trying to debug a separate build issue so I'm trying to clean up all issues to help debugging.

For some reason the `tabbable.isTabbable` and `tabbable.isFocusable` statics were preventing types from being built which caused a `index.d.ts is not a module` build error locally. I haven't spent any time trying to figure out why because I hear this package is being removed soon.