### PR TITLE
Improve AccessibleIcon

### DIFF
--- a/.yarn/versions/e47d961d.yml
+++ b/.yarn/versions/e47d961d.yml
@@ -1,0 +1,5 @@
+releases:
+  "@interop-ui/react-accessible-icon": prerelease
+
+declined:
+  - interop-ui

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -17,9 +17,7 @@
     "prepublish": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@interop-ui/react-polymorphic": "workspace:*",
-    "@interop-ui/react-visually-hidden": "workspace:*",
-    "@interop-ui/utils": "workspace:*"
+    "@interop-ui/react-visually-hidden": "workspace:*"
   },
   "devDependencies": {
     "parcel": "^2.0.0-beta.1"

--- a/packages/react/accessible-icon/src/AccesibleIcon.test.tsx
+++ b/packages/react/accessible-icon/src/AccesibleIcon.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { axe } from 'jest-axe';
 import type { RenderResult } from '@testing-library/react';
 import { render } from '@testing-library/react';
-import { getPartDataAttr } from '@interop-ui/utils';
 import { AccessibleIcon } from './AccessibleIcon';
 
 const LABEL_TEXT = 'Close';
@@ -38,12 +37,6 @@ describe('given a default AccessibleIcon', () => {
     expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
-  it('should have an interop attribute on the container', () => {
-    const container = rendered.container.firstChild;
-    const partDataAttr = getPartDataAttr('AccessibleIcon');
-    expect(container).toHaveAttribute(partDataAttr);
-  });
-
   it('should have a label', () => {
     expect(label).toBeInTheDocument();
   });
@@ -69,22 +62,5 @@ describe('given an AccessibleIcon without children', () => {
     // Mock error to prevent it from logging to console
     spy.mockImplementation(() => ({ TypeError: () => {} }));
     expect(() => render(<AccessibleIconTest />)).toThrowError();
-  });
-});
-
-describe('given a styled AccessibleIcon', () => {
-  let rendered: RenderResult;
-
-  beforeEach(() => {
-    rendered = render(
-      <AccessibleIconTest className="icon-class">
-        <b>Foo</b>
-      </AccessibleIconTest>
-    );
-  });
-
-  it('should pass the className to the container', () => {
-    const container = rendered.container.firstChild;
-    expect(container).toHaveClass('icon-class');
   });
 });

--- a/packages/react/accessible-icon/src/AccessibleIcon.stories.tsx
+++ b/packages/react/accessible-icon/src/AccessibleIcon.stories.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { AccessibleIcon } from './AccessibleIcon';
-import { styled } from '../../../../stitches.config';
 
 export default { title: 'Components/AccessibleIcon' };
 
 export const Styled = () => (
-  <AccessibleIcon label="Close" as={StyledRoot}>
-    <CrossIcon />
-  </AccessibleIcon>
+  <button type="button">
+    <AccessibleIcon label="Close">
+      <CrossIcon />
+    </AccessibleIcon>
+  </button>
 );
 
 const CrossIcon = () => (
@@ -15,16 +16,3 @@ const CrossIcon = () => (
     <path d="M2 30 L30 2 M30 30 L2 2" />
   </svg>
 );
-
-const RECOMMENDED_CSS__ACCESSIBLE_ICON__ROOT = {
-  // ensures child icon is contained correctly, `inline-block` would also work for that
-  // but it would create the usual nasty few extra pixels underneath, so `inline-flex` is a better default.
-  display: 'inline-flex',
-  // better default alignment
-  verticalAlign: 'middle',
-};
-
-const StyledRoot = styled('span', {
-  ...RECOMMENDED_CSS__ACCESSIBLE_ICON__ROOT,
-  color: '$red',
-});

--- a/packages/react/accessible-icon/src/AccessibleIcon.tsx
+++ b/packages/react/accessible-icon/src/AccessibleIcon.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
-import { getPartDataAttrObj } from '@interop-ui/utils';
-import { forwardRefWithAs } from '@interop-ui/react-polymorphic';
 import { VisuallyHidden } from '@interop-ui/react-visually-hidden';
 
 const NAME = 'AccessibleIcon';
-const DEFAULT_TAG = 'span';
 
 type AccessibleIconOwnProps = {
   /**
@@ -14,23 +11,19 @@ type AccessibleIconOwnProps = {
   label: string;
 };
 
-const AccessibleIcon = forwardRefWithAs<typeof DEFAULT_TAG, AccessibleIconOwnProps>(
-  (props, forwardedRef) => {
-    const { as: Comp = DEFAULT_TAG, children, label, ...iconProps } = props;
-    const child = React.Children.only(children);
-
-    return (
-      <Comp {...getPartDataAttrObj(NAME)} ref={forwardedRef} {...iconProps}>
-        {React.cloneElement(child as React.ReactElement, {
-          // accessibility
-          'aria-hidden': true,
-          focusable: 'false', // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
-        })}
-        <VisuallyHidden>{label}</VisuallyHidden>
-      </Comp>
-    );
-  }
-);
+const AccessibleIcon: React.FC<AccessibleIconOwnProps> = ({ children, label }) => {
+  const child = React.Children.only(children);
+  return (
+    <>
+      {React.cloneElement(child as React.ReactElement, {
+        // accessibility
+        'aria-hidden': 'true',
+        focusable: 'false', // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
+      })}
+      <VisuallyHidden>{label}</VisuallyHidden>
+    </>
+  );
+};
 
 AccessibleIcon.displayName = NAME;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,9 +2033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@interop-ui/react-accessible-icon@workspace:packages/react/accessible-icon"
   dependencies:
-    "@interop-ui/react-polymorphic": "workspace:*"
     "@interop-ui/react-visually-hidden": "workspace:*"
-    "@interop-ui/utils": "workspace:*"
     parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
Chatting with @peduarte yesterday about that one in the docs, I was telling him that we have some recommended styles in the story to make sure the element aligns properly, etc.

But then he made a good point that the only reason we have to recommend users to do that is because we add a wrapper that is unnecessary.

So this PR removes the outer wrapper in favour of a fragment.
AFAICT there's no impact on accessibility (screen-readers announce the same) and no impact on layout because visually hidden is out of the flow (I tested in flex and grid containers).