### PR TITLE
Tiny window API tweak in popper

### DIFF
--- a/.yarn/versions/6bb1433b.yml
+++ b/.yarn/versions/6bb1433b.yml
@@ -1,0 +1,11 @@
+releases:
+  "@interop-ui/popper": prerelease
+  "@interop-ui/react-alert-dialog": prerelease
+  "@interop-ui/react-dialog": prerelease
+  "@interop-ui/react-dismissable-layer": prerelease
+  "@interop-ui/react-popover": prerelease
+  "@interop-ui/react-popper": prerelease
+  "@interop-ui/react-tooltip": prerelease
+
+declined:
+  - interop-ui

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -292,8 +292,8 @@ export function getAlignAccountingForCollisions(
 }
 
 function getPlacementStylesForPoint(point: Point): CSS.Properties {
-  const x = Math.round(point.x + window.pageXOffset);
-  const y = Math.round(point.y + window.pageYOffset);
+  const x = Math.round(point.x + window.scrollX);
+  const y = Math.round(point.y + window.scrollY);
   return {
     position: 'absolute',
     top: 0,


### PR DESCRIPTION
I just realised that `window.pageXOffset` and `window.pageYOffset` were just aliases to `window.scrollX` and `window.scrollY` which I think read much better here so updated the.