### PR TITLE
[react-presence]: Reduce `requestAnimationFrame` logic

### DIFF
--- a/.yarn/versions/fc718974.yml
+++ b/.yarn/versions/fc718974.yml
@@ -1,0 +1,15 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.stories.tsx
+++ b/packages/react/checkbox/src/Checkbox.stories.tsx
@@ -15,7 +15,7 @@ export const Styled = () => (
     <Label>
       Label{' '}
       <Checkbox as={StyledRoot}>
-        <CheckboxIndicator as={Indicator} />
+        <CheckboxIndicator as={StyledIndicator} />
       </Checkbox>
     </Label>
   </>
@@ -37,7 +37,7 @@ export const Controlled = () => {
         onCheckedChange={(event) => setChecked(event.target.checked)}
         id="randBox"
       >
-        <CheckboxIndicator as={Indicator} />
+        <CheckboxIndicator as={StyledIndicator} />
       </Checkbox>
     </>
   );
@@ -54,7 +54,7 @@ export const Indeterminate = () => {
           checked={checked}
           onCheckedChange={(event) => setChecked(event.target.checked)}
         >
-          <CheckboxIndicator as={Indicator} indeterminate={checked === 'indeterminate'} />
+          <CheckboxIndicator as={StyledIndicator} />
         </Checkbox>
       </p>
 
@@ -85,7 +85,7 @@ export const WithinForm = () => {
       <p>checked: {String(checked)}</p>
 
       <Checkbox as={StyledRoot}>
-        <CheckboxIndicator as={Indicator} />
+        <CheckboxIndicator as={StyledIndicator} />
       </Checkbox>
     </form>
   );
@@ -122,15 +122,18 @@ const StyledRoot = styled('button', {
 });
 
 const StyledIndicator = styled('span', {
+  backgroundColor: '$red',
   display: 'block',
   width: 20,
-  height: 20,
-  backgroundColor: '$red',
-});
 
-const Indicator = ({ indeterminate, ...props }: any) => (
-  <StyledIndicator {...props} css={{ height: indeterminate ? 4 : undefined }} />
-);
+  '&[data-state="indeterminate"]': {
+    height: 4,
+  },
+
+  '&[data-state="checked"]': {
+    height: 20,
+  },
+});
 
 const fadeIn = css.keyframes({
   from: { opacity: 0 },

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -38,7 +38,6 @@ type PresenceState = { value: 'mounted' | 'unmounted' | 'unmountSuspended'; cont
 function usePresence(present: boolean) {
   const [node, setNode] = React.useState<HTMLElement>();
   const [styles, setStyles] = React.useState<CSSStyleDeclaration>();
-  const prevPresentRef = React.useRef(present);
   const prevAnimationNameRef = React.useRef<string>();
   const { state, send } = useStateMachine<{}, PresenceEvent, PresenceState>({
     id: 'presence',
@@ -52,7 +51,7 @@ function usePresence(present: boolean) {
         },
       },
       unmountSuspended: {
-        on: { ANIMATION_END: 'unmounted', TRANSITION_END: 'unmounted' },
+        on: { MOUNT: 'mounted', ANIMATION_END: 'unmounted', TRANSITION_END: 'unmounted' },
       },
       unmounted: {
         on: { MOUNT: 'mounted' },
@@ -69,46 +68,52 @@ function usePresence(present: boolean) {
   }, [node]);
 
   React.useEffect(() => {
-    return waitForAfterNextFrame(() => {
-      /**
-       * When `present` changes, we check changes to animation-name to determine
-       * whether an animation has started. We chose this approach (reading computed
-       * styles) over using `animationstart` event because we would need to delay
-       * unmount with a `setTimeout` that `animationstart` would clear. That approach
-       * becomes problematic if consumers use `animation-delay`.
-       */
-      const wasPresent = prevPresentRef.current;
-      const prevAnimationName = prevAnimationNameRef.current;
-      const currentAnimationName = getAnimationName(styles);
-      const isAnimating = String(prevAnimationName) !== String(currentAnimationName);
-      prevAnimationNameRef.current = currentAnimationName;
-      prevPresentRef.current = present;
+    let cancelWaitForAfterNextFrame = () => {};
+    const prevAnimationName = prevAnimationNameRef.current;
+    const currentAnimationName = getAnimationName(styles);
+    prevAnimationNameRef.current = currentAnimationName;
 
-      if (present) {
-        send('MOUNT');
-      } else if (wasPresent && isAnimating) {
-        // If the element is hidden, it will not run the animation
-        send(styles?.display === 'none' ? 'UNMOUNT' : 'ANIMATION_OUT');
+    if (present) {
+      send('MOUNT');
+    } else if (styles?.display === 'none') {
+      // If the element is hidden, animations won't run so we unmount instantly
+      send('UNMOUNT');
+    } else {
+      /**
+       * When `present` changes to `false`, we check changes to animation-name to
+       * determine whether an animation has started. We chose this approach (reading
+       * computed styles) because there is no `animationrun` event and `animationstart`
+       * fires after `animation-delay` has expired which would be too late.
+       */
+      const isAnimating = prevAnimationName !== currentAnimationName;
+      if (isAnimating) {
+        send('ANIMATION_OUT');
       } else {
-        send('UNMOUNT');
+        // wait in case a `transitionrun` event fires
+        cancelWaitForAfterNextFrame = waitForAfterNextFrame(() => send('UNMOUNT'));
       }
-    });
+    }
+
+    return cancelWaitForAfterNextFrame;
   }, [present, styles, send]);
 
   React.useEffect(() => {
     if (node) {
+      /**
+       * Triggering an ANIMATION_OUT during an ANIMATION_IN will fire an `animationcancel`
+       * event for ANIMATION_IN after we have entered `unmountSuspended` state. So, we
+       * make sure we only trigger ANIMATION_END for the currently active animation.
+       */
+      const handleAnimationEnd = (event: AnimationEvent) => {
+        const currentAnimationName = getAnimationName(styles);
+        const isCurrentAnimation = event.animationName === currentAnimationName;
+        if (event.target === node && isCurrentAnimation) send('ANIMATION_END');
+      };
       const handleTransitionRun = (event: TransitionEvent) => {
-        const wasPresent = prevPresentRef.current;
-        const isTransitionOut = !present && wasPresent;
-        if (event.target === node && isTransitionOut) {
-          send('TRANSITION_OUT');
-        }
+        if (!present && event.target === node) send('TRANSITION_OUT');
       };
       const handleTransitionEnd = (event: TransitionEvent) => {
         if (event.target === node) send('TRANSITION_END');
-      };
-      const handleAnimationEnd = (event: AnimationEvent) => {
-        if (event.target === node) send('ANIMATION_END');
       };
 
       node.addEventListener('animationcancel', handleAnimationEnd);
@@ -125,13 +130,15 @@ function usePresence(present: boolean) {
         node.removeEventListener('transitionend', handleTransitionEnd);
       };
     }
-  }, [node, present, send]);
+  }, [node, present, styles, send]);
 
   return {
     ref: (node: HTMLElement) => setNode(node),
     isPresent: ['mounted', 'unmountSuspended'].includes(state),
   };
 }
+
+/* -----------------------------------------------------------------------------------------------*/
 
 function getAnimationName(styles?: CSSStyleDeclaration) {
   return styles?.animationName || 'none';
@@ -141,10 +148,9 @@ function waitForAfterNextFrame(cb = () => {}) {
   let nextFrameRaf: number;
   let afterNextFrameRaf: number;
   /**
-   * This first two `requestAnimationFrame` calls are needed because `requestAnimationFrame`
-   * fires *before* the next frame and we need *next* frame. This is to ensure our live
-   * CSSStyleDeclaration has updated before we compare values for animation. The third
-   * `requestAnimationFrame` is to ensure the callback fires after the `transitionrun` event.
+   * Three `requestAnimationFrame` calls are needed because `requestAnimationFrame`
+   * fires *before* the next frame and we need after the *next* frame. This is to ensure
+   * transitions have updated and `transitionrun` has fired.
    */
   const beforeNextFrameRaf = requestAnimationFrame(() => {
     nextFrameRaf = requestAnimationFrame(() => {
@@ -158,8 +164,6 @@ function waitForAfterNextFrame(cb = () => {}) {
     cancelAnimationFrame(afterNextFrameRaf);
   };
 }
-
-/* -----------------------------------------------------------------------------------------------*/
 
 export { Presence };
 export type { PresenceProps };

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -38,6 +38,7 @@ type PresenceState = { value: 'mounted' | 'unmounted' | 'unmountSuspended'; cont
 function usePresence(present: boolean) {
   const [node, setNode] = React.useState<HTMLElement>();
   const [styles, setStyles] = React.useState<CSSStyleDeclaration>();
+  const prevPresentRef = React.useRef(present);
   const prevAnimationNameRef = React.useRef<string>();
   const { state, send } = useStateMachine<{}, PresenceEvent, PresenceState>({
     id: 'presence',
@@ -85,8 +86,10 @@ function usePresence(present: boolean) {
        * computed styles) because there is no `animationrun` event and `animationstart`
        * fires after `animation-delay` has expired which would be too late.
        */
+      const wasPresent = prevPresentRef.current;
       const isAnimating = prevAnimationName !== currentAnimationName;
-      if (isAnimating) {
+
+      if (wasPresent && isAnimating) {
         send('ANIMATION_OUT');
       } else {
         // wait in case a `transitionrun` event fires
@@ -94,6 +97,7 @@ function usePresence(present: boolean) {
       }
     }
 
+    prevPresentRef.current = present;
     return cancelWaitForAfterNextFrame;
   }, [present, styles, send]);
 


### PR DESCRIPTION
This work all stemmed from an issue with `Checkbox` indeterminate state in our stories. There was a FOUC during its indicator unmount phase due to these `requestAnimationFrame`s in `Presence` and the fact that our `Checkbox` stories assume "unmounted" means "unchecked". 

I've updated the story to more explicitly target states for styles as I don't think it's a good idea to assume that when it is not `indeterminate` it is unmounted or `checked`. A new state could be added so the logic should be more explicit. Plus, "unchecked" and "unmounted" are conceptually different things that could happen at different times (like this).

This PR:

- Reduces the amount of logic wrapped in `requestAnimationFrame` to try ease these sorts of issues. I want to try remove/improve the one around the `send('UNMOUNT')` too which is the main culprit here but that's proving more difficult. I'll look into it separately.
- Potential bug fix I spotted which helped clean up some logic: Adds `MOUNT: 'mounted'` event to `unmountSuspended` state since users should be able to re-mount during the animation/transition phase.
- Updates `Checkbox.stories` to more explicitly target states for styles as described above.