### PR TITLE
Improve tree-shaking

### DIFF
--- a/.yarn/versions/c67fccd5.yml
+++ b/.yarn/versions/c67fccd5.yml
@@ -1,0 +1,41 @@
+releases:
+  "@interop-ui/popper": prerelease
+  "@interop-ui/react-accessible-icon": prerelease
+  "@interop-ui/react-accordion": prerelease
+  "@interop-ui/react-alert-dialog": prerelease
+  "@interop-ui/react-announce": prerelease
+  "@interop-ui/react-arrow": prerelease
+  "@interop-ui/react-aspect-ratio": prerelease
+  "@interop-ui/react-avatar": prerelease
+  "@interop-ui/react-checkbox": prerelease
+  "@interop-ui/react-collapsible": prerelease
+  "@interop-ui/react-collection": prerelease
+  "@interop-ui/react-context-menu": prerelease
+  "@interop-ui/react-dialog": prerelease
+  "@interop-ui/react-dismissable-layer": prerelease
+  "@interop-ui/react-dropdown-menu": prerelease
+  "@interop-ui/react-focus-guards": prerelease
+  "@interop-ui/react-focus-scope": prerelease
+  "@interop-ui/react-label": prerelease
+  "@interop-ui/react-menu": prerelease
+  "@interop-ui/react-polymorphic": prerelease
+  "@interop-ui/react-popover": prerelease
+  "@interop-ui/react-popper": prerelease
+  "@interop-ui/react-portal": prerelease
+  "@interop-ui/react-presence": prerelease
+  "@interop-ui/react-progress-bar": prerelease
+  "@interop-ui/react-radio-group": prerelease
+  "@interop-ui/react-roving-focus": prerelease
+  "@interop-ui/react-scroll-area": prerelease
+  "@interop-ui/react-separator": prerelease
+  "@interop-ui/react-slider": prerelease
+  "@interop-ui/react-switch": prerelease
+  "@interop-ui/react-tabs": prerelease
+  "@interop-ui/react-toggle-button": prerelease
+  "@interop-ui/react-tooltip": prerelease
+  "@interop-ui/react-utils": prerelease
+  "@interop-ui/react-visually-hidden": prerelease
+  "@interop-ui/utils": prerelease
+
+declined:
+  - interop-ui

--- a/packages/core/popper/package.json
+++ b/packages/core/popper/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -10,6 +10,7 @@
     "src",
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/progress-bar/package.json
+++ b/packages/react/progress-bar/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/utils/package.json
+++ b/packages/react/utils/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -10,6 +10,7 @@
     "dist",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",


### PR DESCRIPTION
AFAICT we're not doing anything weird with any of our modules so I think it's safe to add `sideEffects: false` to all of them.

I did do some more testing of tree-shaking locally using CRA and although importing from our primitives directly did tree-shake properly, as soon as you re-export them in a file and use that instead then it wouldn't. I then validated that by adding `sideEffects: false` to our primitives packages directly in `node_modules` and it was tree-shaking properly.