### PR TITLE
Use latest canary for stitches in all packages

### DIFF
--- a/.yarn/versions/efc54b58.yml
+++ b/.yarn/versions/efc54b58.yml
@@ -1,0 +1,7 @@
+releases:
+  "@interop-ui/react-progress-bar": prerelease
+  "@interop-ui/react-separator": prerelease
+  "@interop-ui/react-switch": prerelease
+
+declined:
+  - interop-ui

--- a/packages/react/progress-bar/package.json
+++ b/packages/react/progress-bar/package.json
@@ -22,7 +22,7 @@
     "@interop-ui/utils": "workspace:*"
   },
   "devDependencies": {
-    "@stitches/react": "0.0.3-canary.4",
+    "@stitches/react": "canary",
     "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -22,7 +22,7 @@
     "@interop-ui/utils": "workspace:*"
   },
   "devDependencies": {
-    "@stitches/react": "0.0.3-canary.4",
+    "@stitches/react": "canary",
     "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -23,7 +23,7 @@
     "@interop-ui/utils": "workspace:*"
   },
   "devDependencies": {
-    "@stitches/react": "0.0.3-canary.4",
+    "@stitches/react": "canary",
     "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,7 +2029,7 @@ __metadata:
   dependencies:
     "@interop-ui/react-utils": "workspace:*"
     "@interop-ui/utils": "workspace:*"
-    "@stitches/react": 0.0.3-canary.4
+    "@stitches/react": canary
     parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ">=16"
@@ -2055,7 +2055,7 @@ __metadata:
   dependencies:
     "@interop-ui/react-utils": "workspace:*"
     "@interop-ui/utils": "workspace:*"
-    "@stitches/react": 0.0.3-canary.4
+    "@stitches/react": canary
     parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ">=16"
@@ -2084,7 +2084,7 @@ __metadata:
     "@interop-ui/react-label": "workspace:*"
     "@interop-ui/react-utils": "workspace:*"
     "@interop-ui/utils": "workspace:*"
-    "@stitches/react": 0.0.3-canary.4
+    "@stitches/react": canary
     parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ">=16"
@@ -3564,7 +3564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stitches/react@npm:0.0.3-canary.4":
+"@stitches/react@npm:canary":
   version: 0.0.3-canary.4
   resolution: "@stitches/react@npm:0.0.3-canary.4"
   dependencies:


### PR DESCRIPTION
This PR will let us easily keep our internal use of Stitches as a dev dependency up-to-date with the latest canary release automatically. It should also prevent installing multiple versions of stitches in the case where a working branch has pinned its version differently than the main branch.