### PR TITLE
Generate GitHub Release [step 1]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 - [ ] Add or edit tests to reflect the change (run `yarn test`).
 - [ ] Add or edit Storybook examples to reflect the change (run `yarn start`).
 - [ ] Add documentation to support any new features.
+- [ ] Add a brief overview of the change in `RELEASE.md`.
 
 This pull request:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v[0-9]*'
+    branches:
+      - changelogs
+      - 'releases/*'
+    # tags:
+    #   - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body_path: ./current-release.md
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - changelogs
-      - 'releases/*'
-    # tags:
-    #   - 'v*'
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -23,6 +20,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body_path: ./current-release.md
+          body_path: ./RELEASE.md
           draft: false
           prerelease: false

--- a/.yarn/versions/0b609389.yml
+++ b/.yarn/versions/0b609389.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+# Release vX.X.X
+
+<!--
+Add your release notes below this comment. Follow the format as follows, and don't forget to credit yourself under `Controbutors` if you aren't already listed for this release!
+
+## Bugfixes
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Documentation
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Enhancements
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Features
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+### Contributors
+- Your Name ([@your-github-handle](https://github.com/your-github-handle))
+-
+ -->

--- a/current-release.md
+++ b/current-release.md
@@ -1,3 +1,0 @@
-# Release 1.0.0
-
-Yay! This is a fake release. Pay no attention to me.

--- a/current-release.md
+++ b/current-release.md
@@ -1,0 +1,3 @@
+# Release 1.0.0
+
+Yay! This is a fake release. Pay no attention to me.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clean": "yarn workspaces foreach -pv --exclude primitives run clean",
     "reset": "yarn clean && rm -rf .yarn/cache node_modules",
     "bump": "yarn version apply --all",
-    "bump:check": "yarn version check"
+    "bump:check": "yarn version check",
+    "create-release-notes": "cp scripts/release-template.md RELEASE.md"
   },
   "dependencies": {
     "react": "^17.0.1",

--- a/scripts/release-template.md
+++ b/scripts/release-template.md
@@ -1,0 +1,29 @@
+# Release vX.X.X
+
+<!--
+Add your release notes below this comment. Follow the format as follows, and don't forget to credit yourself under `Controbutors` if you aren't already listed for this release!
+
+## Bugfixes
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Documentation
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Enhancements
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+## Features
+* `affected-package-name`
+  * **BREAKING: ** Brief description of a breaking change
+  * Brief description of a non-breaking change
+
+### Contributors
+- Your Name ([@your-github-handle](https://github.com/your-github-handle))
+-
+ -->


### PR DESCRIPTION
This PR will introduce the first step in keeping changelogs via GitHub releases. it uses [this action](https://github.com/marketplace/actions/generate-changelog-action) as suggested by @jjenzz.

With this addition, here's what needs to happen:
- In every PR, any change affecting a package will need to be documented in `RELEASE.md`. We will ask contributors to add this for now before merging a PR.
- When releasing a new version, we'll need to add the correct version to the title in `RELEASE.md`, then create a version tag (e.g., `v0.2.1`) and push that tag to GH. That tag will trigger the action, which creates the GH release with the content from `RELEASE.md`.
- After the release is done, we can run `yarn create-release-notes` to reset the release notes to blank for the next release.

This is intended as an incremental step. As a next step I'd like to use tags and PR titles to populate `RELEASE.md` after merging so we can remove that step for contributors.

I tested this briefly with a dummy commit just to make sure the action works as expected:

![image](https://user-images.githubusercontent.com/3082153/102548913-2f5beb00-4070-11eb-99b1-121b5f31776d.png)
