### PR TITLE
[Popper] Add window size explicit dependency

### DIFF
--- a/.yarn/versions/a6bd4f3f.yml
+++ b/.yarn/versions/a6bd4f3f.yml
@@ -1,0 +1,34 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/utils": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-announce"
+  - "@radix-ui/react-arrow"
+  - "@radix-ui/react-aspect-ratio"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-focus-scope"
+  - "@radix-ui/react-label"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-scroll-area"
+  - "@radix-ui/react-separator"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toggle-button"
+  - "@radix-ui/react-utils"
+  - "@radix-ui/react-visually-hidden"

--- a/packages/core/popper/src/popper.stories.tsx
+++ b/packages/core/popper/src/popper.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useRect, useSize } from '@radix-ui/react-utils';
-import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/utils';
+import { SIDE_OPTIONS, ALIGN_OPTIONS, makeRect } from '@radix-ui/utils';
 import { getPlacementData } from './popper';
 
 export default { title: 'Core/popper' };
@@ -60,8 +60,12 @@ function Demo({ disableCollisions = false }) {
     sideOffset,
     align,
     alignOffset,
-    collisionTolerance,
     shouldAvoidCollisions: !disableCollisions,
+    collisionBoundariesRect: makeRect(
+      { width: window.innerWidth, height: window.innerHeight },
+      { x: 0, y: 0 }
+    ),
+    collisionTolerance,
   });
 
   return (

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import { makeRect, getOppositeSide, getCollisions } from '@radix-ui/utils';
+import { makeRect, getOppositeSide, getCollisions, contractRect } from '@radix-ui/utils';
 
 import type { Axis, Side, Align, Point, Size } from '@radix-ui/utils';
 
@@ -24,6 +24,8 @@ type GetPlacementDataOptions = {
   alignOffset?: number;
   /** An option to turn on/off the collision handling (default: true) */
   shouldAvoidCollisions?: boolean;
+  /** The rect which represent the boundaries for collision checks */
+  collisionBoundariesRect?: ClientRect;
   /** The tolerance used for collisions, ie. if we want them to trigger a bit earlier (default: 0) */
   collisionTolerance?: number;
 };
@@ -56,11 +58,12 @@ export function getPlacementData({
   align,
   alignOffset = 0,
   shouldAvoidCollisions = true,
+  collisionBoundariesRect,
   collisionTolerance = 0,
 }: GetPlacementDataOptions): PlacementData {
   // if we're not ready to do all the measurements yet,
   // we return some good default styles
-  if (!anchorRect || !popperSize) {
+  if (!anchorRect || !popperSize || !collisionBoundariesRect) {
     return {
       popperStyles: UNMEASURED_POPPER_STYLES,
       arrowStyles: UNMEASURED_ARROW_STYLES,
@@ -104,8 +107,14 @@ export function getPlacementData({
   // create a new rect as if element had been moved to new placement
   const popperRect = makeRect(popperSize, popperPoint);
 
+  // create a bew rect representing the collision boundaries but taking into account any added tolerance
+  const collisionBoundariesRectWithTolerance = contractRect(
+    collisionBoundariesRect,
+    collisionTolerance
+  );
+
   // check for any collisions in new placement
-  const popperCollisions = getCollisions(popperRect, collisionTolerance);
+  const popperCollisions = getCollisions(popperRect, collisionBoundariesRectWithTolerance);
 
   // do all the same calculations for the opposite side
   // this is because we need to check for potential collisions if we were to swap side
@@ -114,7 +123,7 @@ export function getPlacementData({
   const updatedOppositeSidePopperPoint = makeRect(popperSize, oppositeSidePopperPoint);
   const oppositeSidePopperCollisions = getCollisions(
     updatedOppositeSidePopperPoint,
-    collisionTolerance
+    collisionBoundariesRectWithTolerance
   );
 
   // adjust side accounting for collisions / opposite side collisions

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import { makeRect, getOppositeSide, getCollisions, contractRect } from '@radix-ui/utils';
+import { makeRect, getOppositeSide, getCollisions, getContractedRect } from '@radix-ui/utils';
 
 import type { Axis, Side, Align, Point, Size } from '@radix-ui/utils';
 
@@ -108,7 +108,7 @@ export function getPlacementData({
   const popperRect = makeRect(popperSize, popperPoint);
 
   // create a new rect representing the collision boundaries but taking into account any added tolerance
-  const collisionBoundariesRectWithTolerance = contractRect(
+  const collisionBoundariesRectWithTolerance = getContractedRect(
     collisionBoundariesRect,
     collisionTolerance
   );

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -24,7 +24,7 @@ type GetPlacementDataOptions = {
   alignOffset?: number;
   /** An option to turn on/off the collision handling (default: true) */
   shouldAvoidCollisions?: boolean;
-  /** The rect which represent the boundaries for collision checks */
+  /** The rect which represents the boundaries for collision checks */
   collisionBoundariesRect?: ClientRect;
   /** The tolerance used for collisions, ie. if we want them to trigger a bit earlier (default: 0) */
   collisionTolerance?: number;
@@ -107,7 +107,7 @@ export function getPlacementData({
   // create a new rect as if element had been moved to new placement
   const popperRect = makeRect(popperSize, popperPoint);
 
-  // create a bew rect representing the collision boundaries but taking into account any added tolerance
+  // create a new rect representing the collision boundaries but taking into account any added tolerance
   const collisionBoundariesRectWithTolerance = contractRect(
     collisionBoundariesRect,
     collisionTolerance

--- a/packages/core/utils/src/geometry.ts
+++ b/packages/core/utils/src/geometry.ts
@@ -63,7 +63,7 @@ function getOppositeSide(side: Side): Side {
 function getCollisions(
   /** The rect to test collisions against */
   rect: ClientRect,
-  /** The rect which represent the boundaries for collision checks */
+  /** The rect which represents the boundaries for collision checks */
   collisionBoundariesRect: ClientRect
 ) {
   return {

--- a/packages/core/utils/src/geometry.ts
+++ b/packages/core/utils/src/geometry.ts
@@ -23,7 +23,7 @@ function makeRect({ width, height }: Size, { x, y }: Point): ClientRect {
  * Creates a new rect (`ClientRect`) based on a given one but contracted by
  * a given amout on each side.
  */
-function contractRect(rect: ClientRect, amount: number) {
+function getContractedRect(rect: ClientRect, amount: number) {
   return makeRect(
     { width: rect.width - amount * 2, height: rect.height - amount * 2 },
     { x: rect.left + amount, y: rect.top + amount }
@@ -78,7 +78,7 @@ export {
   SIDE_OPTIONS,
   ALIGN_OPTIONS,
   makeRect,
-  contractRect,
+  getContractedRect,
   rectEquals,
   getOppositeSide,
   getCollisions,

--- a/packages/core/utils/src/geometry.ts
+++ b/packages/core/utils/src/geometry.ts
@@ -20,16 +20,14 @@ function makeRect({ width, height }: Size, { x, y }: Point): ClientRect {
 }
 
 /**
- * Gets the opposite side of a given side (ie. top => bottom, left => right, …)
+ * Creates a new rect (`ClientRect`) based on a given one but contracted by
+ * a given amout on each side.
  */
-function getOppositeSide(side: Side): Side {
-  const oppositeSides: Record<Side, Side> = {
-    top: 'bottom',
-    right: 'left',
-    bottom: 'top',
-    left: 'right',
-  };
-  return oppositeSides[side];
+function contractRect(rect: ClientRect, amount: number) {
+  return makeRect(
+    { width: rect.width - amount * 2, height: rect.height - amount * 2 },
+    { x: rect.left + amount, y: rect.top + amount }
+  );
 }
 
 /**
@@ -46,16 +44,17 @@ function rectEquals(rect1: ClientRect, rect2: ClientRect) {
   );
 }
 
-function isInsideRect(rect: ClientRect, point: Point, { inclusive = true } = {}) {
-  if (inclusive) {
-    return (
-      point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom
-    );
-  } else {
-    return (
-      point.x > rect.left && point.x < rect.right && point.y > rect.top && point.y < rect.bottom
-    );
-  }
+/**
+ * Gets the opposite side of a given side (ie. top => bottom, left => right, …)
+ */
+function getOppositeSide(side: Side): Side {
+  const oppositeSides: Record<Side, Side> = {
+    top: 'bottom',
+    right: 'left',
+    bottom: 'top',
+    left: 'right',
+  };
+  return oppositeSides[side];
 }
 
 /**
@@ -64,14 +63,14 @@ function isInsideRect(rect: ClientRect, point: Point, { inclusive = true } = {})
 function getCollisions(
   /** The rect to test collisions against */
   rect: ClientRect,
-  /** An optional tolerance if you want the collisions to trigger a bit before/after */
-  tolerance = 0
+  /** The rect which represent the boundaries for collision checks */
+  collisionBoundariesRect: ClientRect
 ) {
   return {
-    top: rect.top < tolerance,
-    right: rect.right > window.innerWidth - tolerance,
-    bottom: rect.bottom > window.innerHeight - tolerance,
-    left: rect.left < tolerance,
+    top: rect.top < collisionBoundariesRect.top,
+    right: rect.right > collisionBoundariesRect.right,
+    bottom: rect.bottom > collisionBoundariesRect.bottom,
+    left: rect.left < collisionBoundariesRect.left,
   };
 }
 
@@ -79,9 +78,9 @@ export {
   SIDE_OPTIONS,
   ALIGN_OPTIONS,
   makeRect,
-  getOppositeSide,
+  contractRect,
   rectEquals,
-  isInsideRect,
+  getOppositeSide,
   getCollisions,
 };
 export type { Axis, Side, Align, Point, Size };

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -3,9 +3,9 @@ import { getPlacementData } from '@radix-ui/popper';
 import { createContext, useRect, useSize, useComposedRefs } from '@radix-ui/react-utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Arrow as ArrowPrimitive } from '@radix-ui/react-arrow';
-import { getPartDataAttrObj } from '@radix-ui/utils';
+import { getPartDataAttrObj, makeRect } from '@radix-ui/utils';
 
-import type { Side, Align, MeasurableElement } from '@radix-ui/utils';
+import type { Side, Align, Size, MeasurableElement } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Root level context
@@ -63,6 +63,9 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
 
     const composedPopperRef = useComposedRefs(forwardedRef, popperRef);
 
+    const windowSize = useWindowSize();
+    const collisionBoundariesRect = windowSize ? makeRect(windowSize, { x: 0, y: 0 }) : undefined;
+
     const { popperStyles, arrowStyles, placedSide, placedAlign } = getPlacementData({
       anchorRect,
       popperSize,
@@ -74,8 +77,9 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
       sideOffset,
       align,
       alignOffset,
-      collisionTolerance,
       shouldAvoidCollisions: avoidCollisions,
+      collisionBoundariesRect,
+      collisionTolerance,
     });
     const isPlaced = placedSide !== undefined;
 
@@ -155,6 +159,30 @@ const PopperArrow = forwardRefWithAs<typeof ArrowPrimitive, PopperArrowOwnProps>
 PopperArrow.displayName = ARROW_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
+
+const WINDOW_RESIZE_DEBOUNCE_WAIT_IN_MS = 100;
+
+function useWindowSize() {
+  const [windowSize, setWindowSize] = React.useState<Size | undefined>(undefined);
+
+  React.useEffect(() => {
+    let debounceTimerId: number;
+
+    function handleResize() {
+      window.clearTimeout(debounceTimerId);
+      debounceTimerId = window.setTimeout(
+        () => setWindowSize({ width: window.innerWidth, height: window.innerHeight }),
+        WINDOW_RESIZE_DEBOUNCE_WAIT_IN_MS
+      );
+    }
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}
 
 const Root = Popper;
 const Arrow = PopperArrow;

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -168,15 +168,16 @@ function useWindowSize() {
   React.useEffect(() => {
     let debounceTimerId: number;
 
-    function handleResize() {
-      window.clearTimeout(debounceTimerId);
-      debounceTimerId = window.setTimeout(
-        () => setWindowSize({ width: window.innerWidth, height: window.innerHeight }),
-        WINDOW_RESIZE_DEBOUNCE_WAIT_IN_MS
-      );
+    function updateWindowSize() {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
     }
 
-    handleResize();
+    function handleResize() {
+      window.clearTimeout(debounceTimerId);
+      debounceTimerId = window.setTimeout(updateWindowSize, WINDOW_RESIZE_DEBOUNCE_WAIT_IN_MS);
+    }
+
+    updateWindowSize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);


### PR DESCRIPTION
Closes #350

We had an implicit dependency on `window.innerWidth` and `window.innerHeight` but our popper wasn't reacting to changes in window size.

This PR adds a more explicit relationship down to the low-level popper utility.
It doesn't have any impact on any public APIs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
