### PR TITLE
`Label`: Add `aria-labelledby` to story

### DIFF
--- a/packages/react/label/src/Label.stories.tsx
+++ b/packages/react/label/src/Label.stories.tsx
@@ -29,7 +29,11 @@ export const WithHtmlFor = () => (
 
 const Control = (props: any) => {
   const id = useLabelContext();
-  return <span {...props}>{id}</span>;
+  return (
+    <span aria-labelledby={id} {...props}>
+      {id}
+    </span>
+  );
 };
 
 export const RECOMMENDED_CSS__LABEL__ROOT = {


### PR DESCRIPTION
I was looking through the stories when writing the docs for this and couldn't really remember what the consumer was supposed to do with the `useLabelContext`. I've updated the story to make that clearer.