### PR TITLE
Build with Preconstruct

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-typescript"]
-}

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules
 dist
 test-output.*
 .cache
-.parcel-cache
 storybook-static
 .env
 .eslintcache

--- a/.yarn/versions/dcda9e1d.yml
+++ b/.yarn/versions/dcda9e1d.yml
@@ -1,0 +1,41 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-guards": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+  "@radix-ui/utils": patch
+
+declined:
+  - primitives

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  babelVersion: 7,
+  presets: [
+    '@babel/preset-typescript',
+    '@babel/preset-react',
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: ['> 0.25%'],
+          node: '8',
+        },
+        useBuiltIns: 'entry',
+        corejs: 2,
+        shippedProposals: true,
+        modules: false,
+      },
+    ],
+  ],
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ['babel-plugin-dev-expression'],
   presets: [
     '@babel/preset-typescript',
     '@babel/preset-react',

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  babelVersion: 7,
   presets: [
     '@babel/preset-typescript',
     '@babel/preset-react',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "clean": "yarn workspaces foreach -pv --exclude primitives run clean",
     "reset": "yarn clean && rm -rf .yarn/cache node_modules",
     "bump": "yarn version apply --all",
-    "bump:check": "yarn version check"
+    "bump:check": "yarn version check",
+    "postinstall": "preconstruct dev"
   },
   "dependencies": {
     "react": "^17.0.1",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@preconstruct/cli": "^2.0.1",
     "@stitches/react": "canary",
     "@storybook/addon-storysource": "6.1.0-beta.4",
     "@storybook/react": "6.1.0-beta.4",
@@ -142,5 +144,11 @@
   },
   "resolutions": {
     "@types/styled-system__core": "npm:@peduarte/styled-system__core@*"
+  },
+  "preconstruct": {
+    "packages": [
+      "packages/core/*",
+      "packages/react/*"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-storybook": "build-storybook",
     "build": "yarn build:config && yarn build:packages && yarn build:cleanup",
     "build:config": "mv tsconfig.json tsconfig.tmp.json && mv tsconfig.production.json tsconfig.json",
-    "build:packages": "yarn workspaces foreach -t --exclude primitives run build",
+    "build:packages": "preconstruct build",
     "build:cleanup": "mv tsconfig.json tsconfig.production.json && mv tsconfig.tmp.json tsconfig.json",
     "publish": "yarn bump && yarn build && yarn workspaces foreach -pv --exclude primitives npm publish --tolerate-republish --access public",
     "clean": "yarn workspaces foreach -pv --exclude primitives run clean",
@@ -31,7 +31,8 @@
     "react-dom": "^17.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.12.10",
+    "@babel/preset-typescript": "^7.12.7",
     "@preconstruct/cli": "^2.0.1",
     "@stitches/react": "canary",
     "@storybook/addon-storysource": "6.1.0-beta.4",
@@ -41,7 +42,6 @@
     "@types/eslint": "^7",
     "@types/jest": "^26.0.10",
     "@types/jest-axe": "^3.5.0",
-    "@types/parcel-bundler": "^1.12.1",
     "@types/react": "^16.9.55",
     "@types/react-dom": "^16.9.9",
     "@types/react-test-renderer": "^16.9.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
     "@preconstruct/cli": "^2.0.1",
     "@stitches/react": "canary",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "2.x",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-dev-expression": "^0.2.2",
     "eslint": "6.x",
     "eslint-config-react-app": "^5.2.1",
     "eslint-plugin-flowtype": "4.x",

--- a/packages/core/popper/package.json
+++ b/packages/core/popper/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-popper.cjs.js",
   "module": "dist/radix-ui-popper.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/core/popper/package.json
+++ b/packages/core/popper/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-popper.cjs.js",
   "module": "dist/radix-ui-popper.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/core/popper/package.json
+++ b/packages/core/popper/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-popper.cjs.js",
+  "module": "dist/radix-ui-popper.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/utils": "workspace:*",
     "csstype": "^3.0.4"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-utils.cjs.js",
+  "module": "dist/radix-ui-utils.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,13 +12,9 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-utils.cjs.js",
   "module": "dist/radix-ui-utils.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-utils.cjs.js",
   "module": "dist/radix-ui-utils.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-accessible-icon.cjs.js",
   "module": "dist/radix-ui-react-accessible-icon.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-accessible-icon.cjs.js",
   "module": "dist/radix-ui-react-accessible-icon.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-accessible-icon.cjs.js",
+  "module": "dist/radix-ui-react-accessible-icon.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,16 +12,12 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
   },
   "dependencies": {
     "@radix-ui/react-visually-hidden": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-accordion.cjs.js",
   "module": "dist/radix-ui-react-accordion.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-accordion.cjs.js",
   "module": "dist/radix-ui-react-accordion.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-accordion.cjs.js",
+  "module": "dist/radix-ui-react-accordion.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-alert-dialog.cjs.js",
+  "module": "dist/radix-ui-react-alert-dialog.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "src",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-alert-dialog.cjs.js",
   "module": "dist/radix-ui-react-alert-dialog.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "src",
     "dist"

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-alert-dialog.cjs.js",
   "module": "dist/radix-ui-react-alert-dialog.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "src",
     "dist"

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-announce.cjs.js",
   "module": "dist/radix-ui-react-announce.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-announce.cjs.js",
+  "module": "dist/radix-ui-react-announce.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,9 +20,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-announce.cjs.js",
   "module": "dist/radix-ui-react-announce.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-arrow.cjs.js",
   "module": "dist/radix-ui-react-arrow.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-arrow.cjs.js",
+  "module": "dist/radix-ui-react-arrow.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-arrow.cjs.js",
   "module": "dist/radix-ui-react-arrow.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-aspect-ratio.cjs.js",
   "module": "dist/radix-ui-react-aspect-ratio.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-aspect-ratio.cjs.js",
   "module": "dist/radix-ui-react-aspect-ratio.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-aspect-ratio.cjs.js",
+  "module": "dist/radix-ui-react-aspect-ratio.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-avatar.cjs.js",
   "module": "dist/radix-ui-react-avatar.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-avatar.cjs.js",
+  "module": "dist/radix-ui-react-avatar.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,9 +20,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-avatar.cjs.js",
   "module": "dist/radix-ui-react-avatar.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-checkbox.cjs.js",
   "module": "dist/radix-ui-react-checkbox.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-checkbox.cjs.js",
+  "module": "dist/radix-ui-react-checkbox.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -23,9 +22,6 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-checkbox.cjs.js",
   "module": "dist/radix-ui-react-checkbox.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-collapsible.cjs.js",
   "module": "dist/radix-ui-react-collapsible.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-collapsible.cjs.js",
   "module": "dist/radix-ui-react-collapsible.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-collapsible.cjs.js",
+  "module": "dist/radix-ui-react-collapsible.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-collection.cjs.js",
   "module": "dist/radix-ui-react-collection.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-collection.cjs.js",
+  "module": "dist/radix-ui-react-collection.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,16 +12,12 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-collection.cjs.js",
   "module": "dist/radix-ui-react-collection.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-context-menu.cjs.js",
   "module": "dist/radix-ui-react-context-menu.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-context-menu.cjs.js",
   "module": "dist/radix-ui-react-context-menu.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-context-menu.cjs.js",
+  "module": "dist/radix-ui-react-context-menu.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-dialog.cjs.js",
+  "module": "dist/radix-ui-react-dialog.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -28,9 +27,6 @@
     "@radix-ui/utils": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dialog.cjs.js",
   "module": "dist/radix-ui-react-dialog.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dialog.cjs.js",
   "module": "dist/radix-ui-react-dialog.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dismissable-layer.cjs.js",
   "module": "dist/radix-ui-react-dismissable-layer.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dismissable-layer.cjs.js",
   "module": "dist/radix-ui-react-dismissable-layer.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-dismissable-layer.cjs.js",
+  "module": "dist/radix-ui-react-dismissable-layer.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,7 +20,6 @@
     "@radix-ui/react-utils": "workspace:*"
   },
   "devDependencies": {
-    "parcel": "^2.0.0-beta.1",
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dropdown-menu.cjs.js",
   "module": "dist/radix-ui-react-dropdown-menu.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-dropdown-menu.cjs.js",
   "module": "dist/radix-ui-react-dropdown-menu.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-dropdown-menu.cjs.js",
+  "module": "dist/radix-ui-react-dropdown-menu.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-focus-guards.cjs.js",
+  "module": "dist/radix-ui-react-focus-guards.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,13 +12,9 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-focus-guards.cjs.js",
   "module": "dist/radix-ui-react-focus-guards.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-focus-guards.cjs.js",
   "module": "dist/radix-ui-react-focus-guards.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-focus-scope.cjs.js",
   "module": "dist/radix-ui-react-focus-scope.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-focus-scope.cjs.js",
+  "module": "dist/radix-ui-react-focus-scope.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-focus-scope.cjs.js",
   "module": "dist/radix-ui-react-focus-scope.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-label.cjs.js",
   "module": "dist/radix-ui-react-label.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-label.cjs.js",
   "module": "dist/radix-ui-react-label.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-label.cjs.js",
+  "module": "dist/radix-ui-react-label.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,9 +20,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-menu.cjs.js",
+  "module": "dist/radix-ui-react-menu.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -30,9 +29,6 @@
     "@radix-ui/utils": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-menu.cjs.js",
   "module": "dist/radix-ui-react-menu.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-menu.cjs.js",
   "module": "dist/radix-ui-react-menu.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-polymorphic.cjs.js",
+  "module": "dist/radix-ui-react-polymorphic.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,14 +12,12 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
   },
   "devDependencies": {
-    "@testing-library/react": "^10.4.8",
-    "parcel": "^2.0.0-beta.1"
+    "@testing-library/react": "^10.4.8"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-polymorphic.cjs.js",
   "module": "dist/radix-ui-react-polymorphic.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-polymorphic.cjs.js",
   "module": "dist/radix-ui-react-polymorphic.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-popover.cjs.js",
+  "module": "dist/radix-ui-react-popover.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -29,9 +28,6 @@
     "@radix-ui/utils": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-popover.cjs.js",
   "module": "dist/radix-ui-react-popover.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-popover.cjs.js",
   "module": "dist/radix-ui-react-popover.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-popper.cjs.js",
+  "module": "dist/radix-ui-react-popper.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -23,9 +22,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-popper.cjs.js",
   "module": "dist/radix-ui-react-popper.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-popper.cjs.js",
   "module": "dist/radix-ui-react-popper.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-portal.cjs.js",
   "module": "dist/radix-ui-react-portal.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-portal.cjs.js",
+  "module": "dist/radix-ui-react-portal.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,16 +12,12 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-portal.cjs.js",
   "module": "dist/radix-ui-react-portal.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-presence.cjs.js",
   "module": "dist/radix-ui-react-presence.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-presence.cjs.js",
   "module": "dist/radix-ui-react-presence.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-presence.cjs.js",
+  "module": "dist/radix-ui-react-presence.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",
     "@xstate/fsm": "^1.5.1"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-progress.cjs.js",
+  "module": "dist/radix-ui-react-progress.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,9 +20,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-progress.cjs.js",
   "module": "dist/radix-ui-react-progress.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-progress.cjs.js",
   "module": "dist/radix-ui-react-progress.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-radio-group.cjs.js",
+  "module": "dist/radix-ui-react-radio-group.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -24,9 +23,6 @@
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-radio-group.cjs.js",
   "module": "dist/radix-ui-react-radio-group.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-radio-group.cjs.js",
   "module": "dist/radix-ui-react-radio-group.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-roving-focus.cjs.js",
+  "module": "dist/radix-ui-react-roving-focus.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-roving-focus.cjs.js",
   "module": "dist/radix-ui-react-roving-focus.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-roving-focus.cjs.js",
   "module": "dist/radix-ui-react-roving-focus.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-scroll-area.cjs.js",
+  "module": "dist/radix-ui-react-scroll-area.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -23,8 +22,7 @@
     "@radix-ui/utils": "workspace:*"
   },
   "devDependencies": {
-    "@stitches/react": "canary",
-    "parcel": "^2.0.0-beta.1"
+    "@stitches/react": "canary"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-scroll-area.cjs.js",
   "module": "dist/radix-ui-react-scroll-area.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-scroll-area.cjs.js",
   "module": "dist/radix-ui-react-scroll-area.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-separator.cjs.js",
+  "module": "dist/radix-ui-react-separator.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-separator.cjs.js",
   "module": "dist/radix-ui-react-separator.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-separator.cjs.js",
   "module": "dist/radix-ui-react-separator.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-slider.cjs.js",
+  "module": "dist/radix-ui-react-slider.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-slider.cjs.js",
   "module": "dist/radix-ui-react-slider.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-slider.cjs.js",
   "module": "dist/radix-ui-react-slider.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-switch.cjs.js",
   "module": "dist/radix-ui-react-switch.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-switch.cjs.js",
+  "module": "dist/radix-ui-react-switch.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-switch.cjs.js",
   "module": "dist/radix-ui-react-switch.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-tabs.cjs.js",
+  "module": "dist/radix-ui-react-tabs.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -22,9 +21,6 @@
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-tabs.cjs.js",
   "module": "dist/radix-ui-react-tabs.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-tabs.cjs.js",
   "module": "dist/radix-ui-react-tabs.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-toggle-button.cjs.js",
   "module": "dist/radix-ui-react-toggle-button.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-toggle-button.cjs.js",
+  "module": "dist/radix-ui-react-toggle-button.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -21,9 +20,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-toggle-button.cjs.js",
   "module": "dist/radix-ui-react-toggle-button.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-tooltip.cjs.js",
   "module": "dist/radix-ui-react-tooltip.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-tooltip.cjs.js",
   "module": "dist/radix-ui-react-tooltip.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-tooltip.cjs.js",
+  "module": "dist/radix-ui-react-tooltip.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -24,9 +23,6 @@
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/utils/package.json
+++ b/packages/react/utils/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-utils.cjs.js",
+  "module": "dist/radix-ui-react-utils.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -23,8 +22,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^10.4.8",
-    "@types/resize-observer-browser": "^0.1.4",
-    "parcel": "^2.0.0-beta.1"
+    "@types/resize-observer-browser": "^0.1.4"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/utils/package.json
+++ b/packages/react/utils/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-utils.cjs.js",
   "module": "dist/radix-ui-react-utils.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/utils/package.json
+++ b/packages/react/utils/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-utils.cjs.js",
   "module": "dist/radix-ui-react-utils.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-visually-hidden.cjs.js",
   "module": "dist/radix-ui-react-visually-hidden.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "main": "dist/radix-ui-react-visually-hidden.cjs.js",
+  "module": "dist/radix-ui-react-visually-hidden.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -12,7 +12,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
     "version": "yarn version",
     "prepublish": "yarn clean && yarn build"
@@ -20,9 +19,6 @@
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "parcel": "^2.0.0-beta.1"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -5,7 +5,6 @@
   "source": "src/index.ts",
   "main": "dist/radix-ui-react-visually-hidden.cjs.js",
   "module": "dist/radix-ui-react-visually-hidden.esm.js",
-  "types": "dist/declarations/index.d.ts",
   "files": [
     "dist",
     "README.md"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/compat-data@npm:7.12.7"
+  checksum: 96e60c267b955a1bc40dcfa845cb10b9d94d1c0f3c76247c00464173e1e45e94b4755246c1cefdd875ec59902effbfd9a99bd0e9d6a364fd04c51af1aa88f6d9
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5, @babel/core@npm:^7.7.7, @babel/core@npm:^7.9.0":
   version: 7.12.3
   resolution: "@babel/core@npm:7.12.3"
@@ -108,6 +115,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-annotate-as-pure@npm:^7.12.10":
+  version: 7.12.10
+  resolution: "@babel/helper-annotate-as-pure@npm:7.12.10"
+  dependencies:
+    "@babel/types": ^7.12.10
+  checksum: d237f38b6a57704dc2a4b98d41cd1744ca12a3ee66b085c348c1ce0d93320f004510c69ab600f9ed1bd7b3737e21d39196cd7c5eb51bc07806699e98319bcbbf
+  languageName: node
+  linkType: hard
+
 "@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.10.4"
@@ -129,6 +145,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-builder-react-jsx-experimental@npm:^7.12.11":
+  version: 7.12.11
+  resolution: "@babel/helper-builder-react-jsx-experimental@npm:7.12.11"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.12.10
+    "@babel/helper-module-imports": ^7.12.5
+    "@babel/types": ^7.12.11
+  checksum: 9b6594e48dd18c926270e18cb58ec2b3c78545ee10ef31d6ee10dd691a8eb278719a4e5b126d751a74741a8806091d839a87b753ea35712f866d3802cf6c9999
+  languageName: node
+  linkType: hard
+
 "@babel/helper-builder-react-jsx@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/helper-builder-react-jsx@npm:7.10.4"
@@ -139,7 +166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.10.4, @babel/helper-compilation-targets@npm:^7.12.1":
+"@babel/helper-compilation-targets@npm:^7.10.4, @babel/helper-compilation-targets@npm:^7.12.1, @babel/helper-compilation-targets@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/helper-compilation-targets@npm:7.12.5"
   dependencies:
@@ -239,7 +266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.1":
+"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.1, @babel/helper-module-imports@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/helper-module-imports@npm:7.12.5"
   dependencies:
@@ -358,6 +385,13 @@ __metadata:
   version: 7.12.1
   resolution: "@babel/helper-validator-option@npm:7.12.1"
   checksum: 5d9a8f67500baf464151d15ca281388e7272ed22e3b909e13ccff89b2b4cc83a3e29972f9feaacb8a372e749028b252187982a59c6e6944ce30e0d15d905ab5c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.12.11":
+  version: 7.12.11
+  resolution: "@babel/helper-validator-option@npm:7.12.11"
+  checksum: c0a861e95f4f24ed59535c28206f62e639404db873473886ec77b50fef53e21111b4093522838927b79be768a885ad2007086b2434353b9d2b89b891ca14028a
   languageName: node
   linkType: hard
 
@@ -571,6 +605,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-numeric-separator@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/plugin-proposal-numeric-separator@npm:7.12.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f08f84f56797df52e947530a9cf4f22f5d1aa0164fb40ec05841961b5a942ef190cbbca7f981903e1c8869e75a0dee349a69bcca2dd6ea036758c5f97b325ccb
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-object-rest-spread@npm:^7.11.0":
   version: 7.11.0
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.11.0"
@@ -619,6 +665,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3cca1bf3b36de3727444178df99d78c36a181dde039032472a861e19d6a47cf1460752df7180d871e7e450434242223cdf92e67b70e5c6b27207b1f12daa6511
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-optional-chaining@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/plugin-proposal-optional-chaining@npm:7.12.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.12.1
+    "@babel/plugin-syntax-optional-chaining": ^7.8.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0a2872ec40ebecb33821094fc3075b1bf5e11cdf51d5a45d4a36a39a140dad15e775211f73a4068566cd0e5c422b6666769ec7f6362d492f68477b0eabb26a31
   languageName: node
   linkType: hard
 
@@ -898,6 +957,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 067f8b55a32ba53c7bc61e730f0a2dd063ee377afea88e153e9b8bd8069d666df3106b80777e37e418d14a21cabd1dee0f7dabfe8cb038d5080d9e332a202e36
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoping@npm:^7.12.11":
+  version: 7.12.11
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.12.11"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6bc227619d7890724eec691e53859914a5420be3f8225cc8901dc839aed05697014a241e81125c541a8b5f7ac2ffc639aab645ec26484ffba696eab2cb7c8c02
   languageName: node
   linkType: hard
 
@@ -1192,6 +1262,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx-development@npm:^7.12.7":
+  version: 7.12.11
+  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.12.11"
+  dependencies:
+    "@babel/helper-builder-react-jsx-experimental": ^7.12.11
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-jsx": ^7.12.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 48d663361d13d7722f982b2764b2394d593930f18fd2bbf8ff89343e0b38e5885da0f0ea6a47c73a7375bb281de55c1f760b8385d6e6813eaa44c053bc8bac4c
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-self@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.12.1"
@@ -1211,6 +1294,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: d5fd8818ad8539e1d74541185b038c952fc8a6a3179b0bcac9ee5644f0bba260ab57335d736b11838bb19b5078cbf5c14bdd5c93927b96e359ccb5414f4a9488
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx@npm:^7.12.10":
+  version: 7.12.11
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.12.11"
+  dependencies:
+    "@babel/helper-builder-react-jsx": ^7.10.4
+    "@babel/helper-builder-react-jsx-experimental": ^7.12.11
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-jsx": ^7.12.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 818174a70d2eeb601fe7d6798519000f99218e6f6deec630f23f79c95e8d209d2f6c6dcb89df0316ad78e7fa432d1bc80503b916591b1c0412107e1860cf6b40
   languageName: node
   linkType: hard
 
@@ -1297,6 +1394,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-sticky-regex@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/plugin-transform-sticky-regex@npm:7.12.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fd49ca42e869d136ccccc4a1bc0c4572f3dc1b231d87a291ae0526a7e155734166767eea9e0843d3473f865793976fb5d728ae1796dad8cfe55d3728fd4a9804
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-template-literals@npm:^7.10.4, @babel/plugin-transform-template-literals@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-transform-template-literals@npm:7.12.1"
@@ -1316,6 +1424,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 73bb34cb448ae2e953b36c8d0283c73b7979577ca470fccae036a0b7b2a8e9b266a377878495f9a5dea1b42b5b33f6f234dc08675600f1ae5e557e73f64bdc48
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typeof-symbol@npm:^7.12.10":
+  version: 7.12.10
+  resolution: "@babel/plugin-transform-typeof-symbol@npm:7.12.10"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 74f29d897134b513c7e62a61258a32088ba26cbe6431c41f8f52318dc223b1f2626f229eb91550074c0d40157bdf47376a6ffed918b32b9b7f323a4aa7c19ad0
   languageName: node
   linkType: hard
 
@@ -1428,6 +1547,82 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 32a9f56fc405ce3545a48dca5daefed0a2ae418e5105c9b0cc26a4c9679346d2cc8b1efb01f1496d6b5d1d53d6037191acbd579b7e42d1f6d605c3ae26f6af22
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.12.11":
+  version: 7.12.11
+  resolution: "@babel/preset-env@npm:7.12.11"
+  dependencies:
+    "@babel/compat-data": ^7.12.7
+    "@babel/helper-compilation-targets": ^7.12.5
+    "@babel/helper-module-imports": ^7.12.5
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/helper-validator-option": ^7.12.11
+    "@babel/plugin-proposal-async-generator-functions": ^7.12.1
+    "@babel/plugin-proposal-class-properties": ^7.12.1
+    "@babel/plugin-proposal-dynamic-import": ^7.12.1
+    "@babel/plugin-proposal-export-namespace-from": ^7.12.1
+    "@babel/plugin-proposal-json-strings": ^7.12.1
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.12.1
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.12.1
+    "@babel/plugin-proposal-numeric-separator": ^7.12.7
+    "@babel/plugin-proposal-object-rest-spread": ^7.12.1
+    "@babel/plugin-proposal-optional-catch-binding": ^7.12.1
+    "@babel/plugin-proposal-optional-chaining": ^7.12.7
+    "@babel/plugin-proposal-private-methods": ^7.12.1
+    "@babel/plugin-proposal-unicode-property-regex": ^7.12.1
+    "@babel/plugin-syntax-async-generators": ^7.8.0
+    "@babel/plugin-syntax-class-properties": ^7.12.1
+    "@babel/plugin-syntax-dynamic-import": ^7.8.0
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-json-strings": ^7.8.0
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.0
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.0
+    "@babel/plugin-syntax-optional-chaining": ^7.8.0
+    "@babel/plugin-syntax-top-level-await": ^7.12.1
+    "@babel/plugin-transform-arrow-functions": ^7.12.1
+    "@babel/plugin-transform-async-to-generator": ^7.12.1
+    "@babel/plugin-transform-block-scoped-functions": ^7.12.1
+    "@babel/plugin-transform-block-scoping": ^7.12.11
+    "@babel/plugin-transform-classes": ^7.12.1
+    "@babel/plugin-transform-computed-properties": ^7.12.1
+    "@babel/plugin-transform-destructuring": ^7.12.1
+    "@babel/plugin-transform-dotall-regex": ^7.12.1
+    "@babel/plugin-transform-duplicate-keys": ^7.12.1
+    "@babel/plugin-transform-exponentiation-operator": ^7.12.1
+    "@babel/plugin-transform-for-of": ^7.12.1
+    "@babel/plugin-transform-function-name": ^7.12.1
+    "@babel/plugin-transform-literals": ^7.12.1
+    "@babel/plugin-transform-member-expression-literals": ^7.12.1
+    "@babel/plugin-transform-modules-amd": ^7.12.1
+    "@babel/plugin-transform-modules-commonjs": ^7.12.1
+    "@babel/plugin-transform-modules-systemjs": ^7.12.1
+    "@babel/plugin-transform-modules-umd": ^7.12.1
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.12.1
+    "@babel/plugin-transform-new-target": ^7.12.1
+    "@babel/plugin-transform-object-super": ^7.12.1
+    "@babel/plugin-transform-parameters": ^7.12.1
+    "@babel/plugin-transform-property-literals": ^7.12.1
+    "@babel/plugin-transform-regenerator": ^7.12.1
+    "@babel/plugin-transform-reserved-words": ^7.12.1
+    "@babel/plugin-transform-shorthand-properties": ^7.12.1
+    "@babel/plugin-transform-spread": ^7.12.1
+    "@babel/plugin-transform-sticky-regex": ^7.12.7
+    "@babel/plugin-transform-template-literals": ^7.12.1
+    "@babel/plugin-transform-typeof-symbol": ^7.12.10
+    "@babel/plugin-transform-unicode-escapes": ^7.12.1
+    "@babel/plugin-transform-unicode-regex": ^7.12.1
+    "@babel/preset-modules": ^0.1.3
+    "@babel/types": ^7.12.11
+    core-js-compat: ^3.8.0
+    semver: ^5.5.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2811bbf697d86d2d7d972215cf07e4b153cb667eefa2ca3521e0eb34c20d3f2643c44ed31734e1db35675267f5a3de284b87e543132f075c28c979b34af6472c
   languageName: node
   linkType: hard
 
@@ -1550,6 +1745,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1083243ebf652f0895f407b2f8f74c602e602056f225b5c9e9f181019e76d6d475130749b4c543437ca78ee84fa54b3552bcd5a7bb2f40de26cdd3adffe7222a
+  languageName: node
+  linkType: hard
+
+"@babel/preset-react@npm:^7.12.10":
+  version: 7.12.10
+  resolution: "@babel/preset-react@npm:7.12.10"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-transform-react-display-name": ^7.12.1
+    "@babel/plugin-transform-react-jsx": ^7.12.10
+    "@babel/plugin-transform-react-jsx-development": ^7.12.7
+    "@babel/plugin-transform-react-pure-annotations": ^7.12.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3afd3d01911d330d120cab571c04cf78a083407639c506515a7e7c142881822e3e20d934b43d538bf73d38c44f4fba1f92f6a83728b42d491363d2a8896acffc
   languageName: node
   linkType: hard
 
@@ -5635,6 +5845,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.15.0":
+  version: 4.16.0
+  resolution: "browserslist@npm:4.16.0"
+  dependencies:
+    caniuse-lite: ^1.0.30001165
+    colorette: ^1.2.1
+    electron-to-chromium: ^1.3.621
+    escalade: ^3.1.1
+    node-releases: ^1.1.67
+  bin:
+    browserslist: cli.js
+  checksum: 5385f3dfb1bd1d321093a88c758a5429b55e5f4c76abd91ce865729cfcaa45dc1a54e934e2a8400aca7200f1b9993b1e147bea9fe0fa6704a968b230abd4f277
+  languageName: node
+  linkType: hard
+
 "bs-logger@npm:0.x":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
@@ -5852,6 +6077,13 @@ __metadata:
   version: 1.0.30001157
   resolution: "caniuse-lite@npm:1.0.30001157"
   checksum: 8fc930094b538a6592bd09d1c444fe5dc44cfc3517effeb722fb9832d200755908f3b3551069f8f61518ffac65c3dcf4ea022b74de60b70468a6c1d18f5b4184
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001165":
+  version: 1.0.30001170
+  resolution: "caniuse-lite@npm:1.0.30001170"
+  checksum: 26ec112bc9d09a2ba5391d6202dcb3de8c10b080766c79c58d6ab9bc2bcd0b5d9e9e440de04aace97a9537ea60ad51feaaf311e1336bf1a0536f17d52a1886d1
   languageName: node
   linkType: hard
 
@@ -6460,6 +6692,16 @@ __metadata:
     browserslist: ^4.14.6
     semver: 7.0.0
   checksum: 4194aaeb0da4cd584aa493069f322b3f6310d22207fae965bda476d4469283e76f4f8857920222b58c083b0e57e1c4199ac039d5337e76bdeb60b793f2a05f3b
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.8.0":
+  version: 3.8.1
+  resolution: "core-js-compat@npm:3.8.1"
+  dependencies:
+    browserslist: ^4.15.0
+    semver: 7.0.0
+  checksum: 964ad886a9f55399d2f33350d15f4653bfd24cb6de04606c515d0266be4101a1f435bab9a6d76b249de5f573aecb230a98468d6a8141743019abab5edd4d4281
   languageName: node
   linkType: hard
 
@@ -7383,6 +7625,13 @@ __metadata:
   version: 1.3.617
   resolution: "electron-to-chromium@npm:1.3.617"
   checksum: d08ea583945d4bbeb11c7993db3be4975449e26b392a8c2faa68ea53d678bca1c19262490a37f1486398e0f2127b7d5cae77961409f83475d7378739e28f3da4
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.3.621":
+  version: 1.3.631
+  resolution: "electron-to-chromium@npm:1.3.631"
+  checksum: 43b2af73143dc7c8f346c91257034b954fbe09d857f2dbe82b5b8569910b2b83d45c3749b32f93bb24495983480889ad4d9a0decd5cca2bf07fd534ae770b7b7
   languageName: node
   linkType: hard
 
@@ -12166,6 +12415,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^1.1.67":
+  version: 1.1.67
+  resolution: "node-releases@npm:1.1.67"
+  checksum: 19a76af9498421b28bbc0123effc870a2ebe68a6364a4eb6547c5f871d6c2d8095fb66cc582a2378af8fbb6124ef8360207ef29d7a5a507e27691c53a85e9df4
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -13234,6 +13490,8 @@ fsevents@^1.2.7:
   resolution: "primitives@workspace:."
   dependencies:
     "@babel/core": ^7.12.10
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@preconstruct/cli": ^2.0.1
     "@stitches/react": canary

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,6 +5198,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-dev-expression@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "babel-plugin-dev-expression@npm:0.2.2"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 3bd43a87ebca39ff02dc9bc77fdd8c0019b57eb51c6cc65bf4a46a88b5d1366a637059345edf051dab892bc7ea9f1a747e64ac565430ec1349cdc47e525f1885
+  languageName: node
+  linkType: hard
+
 "babel-plugin-dynamic-import-node@npm:^2.3.3":
   version: 2.3.3
   resolution: "babel-plugin-dynamic-import-node@npm:2.3.3"
@@ -13509,6 +13518,7 @@ fsevents@^1.2.7:
     "@typescript-eslint/parser": 2.x
     babel-eslint: ^10.1.0
     babel-loader: ^8.1.0
+    babel-plugin-dev-expression: ^0.2.2
     eslint: 6.x
     eslint-config-react-app: ^5.2.1
     eslint-plugin-flowtype: 4.x

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5, @babel/core@npm:^7.7.7, @babel/core@npm:^7.9.0":
+"@babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5, @babel/core@npm:^7.7.7, @babel/core@npm:^7.9.0":
   version: 7.12.3
   resolution: "@babel/core@npm:7.12.3"
   dependencies:
@@ -54,6 +54,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.12.10":
+  version: 7.12.10
+  resolution: "@babel/core@npm:7.12.10"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/generator": ^7.12.10
+    "@babel/helper-module-transforms": ^7.12.1
+    "@babel/helpers": ^7.12.5
+    "@babel/parser": ^7.12.10
+    "@babel/template": ^7.12.7
+    "@babel/traverse": ^7.12.10
+    "@babel/types": ^7.12.10
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.1
+    json5: ^2.1.2
+    lodash: ^4.17.19
+    semver: ^5.4.1
+    source-map: ^0.5.0
+  checksum: 4d7b892764009b80ac36b193ee37dd27a04244113dfa7510a937e81999e4b0f8ad3237f809792975abab5e07b44a7f7c36bb21e6f9957cdf54cd91cbf149c411
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.12.1, @babel/generator@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/generator@npm:7.12.5"
@@ -62,6 +85,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: 7706cb3d29060e6dfcdbc982ded9a02f0bda36329cc35aabc6b3f9f30ef7b3b3bcaba51c24714663f3ea9529994cd3461ab8a664b26398208b9b9a96476bf43c
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.12.10":
+  version: 7.12.11
+  resolution: "@babel/generator@npm:7.12.11"
+  dependencies:
+    "@babel/types": ^7.12.11
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: eb76477ff89b609393fc002975fe7f9aafe91e915218e56a5f3cc6c5b54690762a06ff654b3d322ab454823b271c14e40bc8c92e97fa0a91a29f7f2047973b54
   languageName: node
   linkType: hard
 
@@ -313,6 +347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.12.11":
+  version: 7.12.11
+  resolution: "@babel/helper-validator-identifier@npm:7.12.11"
+  checksum: 18de432203264b501db2690b53370a4289dc56084f5a2c66de624b159ee28b8abaeb402b2b7584296d9261645d91ddb6bfd21125d3ffd9bf02e9262e77baf3d2
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/helper-validator-option@npm:7.12.1"
@@ -332,7 +373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.12.1":
+"@babel/helpers@npm:^7.12.1, @babel/helpers@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/helpers@npm:7.12.5"
   dependencies:
@@ -360,6 +401,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: ff03d2389e32e3710c759d7bbcffc2d2e0637498e3a36aeaa0dbf961c48adb7027c393d0458247e54e24fed66ce0ea00e3e8d63089d22931e4175ee398727c15
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.12.10, @babel/parser@npm:^7.12.7":
+  version: 7.12.11
+  resolution: "@babel/parser@npm:7.12.11"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 2f650e8e57342bdd1b624ba89d6df2332ee8e6ec0287316aa47d49a7bee8a6d9bab4581e753a4b72a2ddd8f272a2f9947f6c7f1ca191a0006a297789226f4b55
   languageName: node
   linkType: hard
 
@@ -1515,6 +1565,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-typescript@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/preset-typescript@npm:7.12.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/helper-validator-option": ^7.12.1
+    "@babel/plugin-transform-typescript": ^7.12.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9a808f4798973b05b3b4fb83eb6093bd9e71a308bfc428e16ac856775bca3b61214eef3307d1ab428bf04ec87f4d87a5c5fbcfd49c21a33ad6b9bf92c4a26503
+  languageName: node
+  linkType: hard
+
 "@babel/register@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/register@npm:7.12.1"
@@ -1560,6 +1623,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.12.7":
+  version: 7.12.7
+  resolution: "@babel/template@npm:7.12.7"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/parser": ^7.12.7
+    "@babel/types": ^7.12.7
+  checksum: 6e0a050be7d07ca6755305d74892dfa1e119d1193929275f8019339fbbf45257eea41385cf99325301001a2b2912d186e447393229fe169f50a8bfbcbf8a850a
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.10.4, @babel/traverse@npm:^7.12.1, @babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.7.0":
   version: 7.12.5
   resolution: "@babel/traverse@npm:7.12.5"
@@ -1577,6 +1651,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.12.10":
+  version: 7.12.10
+  resolution: "@babel/traverse@npm:7.12.10"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/generator": ^7.12.10
+    "@babel/helper-function-name": ^7.10.4
+    "@babel/helper-split-export-declaration": ^7.11.0
+    "@babel/parser": ^7.12.10
+    "@babel/types": ^7.12.10
+    debug: ^4.1.0
+    globals: ^11.1.0
+    lodash: ^4.17.19
+  checksum: 63e8500aed71da6fba8058751298c3bc1b54628585fb27047cbf2c0ed66df03f19e6b0fa9a8809bbb5131c27464b4ce950753479ef4333759fe5a400ae954956
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.10.4, @babel/types@npm:^7.10.5, @babel/types@npm:^7.11.0, @babel/types@npm:^7.11.5, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.9.5":
   version: 7.12.6
   resolution: "@babel/types@npm:7.12.6"
@@ -1585,6 +1676,17 @@ __metadata:
     lodash: ^4.17.19
     to-fast-properties: ^2.0.0
   checksum: e8d02f859c16c8ae941a1eb84954189eacdd9488c8f9ad54c29dedf2bf8456f45c7fe401c54ea2c4d45d890d865aaac0283a78b62a87f796e92078eac49aa040
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7":
+  version: 7.12.11
+  resolution: "@babel/types@npm:7.12.11"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.12.11
+    lodash: ^4.17.19
+    to-fast-properties: ^2.0.0
+  checksum: e592c52b097da2c56f7388f35bf84a267c88e0e1bd7d3b7730892a8c70b2a80bd7f67a2ee57b2acf6aee58a074a234214d3e43ff6968dfb834733aa1417a5a43
   languageName: node
   linkType: hard
 
@@ -3480,17 +3582,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:*":
-  version: 4.17.13
-  resolution: "@types/express-serve-static-core@npm:4.17.13"
-  dependencies:
-    "@types/node": "*"
-    "@types/qs": "*"
-    "@types/range-parser": "*"
-  checksum: 6db6f2e0ebadcb3492b97fc76e66bc49c44385c8c1a6c7df75f7bce5fdade53061393cc3271b9183137d9877df03dd45dc42f4e0ec2d89f8ad5479341da302f0
-  languageName: node
-  linkType: hard
-
 "@types/glob-base@npm:^0.3.0":
   version: 0.3.0
   resolution: "@types/glob-base@npm:0.3.0"
@@ -3676,15 +3767,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/parcel-bundler@npm:^1.12.1":
-  version: 1.12.1
-  resolution: "@types/parcel-bundler@npm:1.12.1"
-  dependencies:
-    "@types/express-serve-static-core": "*"
-  checksum: 297acd0fc2ec2ab2404fb796995b33b918b45986ea52a85e8789c7ec4dd275ffcc4d2f663457d7e021e181af4fcadbd0c0cc33838b17a04c3fdf29cd93e949c0
-  languageName: node
-  linkType: hard
-
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
@@ -3713,17 +3795,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*, @types/qs@npm:^6.9.0":
+"@types/qs@npm:^6.9.0":
   version: 6.9.5
   resolution: "@types/qs@npm:6.9.5"
   checksum: afe4721a802a4b5fa874a7d6d9fd33c9e812bb0ef90dabb050e8072be4ab2e5e817c0feacb9b4e0771d875de99f4d9738217976aeb8d36b81ccd82ded5e9fdc0
-  languageName: node
-  linkType: hard
-
-"@types/range-parser@npm:*":
-  version: 1.2.3
-  resolution: "@types/range-parser@npm:1.2.3"
-  checksum: 092fabae0ecbd728d3e4debc938cd043e97cb9f210cfec1c56ff6065c6e91666f376eb586591825d6757a058fd1a1dc4831d34e04ecfbb0800f35b8d86d38635
   languageName: node
   linkType: hard
 
@@ -13158,7 +13233,8 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "primitives@workspace:."
   dependencies:
-    "@babel/core": ^7.0.0
+    "@babel/core": ^7.12.10
+    "@babel/preset-typescript": ^7.12.7
     "@preconstruct/cli": ^2.0.1
     "@stitches/react": canary
     "@storybook/addon-storysource": 6.1.0-beta.4
@@ -13168,7 +13244,6 @@ fsevents@^1.2.7:
     "@types/eslint": ^7
     "@types/jest": ^26.0.10
     "@types/jest-axe": ^3.5.0
-    "@types/parcel-bundler": ^1.12.1
     "@types/react": ^16.9.55
     "@types/react-dom": ^16.9.9
     "@types/react-test-renderer": ^16.9.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5, @babel/core@npm:^7.9.0":
+"@babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.7.5, @babel/core@npm:^7.7.7, @babel/core@npm:^7.9.0":
   version: 7.12.3
   resolution: "@babel/core@npm:7.12.3"
   dependencies:
@@ -54,7 +54,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.0.0, @babel/generator@npm:^7.12.1, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.3.3":
+"@babel/generator@npm:^7.12.1, @babel/generator@npm:^7.12.5":
   version: 7.12.5
   resolution: "@babel/generator@npm:7.12.5"
   dependencies:
@@ -105,7 +105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.10.4, @babel/helper-compilation-targets@npm:^7.12.1, @babel/helper-compilation-targets@npm:^7.8.4":
+"@babel/helper-compilation-targets@npm:^7.10.4, @babel/helper-compilation-targets@npm:^7.12.1":
   version: 7.12.5
   resolution: "@babel/helper-compilation-targets@npm:7.12.5"
   dependencies:
@@ -354,7 +354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.0.0, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.10.4, @babel/parser@npm:^7.12.3, @babel/parser@npm:^7.12.5, @babel/parser@npm:^7.7.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.10.4, @babel/parser@npm:^7.12.3, @babel/parser@npm:^7.12.5, @babel/parser@npm:^7.7.0":
   version: 7.12.5
   resolution: "@babel/parser@npm:7.12.5"
   bin:
@@ -926,7 +926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-flow-strip-types@npm:^7.0.0, @babel/plugin-transform-flow-strip-types@npm:^7.12.1":
+"@babel/plugin-transform-flow-strip-types@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-transform-flow-strip-types@npm:7.12.1"
   dependencies:
@@ -996,7 +996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.0.0, @babel/plugin-transform-modules-commonjs@npm:^7.10.4":
+"@babel/plugin-transform-modules-commonjs@npm:^7.10.4":
   version: 7.10.4
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.10.4"
   dependencies:
@@ -1010,7 +1010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.12.1":
+"@babel/plugin-transform-modules-commonjs@npm:^7.12.1, @babel/plugin-transform-modules-commonjs@npm:^7.7.5":
   version: 7.12.1
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.12.1"
   dependencies:
@@ -1269,7 +1269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.12.1, @babel/plugin-transform-typescript@npm:^7.4.5":
+"@babel/plugin-transform-typescript@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/plugin-transform-typescript@npm:7.12.1"
   dependencies:
@@ -1305,7 +1305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.0.0, @babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.4.0":
+"@babel/preset-env@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/preset-env@npm:7.12.1"
   dependencies:
@@ -1486,7 +1486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-react@npm:^7.0.0, @babel/preset-react@npm:^7.12.1, @babel/preset-react@npm:^7.9.4":
+"@babel/preset-react@npm:^7.12.1, @babel/preset-react@npm:^7.9.4":
   version: 7.12.5
   resolution: "@babel/preset-react@npm:7.12.5"
   dependencies:
@@ -1540,7 +1540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.12.5
   resolution: "@babel/runtime@npm:7.12.5"
   dependencies:
@@ -1549,7 +1549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.10.4, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.0":
+"@babel/template@npm:^7.10.4, @babel/template@npm:^7.3.3":
   version: 7.10.4
   resolution: "@babel/template@npm:7.10.4"
   dependencies:
@@ -1560,7 +1560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.10.4, @babel/traverse@npm:^7.12.1, @babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.2.3, @babel/traverse@npm:^7.7.0":
+"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.10.4, @babel/traverse@npm:^7.12.1, @babel/traverse@npm:^7.12.5, @babel/traverse@npm:^7.7.0":
   version: 7.12.5
   resolution: "@babel/traverse@npm:7.12.5"
   dependencies:
@@ -1742,13 +1742,6 @@ __metadata:
   version: 0.2.5
   resolution: "@emotion/weak-memoize@npm:0.2.5"
   checksum: 9fe31f0c9d761468d7868be2faf924ddef3506160c72a1979ced8f72cec5d90499403a29c904af570496ef06803e484495f84d4c311bd0787259c89dba4119ed
-  languageName: node
-  linkType: hard
-
-"@iarna/toml@npm:^2.2.0":
-  version: 2.2.5
-  resolution: "@iarna/toml@npm:2.2.5"
-  checksum: 929a8516a24996b75768f7e0591815e37004f2cdda12b245c9a5ae64f423b4bd2bdd6943fc80e9bb5360a7be0b6d05bac57c178578d9a73acfb2eab125c594ee
   languageName: node
   linkType: hard
 
@@ -2029,960 +2022,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/babel-ast-utils@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/babel-ast-utils@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@babel/generator": ^7.0.0
-    "@babel/parser": ^7.0.0
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: 5c5b5160b73433e1d90a1cddd8caa51725dcca655dc062490ff689d007fa35184f027aac8b82bbf7e0526572e6b991de4772f8c2359ead72e226377a538d5c98
-  languageName: node
-  linkType: hard
-
-"@parcel/babel-preset-env@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/babel-preset-env@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/preset-env": ^7.4.0
-    semver: ^5.4.1
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 1fff7a741aed0a4f07ce56a1c813d38527c2ed113ee681354bee9b0d3753a62726f992fb06b37870b5c10cef5cc59e5676a0ee68377f2ec0e2dd738237ba5385
-  languageName: node
-  linkType: hard
-
-"@parcel/babylon-walk@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/babylon-walk@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@babel/types": ^7.0.0
-    lodash.clone: ^4.5.0
-  checksum: b3368f9d54fda581704471b342e47b2ec4d69ef106f8994962bd60c9d6ae0ff440a4e8a241e20dbb2c45d4a244d52fa371e2ae624c0efcf08982a7c1851187eb
-  languageName: node
-  linkType: hard
-
-"@parcel/bundler-default@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/bundler-default@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  checksum: 65faf5faaeedb61c4ecae041cbb176598a1107444443a8d15a7310c78d0259d27f0df4c2cfbe73f4117125e69928f2ed6904808c4a9c3b5e7a2b149464a64d2b
-  languageName: node
-  linkType: hard
-
-"@parcel/cache@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/cache@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: ae8047e3f14ee88f880ee66c2d9eaced6e8acf39a3703e4ab524a4a5e13ddccf4d62f02d67b636683adba483dd1f9cf1c265690334e9b12a0a4a02b22a8be3c4
-  languageName: node
-  linkType: hard
-
-"@parcel/codeframe@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/codeframe@npm:2.0.0-nightly.444"
-  dependencies:
-    chalk: ^2.4.2
-    emphasize: ^2.1.0
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.0
-  checksum: 2499401fe64246ec5f1d8653c184ab3503f3587c9233c0aa8c0e0b78fc44f9dae2898c0046ab74b8d18987df3e003b587fb17cfa2416ddac95fa03944578c02a
-  languageName: node
-  linkType: hard
-
-"@parcel/config-default@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/config-default@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/bundler-default": 2.0.0-nightly.444+e2136965
-    "@parcel/namer-default": 2.0.0-nightly.444+e2136965
-    "@parcel/optimizer-cssnano": 2.0.0-nightly.444+e2136965
-    "@parcel/optimizer-data-url": 2.0.0-nightly.444+e2136965
-    "@parcel/optimizer-htmlnano": 2.0.0-nightly.444+e2136965
-    "@parcel/optimizer-terser": 2.0.0-nightly.444+e2136965
-    "@parcel/packager-css": 2.0.0-nightly.444+e2136965
-    "@parcel/packager-html": 2.0.0-nightly.444+e2136965
-    "@parcel/packager-js": 2.0.0-nightly.444+e2136965
-    "@parcel/packager-raw": 2.0.0-nightly.444+e2136965
-    "@parcel/packager-raw-url": 2.0.0-nightly.2066+e2136965
-    "@parcel/packager-ts": 2.0.0-nightly.444+e2136965
-    "@parcel/reporter-bundle-analyzer": 2.0.0-nightly.2066+e2136965
-    "@parcel/reporter-bundle-buddy": 2.0.0-nightly.2066+e2136965
-    "@parcel/reporter-cli": 2.0.0-nightly.444+e2136965
-    "@parcel/reporter-dev-server": 2.0.0-nightly.444+e2136965
-    "@parcel/resolver-default": 2.0.0-nightly.444+e2136965
-    "@parcel/runtime-browser-hmr": 2.0.0-nightly.444+e2136965
-    "@parcel/runtime-js": 2.0.0-nightly.444+e2136965
-    "@parcel/runtime-react-refresh": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-babel": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-coffeescript": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-css": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-glsl": 2.0.0-nightly.2066+e2136965
-    "@parcel/transformer-graphql": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-html": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-image": 2.0.0-nightly.2066+e2136965
-    "@parcel/transformer-inline-string": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-js": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-json": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-jsonld": 2.0.0-nightly.2066+e2136965
-    "@parcel/transformer-less": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-mdx": 2.0.0-nightly.2066+e2136965
-    "@parcel/transformer-postcss": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-posthtml": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-pug": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-raw": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-react-refresh-babel": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-react-refresh-wrap": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-sass": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-stylus": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-sugarss": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-toml": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-typescript-types": 2.0.0-nightly.444+e2136965
-    "@parcel/transformer-vue": 2.0.0-nightly.2066+e2136965
-    "@parcel/transformer-yaml": 2.0.0-nightly.444+e2136965
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: 85435c4b4b4ebda52d1c80770417fe5da6d24155fccb6d3410d8a52af7a5b6e16c11c5d56bf99b9fa458419c0dc5968296f4d80e46eaa69de146b4522af0da5d
-  languageName: node
-  linkType: hard
-
-"@parcel/core@npm:2.0.0-nightly.442, @parcel/core@npm:2.0.0-nightly.442+e2136965":
-  version: 2.0.0-nightly.442
-  resolution: "@parcel/core@npm:2.0.0-nightly.442"
-  dependencies:
-    "@parcel/cache": 2.0.0-nightly.444+e2136965
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/events": 2.0.0-nightly.444+e2136965
-    "@parcel/fs": 2.0.0-nightly.444+e2136965
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/package-manager": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/types": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    "@parcel/workers": 2.0.0-nightly.444+e2136965
-    abortcontroller-polyfill: ^1.1.9
-    base-x: ^3.0.8
-    browserslist: ^4.6.6
-    clone: ^2.1.1
-    dotenv: ^7.0.0
-    dotenv-expand: ^5.1.0
-    json-source-map: ^0.6.1
-    json5: ^1.0.1
-    micromatch: ^4.0.2
-    nullthrows: ^1.1.1
-    querystring: ^0.2.0
-    semver: ^5.4.1
-  checksum: f07e09d8fb0b648a5155d72da90ee9daa286f8b8dc856fdac53946e037f30a8cb1dc5edbb723acad299afd57de2598ff9080cdd4fb3bf7298923d1f656e74f97
-  languageName: node
-  linkType: hard
-
-"@parcel/diagnostic@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/diagnostic@npm:2.0.0-nightly.444"
-  dependencies:
-    json-source-map: ^0.6.1
-    nullthrows: ^1.1.1
-  checksum: f15a3b83b2c954399f97a3ac11822b79d3c9969dc4d197b26a909df4f1c83ac54f2bed9ade6d728f4d0b3ef720643e6b90dbaf784e67bc5d8cb51258d6d45773
-  languageName: node
-  linkType: hard
-
-"@parcel/events@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/events@npm:2.0.0-nightly.444"
-  checksum: a8067244abf05cb64a1b0469146bd80e59c35082947327ec659bbcf43545cba31e44bc064f1a50d503912d6f4e25d66ad11382d665bbd676c6fd712435e65df3
-  languageName: node
-  linkType: hard
-
-"@parcel/fs-write-stream-atomic@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/fs-write-stream-atomic@npm:2.0.0-nightly.2066"
-  dependencies:
-    graceful-fs: ^4.1.2
-    iferr: ^1.0.2
-    imurmurhash: ^0.1.4
-    readable-stream: 1 || 2
-  checksum: 6918e69ae323ad85ffe595d22e3e5d4d5bc2ef6e40ac1b51e697e9cdeb1212a2337cf430ecb9858b6a7514498b05c9d23d1f591c8eb8548ba4b92e7cbbb33b7f
-  languageName: node
-  linkType: hard
-
-"@parcel/fs@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/fs@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/fs-write-stream-atomic": 2.0.0-nightly.2066+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    "@parcel/watcher": 2.0.0-alpha.8
-    "@parcel/workers": 2.0.0-nightly.444+e2136965
-    graceful-fs: ^4.2.4
-    mkdirp: ^0.5.1
-    ncp: ^2.0.0
-    nullthrows: ^1.1.1
-    rimraf: ^3.0.2
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: c7761a90d025fbc8f9b21f1cb99ce9be0a816a0ae46b0a5677cf6163a0f7fe0f444e24b92494e8044272cebf1f600f81e5afb6929f88f24a20ecd1b51ff459c2
-  languageName: node
-  linkType: hard
-
-"@parcel/logger@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/logger@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/events": 2.0.0-nightly.444+e2136965
-  checksum: 54b30a0770763abd107b17d52cc69bcd25f4e89403fa827bbe03472aff1b958c064cb568a445f52c68f363c795cffdaeb36fa2340775a6365b2d002db179f803
-  languageName: node
-  linkType: hard
-
-"@parcel/markdown-ansi@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/markdown-ansi@npm:2.0.0-nightly.444"
-  dependencies:
-    chalk: ^2.4.2
-  checksum: d76d6c97f8594e005c0c9ad298fb5aad535bd6e190849fca94d299e538b1083c6cd3545d35ee841d12253c552a4e03bc8387ee910fd5f5b97b2709dd383b0ba9
-  languageName: node
-  linkType: hard
-
-"@parcel/namer-default@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/namer-default@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  checksum: 1e8459c0a925569507040b12e3fc2c38f52c640b2cca7235695f866dc054b620853892e8741391fc79eeb201cf68ee563546f16f78513b5eb589730ab3dec0cb
-  languageName: node
-  linkType: hard
-
-"@parcel/node-libs-browser@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/node-libs-browser@npm:2.0.0-nightly.2066"
-  dependencies:
-    assert: ^2.0.0
-    browserify-zlib: ^0.2.0
-    buffer: ^5.5.0
-    console-browserify: ^1.2.0
-    constants-browserify: ^1.0.0
-    crypto-browserify: ^3.12.0
-    domain-browser: ^3.5.0
-    events: ^3.1.0
-    https-browserify: ^1.0.0
-    os-browserify: ^0.3.0
-    path-browserify: ^1.0.0
-    process: ^0.11.10
-    punycode: ^1.4.1
-    querystring-es3: ^0.2.1
-    readable-stream: ^3.6.0
-    stream-http: ^3.1.0
-    string_decoder: ^1.3.0
-    timers-browserify: ^2.0.11
-    tty-browserify: ^0.0.1
-    url: ^0.11.0
-    util: ^0.12.3
-    vm-browserify: ^1.1.2
-  checksum: d605565d04539880ec716979c94af1e44ea5f421ddce9eafd9e9e7d9a860dc4f32d89f7156337f0080f00bb5a992b212cbe781bda26292a468c510e80a67ca91
-  languageName: node
-  linkType: hard
-
-"@parcel/node-resolver-core@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/node-resolver-core@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/node-libs-browser": 2.0.0-nightly.2066+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    micromatch: ^3.0.4
-    nullthrows: ^1.1.1
-    querystring: ^0.2.0
-  checksum: 6f7bedc4dc2780f29596800d47c6a84e160633f197e1754fc9c6b06c7eb51ab329b395aad7eb38db5448fa61d3736cc5e2925e71a742138629d75445186e5f8a
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-cssnano@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/optimizer-cssnano@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    cssnano: ^4.1.10
-    postcss: ^8.0.5
-  checksum: fc84cda15ae2353d0a7e2a90e7809c0274f99186d421daa91606c7b494bd0a566d0642b355b48e53c0f107705c56b0a950c8cdcbf4499566dc19ccef35dffcc7
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-data-url@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/optimizer-data-url@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    isbinaryfile: ^4.0.2
-    mime: ^2.4.4
-  checksum: e424cfc9aeb806aea1317504fe74f60d3cb0dfa13cce9f4b88c60ac8dca69d94225ce401191970abe2c3fe22e68d52e30fba577aee8212c54ccc29ef87c6bf72
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-htmlnano@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/optimizer-htmlnano@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    htmlnano: ^0.2.2
-    nullthrows: ^1.1.1
-    posthtml: ^0.11.3
-  checksum: 127fae2e51bc6b3af2a7b3697233298b17d7b5d508fab1d02a466b8a1046ae27dc3913d8905a2f0367eb656185a0d7f2fcec66e8424c45768a299e8edb8c581c
-  languageName: node
-  linkType: hard
-
-"@parcel/optimizer-terser@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/optimizer-terser@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-    terser: ^5.2.0
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: 64700ade6910c10320b2e499eebbce2088f1099c8daf40c600f34b0446be6f29e83e1af9be5d32479db27b57efb802e535c1e4538af941e3e671ec1e5ccb4436
-  languageName: node
-  linkType: hard
-
-"@parcel/package-manager@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/package-manager@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/fs": 2.0.0-nightly.444+e2136965
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    "@parcel/workers": 2.0.0-nightly.444+e2136965
-    command-exists: ^1.2.6
-    cross-spawn: ^6.0.4
-    nullthrows: ^1.1.1
-    resolve: ^1.12.0
-    semver: ^5.4.1
-    split2: ^3.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: d7ce8fe7761bff57f36f7bd4e4d7f3d2d965bde4222d029da6af90512803a355714a439c9f3e1cf4519a9aee3ba496ba800a8a5dcc23e4c34f5e0f1b3bdf343a
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-css@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/packager-css@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: 8e89bb95fc5eb10f1567b04aa914cfc16676668fde0826c5bb1f83afab633ebcb374070d10b1b0d829710842186296032c0be207539c6688986a92670fc63044
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-html@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/packager-html@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/types": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-    posthtml: ^0.11.3
-  checksum: 494fff48de29c5c192b9980b0047691422f236206747f4dd521ce914eb0d9d5c7b51a760f4a596660fd019e616678503f35d71ee32e9a3f52e53b3030da5d466
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-js@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/packager-js@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/traverse": ^7.2.3
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/scope-hoisting": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: aa342525fb80e4f9ee862ae54a5aaf0fd5e5f70a7c6f1933d3a66a7fc23c81c36e075da9b4771dd3fe6073cf831ce5a0176b598e50530df25f80455deb379ad9
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-raw-url@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/packager-raw-url@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: 77abd92c1df1876c37b82ac2debd7e4e8cbcc0afeb1e420cbf6b5955b31afde6df2a5bb73b73002543f4e2637b66c66cf859c2b37f9191b4fe7558f80fa0132c
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-raw@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/packager-raw@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: aee4f9108149e47de0a01aad148f5f799360407ac02f7bf2ef6d4af4170a071e3c11aab0390b3bb2060e54dd9372efc06eb1e8d1a83b7bde7278cde6b75d0b63
-  languageName: node
-  linkType: hard
-
-"@parcel/packager-ts@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/packager-ts@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 6858d5b7c68263640e3e7d7d9ac698b8818aa2ea7a00f4fcad35c363eb5416e1492c73a4ef82340696e6a910087d36bc05e8310f0caa25d9092cb91faca7e698
-  languageName: node
-  linkType: hard
-
-"@parcel/plugin@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/plugin@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/types": 2.0.0-nightly.444+e2136965
-  checksum: f67f9b8ce9ac1630dba1c7da74c9e14f8682674d7d9965860104ab97633bd7c8a3705678d5a1a0f4c9ce39d8ded0ef36cc1dc09e30c8988048b2e785a322d4a7
-  languageName: node
-  linkType: hard
-
-"@parcel/reporter-bundle-analyzer@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/reporter-bundle-analyzer@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  checksum: 635fea7b209ba2c19749dd283f6a724a0b521166704c8661a6cce40912ba738f245aa43a7e8c9d848a0696112b950705746f00b3210eecd37d1f4ccc974b9ec3
-  languageName: node
-  linkType: hard
-
-"@parcel/reporter-bundle-buddy@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/reporter-bundle-buddy@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: c09501cd87987109b96ef06d8cabd4f9ee4e3a2ae1db693a46791d4d7fa279efb67d25a6307e5768e627f5ae426874e1798b5e04f6f09dbe8f3d038e1c5ebd43
-  languageName: node
-  linkType: hard
-
-"@parcel/reporter-cli@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/reporter-cli@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/types": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    chalk: ^3.0.0
-    filesize: ^3.6.0
-    nullthrows: ^1.1.1
-    ora: ^4.0.3
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    term-size: ^2.1.1
-  checksum: 4d832aeb389734d87cef21221acfd6f18f458603ea2cc367d76cf3a8542696b9a216363d9af3c9d0aecb001e8da4f7225eec81fb1db3b1a00b04aaf0175e0c1a
-  languageName: node
-  linkType: hard
-
-"@parcel/reporter-dev-server@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/reporter-dev-server@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    connect: ^3.7.0
-    ejs: ^2.6.1
-    http-proxy-middleware: ^1.0.0
-    nullthrows: ^1.1.1
-    serve-handler: ^6.0.0
-    ws: ^6.2.0
-  checksum: 048b0ac5157d1eb7ef0c23caa1ae4f25190299b4b32701adc7084c8ca94c7f67bd89cdd9bc976db6eb1121f8b2b4c79a3808ec688a81d66f517780834d7c90c4
-  languageName: node
-  linkType: hard
-
-"@parcel/resolver-default@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/resolver-default@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/node-resolver-core": 2.0.0-nightly.2066+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 11aa1fcd984d2eef76bd88e80e6f29ce6fae9c1ea2670e9ca126954ec3cc6b9692e4a34509148b252cbed6da514a409ae0963bf4cd5e5a5cd4e2865409684e6c
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-browser-hmr@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/runtime-browser-hmr@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: bf36a33eca1cc0bc57bf8565ec2b0cff9e06b19e50fe8b27ce9a7d52642cd87d5b496db8e9c3a22a71d3089a78e3a9d5ef41f43e1ab9fe707f6ec7d87abe8497
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-js@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/runtime-js@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  checksum: 5e94b9daf1aa06b5e302a3d97b99670d28ed1c3c16dcec77e37817760ca9bf379198a02d6712591f4da031f307f3c67b237db31ab676fa3e51238d1a589ac814
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-react-refresh@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/runtime-react-refresh@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    react-refresh: ^0.9.0
-  checksum: ce93aa936014d53e30dc76a0324c78c3f7a2706971c60a266dbeca12c057d06384790bfbdd1ce19919d7dc81e1dc6e783c8a52f3c42d767e979c11faf9485dfc
-  languageName: node
-  linkType: hard
-
-"@parcel/scope-hoisting@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/scope-hoisting@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/generator": ^7.3.3
-    "@babel/parser": ^7.0.0
-    "@babel/template": ^7.4.0
-    "@babel/traverse": ^7.2.3
-    "@babel/types": ^7.3.3
-    "@parcel/babel-ast-utils": 2.0.0-nightly.2066+e2136965
-    "@parcel/babylon-walk": 2.0.0-nightly.2066+e2136965
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  checksum: c68ebff4d4f8bd583fd2a1fc2d0aede86c4e7687f6e153083f974979945096da87add8dcdb40d0c54a15d3666e5085cde314221a91e972c70160a1d9c93a2df8
-  languageName: node
-  linkType: hard
-
-"@parcel/source-map@npm:2.0.0-alpha.4.16":
-  version: 2.0.0-alpha.4.16
-  resolution: "@parcel/source-map@npm:2.0.0-alpha.4.16"
-  dependencies:
-    node-addon-api: ^3.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.2.2
-  checksum: 7c99c9d84fd2e6d264642d7a27ab0ab5b8e5c867265950d3c693f2339f44d4b5977c6864f14a8ca64fe67474aaa8d9ae5cb9f166e9a94490eb5893ae718f6e0f
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-babel@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-babel@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/core": ^7.0.0
-    "@babel/generator": ^7.0.0
-    "@babel/helper-compilation-targets": ^7.8.4
-    "@babel/plugin-transform-flow-strip-types": ^7.0.0
-    "@babel/plugin-transform-typescript": ^7.4.5
-    "@babel/preset-env": ^7.0.0
-    "@babel/preset-react": ^7.0.0
-    "@babel/traverse": ^7.0.0
-    "@parcel/babel-ast-utils": 2.0.0-nightly.2066+e2136965
-    "@parcel/babel-preset-env": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    browserslist: ^4.6.6
-    core-js: ^3.2.1
-    nullthrows: ^1.1.1
-    semver: ^5.7.0
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: b801eb3dfa07479608cb99e95bbd24c2996a75b77a90c1d158c9ae6b5d195d05584a9b0c07695a20f6205a9a5d29500446e73ed8581351541deb91df1367be48
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-coffeescript@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-coffeescript@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    coffeescript: ^2.0.3
-    nullthrows: ^1.1.1
-    semver: ^5.4.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: 9206ed6685a1df881273abb67e9c7841c9f8f728732bffd65bb82562d4b8130f4ba081fddb66e38c0715c276628a06b015aa7be882f0e096cbaf974a3bf314f7
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-css@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-css@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    postcss: ^8.0.5
-    postcss-value-parser: ^4.1.0
-    semver: ^5.4.1
-  checksum: 47078298051fbf483e28a0177279d28782b7f26f5eb688bb13d77f773dd5cf865603e65a50d83c0c5b605f7c5d90f645a75deb12ce21091b461b160019fb9f2e
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-glsl@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/transformer-glsl@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: 4773fab17bc82520f713c1a247c6d793aa2fc789f277fc1e45b45816cdb0dd3edaa1073ccd7d1921e4c22bc38bb883aedaf0afe5fb23b21e0750b6641aa5521e
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-graphql@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-graphql@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 6adb6bba07adc7c6f6ad99374fda4af365367d6a7a6c2394c406f0c400b30b467c2538465af29157b5b28fa6cf1a6c5bc2b6ca7b8bbed9dccb0c0b1fc192828d
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-html@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-html@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-    posthtml: ^0.11.3
-    posthtml-parser: ^0.4.1
-    posthtml-render: ^1.1.5
-    semver: ^5.4.1
-  checksum: 76c262a6ce979993845afcdc80b03fec89a8398b5b8fc9c5ec819589c45baf58dc90b5782a9a1b33b3f12911ce6ebc01f6a298e28f55cd4b2fb0794b5d0893fa
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-image@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/transformer-image@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: a5b68a0d9d69b5e68b806e54e5b601cc229aa31dc799843874e9342faf5fc2558491d670aa76dce5cf0cac7c46df0e0eb0e16cd2c2785252f5be39cb86dd2f75
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-inline-string@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-inline-string@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 5e12c6f25631d08212cbcd6f6da4de71c60580a169adee618c570673f401ef558c9c833c0505ac1e9917717f4bcb78a181ff7ee3791af130513c36b2996841b2
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-js@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-js@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/core": ^7.0.0
-    "@babel/generator": ^7.0.0
-    "@babel/parser": ^7.0.0
-    "@babel/plugin-transform-modules-commonjs": ^7.0.0
-    "@babel/template": ^7.4.0
-    "@babel/traverse": ^7.0.0
-    "@babel/types": ^7.0.0
-    "@parcel/babel-ast-utils": 2.0.0-nightly.2066+e2136965
-    "@parcel/babylon-walk": 2.0.0-nightly.2066+e2136965
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/scope-hoisting": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    micromatch: ^4.0.2
-    nullthrows: ^1.1.1
-    semver: ^5.4.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: f18aea7445147695cb0cc301e80e8acee55feddb1722ae0de7566adf65724144cd36149342c3e963bdbc8ee2132685ee9e720d608cd3b07a2d250f6a234b8f73
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-json@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-json@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    json5: ^2.1.0
-  checksum: 0fa2b21c96c4ba1d298e457733328112662f341d1c4db545c6aa267d386f35c9e9f0a465b7ed71e097bbd77d335428bc4f7307515b41849b771b4094eb839b4e
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-jsonld@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/transformer-jsonld@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/types": 2.0.0-nightly.444+e2136965
-    json5: ^2.1.2
-  checksum: f059b65e501ae782ead0e3e5b0b02bc5cc733b51cf9b29c545ab6c44c5c1d4c916f5ed34cfcf3de320b827967466bc54c6421382a8b5ea62a06a0fe050a8c515
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-less@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-less@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-  checksum: 1aa315a0edbde8eb4fd71c3570de4799e5b73483ffb16fc0c420502b1428cbfe73b3f74b94db9971e7610963458846eba55dd50a95b1426db07cc05b775d08ad
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-mdx@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/transformer-mdx@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: ea6987c0fecd24df07aade0a6bf2378adfefdee714125408bf7dd113175589a8750f878193d2a9d99bab4dd42047beb2ba4f58f904a289723227deb3f8dbf7d1
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-postcss@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-postcss@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    css-modules-loader-core: ^1.1.0
-    nullthrows: ^1.1.1
-    postcss-value-parser: ^4.1.0
-    semver: ^5.4.1
-  checksum: 094b1f9d80dd307fc9bf4ea9cd221f246ee20d58c1af56effe524d0d253ccb4df2ea3a2552c497c186185bb6d3207b62332f3dafbdd696ff3a2c3bfea5b69fa3
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-posthtml@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-posthtml@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-    posthtml: ^0.11.3
-    posthtml-parser: ^0.4.1
-    posthtml-render: ^1.1.5
-    semver: ^5.4.1
-  checksum: e4efa58e4a02c6ebc29a1138f54050b1f24b9158184ecb5bef48ba46f9baebfc2a30151fa224434e499767061f6831116346850485066c01dbe28c8b16e67629
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-pug@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-pug@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: fd0eb4f3bc46c96383b667938f0e1922f89eb593b11eb3f0a2117b2dd8fb5a79e91a160e249fa8df2397c1de8ba8bca217ddaed086873a3c198fc4476f0e7c19
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-raw@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-raw@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 50de60b7a8803a6d26517f59295b6d8d7cf2625c3535052fa0e20ff072b576375ea82177a43dfa7477ac44705e976964e1877e630d35a986bc2cb5353806a96a
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-react-refresh-babel@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-react-refresh-babel@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    react-refresh: ^0.9.0
-  checksum: e0f1a88929a4fc51f3618c42a92396829e8b96478ecf473e9606897ae2856785820ca9fd7c06931d3b0e8ba0684f02cc356605017dcdbf5419dd2eef3ddbbc21
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-react-refresh-wrap@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.0.0-nightly.444"
-  dependencies:
-    "@babel/generator": ^7.0.0
-    "@babel/parser": ^7.0.0
-    "@babel/template": ^7.4.0
-    "@babel/types": ^7.0.0
-    "@parcel/babel-ast-utils": 2.0.0-nightly.2066+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    react-refresh: ^0.9.0
-    semver: ^5.4.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: fe308acbd87e2bacd0d15f6b9138029bf944e90bc68893669ff40c023f0ba8e1adfd40f743153e0c023eba64720e3d24a60f410a899749f3f97ec8c18f75fd33
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-sass@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-sass@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/fs": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: ff0c7dfaf5f7d50b024331d0c7ec6ad0fb4fbea27381f52dfe4bd76a125ada1156942c7fb667e144f081d0c56ddff6d4041384510fa415f127cc7ec6af0c7745
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-stylus@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-stylus@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-  checksum: 7ee4abb0b9ec883727f9f90378ec364ababc92ea5ae40c25ff70b3b949a5feda2628efddda17768532e61332062fc602e72ec0a7540d9d93b578c1d0e03b1583
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-sugarss@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-sugarss@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    postcss: ^8.0.5
-  checksum: 1c665833c62bcecd9c366a962e93c31a6bb0fa74a399900ed3f347b72f1d509e1cedfde85287b895ad29f0be3039bf12cf1d8ce46220015241f77ff1975ac538
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-toml@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-toml@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 235d014d720cf5c166c9013891eb374de23c7d636f668b9d2d7d8aefaa60d22529d8cd8c3cf30c8da3947fef7238c921763c24c603c4c0f24d6402729628b391
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-typescript-types@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-typescript-types@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/ts-utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: 9b6c0201c3102010beba44ee2b46aec4d8e839f4c39a95a0508ad3ce74206ca8d82b9685c3599a621163a15ef297c7a60108e3ec22d9a03e239a5edd00d35c1d
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-vue@npm:2.0.0-nightly.2066+e2136965":
-  version: 2.0.0-nightly.2066
-  resolution: "@parcel/transformer-vue@npm:2.0.0-nightly.2066"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    nullthrows: ^1.1.1
-    semver: ^5.4.1
-  checksum: d2f41a5582f1381f4ee17df2397dc4f73f21c313cd9e0e7f24e9dd213f48d2782d472239be0ae8eea1bd0d5085fd8ca4e6615cd069a191e5bdf752c9a983eeef
-  languageName: node
-  linkType: hard
-
-"@parcel/transformer-yaml@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/transformer-yaml@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/plugin": 2.0.0-nightly.444+e2136965
-  checksum: 10d7e00425ae8ae71fa89394515211c3046ae7c1e7f2b24268c4110839b57157957fdd2b00c0c94b73d7fbc38d0c6e5fc9e856810afae1e1b1e7f715149e9986
-  languageName: node
-  linkType: hard
-
-"@parcel/ts-utils@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/ts-utils@npm:2.0.0-nightly.444"
-  dependencies:
-    nullthrows: ^1.1.1
-  checksum: 80879b2d126b421af840e3c94e75563b24ccbe16608bc4db7fb67fa6242c387c2d332414bd9bdbf8a8e798432b8929cfaab332b8778cc2fedc9a4d210ca6707b
-  languageName: node
-  linkType: hard
-
-"@parcel/types@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/types@npm:2.0.0-nightly.444"
-  checksum: 7a26d6b9be9901080f8ce610139519bedce3bc950b2dd4a63ee68bbbe21e8a1628d4f92178119b3f63458ac017001f72865c177c1659abc1424df5fdd802a4a1
-  languageName: node
-  linkType: hard
-
-"@parcel/utils@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/utils@npm:2.0.0-nightly.444"
-  dependencies:
-    "@iarna/toml": ^2.2.0
-    "@parcel/codeframe": 2.0.0-nightly.444+e2136965
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/markdown-ansi": 2.0.0-nightly.444+e2136965
-    "@parcel/source-map": 2.0.0-alpha.4.16
-    ansi-html: ^0.0.7
-    chalk: ^2.4.2
-    clone: ^2.1.1
-    fast-glob: 3.1.1
-    fastest-levenshtein: ^1.0.8
-    is-glob: ^4.0.0
-    is-url: ^1.2.2
-    json5: ^1.0.1
-    micromatch: ^4.0.2
-    node-forge: ^0.10.0
-    nullthrows: ^1.1.1
-    open: ^7.0.3
-    resolve: ^1.12.0
-  checksum: 443fc192f031d996ad2204a4c83f0feaf1ffd0c68d4cd21ee597db99583690d6aa8c48244eeda50699b4204ba0693be7224f2f65abfb69a856d22af0a79cde29
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher@npm:2.0.0-alpha.8":
-  version: 2.0.0-alpha.8
-  resolution: "@parcel/watcher@npm:2.0.0-alpha.8"
-  dependencies:
-    lint-staged: ^10.0.8
-    node-addon-api: ^3.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.2.1
-  checksum: bc03479436fd072e6104e745ece7c66f968602960cf6759ca495214d8d65277193eeae24e2eb51a177fe65250deeb0ccf59c764fcf20631293b1247a867dc1b7
-  languageName: node
-  linkType: hard
-
-"@parcel/workers@npm:2.0.0-nightly.444+e2136965":
-  version: 2.0.0-nightly.444
-  resolution: "@parcel/workers@npm:2.0.0-nightly.444"
-  dependencies:
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    chrome-trace-event: ^1.0.2
-    nullthrows: ^1.1.1
-  peerDependencies:
-    "@parcel/core": ^2.0.0-alpha.3.1
-  checksum: 4c380bc17b2b12c0201cd9356c00d6ce72d5bca1ad324accc1dfd4ed3f090f81710c587e95ba355328d6d0173d8d015052581b8520389ca460b33f0a0f50401d
-  languageName: node
-  linkType: hard
-
 "@pmmmwh/react-refresh-webpack-plugin@npm:^0.4.2":
   version: 0.4.3
   resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.4.3"
@@ -3026,13 +2065,70 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@preconstruct/cli@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@preconstruct/cli@npm:2.0.1"
+  dependencies:
+    "@babel/code-frame": ^7.5.5
+    "@babel/core": ^7.7.7
+    "@babel/helper-module-imports": ^7.10.4
+    "@babel/runtime": ^7.7.7
+    "@preconstruct/hook": ^0.4.0
+    "@rollup/plugin-alias": ^3.1.1
+    "@rollup/plugin-commonjs": ^15.0.0
+    "@rollup/plugin-json": ^4.1.0
+    "@rollup/plugin-node-resolve": ^9.0.0
+    "@rollup/plugin-replace": ^2.3.3
+    builtin-modules: ^3.1.0
+    chalk: ^4.1.0
+    dataloader: ^2.0.0
+    detect-indent: ^6.0.0
+    enquirer: ^2.3.6
+    estree-walker: ^2.0.1
+    fast-deep-equal: ^2.0.1
+    fast-glob: ^3.2.4
+    fs-extra: ^9.0.1
+    is-ci: ^2.0.0
+    is-reference: ^1.2.1
+    jest-worker: ^26.3.0
+    magic-string: ^0.25.7
+    meow: ^7.1.0
+    ms: ^2.1.2
+    normalize-path: ^3.0.0
+    npm-packlist: ^2.1.2
+    p-limit: ^3.0.2
+    parse-glob: ^3.0.4
+    parse-json: ^5.1.0
+    quick-lru: ^5.1.1
+    resolve: ^1.17.0
+    resolve-from: ^5.0.0
+    rollup: ^2.32.0
+    terser: ^5.2.1
+    v8-compile-cache: ^2.1.1
+  bin:
+    preconstruct: bin.js
+  checksum: be0c681ebed8aa4588e951f6a7fc40251df999800cd2794714ad7fdd312f825fbed5e01ddc92decb2a72ee25777a741b54848e78c68b48ebe59c0c9e55661c91
+  languageName: node
+  linkType: hard
+
+"@preconstruct/hook@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@preconstruct/hook@npm:0.4.0"
+  dependencies:
+    "@babel/core": ^7.7.7
+    "@babel/plugin-transform-modules-commonjs": ^7.7.5
+    pirates: ^4.0.1
+    source-map-support: ^0.5.16
+  checksum: 1676cdddb2efb287692820d85c46c4b8032fd4e2a60746afbba2c91e3844b8103a772de22187adf6f8eaa551c9c992592770e6e23c8cced20eb3b385bd1791fc
+  languageName: node
+  linkType: hard
+
 "@radix-ui/popper@workspace:*, @radix-ui/popper@workspace:packages/core/popper":
   version: 0.0.0-use.local
   resolution: "@radix-ui/popper@workspace:packages/core/popper"
   dependencies:
     "@radix-ui/utils": "workspace:*"
     csstype: ^3.0.4
-    parcel: ^2.0.0-beta.1
   languageName: unknown
   linkType: soft
 
@@ -3041,7 +2137,6 @@ __metadata:
   resolution: "@radix-ui/react-accessible-icon@workspace:packages/react/accessible-icon"
   dependencies:
     "@radix-ui/react-visually-hidden": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3055,7 +2150,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3069,7 +2163,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ">=16.8"
   languageName: unknown
@@ -3082,7 +2175,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0
@@ -3095,7 +2187,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3107,7 +2198,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3120,7 +2210,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3135,7 +2224,6 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3149,7 +2237,6 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3160,7 +2247,6 @@ __metadata:
   resolution: "@radix-ui/react-collection@workspace:packages/react/collection"
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3174,7 +2260,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3193,7 +2278,6 @@ __metadata:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
     aria-hidden: ^1.1.1
-    parcel: ^2.0.0-beta.1
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3205,7 +2289,6 @@ __metadata:
   resolution: "@radix-ui/react-dismissable-layer@workspace:packages/react/dismissable-layer"
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3220,7 +2303,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3229,8 +2311,6 @@ __metadata:
 "@radix-ui/react-focus-guards@workspace:*, @radix-ui/react-focus-guards@workspace:packages/react/focus-guards":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-focus-guards@workspace:packages/react/focus-guards"
-  dependencies:
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3242,7 +2322,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3255,7 +2334,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3276,7 +2354,6 @@ __metadata:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
     aria-hidden: ^1.1.1
-    parcel: ^2.0.0-beta.1
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3288,7 +2365,6 @@ __metadata:
   resolution: "@radix-ui/react-polymorphic@workspace:packages/react/polymorphic"
   dependencies:
     "@testing-library/react": ^10.4.8
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3308,7 +2384,6 @@ __metadata:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
     aria-hidden: ^1.1.1
-    parcel: ^2.0.0-beta.1
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3324,7 +2399,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3335,7 +2409,6 @@ __metadata:
   resolution: "@radix-ui/react-portal@workspace:packages/react/portal"
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0
@@ -3348,7 +2421,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
     "@xstate/fsm": ^1.5.1
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ">=16.8"
   languageName: unknown
@@ -3361,7 +2433,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3377,7 +2448,6 @@ __metadata:
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3389,7 +2459,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3403,7 +2472,6 @@ __metadata:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
     "@stitches/react": canary
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3415,7 +2483,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3429,7 +2496,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3443,7 +2509,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3457,7 +2522,6 @@ __metadata:
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3470,7 +2534,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3486,7 +2549,6 @@ __metadata:
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3500,7 +2562,6 @@ __metadata:
     "@radix-ui/utils": "workspace:*"
     "@testing-library/react": ^10.4.8
     "@types/resize-observer-browser": ^0.1.4
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3512,7 +2573,6 @@ __metadata:
   dependencies:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/utils": "workspace:*"
-    parcel: ^2.0.0-beta.1
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3521,8 +2581,6 @@ __metadata:
 "@radix-ui/utils@workspace:*, @radix-ui/utils@workspace:packages/core/utils":
   version: 0.0.0-use.local
   resolution: "@radix-ui/utils@workspace:packages/core/utils"
-  dependencies:
-    parcel: ^2.0.0-beta.1
   languageName: unknown
   linkType: soft
 
@@ -3538,6 +2596,86 @@ __metadata:
     react: 15.x || 16.x || 16.4.0-alpha.0911da3
     react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
   checksum: 7fedb32b5f589d0de236f83af7a0098bef93327925ac3dc090026ce79f6571005207d872fb01378ef00dfcd6e9ed0f0583755c5817ae9d85f3fd6d5b34b84417
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-alias@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@rollup/plugin-alias@npm:3.1.1"
+  dependencies:
+    slash: ^3.0.0
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 785d8a4283e59bbd76447e2ea5128e34c9ebf59b626841a82d5c8366687439c2fe7d0690be04e73e51ada5264d1efdfd4de8ec2528f4f9428f9541040311262c
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-commonjs@npm:^15.0.0":
+  version: 15.1.0
+  resolution: "@rollup/plugin-commonjs@npm:15.1.0"
+  dependencies:
+    "@rollup/pluginutils": ^3.1.0
+    commondir: ^1.0.1
+    estree-walker: ^2.0.1
+    glob: ^7.1.6
+    is-reference: ^1.2.1
+    magic-string: ^0.25.7
+    resolve: ^1.17.0
+  peerDependencies:
+    rollup: ^2.22.0
+  checksum: 307bdc17f35807559ca5796137a1a620b6c9311a6f62166d38ce78f793cd10883843c4c13b7c39f547cefcc0d06e442fc8c746e003077b96df76ec0e6b1eaa4f
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-json@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@rollup/plugin-json@npm:4.1.0"
+  dependencies:
+    "@rollup/pluginutils": ^3.0.8
+  peerDependencies:
+    rollup: ^1.20.0 || ^2.0.0
+  checksum: 07bc6bc83d07aefd35278e4e1a125e65210061b3dcab50c0f01273c54f43a60a3e01c1a0fed451e35d592ef1cbc8288ec8148a6229cf8cca9cdbf11a6d2d7d1c
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-node-resolve@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@rollup/plugin-node-resolve@npm:9.0.0"
+  dependencies:
+    "@rollup/pluginutils": ^3.1.0
+    "@types/resolve": 1.17.1
+    builtin-modules: ^3.1.0
+    deepmerge: ^4.2.2
+    is-module: ^1.0.0
+    resolve: ^1.17.0
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 34576bbd9cfb096ed6fcce256e9210995144ccfd352ef09134507a7c6b479cee20da2896525ebf8bf139d9a31e8eec4b6787ed9de3209ee6610a949dc9f7c268
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-replace@npm:^2.3.3":
+  version: 2.3.4
+  resolution: "@rollup/plugin-replace@npm:2.3.4"
+  dependencies:
+    "@rollup/pluginutils": ^3.1.0
+    magic-string: ^0.25.7
+  peerDependencies:
+    rollup: ^1.20.0 || ^2.0.0
+  checksum: 97ae11600a959b7668105d9e28801319f9158b01a1d9dbf4f910136491463d8798c1bb1d62e47bf04d5ff08c9c5b3f333aa39ccad57a4e5531d8edaa38ffd74e
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^3.0.8, @rollup/pluginutils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@rollup/pluginutils@npm:3.1.0"
+  dependencies:
+    "@types/estree": 0.0.39
+    estree-walker: ^1.0.1
+    picomatch: ^2.2.2
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 45da6411e045d1b034242a8144f4a5e8c02ff1b68a2e0857807f5bb4b091c416f2015e075057f0f0dec200e7b35efe6ed4e301b43e365cedea09192f01a6839b
   languageName: node
   linkType: hard
 
@@ -4335,6 +3473,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/estree@npm:0.0.39":
+  version: 0.0.39
+  resolution: "@types/estree@npm:0.0.39"
+  checksum: 43e5361de39969def145f32f4599391ab13055ec94841f1633a7cfe10f0e8a940ebf0e9a4b2770454a6bddd034b57e7e0d51a4d565cb2714ee2accf10a7718be
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:*":
   version: 4.17.13
   resolution: "@types/express-serve-static-core@npm:4.17.13"
@@ -4392,15 +3537,6 @@ __metadata:
   version: 5.1.1
   resolution: "@types/html-minifier-terser@npm:5.1.1"
   checksum: 1e750b93e1240a6a3bc6d2748a4f09215c9557b8f6655ee57d1e88c7afcc171e2998a1e97a771c64ef8eeadc9db5623f9e08e09574a549cb74549cdbad5a73b7
-  languageName: node
-  linkType: hard
-
-"@types/http-proxy@npm:^1.17.4":
-  version: 1.17.4
-  resolution: "@types/http-proxy@npm:1.17.4"
-  dependencies:
-    "@types/node": "*"
-  checksum: 9f5ba01f1031010f686f628d1b7f8b0989cd0562436675eff13f944ae2ffbaa90be0d2a7f89a6caf5763e00822080ae28c58ce0e1cde138322decb636641e568
   languageName: node
   linkType: hard
 
@@ -4492,6 +3628,13 @@ __metadata:
   version: 3.0.3
   resolution: "@types/minimatch@npm:3.0.3"
   checksum: 672ccdac197e8176eed1a9441d0caf8a29a90eb139b1cefdd4c9e71b1c48f5c749f5d101a2d85da15c6259214ebda95072835021407d60330a731a2672964b82
+  languageName: node
+  linkType: hard
+
+"@types/minimist@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@types/minimist@npm:1.2.1"
+  checksum: 3a6f5fe35f1656b34a4ccd5a5db1c38509d8d5b59625865b8c2b997994fcb0cfde0d9af7c5507b95dc5a0a32a22886c189e505cd2e52a7ef36d3c9982f07ed5a
   languageName: node
   linkType: hard
 
@@ -4654,6 +3797,15 @@ __metadata:
   version: 0.1.4
   resolution: "@types/resize-observer-browser@npm:0.1.4"
   checksum: c620f74e61e840e9cb92218ea6d692c040a22d2e2450d0792e9cbc87723ce5d237ed505a1961844f13c6ecc49f80a4f02fe5e870bcf3cf115d752fb220c87b43
+  languageName: node
+  linkType: hard
+
+"@types/resolve@npm:1.17.1":
+  version: 1.17.1
+  resolution: "@types/resolve@npm:1.17.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 8e72a73574f9489760662498c1ad512a8d4084a5db15f327e0d785cb277bb0a3146cd049241a8e3268bd0ed204ad3ee7b4a6b4622ef681e70547be9af258ca6a
   languageName: node
   linkType: hard
 
@@ -5040,7 +4192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abab@npm:^2.0.0, abab@npm:^2.0.3":
+"abab@npm:^2.0.3":
   version: 2.0.5
   resolution: "abab@npm:2.0.5"
   checksum: a42b91bd9dd2451a3fc6996bc8953139904ff7b1a793719205041148da892337afc97ed0589ef2c44765c4da3d688eed145781db1623b611621d805294c367a3
@@ -5054,13 +4206,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abortcontroller-polyfill@npm:^1.1.9":
-  version: 1.5.0
-  resolution: "abortcontroller-polyfill@npm:1.5.0"
-  checksum: be16982004c589e72e4e197c4828745baa94ef2fa02ec50ab449446071bd9ff1b9968e1adaa3b4ccb039144d4b11e43445383771048015ce7006dc0dfdaf342a
-  languageName: node
-  linkType: hard
-
 "accepts@npm:~1.3.7":
   version: 1.3.7
   resolution: "accepts@npm:1.3.7"
@@ -5068,16 +4213,6 @@ __metadata:
     mime-types: ~2.1.24
     negotiator: 0.6.2
   checksum: 2686fa30dbc850db1bf458dc8171fba13c54ed6cb25f4298ec7c2f88b8dfc50351f25c40abe3a948e4ec7a0cc8ea83d1c55c2f73ffa612d18840a8778d4a2ee0
-  languageName: node
-  linkType: hard
-
-"acorn-globals@npm:^4.3.0":
-  version: 4.3.4
-  resolution: "acorn-globals@npm:4.3.4"
-  dependencies:
-    acorn: ^6.0.1
-    acorn-walk: ^6.0.1
-  checksum: 6c3511f40d25daefda449b803f9d651c1b2427009d5dc74ae485efe5b704be0ce17983ac9571df3f5344a6ab1df77a29cb4e19c5f34796cec3c1c049f3ad5951
   languageName: node
   linkType: hard
 
@@ -5100,13 +4235,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^6.0.1":
-  version: 6.2.0
-  resolution: "acorn-walk@npm:6.2.0"
-  checksum: 3bd8415090ecfcf0a40e9bdde722993104d209d8e7721b48d9c77c46fb1dd261cc29ae0ee47e6532db9fbfe96d911b19ec0d72a383b20ed331364ab18d35b75b
-  languageName: node
-  linkType: hard
-
 "acorn-walk@npm:^7.1.1":
   version: 7.2.0
   resolution: "acorn-walk@npm:7.2.0"
@@ -5114,7 +4242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^6.0.1, acorn@npm:^6.0.4, acorn@npm:^6.4.1":
+"acorn@npm:^6.4.1":
   version: 6.4.2
   resolution: "acorn@npm:6.4.2"
   bin:
@@ -5201,13 +4329,6 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 19a8f3b0a06001eb68e6268f4f9f04424b32baadd5df6ba8292cd473e22e5f4019ed9ab17c3e3510394178ed8bef9b42ad0bdb5c675d65f042421a774780ce1a
-  languageName: node
-  linkType: hard
-
-"alphanum-sort@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "alphanum-sort@npm:1.0.2"
-  checksum: 28bad91719e15959e36a791a3538924e07da356ebe3b5f992e7668e8018cfc417a7ba4a69512771e5ffa306c7e028435c7748546f66f72d4f7b0ad694cf55069
   languageName: node
   linkType: hard
 
@@ -5416,20 +4537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-equal@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "array-equal@npm:1.0.0"
-  checksum: ad82ed549385a7cacb7ed3a2be9cef73ccc0ebf371e4a30635bfc5737464f7fd5c70433e25c1bbdeec3d230d41be13e46b778e5a373300655531b4b7eff1f447
-  languageName: node
-  linkType: hard
-
-"array-filter@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "array-filter@npm:1.0.0"
-  checksum: e0edbae5296e6904f369b5ad2919e932b6aa4ac525951b8713f4379183bbeb2f73c3e788dca1104b95c5ed919c430ba0a4b036dfb32be492665ba5213e80791c
-  languageName: node
-  linkType: hard
-
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -5563,18 +4670,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "assert@npm:2.0.0"
-  dependencies:
-    es6-object-assign: ^1.1.0
-    is-nan: ^1.2.1
-    object-is: ^1.0.1
-    util: ^0.12.0
-  checksum: c3593bcc4c63c1e6fd3b62a7c788cf7337118d79b827d79b0ed60e596d4968b80b2f8aa8e41bc5742621596bd60aa9de62ea166d85a584a6db177d7087e907f3
-  languageName: node
-  linkType: hard
-
 "assign-symbols@npm:^1.0.0":
   version: 1.0.0
   resolution: "assign-symbols@npm:1.0.0"
@@ -5616,13 +4711,6 @@ __metadata:
   version: 1.0.3
   resolution: "async-each@npm:1.0.3"
   checksum: 0cf01982ae42db5ce591aab153e45e77aa7c813c4fb282f1e7cac2259f90949f82542e82a33f73ef308e0126c9a8bc702ee117a87614549fe88840cf5a44aec4
-  languageName: node
-  linkType: hard
-
-"async-limiter@npm:~1.0.0":
-  version: 1.0.1
-  resolution: "async-limiter@npm:1.0.1"
-  checksum: d123312ace75c07399ddc58e06cc028dacce35f71cdf59cf9b22f6c31dde221c22285e6185ede823ecb67f3b3065e26205eb9f74fcbba3f12ce7a2c2b09d7763
   languageName: node
   linkType: hard
 
@@ -5670,15 +4758,6 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: b406d8047a97fcc39c9c6d208fd6f1974e5957800461d9a79457a3ecaca2c0ea090bd06f30c8653f48f751c31115c63a80502ff8c9a6bb7b8a5a5063021827d4
-  languageName: node
-  linkType: hard
-
-"available-typed-arrays@npm:^1.0.0, available-typed-arrays@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "available-typed-arrays@npm:1.0.2"
-  dependencies:
-    array-filter: ^1.0.0
-  checksum: 1f01d36fa3f25a06fd00968a1bc32fa75e5b56268828be5a7c6d0bdf37be0d7517d1b9aa5f1a6d2626725cb59708e280c5a9cf9a1b4d86f5e571d48168904061
   languageName: node
   linkType: hard
 
@@ -6175,15 +5254,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.8":
-  version: 3.0.8
-  resolution: "base-x@npm:3.0.8"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 9e5832ab00f4413d63f8227901c18b2a9db5f379525f70b627e6e284007dc5e7940a765ef4ab03974b4c14a664153208758656ebb86979451d1995d13e3fa29b
-  languageName: node
-  linkType: hard
-
 "base64-js@npm:^1.0.2":
   version: 1.3.1
   resolution: "base64-js@npm:1.3.1"
@@ -6461,7 +5531,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.14.5, browserslist@npm:^4.14.6":
+"browserslist@npm:^4.12.0":
+  version: 4.13.0
+  resolution: "browserslist@npm:4.13.0"
+  dependencies:
+    caniuse-lite: ^1.0.30001093
+    electron-to-chromium: ^1.3.488
+    escalade: ^3.0.1
+    node-releases: ^1.1.58
+  bin:
+    browserslist: cli.js
+  checksum: 91657dcc024f03f7b8a03f897e4a15c73774f39040f4e2fa9cb0e10b057113d71c97b29721590a80bf03dccfae1d69ad3fdf7326644c2c41cdd0410fb1a679a0
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.14.5, browserslist@npm:^4.14.6":
   version: 4.14.7
   resolution: "browserslist@npm:4.14.7"
   dependencies:
@@ -6473,20 +5557,6 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 62b671a69a8d5636d848383ef2cdb64299a436149a889e08c6b91bf0d595bee6c1d358edf1f3dcde72b5fb803f138015b9c1de75566b19330d071ab76f3d1339
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.12.0, browserslist@npm:^4.6.6":
-  version: 4.13.0
-  resolution: "browserslist@npm:4.13.0"
-  dependencies:
-    caniuse-lite: ^1.0.30001093
-    electron-to-chromium: ^1.3.488
-    escalade: ^3.0.1
-    node-releases: ^1.1.58
-  bin:
-    browserslist: cli.js
-  checksum: 91657dcc024f03f7b8a03f897e4a15c73774f39040f4e2fa9cb0e10b057113d71c97b29721590a80bf03dccfae1d69ad3fdf7326644c2c41cdd0410fb1a679a0
   languageName: node
   linkType: hard
 
@@ -6533,13 +5603,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0":
-  version: 5.6.0
-  resolution: "buffer@npm:5.6.0"
-  dependencies:
-    base64-js: ^1.0.2
-    ieee754: ^1.1.4
-  checksum: e18fdf099c25cae354d673c7deee0391978bde5a47b785cf81e118c75853f0f36838b0a5ea5ee7adf8c02eedb9664292608efdcac9945f4f4f514d14054656f7
+"builtin-modules@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "builtin-modules@npm:3.2.0"
+  checksum: f0e7240f70ae472a0a0167bf76d2e828c73028fe60be8cd229939c38a27527ea68c92f700553dac1316fa124af3037bc7a765ca0e029a03d2e9201dfb372ea24
   languageName: node
   linkType: hard
 
@@ -6547,13 +5614,6 @@ __metadata:
   version: 3.0.0
   resolution: "builtin-status-codes@npm:3.0.0"
   checksum: 8e2872a69ae05c6a24adc3b6dd4c340f077ea842fc8115ab5b4896f3ab68cf38f56438d430273efd152def59313fd8ca3a35bdad4c3e88b8bb88ba4a371b3866
-  languageName: node
-  linkType: hard
-
-"bytes@npm:3.0.0":
-  version: 3.0.0
-  resolution: "bytes@npm:3.0.0"
-  checksum: 98d6c0ab36f7a5527226fd928e65495ffd3d53cb22da627eba3300eed36bd283ae3dfdf3a0aa017df13a09115b5b8847e3d51f66c2f0304a262264c86a317c05
   languageName: node
   linkType: hard
 
@@ -6688,6 +5748,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase-keys@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "camelcase-keys@npm:6.2.2"
+  dependencies:
+    camelcase: ^5.3.1
+    map-obj: ^4.0.0
+    quick-lru: ^4.0.1
+  checksum: d4bd5fa5249127be0f5b1aa961da3a9de7d0a578d9524c5013f21c0ed345637eaa1e42bab28a75bbfc8511911ffb30fec4191a9efcec52741c1a3402dc38dd53
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^5.0.0, camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -6702,19 +5773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-api@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "caniuse-api@npm:3.0.0"
-  dependencies:
-    browserslist: ^4.0.0
-    caniuse-lite: ^1.0.0
-    lodash.memoize: ^4.1.2
-    lodash.uniq: ^4.5.0
-  checksum: 6822fb3d421b438f9274b15f9a20f54937402730c978285ceb07b569de5876882b0bbc94274519f7308baaae8dc84227d846fc7dacc4f4b54fac7d2515aca582
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001093, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001157":
+"caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001093, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001157":
   version: 1.0.30001157
   resolution: "caniuse-lite@npm:1.0.30001157"
   checksum: 8fc930094b538a6592bd09d1c444fe5dc44cfc3517effeb722fb9832d200755908f3b3551069f8f61518ffac65c3dcf4ea022b74de60b70468a6c1d18f5b4184
@@ -6744,7 +5803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.0.1, chalk@npm:^2.1.0, chalk@npm:^2.3.2, chalk@npm:^2.4.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
+"chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.0.1, chalk@npm:^2.1.0, chalk@npm:^2.3.2, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -6963,13 +6022,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.2.0":
-  version: 2.5.0
-  resolution: "cli-spinners@npm:2.5.0"
-  checksum: a275c3588179de0a07579742e1fedb508caa6840516761dac1f8544886d4aa025fc2d536323ac9c325624349203010e149ca8b0028be239fc45ed3a1c1252677
-  languageName: node
-  linkType: hard
-
 "cli-table3@npm:0.6.0":
   version: 0.6.0
   resolution: "cli-table3@npm:0.6.0"
@@ -7043,20 +6095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "clone@npm:1.0.4"
-  checksum: aaaa58f9906002d9c07630682536cb00581ee02d7a76cfa8573ad59784add4d5d6d4afe894c21899b974044f153f8c5c6419ffc8b1cdde61bf104ad52e3a185d
-  languageName: node
-  linkType: hard
-
-"clone@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "clone@npm:2.1.2"
-  checksum: 85232d66015d2d703dc59812e30049931d97c7815bf70569ae4fb7a66be257f46fcf47040e4e7050966ca195a9e615d59d73ba9e39fc37eedba1a76865f27ab1
-  languageName: node
-  linkType: hard
-
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -7082,16 +6120,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"coffeescript@npm:^2.0.3":
-  version: 2.5.1
-  resolution: "coffeescript@npm:2.5.1"
-  bin:
-    cake: bin/cake
-    coffee: bin/coffee
-  checksum: a2fb59193851d4e8fc1eef8792efc30a7491eef667b910a7046a1628cdd735d7c9a64f3b55be34d96a305744b845d90614d2d73a152662c2d9e2d291916e3a33
-  languageName: node
-  linkType: hard
-
 "collect-v8-coverage@npm:^1.0.0":
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
@@ -7109,7 +6137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0, color-convert@npm:^1.9.1":
+"color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -7134,30 +6162,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 3e1c9a4dee12eada307436f61614dd11fe300469db2b83f80c8b7a7cd8a1015f0f18dd13403f018927b249003777ff60baba4a03c65f12e6bddc0dfd9642021f
-  languageName: node
-  linkType: hard
-
-"color-string@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "color-string@npm:1.5.4"
-  dependencies:
-    color-name: ^1.0.0
-    simple-swizzle: ^0.2.2
-  checksum: 181ab2a0a13dc87b13db1bceab8585c159f1cbf169c4210df61d24349f90e5f6087a18c8c12842dbdd5d4cff9a1008ef86c153201429bc456fb7bf9c9495d366
-  languageName: node
-  linkType: hard
-
-"color@npm:^3.0.0":
-  version: 3.1.3
-  resolution: "color@npm:3.1.3"
-  dependencies:
-    color-convert: ^1.9.1
-    color-string: ^1.5.4
-  checksum: d0f4139e986806aaacaa748d170c9778faed93695fb776cd27d9c5825424263eb9354f69033804d0d2d350d9831a31d14dddff045da00713499f279da97e602f
   languageName: node
   linkType: hard
 
@@ -7188,13 +6196,6 @@ __metadata:
   version: 1.0.8
   resolution: "comma-separated-tokens@npm:1.0.8"
   checksum: 31a5a2fa6e0f02764b0634e0aa31913c9be0ef568f4e58b5c1ec85d0a6e4a6c367905eacf2c7e59b57d3d05f40cff166ea3c9b6ee8338625cad060ce43ede9fd
-  languageName: node
-  linkType: hard
-
-"command-exists@npm:^1.2.6":
-  version: 1.2.9
-  resolution: "command-exists@npm:1.2.9"
-  checksum: c682ee2215e20c3e3ea9ebaaec403928f4e927dec75778e798766db9967a842f89ae2318ff3b384706bb22abb22eac983fe53d9ecd54d7b781a8dbed47ed6c6a
   languageName: node
   linkType: hard
 
@@ -7280,19 +6281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connect@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "connect@npm:3.7.0"
-  dependencies:
-    debug: 2.6.9
-    finalhandler: 1.1.2
-    parseurl: ~1.3.3
-    utils-merge: 1.0.1
-  checksum: 25b827ceb48e6355f6395b44b1ad09ac46002b89e3789952ca0372fd3ef04b81ad40fdc5896ecc21577a0583304731d86c050331575fbde398b2a6fd27c4a643
-  languageName: node
-  linkType: hard
-
-"console-browserify@npm:^1.1.0, console-browserify@npm:^1.2.0":
+"console-browserify@npm:^1.1.0":
   version: 1.2.0
   resolution: "console-browserify@npm:1.2.0"
   checksum: ddc0e717a48ffa11d6b7ad08a81a706151ff7c08db313c14ae28f1dce88360b2f2d88ccd7b760243a47b67d821f1294273511af5de61f4f201855bb55e8e1d58
@@ -7317,13 +6306,6 @@ __metadata:
   version: 0.1.0
   resolution: "contains-path@npm:0.1.0"
   checksum: 59920a59a0c7d1244235d76b8cfd2b2e7a8dcc463fa578ef9d4d5a5a73eeb14d75dada6b21188e0b35f2474ae9efd10c3698372e674db9c6a904b281998b97d6
-  languageName: node
-  linkType: hard
-
-"content-disposition@npm:0.5.2":
-  version: 0.5.2
-  resolution: "content-disposition@npm:0.5.2"
-  checksum: 5d54ba7c9a6e865d1fea321e43d9e56be091aa20706f4632a236ebe7824ed3cb0eac314b80e76a9db2092d287d69add03efcaf743068ee0be1f71159c14a134c
   languageName: node
   linkType: hard
 
@@ -7413,7 +6395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.0.1, core-js@npm:^3.0.4, core-js@npm:^3.2.1, core-js@npm:^3.6.5":
+"core-js@npm:^3.0.1, core-js@npm:^3.0.4, core-js@npm:^3.6.5":
   version: 3.7.0
   resolution: "core-js@npm:3.7.0"
   checksum: 95958cddb786e51d5ba2a0f60a0232270da1ba460e20870604adb03fbc282f83df78b84509b95ad5990ddbe79b990d9fb5a27426bd36a0e6243b50788fae369f
@@ -7578,7 +6560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.4, cross-spawn@npm:^6.0.5":
+"cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
   dependencies:
@@ -7602,7 +6584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-browserify@npm:^3.11.0, crypto-browserify@npm:^3.12.0":
+"crypto-browserify@npm:^3.11.0":
   version: 3.12.0
   resolution: "crypto-browserify@npm:3.12.0"
   dependencies:
@@ -7618,23 +6600,6 @@ __metadata:
     randombytes: ^2.0.0
     randomfill: ^1.0.3
   checksum: 8b558367b3759652b7c8dfd8fa0dc55a69362ae3efe039ac44d4b010bc63143708f4748ef8efc079945bf61dbc53c829cda968cd2abc1f34fcf43f669a414f73
-  languageName: node
-  linkType: hard
-
-"css-color-names@npm:0.0.4, css-color-names@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "css-color-names@npm:0.0.4"
-  checksum: 6842f38c3ae176f9beef3f92be258936aa508d5c4aa6dca48abfc324574eeda275e265dd0589d6e7a9a29768b6d6dd5ab7c4de27b8255c6142330fde84821af2
-  languageName: node
-  linkType: hard
-
-"css-declaration-sorter@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "css-declaration-sorter@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.1
-    timsort: ^0.3.0
-  checksum: 9cd18a0cca0e8e983ca3cd59461c05b650c244e0fbf28810e20ec8478dd715701538bf097980b50b92aed916825fd706d0546a8fd203b6e81612b7a67184bf98
   languageName: node
   linkType: hard
 
@@ -7658,20 +6623,6 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: f916e1dc6914e9fda52e81e603e5afd8cf68c866d9d1cb84edf245fa3ce6bec4252be841edc694c8f6aeb855c94dbde1baccb44678f0b652bbb8fb7ca68a1a0a
-  languageName: node
-  linkType: hard
-
-"css-modules-loader-core@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "css-modules-loader-core@npm:1.1.0"
-  dependencies:
-    icss-replace-symbols: 1.1.0
-    postcss: 6.0.1
-    postcss-modules-extract-imports: 1.1.0
-    postcss-modules-local-by-default: 1.2.0
-    postcss-modules-scope: 1.1.0
-    postcss-modules-values: 1.3.0
-  checksum: 883fef7c950c6df72cfcf6af8935bd96e4c9be7866b9e1907cf71018a4a5ac87fe4147c2d82d4018cce51bf80e3ca7fa5db29e24ada080a9e05c96875501050d
   languageName: node
   linkType: hard
 
@@ -7703,16 +6654,6 @@ __metadata:
     domutils: ^1.7.0
     nth-check: ^1.0.2
   checksum: b534aad04abbd433849d55b93e234b81c1ade4422c638a916fd7163db5a3b07186e92ce43c292d954417c8ce020eb31b8990ed2fb30c9c145c7f2549621e8095
-  languageName: node
-  linkType: hard
-
-"css-selector-tokenizer@npm:^0.7.0":
-  version: 0.7.3
-  resolution: "css-selector-tokenizer@npm:0.7.3"
-  dependencies:
-    cssesc: ^3.0.0
-    fastparse: ^1.1.2
-  checksum: b4c0095098fe69fb079ca8b9e42767d5ae3222b752276a94be88d8ad68b485478109b96d11d646393edfa055a5f6d3a2269e384b821d645d35d1324f2e17fb2b
   languageName: node
   linkType: hard
 
@@ -7777,99 +6718,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-default@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "cssnano-preset-default@npm:4.0.7"
-  dependencies:
-    css-declaration-sorter: ^4.0.1
-    cssnano-util-raw-cache: ^4.0.1
-    postcss: ^7.0.0
-    postcss-calc: ^7.0.1
-    postcss-colormin: ^4.0.3
-    postcss-convert-values: ^4.0.1
-    postcss-discard-comments: ^4.0.2
-    postcss-discard-duplicates: ^4.0.2
-    postcss-discard-empty: ^4.0.1
-    postcss-discard-overridden: ^4.0.1
-    postcss-merge-longhand: ^4.0.11
-    postcss-merge-rules: ^4.0.3
-    postcss-minify-font-values: ^4.0.2
-    postcss-minify-gradients: ^4.0.2
-    postcss-minify-params: ^4.0.2
-    postcss-minify-selectors: ^4.0.2
-    postcss-normalize-charset: ^4.0.1
-    postcss-normalize-display-values: ^4.0.2
-    postcss-normalize-positions: ^4.0.2
-    postcss-normalize-repeat-style: ^4.0.2
-    postcss-normalize-string: ^4.0.2
-    postcss-normalize-timing-functions: ^4.0.2
-    postcss-normalize-unicode: ^4.0.1
-    postcss-normalize-url: ^4.0.1
-    postcss-normalize-whitespace: ^4.0.2
-    postcss-ordered-values: ^4.1.2
-    postcss-reduce-initial: ^4.0.3
-    postcss-reduce-transforms: ^4.0.2
-    postcss-svgo: ^4.0.2
-    postcss-unique-selectors: ^4.0.1
-  checksum: 7e947b0e09c15816638ff6e8cc881f58a99532271a94e7fc259e01a89e6eececb4a028f931d6940fd44c27f3134c54146a7b877cfa7497cd24fc5e299c493a51
-  languageName: node
-  linkType: hard
-
-"cssnano-util-get-arguments@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "cssnano-util-get-arguments@npm:4.0.0"
-  checksum: 40017863677fe03979bf6d8f3cbddbba58913e6257e50eaad65c5b0de567a2e4d704b889919d299f6a8efa272cf89b862481c04e9a0faea4f2fc4dc501abd7ee
-  languageName: node
-  linkType: hard
-
-"cssnano-util-get-match@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "cssnano-util-get-match@npm:4.0.0"
-  checksum: 1220816e194911db505ea7f0489a5e966914de726ef2c753562a0cc4e31f184a09409806aa18fb07c4d97e68c0c950f2ad60b91c946954240f22356d256eb568
-  languageName: node
-  linkType: hard
-
-"cssnano-util-raw-cache@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "cssnano-util-raw-cache@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: d3eb80e96fc680e7b764ed8d622fbe860c7b80e831fb00552717d618c220940ba595cdd471b69bcf5b7d38fbb176d132512e68f6501e197cd10baa726f4d8cbd
-  languageName: node
-  linkType: hard
-
-"cssnano-util-same-parent@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "cssnano-util-same-parent@npm:4.0.1"
-  checksum: c01d567f9d1e867c3e591338bbfff5fb96dd6843ce0b78cda012a0096dae8c05237d4aedeeadebfbf5e1555c567d40cbc940bf44afc2716c1d077d7c8d907579
-  languageName: node
-  linkType: hard
-
-"cssnano@npm:^4.1.10":
-  version: 4.1.10
-  resolution: "cssnano@npm:4.1.10"
-  dependencies:
-    cosmiconfig: ^5.0.0
-    cssnano-preset-default: ^4.0.7
-    is-resolvable: ^1.0.0
-    postcss: ^7.0.0
-  checksum: 7578b1238992f6226e3aaa104fecfac97224ebebb20e58910ce71c6a8f966d2ee116ea1e9bc6c7a59dbf79941feb875452149938d34642898b19de87ff728e01
-  languageName: node
-  linkType: hard
-
 "csso@npm:^4.0.2":
   version: 4.1.0
   resolution: "csso@npm:4.1.0"
   dependencies:
     css-tree: ^1.0.0
   checksum: 9c250d8206d0d083dfbd6b00e4901914c08b51c4b24c882442117811b767e174be469a92a73b02e7da30db258f1f52a003c46ffa5885d8deabadfc684854769a
-  languageName: node
-  linkType: hard
-
-"cssom@npm:0.3.x, cssom@npm:^0.3.4, cssom@npm:~0.3.6":
-  version: 0.3.8
-  resolution: "cssom@npm:0.3.8"
-  checksum: b7fb8b13aa2014a6c168c7644baa2f4d447a28b624544c87c8ef905bbec64ef247b3d167270f87e043acc6df30ea0f80e0da545a45187ff4006eb2c24988dfae
   languageName: node
   linkType: hard
 
@@ -7880,12 +6734,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^1.1.1":
-  version: 1.4.0
-  resolution: "cssstyle@npm:1.4.0"
-  dependencies:
-    cssom: 0.3.x
-  checksum: 5c138c9b0761a2826929ba1af06d541968c8ce2e147bc88719a9219554dbc2a7e48d2507936b4837c4cd75c07fa4988e51c6fe96dd96a45cd404c8a0012a46d3
+"cssom@npm:~0.3.6":
+  version: 0.3.8
+  resolution: "cssom@npm:0.3.8"
+  checksum: b7fb8b13aa2014a6c168c7644baa2f4d447a28b624544c87c8ef905bbec64ef247b3d167270f87e043acc6df30ea0f80e0da545a45187ff4006eb2c24988dfae
   languageName: node
   linkType: hard
 
@@ -7945,17 +6797,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-urls@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "data-urls@npm:1.1.0"
-  dependencies:
-    abab: ^2.0.0
-    whatwg-mimetype: ^2.2.0
-    whatwg-url: ^7.0.0
-  checksum: 04d211e1e9f83bab75450487da34b124b32beacd1ad0df96e3a747b705c24c65579833a04a6ea30a528ea5b99d5247660408c513b38905bf855f2de585b9e91c
-  languageName: node
-  linkType: hard
-
 "data-urls@npm:^2.0.0":
   version: 2.0.0
   resolution: "data-urls@npm:2.0.0"
@@ -7964,6 +6805,13 @@ __metadata:
     whatwg-mimetype: ^2.3.0
     whatwg-url: ^8.0.0
   checksum: 42239927c6a202e2d02b7f41c94ca53e3cea036898b97b8bf6120ed1b25e0dd11c48ec7aa5c84cf807c2cb9f3a637df9fb50f3ca25a52863186a4ac46254726b
+  languageName: node
+  linkType: hard
+
+"dataloader@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dataloader@npm:2.0.0"
+  checksum: 0165c2e80751d269c33d2a14b0078a4f3853cb010e2531e7aa99523aba8d0cdc922b9ad67e4c2bb9074c90e0ee0a41b6e7f5f63c40d31224a71c8a0b703f4be3
   languageName: node
   linkType: hard
 
@@ -7999,7 +6847,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.2.0":
+"decamelize-keys@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "decamelize-keys@npm:1.1.0"
+  dependencies:
+    decamelize: ^1.1.0
+    map-obj: ^1.0.0
+  checksum: dbfe6d594810ef134f8e3b8aa1684c854187a225999a0c3871b8c32d8fda886d1832b79b952a53e9557be17a78ec0198b6c26a5a5a35d012d6b18340a4dc6356
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.1.0, decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 8ca9d03ea8ac07920f4504e219d18edff2491bdd0a3e05a1e5ca2e9a0bf6333564231de3528b01d5e76c40a38c37bbc1e09cb5a0424714f53dd615ed78ced464
@@ -8045,15 +6903,6 @@ __metadata:
   version: 4.2.2
   resolution: "deepmerge@npm:4.2.2"
   checksum: 85abf8e0045ee280996e7d2396979c877ef0741e413b716e42441110e0a83ac08098b2a49cea035510060bf667c0eae3189b2a52349f5fa4b000c211041637b1
-  languageName: node
-  linkType: hard
-
-"defaults@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "defaults@npm:1.0.3"
-  dependencies:
-    clone: ^1.0.2
-  checksum: 974f63dd0acb79d14e94ac0f2ea69a880ab2a6e4b341bb9bdc2409b4091b928abe2709a4e140528948d02f29c286efdef22851d1dc972636eed2ce8e1c5b7465
   languageName: node
   linkType: hard
 
@@ -8136,6 +6985,13 @@ __metadata:
   version: 1.0.4
   resolution: "destroy@npm:1.0.4"
   checksum: 5a516fc5a8a8089eecdac11da2339353542be7a71102dc5a1372ef6161501bf5c1ee59ff9f8a3f5f14cc8c88594d606f855f816d46a228ee5e0e5cb2b543534b
+  languageName: node
+  linkType: hard
+
+"detect-indent@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "detect-indent@npm:6.0.0"
+  checksum: ad0619414151942d278c06cd4b6b79feb96c16eebf4979ef1d03433941f1a85c9bba7daba73a73814d629923716169da5416bbc4290c232d53a2dc06f462da5f
   languageName: node
   linkType: hard
 
@@ -8270,17 +7126,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-serializer@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "dom-serializer@npm:1.0.1"
-  dependencies:
-    domelementtype: ^2.0.1
-    domhandler: ^3.0.0
-    entities: ^2.0.0
-  checksum: 45734411e474813859cde8d5513a5cf424c592a6fd82e97ef1504d277b021aac6ddbfedb88ae683d7f8ff80d5cd7991a5301aefb33a04ae6bec781669e2e5f7b
-  languageName: node
-  linkType: hard
-
 "dom-walk@npm:^0.1.0":
   version: 0.1.2
   resolution: "dom-walk@npm:0.1.2"
@@ -8295,13 +7140,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domain-browser@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "domain-browser@npm:3.5.0"
-  checksum: 219418093bba2bdae8e57cb5d63d5c41b038903503636b0284f34cbcb7e52a23566847b1152ed96ffdd5dc49ccf60ea23a2f1e1161564f10ec671a16bc699bca
-  languageName: node
-  linkType: hard
-
 "domelementtype@npm:1, domelementtype@npm:^1.3.1":
   version: 1.3.1
   resolution: "domelementtype@npm:1.3.1"
@@ -8313,15 +7151,6 @@ __metadata:
   version: 2.0.2
   resolution: "domelementtype@npm:2.0.2"
   checksum: 80a6e339f77079de7d606f7032c1a060584081bc0a16f6161becf3d8e8c2ba555b4ee21843352cde4db9182adf336445324db5143f2e69b1e5b1883b9c548b58
-  languageName: node
-  linkType: hard
-
-"domexception@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "domexception@npm:1.0.1"
-  dependencies:
-    webidl-conversions: ^4.0.2
-  checksum: 0a678e600248b8a6f0149cb6a6ddae77d698d16a6fcf39d4228b933d5ac2b9ee657a36b2cd08ea82ec6196da756535bd30b8362f697cc9e564d969e52437fcd8
   languageName: node
   linkType: hard
 
@@ -8340,24 +7169,6 @@ __metadata:
   dependencies:
     domelementtype: 1
   checksum: dbe99b096aaf6e0618efc2e7e39d46448cba00999b08ba14970ee4d7a8916c4d4d463fcc1b4a7f247b34f47d1c115eec8fa5f8a4d1e430b2207da32bdf41f49a
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "domhandler@npm:3.0.0"
-  dependencies:
-    domelementtype: ^2.0.1
-  checksum: 2d935dbe3eafb5e5bcbd512d9bab541fdfcdcb36b9a73ab32bd8cbb2d055ee0d689c921f68774ee2afb97d4ef49e0932ddfb0c9d4ea0135457106ef508924b56
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "domhandler@npm:3.3.0"
-  dependencies:
-    domelementtype: ^2.0.1
-  checksum: dcc53af0ac02f1fc30abf3a794e31c13ad5e47dd00eeb06465211d854cba11c8db60eb65f4f11410fcd332a850eaca394cdd210805628b4f82d1cbcec78c8368
   languageName: node
   linkType: hard
 
@@ -8381,17 +7192,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "domutils@npm:2.4.2"
-  dependencies:
-    dom-serializer: ^1.0.1
-    domelementtype: ^2.0.1
-    domhandler: ^3.3.0
-  checksum: 43d7e55714e6597982fc1088e1b5136ede8068b47d831ec9a9047e4ca49a480f3a6e289e636768d0d29077164888e44110cbd19079f780f91a1362f3b77adb73
-  languageName: node
-  linkType: hard
-
 "dot-case@npm:^3.0.3":
   version: 3.0.3
   resolution: "dot-case@npm:3.0.3"
@@ -8399,15 +7199,6 @@ __metadata:
     no-case: ^3.0.3
     tslib: ^1.10.0
   checksum: 31e5037039fb696ed7f1da1d3f0cea5fa0ffe0523334229a2f241856411fbbb59a5a7a6f8ae1447820718797708650bd6f90836d510ec27a81694fbc006c946a
-  languageName: node
-  linkType: hard
-
-"dot-prop@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "dot-prop@npm:5.3.0"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: 76e6693d8803eeff9cb920988446bf223cf1f6e5b1c0c2fe07a66906392134931a481b11e3c0bd852c5cfc97fad65258bcb4359169ad1d8d624cb3f56932be98
   languageName: node
   linkType: hard
 
@@ -8442,13 +7233,6 @@ __metadata:
   version: 6.2.0
   resolution: "dotenv@npm:6.2.0"
   checksum: 2589b4c8e3d9a54eaad276d0a6a3821eb73250b439edd7ba70147dfe4e12148461919817506c7dfae3f1ea72a88cb38bf01b0656fe0c28e8e51df9391ef76e73
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dotenv@npm:7.0.0"
-  checksum: 6d7288f9b30e779928f16662c11a161738ead475852baea973754662ab5daccf89fed3d009fc1e32591b5ee946e805ef182453fdfbf1b87017d8fafe5ede5228
   languageName: node
   linkType: hard
 
@@ -8506,13 +7290,6 @@ __metadata:
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
   checksum: ba74f91398e3ee3b6d665b2f0d13ad6530e89a7e64ec886a6eec0602fb8a5a274652960e21bd5d4b42fdeb9017d873ff872f50342d38779e955285977edb337c
-  languageName: node
-  linkType: hard
-
-"ejs@npm:^2.6.1":
-  version: 2.7.4
-  resolution: "ejs@npm:2.7.4"
-  checksum: f066d9a932fb921bdb6e87133d747d5e3408a1c1303f9a15e5a7a3973afdf444a672c98c2f6d97b9a1a76363bd8ae6d05286f26c6b6b7b9674dfc5802fc8546d
   languageName: node
   linkType: hard
 
@@ -8614,17 +7391,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emphasize@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "emphasize@npm:2.1.0"
-  dependencies:
-    chalk: ^2.4.0
-    highlight.js: ~9.12.0
-    lowlight: ~1.9.0
-  checksum: ad53c071b9424cd5bcca91800bbaea4ce8f1e625a4aea0d4d18887fd497392781095ff288b5474e0cebd1149f3593c321196c509c1b0fe0e3e0a16ef95bbdeff
-  languageName: node
-  linkType: hard
-
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
@@ -8722,7 +7488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.0, es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.0-next.1, es-abstract@npm:^1.17.4, es-abstract@npm:^1.17.5":
+"es-abstract@npm:^1.17.0, es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.0-next.1, es-abstract@npm:^1.17.5":
   version: 1.17.7
   resolution: "es-abstract@npm:1.17.7"
   dependencies:
@@ -8824,13 +7590,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-object-assign@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "es6-object-assign@npm:1.1.0"
-  checksum: 18f01190b46b15a5fd6275dfc37c1c10bb331be4e392362785f63a141aa33edd0d8fbd2d5150c4b0a524aa14b8c4f825a559274cbc765bce59331e015923b4d8
-  languageName: node
-  linkType: hard
-
 "es6-shim@npm:^0.35.5":
   version: 0.35.6
   resolution: "es6-shim@npm:0.35.6"
@@ -8876,7 +7635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^1.11.0, escodegen@npm:^1.14.1":
+"escodegen@npm:^1.14.1":
   version: 1.14.3
   resolution: "escodegen@npm:1.14.3"
   dependencies:
@@ -9164,6 +7923,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "estree-walker@npm:1.0.1"
+  checksum: 85e7cee763e9125a7d8a947b3a06a8b9282873936df220dd0d791d9b3315e45e40ab096b43ba71bdc99140c11a6d23fdcf686642dc119a7b2d6181004fdb24d2
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 378cc9d3be56962c5219c55ad1fde732cb7d55a11cde5acbf5995f39ddd0e98c1095a43c0ef15a520d1d6910e816bd3daff5fc5d7d38baaf8b12d5a2970df57c
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -9178,14 +7951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 1fc12c7bc3b4194c50975827e72d56ff57c32b75a4c7dbf4d5eebf3c8371f6f1aad6799150b609de1b867c0d8a9885c08b6ca5e7e0dc437d6152f3063b2607dd
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.0.0, events@npm:^3.1.0":
+"events@npm:^3.0.0":
   version: 3.2.0
   resolution: "events@npm:3.2.0"
   checksum: 6ea52b160c2dfbe060feb2388d3d6d8b76a58779c2b14d66d96fdfcb255ccecaac11464634af4e5a7ba272b5412de929ead65d24cd203f3ff8ca881d4ba3796b
@@ -9415,23 +8181,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-deep-equal@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "fast-deep-equal@npm:2.0.1"
+  checksum: ad315b79abe335f25271821447bdbbca5d7a6e5930da498fbb2628d28399e958a679adddbb665f5b2943bfd83d9dd375ac5fb45e9004c9516177008ebb7efc16
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 451526766b219503131d11e823eaadd1533080b0be4860e316670b039dcaf31cd1007c2fe036a9b922abba7c040dfad5e942ed79d21f2ff849e50049f36e0fb7
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:3.1.1":
-  version: 3.1.1
-  resolution: "fast-glob@npm:3.1.1"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.0
-    merge2: ^1.3.0
-    micromatch: ^4.0.2
-  checksum: 74bc2df1287f12a1e69127c9ba3599d622c662b617431de1598e1d80f4bd427f553e76e25651d48a6b21615cdd921b4c32f8b1e74590d890e4c8cd6ef912df38
   languageName: node
   linkType: hard
 
@@ -9446,6 +8206,20 @@ __metadata:
     merge2: ^1.2.3
     micromatch: ^3.1.10
   checksum: 9dc5c93807e43257b39fc53aa8ed10ffa253e997dd1d473377a7e9daa4b6c675c730b72f1aa132b80f068c4ece012ff9236a88085fc0229b180fe7c85afcae84
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "fast-glob@npm:3.2.4"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.0
+    merge2: ^1.3.0
+    micromatch: ^4.0.2
+    picomatch: ^2.2.1
+  checksum: 18f9eca898bc3be71b717cb59cb424e937bb9f5629449ba4e93e498dca9db921a9fd3cbdc3389d3f94aec3074bbe2ff6a74f779627a93e81ba0262b795ec44e4
   languageName: node
   linkType: hard
 
@@ -9470,29 +8244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-url-parser@npm:1.1.3":
-  version: 1.1.3
-  resolution: "fast-url-parser@npm:1.1.3"
-  dependencies:
-    punycode: ^1.3.2
-  checksum: 8dbc306b736e32963fe4391a581401c422d826497ce5cacf6e7c60525febfbcea477fbc5b012fe3316f6634a20fa00882168c5ed792ff3ef904c5bc6a11a598d
-  languageName: node
-  linkType: hard
-
-"fastest-levenshtein@npm:^1.0.8":
-  version: 1.0.12
-  resolution: "fastest-levenshtein@npm:1.0.12"
-  checksum: aa3c45b6c9d0993c41fed6d637cb9c3bc03d968bec21b66b85a6a294ab25b613cf71dd501f9a7b35853e61d4f0e407242c8b26033351c77e14161af9e950559b
-  languageName: node
-  linkType: hard
-
-"fastparse@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "fastparse@npm:1.1.2"
-  checksum: a701639184b1507122e04c2863b96630e1d229f755369fd0aaf096db4d4575ccc2db475ef1ec171fe631a2df90ee38070afd520694fa39dd5ca4041a7716917d
-  languageName: node
-  linkType: hard
-
 "fastq@npm:^1.6.0":
   version: 1.9.0
   resolution: "fastq@npm:1.9.0"
@@ -9502,7 +8253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fault@npm:^1.0.0, fault@npm:^1.0.2":
+"fault@npm:^1.0.0":
   version: 1.0.4
   resolution: "fault@npm:1.0.4"
   dependencies:
@@ -9591,13 +8342,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filesize@npm:^3.6.0":
-  version: 3.6.1
-  resolution: "filesize@npm:3.6.1"
-  checksum: 9fb54113c906f0b7aecc05440185dc8b8dac83bd73b839a5298ce02500a487151b3a4735784bfab027fc58776f5281ec4c31e60f59b9173d62f47838dae31783
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^4.0.0":
   version: 4.0.0
   resolution: "fill-range@npm:4.0.0"
@@ -9619,7 +8363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.1.2, finalhandler@npm:~1.1.2":
+"finalhandler@npm:~1.1.2":
   version: 1.1.2
   resolution: "finalhandler@npm:1.1.2"
   dependencies:
@@ -9728,13 +8472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.13.0
-  resolution: "follow-redirects@npm:1.13.0"
-  checksum: f220828d3f153da30ea616fdbe9f6676e74e4e68c51d336a751037c1d556e2de34aa5918f58951fa19bb6517c9c88b4403a0a8bdfc40d3e779d37def2ac0f2c4
-  languageName: node
-  linkType: hard
-
 "for-in@npm:^0.1.3":
   version: 0.1.8
   resolution: "for-in@npm:0.1.8"
@@ -9755,13 +8492,6 @@ __metadata:
   dependencies:
     for-in: ^1.0.1
   checksum: 7b9778a9197ab519e2c94aec35b44efb467d1867c181cea5a28d7a819480ce5ffcae0b4ae63f15d42f16312d72e63c3cdb1acbc407528ea0ba27afb9df4c958a
-  languageName: node
-  linkType: hard
-
-"foreach@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "foreach@npm:2.0.5"
-  checksum: 890d6c3dec185be6b1f7a94003d67d1b36a068fd7ac5a89f92818c3459d7d43e040a0b228a632e2e50d8a5aa804da6a5d27258ccbc1b7b724fe39eea3834f240
   languageName: node
   linkType: hard
 
@@ -9878,7 +8608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^9.0.0":
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1":
   version: 9.0.1
   resolution: "fs-extra@npm:9.0.1"
   dependencies:
@@ -10054,13 +8784,6 @@ fsevents@^1.2.7:
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: a5b8beaf68d8bcdb507e23b3d2b6458e54b9061e84e2a8a94b846c8e1d794beb47fdcbda895da16ae59225bb3ea1608c0719e4f986e8a987ec2f228eaf00d78b
-  languageName: node
-  linkType: hard
-
-"get-port@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "get-port@npm:4.2.0"
-  checksum: a87cf447bbcf04507a3a2ddf5d8369b2addad34a41fcaf165811383065c407cccfcfd820773ef9640967d007a39288a850f5023bb0158facf29d72896447002d
   languageName: node
   linkType: hard
 
@@ -10325,19 +9048,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"hard-rejection@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "hard-rejection@npm:2.1.0"
+  checksum: 27bc09d185ca8131356f0f3391ae5965c5ed8ec9eddf697d604e33c76eb995831e60ac636e5e5839587d0499f29719171c19d0af5fa12e9e7f7c0a1689e22b6f
+  languageName: node
+  linkType: hard
+
 "has-ansi@npm:^2.0.0":
   version: 2.0.0
   resolution: "has-ansi@npm:2.0.0"
   dependencies:
     ansi-regex: ^2.0.0
   checksum: c6805f5d01ced45ba247ff2b8c914f401e70aa9086552d8eafbdf6bc0b0e38ea4a3bf1a387d100ff5f07e5854bca96532a01777820a16be2cdf8cf6582091bad
-  languageName: node
-  linkType: hard
-
-"has-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-flag@npm:1.0.0"
-  checksum: 556423170e15c694061a69052773114159c18ddf4ca0c72912591343f9568878c0ab29c16ab901f3466eaca25faf5ca4b1c6831b6795a3a3cd5d1606bdc6fa1f
   languageName: node
   linkType: hard
 
@@ -10417,7 +9140,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"has@npm:^1.0.0, has@npm:^1.0.3":
+"has@npm:^1.0.3":
   version: 1.0.3
   resolution: "has@npm:1.0.3"
   dependencies:
@@ -10476,24 +9199,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"hex-color-regex@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "hex-color-regex@npm:1.1.0"
-  checksum: 89899f5f74cdef884e352fe8791018f2f112c338b97f3b486f7d5f4760a9c58181f688eb147937f9f2dd69c976a7296b53d1509c9a0871903eeb26a8382e486c
-  languageName: node
-  linkType: hard
-
 "highlight.js@npm:^10.1.1, highlight.js@npm:~10.3.0":
   version: 10.3.2
   resolution: "highlight.js@npm:10.3.2"
   checksum: 8dab959070ff2e20190cbe7ea9bc03ce0163f0a6a09d88cfec8f7e21ca12111c0553515b4c5b273748da531fb26de8f34a361f6f0f03c1348175d2424e265599
-  languageName: node
-  linkType: hard
-
-"highlight.js@npm:~9.12.0":
-  version: 9.12.0
-  resolution: "highlight.js@npm:9.12.0"
-  checksum: cce35377b95ed153c66bd617ea72cb3e6b5ed91c2ae1d5a9791a39258140afaf79538541e186192b650cdacc03eb91ebc6c023208d550e5d6ed4e056c6d7b01c
   languageName: node
   linkType: hard
 
@@ -10521,36 +9230,6 @@ fsevents@^1.2.7:
   version: 2.8.8
   resolution: "hosted-git-info@npm:2.8.8"
   checksum: 3ecc389dc6ecbd5463fada7e04461e96f3c817fe2f989ca41e9dd3b503745a0bfa26fba405861b2831ca64edc1abc5d2fbc97ee977303f89650dac4fbfdc2d7a
-  languageName: node
-  linkType: hard
-
-"hsl-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "hsl-regex@npm:1.0.0"
-  checksum: b04a50c6c75fc4035e9e212a2c581dcae64289f0ad45bb010a32dd3899c9a5ac95c4d23507a89027aa7950a8a9241de0e6ad66bc87535f261c0eef4817222a1f
-  languageName: node
-  linkType: hard
-
-"hsla-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "hsla-regex@npm:1.0.0"
-  checksum: 2460f935b556795a7cadc17978bc4cd90f74aaba05505f7040e7809336c68e757dcdcc2121004a4d926a6f04295cf68a575a81c0fd2d4e7280dc201a98eb2859
-  languageName: node
-  linkType: hard
-
-"html-comment-regex@npm:^1.1.0":
-  version: 1.1.2
-  resolution: "html-comment-regex@npm:1.1.2"
-  checksum: f3bf135002dc424aa5e59aa5f7697b4538898ce8af2375a42c4fcb53dbde3d430ec406b9ea59853b6fef7ca6f8de2939f12b285045850a70a757628bd5483cbf
-  languageName: node
-  linkType: hard
-
-"html-encoding-sniffer@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "html-encoding-sniffer@npm:1.0.2"
-  dependencies:
-    whatwg-encoding: ^1.0.1
-  checksum: fff1462d9845f08315b41a19b3deaeebf465b4abc44c12218ee2be42a4655dec18b8ca4ae2ea72270d564164a3092b9a72701c1c529777e378036a49c4f6bc80
   languageName: node
   linkType: hard
 
@@ -10594,13 +9273,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"html-tags@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "html-tags@npm:1.2.0"
-  checksum: 7b61316022db1540d1bdf80d2b3e882318789d7c39fcca3ace40755314540f37ea2f5be5ad0277c6dd409b1c23c766343aac4947bcc15729ba9bebec074fa8f8
-  languageName: node
-  linkType: hard
-
 "html-webpack-plugin@npm:^4.2.1":
   version: 4.5.0
   resolution: "html-webpack-plugin@npm:4.5.0"
@@ -10620,23 +9292,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"htmlnano@npm:^0.2.2":
-  version: 0.2.7
-  resolution: "htmlnano@npm:0.2.7"
-  dependencies:
-    cssnano: ^4.1.10
-    posthtml: ^0.13.4
-    posthtml-render: ^1.2.2
-    purgecss: ^2.3.0
-    relateurl: ^0.2.7
-    svgo: ^1.3.2
-    terser: ^4.8.0
-    uncss: ^0.17.3
-  checksum: f245f1e2bc1c5b030868746c1cf1e1fc4bd7ac176925416570f206428c78bd9f44041c1ed9195fffda927218479b5cfe465e581a37397896eeb5b97c444784e7
-  languageName: node
-  linkType: hard
-
-"htmlparser2@npm:^3.3.0, htmlparser2@npm:^3.9.2":
+"htmlparser2@npm:^3.3.0":
   version: 3.10.1
   resolution: "htmlparser2@npm:3.10.1"
   dependencies:
@@ -10647,18 +9303,6 @@ fsevents@^1.2.7:
     inherits: ^2.0.1
     readable-stream: ^3.1.1
   checksum: 94fa6312e6c378b1c0f1626d3f468f0b25c5dcf6689bfa61fa0002c044c4c77842b5122feb84b501b02539165917febba0ffe754046996c9e8ed77c1bb65e66c
-  languageName: node
-  linkType: hard
-
-"htmlparser2@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "htmlparser2@npm:5.0.1"
-  dependencies:
-    domelementtype: ^2.0.1
-    domhandler: ^3.3.0
-    domutils: ^2.4.2
-    entities: ^2.0.0
-  checksum: c3564b7d26b5e894ee9aae9132ddf23ce79c4d31881b75aef14224b5d89c2e17dc638fa77c0a576e0fcc4c73cc608890bc63b4452f79d7960d2b4af836247fc0
   languageName: node
   linkType: hard
 
@@ -10685,30 +9329,6 @@ fsevents@^1.2.7:
     statuses: ">= 1.5.0 < 2"
     toidentifier: 1.0.0
   checksum: 563ae4a3f19c89029212922bade6ffcd0e4b7fa52e539f08c8f6941de7eaccb00bf76cb7692662192f2f0d567d4ac1f9d6a3d0ee70b166c8540cf791497f90ea
-  languageName: node
-  linkType: hard
-
-"http-proxy-middleware@npm:^1.0.0":
-  version: 1.0.6
-  resolution: "http-proxy-middleware@npm:1.0.6"
-  dependencies:
-    "@types/http-proxy": ^1.17.4
-    http-proxy: ^1.18.1
-    is-glob: ^4.0.1
-    lodash: ^4.17.20
-    micromatch: ^4.0.2
-  checksum: 46385b03f1a2c5895e6ed054ebb966ac6e8929405bbe8690db78dce460ec19f4cd892fcb12f99f869a047ef888409d0fe7db703d936d853c2c22ea17dddba27b
-  languageName: node
-  linkType: hard
-
-"http-proxy@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "http-proxy@npm:1.18.1"
-  dependencies:
-    eventemitter3: ^4.0.0
-    follow-redirects: ^1.0.0
-    requires-port: ^1.0.0
-  checksum: fc2062718d77868eff0d2707652d7e0d302a0f85d90f317daa410df5c41fbe009589c80bc73cc72a44368bb37d071c8f52aaa5b3ce82a08f3524a79ddf178b9b
   languageName: node
   linkType: hard
 
@@ -10767,13 +9387,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"icss-replace-symbols@npm:1.1.0, icss-replace-symbols@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "icss-replace-symbols@npm:1.1.0"
-  checksum: 6529ec8274f670e4ed5ded7d48f3f6d6f1576078353f3a363e6183f0be95166c74b4e2a93e1557d1852c59d0ce573ad5e91329e65a8fe94ab88fbb12a02f0ea9
-  languageName: node
-  linkType: hard
-
 "icss-utils@npm:^4.0.0, icss-utils@npm:^4.1.1":
   version: 4.1.1
   resolution: "icss-utils@npm:4.1.1"
@@ -10797,10 +9410,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"iferr@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "iferr@npm:1.0.2"
-  checksum: 6f7764128db7e68a762565d3ddab3f00e2467df5c61f7b7ee0f7bb93c26dac862fece2757773b6a6c2d0f1d12b62cb19630e4becfaca9a5120933be6b3feaabb
+"ignore-walk@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "ignore-walk@npm:3.0.3"
+  dependencies:
+    minimatch: ^3.0.4
+  checksum: 08394ce8c47dc086d44ef65a1e1d30352ff3d6605bdec90f59e985b710cc660aafa7975cb30312891d21d826d10b3a8b3210c5d68251678e2dcd366362865170
   languageName: node
   linkType: hard
 
@@ -11045,20 +9660,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-absolute-url@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-absolute-url@npm:2.1.0"
-  checksum: f9d193d86b5a255de08eb22653026e09952b5b1335c1c1c9c171237cb056c54d8c12ef45a069ac34270b7e960e46c89bc43f52d911317a2aaaab6d315c0da0e0
-  languageName: node
-  linkType: hard
-
-"is-absolute-url@npm:^3.0.1":
-  version: 3.0.3
-  resolution: "is-absolute-url@npm:3.0.3"
-  checksum: 1beac700465defee2bfa881cafcf144f3365cf0f748d62880e4a726c1de525ac39e8203bed14032f10509916dd392908e24d50ce1c1a444b44655a74708f9556
-  languageName: node
-  linkType: hard
-
 "is-accessor-descriptor@npm:^0.1.6":
   version: 0.1.6
   resolution: "is-accessor-descriptor@npm:0.1.6"
@@ -11108,13 +9709,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 0687b6b8f2443a45116ce25d8b11979591af625bd8a7515f5d8de2fcb80979655bc9d1cbbd2146c34f2728a234d1ea81d397e06f1ae3feb02c8f6df16766a4a0
-  languageName: node
-  linkType: hard
-
 "is-binary-path@npm:^1.0.0":
   version: 1.0.1
   resolution: "is-binary-path@npm:1.0.1"
@@ -11155,20 +9749,6 @@ fsevents@^1.2.7:
   bin:
     is-ci: bin.js
   checksum: 09083018edafd63221ff0506356f13c0aaf4b75a6435ea648bc67d07ddab199b2d5b9297de43d0821df1a14c18cd9f1edd1775a0166abfe37390843e79137213
-  languageName: node
-  linkType: hard
-
-"is-color-stop@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "is-color-stop@npm:1.1.0"
-  dependencies:
-    css-color-names: ^0.0.4
-    hex-color-regex: ^1.1.0
-    hsl-regex: ^1.0.0
-    hsla-regex: ^1.0.0
-    rgb-regex: ^1.0.1
-    rgba-regex: ^1.0.0
-  checksum: 0e3d46b1e1669891fe38f019188c6edc8b6239ba21b391c2f25bd1887975f11fed0764771adb550e30c7726f737547953c9260b411c9813e573b8b9434e760c4
   languageName: node
   linkType: hard
 
@@ -11251,6 +9831,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-dotfile@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "is-dotfile@npm:1.0.3"
+  checksum: 82be54d6d57710d393c2275a63f4c60b33bfe5e21080899073b4ef315f13c9017891aed3477c2c1ecfc43b2a1c2180151fad8fab02aba930473e88b00393501f
+  languageName: node
+  linkType: hard
+
 "is-extendable@npm:^0.1.0, is-extendable@npm:^0.1.1":
   version: 0.1.1
   resolution: "is-extendable@npm:0.1.1"
@@ -11318,13 +9905,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-generator-function@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "is-generator-function@npm:1.0.7"
-  checksum: 6842c326097d94397bee53544b8d903dabf57a771e2bc36c1f4021106192b601b563372a1d34e921b10871740233a5f62d5d15adb3caf87665ab5932ccb8a83c
-  languageName: node
-  linkType: hard
-
 "is-glob@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-glob@npm:2.0.1"
@@ -11359,22 +9939,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-html@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-html@npm:1.1.0"
-  dependencies:
-    html-tags: ^1.0.0
-  checksum: 16c618ccc5ca268efb0da5f21fc06574ea32d990f15bb4c9dba7e6124d780b5820c6b99f256b6c7e9eb980142af3cecb661db0ac6033349ebe154d67e54e136e
-  languageName: node
-  linkType: hard
-
-"is-interactive@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-interactive@npm:1.0.0"
-  checksum: d79b435e5134ccd60dfe035117b1cddd5c5100e90b2d33428adfe1667e26f0114cc1bc7b3ff84a1b107de8ef27f155e3ecc3bb08c0e502a15c66300b4a45d9e5
-  languageName: node
-  linkType: hard
-
 "is-map@npm:^2.0.1":
   version: 2.0.1
   resolution: "is-map@npm:2.0.1"
@@ -11382,12 +9946,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-nan@npm:^1.2.1":
-  version: 1.3.0
-  resolution: "is-nan@npm:1.3.0"
-  dependencies:
-    define-properties: ^1.1.3
-  checksum: ab2520c43596daaa38185b02736a51d22a9c0fff4a640d67b9a8f083d4ad990adc249a48508fca5373b9471ad5c09f98aa392a54f28f11a5c8ad805eb5d825ae
+"is-module@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-module@npm:1.0.0"
+  checksum: 2cbd41e2760874130b76aee84cc53120c4feef0d0f196fa665326857b444c8549909cc840f3f3a59652a7e8df46146a77f6c0f3f70a578704e03670975843e74
   languageName: node
   linkType: hard
 
@@ -11421,17 +9983,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-obj@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-obj@npm:2.0.0"
-  checksum: ffa67ed5df66e37757876cd976380737a0430551789a0457b8c031eaedef8f5c6bc4ab6d903e529efb777545f8718ab73d9badde61c8b08720a3747ccff0b2a0
-  languageName: node
-  linkType: hard
-
 "is-path-inside@npm:^3.0.2":
   version: 3.0.2
   resolution: "is-path-inside@npm:3.0.2"
   checksum: 709ba85a713d25fb058a4c2f62e9e7160bcc1a3e48af2f201045cde027fc1efe61a6e1b5c1cf21b8329f764e3649e160976fde14317c1b848caa9c1f31d5beec
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "is-plain-obj@npm:1.1.0"
+  checksum: d2eb5a32eacd7c79f3b2fe20552d091805a5ae88a7ca2aa71226bf822e4d690ef046ed2beb795f32666a401dfbf9a25ee3d4acde5426f963d55474468708ad22
   languageName: node
   linkType: hard
 
@@ -11451,6 +10013,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-reference@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-reference@npm:1.2.1"
+  dependencies:
+    "@types/estree": "*"
+  checksum: 9daa3d7c4dc159e326be68c025a43bf714b36a6d065c2cc6907f7c44d010867dd10ec7f74bff37cb5d2000ac8b03c94cde3d69c85dc9a56a887ce576200ad01f
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-regex@npm:1.1.1"
@@ -11464,13 +10035,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "is-regexp@npm:1.0.0"
   checksum: b6c3ea4f405d31e20c9612f0480b5deb86d71477f3e08c78a889a8b7b4c9f9e9944b2621b997bede7b94b6f8607dc8333b521b6b69a2f8ad97c80d9eb47d04a9
-  languageName: node
-  linkType: hard
-
-"is-resolvable@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "is-resolvable@npm:1.1.0"
-  checksum: ef1a289c54e1115f668cd4fbfd6dc53d6bfa02c2c12e812a578aefbe795b72339cde37e9ee5709d15a21009cadadba2c61cf810f2dd1da29e3c651776c98dda8
   languageName: node
   linkType: hard
 
@@ -11509,15 +10073,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-svg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-svg@npm:3.0.0"
-  dependencies:
-    html-comment-regex: ^1.1.0
-  checksum: 7dd3f5f18dc7816dcf370b937c3d12f3a74e6aab886032e34d187af7627acaa1c1b0230be6af83dbe02b0f10d97a2d392b12c9be7627fc11a1c588851953c46e
-  languageName: node
-  linkType: hard
-
 "is-symbol@npm:^1.0.2, is-symbol@npm:^1.0.3":
   version: 1.0.3
   resolution: "is-symbol@npm:1.0.3"
@@ -11527,29 +10082,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "is-typed-array@npm:1.1.3"
-  dependencies:
-    available-typed-arrays: ^1.0.0
-    es-abstract: ^1.17.4
-    foreach: ^2.0.5
-    has-symbols: ^1.0.1
-  checksum: 9e4d525e831fd4f577ea1a74e103508d4ef1a138ffcd2f2ed7335eb513bde315b5e1ee6f82556e8414c14b414ecc1f6fd306129dd3a74370fc7209b8e26b75a4
-  languageName: node
-  linkType: hard
-
 "is-typedarray@npm:^1.0.0, is-typedarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 4e21156e7360a5916eded35c5938adf6278299a8055640864eebb251e4351cd605beccddf9af27477e19f753d453412fe0c21379bb54b55cfdf5add263076959
-  languageName: node
-  linkType: hard
-
-"is-url@npm:^1.2.2":
-  version: 1.2.4
-  resolution: "is-url@npm:1.2.4"
-  checksum: 76d309e9fafdb3117c110ae2911e23f0fb6bf595f5d2c3470def80480e86903e95d84dbdf050f1f9cc746a47e7ea3b24c7096758c724224c5b67211783852e53
   languageName: node
   linkType: hard
 
@@ -11587,13 +10123,6 @@ fsevents@^1.2.7:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: cfb3e907b3c7957fb18e479bbe9102df4e84c5386839b4a33076f38ee31a8934e77d43ff517967fd39192a7c06b894770454886a5ffc8a3ddc36f6b746d70726
-  languageName: node
-  linkType: hard
-
-"isbinaryfile@npm:^4.0.2":
-  version: 4.0.6
-  resolution: "isbinaryfile@npm:4.0.6"
-  checksum: 23d94f36fbf9898c7095d29aa1e4f4b1afad77fac6e1e987f32e89036fa45d7365f3a55990de7d99b76ca591b683640efa594f1fa19b03e3d712c4f2a690efa0
   languageName: node
   linkType: hard
 
@@ -12168,7 +10697,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^26.2.1, jest-worker@npm:^26.6.2":
+"jest-worker@npm:^26.2.1, jest-worker@npm:^26.3.0, jest-worker@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
   dependencies:
@@ -12222,40 +10751,6 @@ fsevents@^1.2.7:
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
   checksum: b530d48a64e6aff9523407856a54c5b9beee30f34a410612057f4fa097d90072fc8403c49604dacf0c3e7620dca43c2b7f0de3f954af611e43716a254c46f6f5
-  languageName: node
-  linkType: hard
-
-"jsdom@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "jsdom@npm:14.1.0"
-  dependencies:
-    abab: ^2.0.0
-    acorn: ^6.0.4
-    acorn-globals: ^4.3.0
-    array-equal: ^1.0.0
-    cssom: ^0.3.4
-    cssstyle: ^1.1.1
-    data-urls: ^1.1.0
-    domexception: ^1.0.1
-    escodegen: ^1.11.0
-    html-encoding-sniffer: ^1.0.2
-    nwsapi: ^2.1.3
-    parse5: 5.1.0
-    pn: ^1.1.0
-    request: ^2.88.0
-    request-promise-native: ^1.0.5
-    saxes: ^3.1.9
-    symbol-tree: ^3.2.2
-    tough-cookie: ^2.5.0
-    w3c-hr-time: ^1.0.1
-    w3c-xmlserializer: ^1.1.2
-    webidl-conversions: ^4.0.2
-    whatwg-encoding: ^1.0.5
-    whatwg-mimetype: ^2.3.0
-    whatwg-url: ^7.0.0
-    ws: ^6.1.2
-    xml-name-validator: ^3.0.0
-  checksum: 1a0948d5302dd079feab5caf9ea7d38f455c6d5238a3f3a0de88f386e2723a089875c0ede155ff284425fba5e9f848d1bf980f7546421efce702283586f84b52
   languageName: node
   linkType: hard
 
@@ -12344,13 +10839,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json-source-map@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "json-source-map@npm:0.6.1"
-  checksum: 664179fd574faafae523482613d21aa38d7e87e7f49c723f0efaa94c85b046874efd76c5a799187d6558a28b25a2c5c695b1700b544a79d5a87db3ad3a302c35
-  languageName: node
-  linkType: hard
-
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -12365,7 +10853,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json5@npm:2.x, json5@npm:^2.1.0, json5@npm:^2.1.1, json5@npm:^2.1.2":
+"json5@npm:2.x, json5@npm:^2.1.1, json5@npm:^2.1.2":
   version: 2.1.3
   resolution: "json5@npm:2.1.3"
   dependencies:
@@ -12475,7 +10963,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2":
+"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 5de5d6577796af87a983199d6350ed41c670abec4a306cc43ca887c1afdbd6b89af9ab00016e3ca17eb7ad89ebfd9bb817d33baa89f855c6c95398a8b8abbf08
@@ -12570,45 +11058,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"line-column@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "line-column@npm:1.0.2"
-  dependencies:
-    isarray: ^1.0.0
-    isobject: ^2.0.0
-  checksum: e6fa785b0c75c4485d0f181beaeb2f0b482ebf16921b64d5b61e75e86a61504b42053655d481b1c8de5c4d8b551473c034eb48780c65d76be377e643d395f6e5
-  languageName: node
-  linkType: hard
-
 "lines-and-columns@npm:^1.1.6":
   version: 1.1.6
   resolution: "lines-and-columns@npm:1.1.6"
   checksum: 798b80ed7ae3fba34d43fe29591ccb4f16f6fca1da4e1f9922b92264b91d931012433c248daf8e44caa74feb40c0eaa0f27a14f8ee68b6ffb425f3c3f785af27
-  languageName: node
-  linkType: hard
-
-"lint-staged@npm:^10.0.8":
-  version: 10.5.1
-  resolution: "lint-staged@npm:10.5.1"
-  dependencies:
-    chalk: ^4.1.0
-    cli-truncate: ^2.1.0
-    commander: ^6.2.0
-    cosmiconfig: ^7.0.0
-    debug: ^4.2.0
-    dedent: ^0.7.0
-    enquirer: ^2.3.6
-    execa: ^4.1.0
-    listr2: ^3.2.2
-    log-symbols: ^4.0.0
-    micromatch: ^4.0.2
-    normalize-path: ^3.0.0
-    please-upgrade-node: ^3.2.0
-    string-argv: 0.3.1
-    stringify-object: ^3.3.0
-  bin:
-    lint-staged: bin/lint-staged.js
-  checksum: d22748dde5117c1d63e6829a73cf5755b4b99b5c93adaf53d1842941bf8b415d18577fe58291c4e44d40446e05400fe7cafe88727bcd61ef2837840406b89496
   languageName: node
   linkType: hard
 
@@ -12743,14 +11196,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.clone@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.clone@npm:4.5.0"
-  checksum: c506ed9675f21cccf0107068c411fa1deffe3756b1ffd91f00093268ddf494fd9b442bd28114844d33374da959986de3c97f3c125ff636510e1bad694bbf73be
-  languageName: node
-  linkType: hard
-
-"lodash.memoize@npm:4.x, lodash.memoize@npm:^4.1.2":
+"lodash.memoize@npm:4.x":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: 080c1095b7795b293a06078737550dc0c8138192cadbafb4e4b1303357d367ac589a1a570fad8de154175b008ca7b2b48d6a7f1755a143e13b764e20a7104080
@@ -12771,13 +11217,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.uniq@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.uniq@npm:4.5.0"
-  checksum: 47cb25b59bf40ef3bdf441b7b6cb41d0b95ae0ca576be2c206724dd66041fa8aadab55c1210792671aa0b1c9878d5c0be48927bf4d22f3ed50e5f79d3b2e90b7
-  languageName: node
-  linkType: hard
-
 "lodash@npm:^4.0.1, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20":
   version: 4.17.20
   resolution: "lodash@npm:4.17.20"
@@ -12791,15 +11230,6 @@ fsevents@^1.2.7:
   dependencies:
     chalk: ^2.0.1
   checksum: e2dfd255f3e3080134055597fb67bd67798d65383488683ed90f0376f7264dd21028f30d4c3a0686251dcfc4dc71172e8061cef21e89c6deabb8b375450d5166
-  languageName: node
-  linkType: hard
-
-"log-symbols@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "log-symbols@npm:3.0.0"
-  dependencies:
-    chalk: ^2.4.2
-  checksum: bfa7cceaea16d7e378b4f6a16e22c5c78bc4250350a84d653766927bdf27e5b94015f616e193bc275e80d13f882867ddf224a3c6c152e24289ed5e58d84d306e
   languageName: node
   linkType: hard
 
@@ -12864,16 +11294,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lowlight@npm:~1.9.0":
-  version: 1.9.2
-  resolution: "lowlight@npm:1.9.2"
-  dependencies:
-    fault: ^1.0.2
-    highlight.js: ~9.12.0
-  checksum: 2d4a78e977ff197ac55f8186c58dd5f23ccd30b88672a01c3fbb65c2d083134b701c4f4710b20b209329045fa33f36150e6d21fce3cca2e07ff9fb22bbaf9d49
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^4.0.0":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -12908,6 +11328,15 @@ fsevents@^1.2.7:
   bin:
     lz-string: bin/bin.js
   checksum: 60a13f8a724d109cffc7dda4cb98569adfa0516750f8a75b7236f6bc94b47edffb59e8a1e501364404e3867cf399e6612c3981f9c81c2de75751203431bf2e69
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.25.7":
+  version: 0.25.7
+  resolution: "magic-string@npm:0.25.7"
+  dependencies:
+    sourcemap-codec: ^1.4.4
+  checksum: 4b70c13eb21c6f1c54bf7fb029748dc44d6bfcd3c59e5deeda060eecc38df6144b91d10fb7a3cf6156fadab1a68f83d69a189df20ca5f6bd088bf0196ea8f039
   languageName: node
   linkType: hard
 
@@ -12950,6 +11379,20 @@ fsevents@^1.2.7:
   version: 0.2.2
   resolution: "map-cache@npm:0.2.2"
   checksum: 3d205d20e0135a5b5f3e2b85e7bfa289cc2fc3c748fe802795e74c6fe157e5f2bed3b7c3a270b82fe36a02123880cb2e0dc525e1ae37ac7e673ce3e75a2e2c56
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "map-obj@npm:1.0.1"
+  checksum: e68b20e4fa76efdbba9a7af05b879eb7a6c5ccb7a9d813796de825da4c182fc3dab66f4b2a32a9aefae83db152a0172deb1e19a9c2322c6d412b8f9f81ca51a4
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "map-obj@npm:4.1.0"
+  checksum: 91827cab5aa21840605cb5e77c8cabd3089251f95f939419a7208c29fb6b1032006d8b2ad9d407c91b6e0a9e282105c1811eabd750df87f8b55ae758f87c2063
   languageName: node
   linkType: hard
 
@@ -13049,6 +11492,25 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"meow@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "meow@npm:7.1.1"
+  dependencies:
+    "@types/minimist": ^1.2.0
+    camelcase-keys: ^6.2.2
+    decamelize-keys: ^1.1.0
+    hard-rejection: ^2.1.0
+    minimist-options: 4.1.0
+    normalize-package-data: ^2.5.0
+    read-pkg-up: ^7.0.1
+    redent: ^3.0.0
+    trim-newlines: ^3.0.0
+    type-fest: ^0.13.1
+    yargs-parser: ^18.1.3
+  checksum: de6d2f15332a18da5e13bb3f935f9718cf7ae697d121009adee7a3410bfc63f6b7896476bb0e1ef101faacea4d4a4dc95108e3c9eab0e336b990a115646b72e8
+  languageName: node
+  linkType: hard
+
 "merge-deep@npm:^3.0.2":
   version: 3.0.2
   resolution: "merge-deep@npm:3.0.2"
@@ -13095,7 +11557,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^3.0.4, micromatch@npm:^3.1.10, micromatch@npm:^3.1.4":
+"micromatch@npm:^3.1.10, micromatch@npm:^3.1.4":
   version: 3.1.10
   resolution: "micromatch@npm:3.1.10"
   dependencies:
@@ -13142,22 +11604,6 @@ fsevents@^1.2.7:
   version: 1.44.0
   resolution: "mime-db@npm:1.44.0"
   checksum: b4e3b2141418572fba9786f7e36324faef15e23032ad0871f56760cb304ee721ba4c8cc795d3c1cac69a2a8b94045c1d6b08c4a8d1ef6ba1226a3a5193915c57
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:~1.33.0":
-  version: 1.33.0
-  resolution: "mime-db@npm:1.33.0"
-  checksum: f33acedd5b2bfd57fe987aa01c209abd3c6f762c6746c2a1ffefa77f8c10d39a2af9a591bd44f39f8d42a5ee30e43407cfd8535392773f211c2c7d7b6def90d4
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:2.1.18":
-  version: 2.1.18
-  resolution: "mime-types@npm:2.1.18"
-  dependencies:
-    mime-db: ~1.33.0
-  checksum: f1e2fed4f9d04a0d158c48b42f8ac5f1a655b27399674f7bd9f16e6784221ec4c2d30b20f24174f741ee6aa2556170f63b3ec9f51cb4e99e0a04c56799c8317c
   languageName: node
   linkType: hard
 
@@ -13231,6 +11677,17 @@ fsevents@^1.2.7:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: 47eab9263962cacd5733e274ecad2d8e54b0f8e124ba35ae69189e296058f634a4967b87a98954f86fa5c830ff177caf827ce0136d28717ed3232951fb4fae62
+  languageName: node
+  linkType: hard
+
+"minimist-options@npm:4.1.0":
+  version: 4.1.0
+  resolution: "minimist-options@npm:4.1.0"
+  dependencies:
+    arrify: ^1.0.1
+    is-plain-obj: ^1.1.0
+    kind-of: ^6.0.3
+  checksum: 51f1aba56f9c2c2986d85c98a29abec26c632019abd2966a151029cf2cf0903d81894781460e0d5755d4f899bb3884bc86fc9af36ab31469a38d82cf74f4f651
   languageName: node
   linkType: hard
 
@@ -13409,6 +11866,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"ms@npm:^2.1.2":
+  version: 2.1.3
+  resolution: "ms@npm:2.1.3"
+  checksum: 6e721e648a544154d5de4c114b32f573d8027ca8ec505cf6c1105e505986d6ac46934a1256735aa0eece8eb2f5b2a1230503b2dddd3b100f9f016fd8a4f15f33
+  languageName: node
+  linkType: hard
+
 "multimatch@npm:^4.0.0":
   version: 4.0.0
   resolution: "multimatch@npm:4.0.0"
@@ -13435,15 +11899,6 @@ fsevents@^1.2.7:
   dependencies:
     node-gyp: latest
   checksum: 36349b2e5df4182aa0d0cc43fcd6cc782ca560a83c2764743d80c14ba5028d0c54041a2f464b8d4cb18a884e04415034a0a764c745e1d5502ea34a5cb6470a39
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.1.12":
-  version: 3.1.16
-  resolution: "nanoid@npm:3.1.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 1903aa0a7602e881ef7015d4c8ccf8a2a92b45b1bd6c4bb9c1dd2119f41ebe08a44c9195ecf4c1fbaef147bd4d050e41adbcb747ec96d7d14c1f662e3ac52790
   languageName: node
   linkType: hard
 
@@ -13479,15 +11934,6 @@ fsevents@^1.2.7:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 2daf93d9bb516eddb06e2e80657a605af2e494d47c65d090ba43691aaffbc41f520840f1c9d3b7b641977af950217a4ab6ffb85bafcd5dfa8ba6fe4e68c43b53
-  languageName: node
-  linkType: hard
-
-"ncp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ncp@npm:2.0.0"
-  bin:
-    ncp: ./bin/ncp
-  checksum: a751e4c94bc810b34b81c8cad288b90ac59fa83890e701483fd70f800d3c2228bea9eff84d1c034074cd1b393cec40696c04558a70b17476eba7acb06e20e71c
   languageName: node
   linkType: hard
 
@@ -13543,15 +11989,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "node-addon-api@npm:3.0.2"
-  dependencies:
-    node-gyp: latest
-  checksum: 7f401e4ad9ed75cea9ba8590da8048b37e99531e8d8b46b941e6c951ca1cf8e0db29f31ddf25d3e87c13cb6653c06e0db72c05ef50eff9db3529cd929ae69747
-  languageName: node
-  linkType: hard
-
 "node-dir@npm:^0.1.10":
   version: 0.1.17
   resolution: "node-dir@npm:0.1.17"
@@ -13565,24 +12002,6 @@ fsevents@^1.2.7:
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: cbb171635e538162b977eac5dfe7a1e07a9a02e991924377a6435502291e2f823d306b95aabc455caebf4a118ccf836868462bc70ccc3095af02bb9da61fda37
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "node-forge@npm:0.10.0"
-  checksum: c7a729933a0391e4f434d4455705e869340bf91c3cc6b51b3844a91a5ac9db6f8697f600ab1e62e25f990382b2c1592d93d31fd831bb1a0b1e66ce28d9d6d124
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.2.1, node-gyp-build@npm:^4.2.2":
-  version: 4.2.3
-  resolution: "node-gyp-build@npm:4.2.3"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 8512c25498b1605dbe9d2605cac7f8996d18c35097b3079b232674b0f3b8f1559be6f531ec3a00a94f90a0a69ccc452edb62f8f6dfff8caa3abe4b729cc21b06
   languageName: node
   linkType: hard
 
@@ -13718,10 +12137,33 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^3.0.0":
-  version: 3.3.0
-  resolution: "normalize-url@npm:3.3.0"
-  checksum: 5704115f74833cf157a5f104477d9c8e8b4e2c00275624159bcd3c65dbdac93db4f6f008f91364d0f20f93655bd2b643afa9e8875c67b4ab8673cd1dd0fb7a5c
+"npm-bundled@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "npm-bundled@npm:1.1.1"
+  dependencies:
+    npm-normalize-package-bin: ^1.0.1
+  checksum: f51ddba86970fc568a40449f51348de535ac71d93a2ce31195e978d0189899a0da696b3e51a5eb6e77a88890482ac873767c58c81763dda3dab410c9c1e99ca5
+  languageName: node
+  linkType: hard
+
+"npm-normalize-package-bin@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "npm-normalize-package-bin@npm:1.0.1"
+  checksum: 495fae761551a765064f6937ed578a1d749c110355b63f5bbf6df9f0237862639de184a5c13fb9982d2a7745b2bd983e427bf16893ad98f20e53a32ad0254fc9
+  languageName: node
+  linkType: hard
+
+"npm-packlist@npm:^2.1.2":
+  version: 2.1.4
+  resolution: "npm-packlist@npm:2.1.4"
+  dependencies:
+    glob: ^7.1.6
+    ignore-walk: ^3.0.3
+    npm-bundled: ^1.1.1
+    npm-normalize-package-bin: ^1.0.1
+  bin:
+    npm-packlist: bin/index.js
+  checksum: af6335c94cefe599d710e8dbc5295b854e2b50659f68ef775a918f47d7a94212f3483d31cf68556bd3daf1390aab2514ad39e1a35354b3b0f8fc3b44a51bdee7
   languageName: node
   linkType: hard
 
@@ -13782,13 +12224,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nullthrows@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "nullthrows@npm:1.1.1"
-  checksum: 47afb80d9784485fe69facb16207a9b3de09258f5c86d4c21680abb3708eb4d3e8b04c2df288938eb7e1a82be0b73b00b991ca3c20ccb8c00a12a5cdc3a08fb5
-  languageName: node
-  linkType: hard
-
 "num2fraction@npm:^1.2.2":
   version: 1.2.2
   resolution: "num2fraction@npm:1.2.2"
@@ -13803,7 +12238,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.1.3, nwsapi@npm:^2.2.0":
+"nwsapi@npm:^2.2.0":
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
   checksum: fb0f05113a829296f964688503d991b136d02d153769288d12226a4d52e17b50c073eceeee0ff1e8377ca8e86c244e1f9b849c9eed7fca97a03aa8a59f074c06
@@ -13839,16 +12274,6 @@ fsevents@^1.2.7:
   version: 1.8.0
   resolution: "object-inspect@npm:1.8.0"
   checksum: 4da23a188b3811d75fcd6e7916471465f94e4752159e064f9621040945d375dca1afa092a000a398267d81b4f40bf33cfdbe1e99eff98f1972155efe055f80c8
-  languageName: node
-  linkType: hard
-
-"object-is@npm:^1.0.1":
-  version: 1.1.3
-  resolution: "object-is@npm:1.1.3"
-  dependencies:
-    define-properties: ^1.1.3
-    es-abstract: ^1.18.0-next.1
-  checksum: f16b6ae28ca9a46154dc549c1660d1db411bbe57643a0479292814cb1842c9ecacb13aac9a18df6ce7af0991c5b034113bdb5a4a9feb282d6deaa136d2ea14e2
   languageName: node
   linkType: hard
 
@@ -13998,22 +12423,6 @@ fsevents@^1.2.7:
     type-check: ~0.3.2
     word-wrap: ~1.2.3
   checksum: a5cdced2c92d2bf2b2338b7e29b871eb97987424f7b50d5446853f709f53c855714465ee4bf1842fed2a175445d78cd44376a16666e38ef90ebf4670173d98b8
-  languageName: node
-  linkType: hard
-
-"ora@npm:^4.0.3":
-  version: 4.1.1
-  resolution: "ora@npm:4.1.1"
-  dependencies:
-    chalk: ^3.0.0
-    cli-cursor: ^3.1.0
-    cli-spinners: ^2.2.0
-    is-interactive: ^1.0.0
-    log-symbols: ^3.0.0
-    mute-stream: 0.0.8
-    strip-ansi: ^6.0.0
-    wcwidth: ^1.0.1
-  checksum: 21db2c0af36b9c4cb423dbdaeed726d84c4db4faec8c69eca80f2ee60465c5520a0de54618c53226925a787181ec61b5760522b0240a6998de4a5a9c5cf129ed
   languageName: node
   linkType: hard
 
@@ -14223,28 +12632,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parcel@npm:^2.0.0-beta.1":
-  version: 2.0.0-nightly.442
-  resolution: "parcel@npm:2.0.0-nightly.442"
-  dependencies:
-    "@parcel/config-default": 2.0.0-nightly.444+e2136965
-    "@parcel/core": 2.0.0-nightly.442+e2136965
-    "@parcel/diagnostic": 2.0.0-nightly.444+e2136965
-    "@parcel/events": 2.0.0-nightly.444+e2136965
-    "@parcel/fs": 2.0.0-nightly.444+e2136965
-    "@parcel/logger": 2.0.0-nightly.444+e2136965
-    "@parcel/package-manager": 2.0.0-nightly.444+e2136965
-    "@parcel/utils": 2.0.0-nightly.444+e2136965
-    chalk: ^2.1.0
-    commander: ^2.19.0
-    get-port: ^4.2.0
-    v8-compile-cache: ^2.0.0
-  bin:
-    parcel: lib/bin.js
-  checksum: 2b2368f0bd22a907e16dd317a19ec7480cede4fab0f8664e87bad90a8018f9e9544e5224fe81e47d69507423f7c0f31242c7628c0fc8928dfdc7cfb229267fcb
-  languageName: node
-  linkType: hard
-
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -14281,6 +12668,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"parse-glob@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "parse-glob@npm:3.0.4"
+  dependencies:
+    glob-base: ^0.3.0
+    is-dotfile: ^1.0.0
+    is-extglob: ^1.0.0
+    is-glob: ^2.0.0
+  checksum: bc9f7a8ed61b8005cce9b6f63130f9080e7034472b3e0c48cc28bfbad8c1290cca25b4fefddc7cd96d6f44e5bc2bace9e0c1f26e665cb2f693a13c2c7fcd5ff2
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^2.2.0":
   version: 2.2.0
   resolution: "parse-json@npm:2.2.0"
@@ -14300,7 +12699,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.0.0":
+"parse-json@npm:^5.0.0, parse-json@npm:^5.1.0":
   version: 5.1.0
   resolution: "parse-json@npm:5.1.0"
   dependencies:
@@ -14309,13 +12708,6 @@ fsevents@^1.2.7:
     json-parse-even-better-errors: ^2.3.0
     lines-and-columns: ^1.1.6
   checksum: 5e09955194d4ced3a7c8d2e41302834c1420e3709e06b16fa0d4bff575f054f7323cb4d4551fb6680d4c487184883ba20229de19edd5a52e1c5920148778d8cc
-  languageName: node
-  linkType: hard
-
-"parse5@npm:5.1.0":
-  version: 5.1.0
-  resolution: "parse5@npm:5.1.0"
-  checksum: f82ab2581011704c1dd3f56fa9509904a169d06bee8d4154d40a774335ad158bc59693c6620d29093252ad120521302ff25b257bcc9aebbe12453f74659a5d65
   languageName: node
   linkType: hard
 
@@ -14357,13 +12749,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"path-browserify@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "path-browserify@npm:1.0.1"
-  checksum: 45bb7389177dfe5cba5d1ee9589e578c8272ac330c00d388343845199c1d30227ca8d59bb3a15618e478673fcfa2fb7a5ad2bfcc1083d442a61a3a71aecd7dd6
-  languageName: node
-  linkType: hard
-
 "path-dirname@npm:^1.0.0":
   version: 1.0.2
   resolution: "path-dirname@npm:1.0.2"
@@ -14389,13 +12774,6 @@ fsevents@^1.2.7:
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
   checksum: 907e1e3e6ac0aef6e65adffd75b3892191d76a5b94c5cf26b43667c4240531d11872ca6979c209b2e5e1609f7f579d02f64ba9936b48bb59d36cc529f0d965ed
-  languageName: node
-  linkType: hard
-
-"path-is-inside@npm:1.0.2":
-  version: 1.0.2
-  resolution: "path-is-inside@npm:1.0.2"
-  checksum: 9c1841199d18398ee5f6d79f57eaa57f8eb85743353ea97c6d933423f246f044575a10c1847c638c36440b050aef82665b9cb4fc60950866cd239f3d51835ef4
   languageName: node
   linkType: hard
 
@@ -14431,13 +12809,6 @@ fsevents@^1.2.7:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 342fdb0ca48415d6eccdbe6d4180fd0fa4786ccc96ab3f74fcdf7acfc99e075af25e6077c8086c341dcfb4f5f84401ecd21e6cd7b24e0c3b556fb7ffb2570da7
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:2.2.1":
-  version: 2.2.1
-  resolution: "path-to-regexp@npm:2.2.1"
-  checksum: 1f9be3a4100c23f845892406bcdfcf79d62044ce24c1c50dca28719123ce7d338ac584e98d21d23eef2702754925511812e768523e59916777ec1f444438d9a4
   languageName: node
   linkType: hard
 
@@ -14486,7 +12857,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.0.5, picomatch@npm:^2.2.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.0.5, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2":
   version: 2.2.2
   resolution: "picomatch@npm:2.2.2"
   checksum: 20fa75e0a58b39d83425b3db68744d5f6f361fd4fd66ec7745d884036d502abba0d553a637703af79939b844164b13e60eea339ccb043d7fbd74c3da2592b864
@@ -14584,13 +12955,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pn@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "pn@npm:1.1.0"
-  checksum: 7df19be13c86dfab22e8484590480e49d496b270430a731be0bb40cea8a16c29e45188a7303d7c57b7140754f807877b0c10aa95400ad30a7ad4fb3f7d132381
-  languageName: node
-  linkType: hard
-
 "pnp-webpack-plugin@npm:1.6.4":
   version: 1.6.4
   resolution: "pnp-webpack-plugin@npm:1.6.4"
@@ -14613,76 +12977,6 @@ fsevents@^1.2.7:
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
   checksum: 984f83c2d4dec5abb9a6ac2b4a184132a58c4af9ce25704bfda2be6e8139335673c45d959ef6ffea3756dc88d3a0cb27c745a84d875ae5142b76e661a37a5f0e
-  languageName: node
-  linkType: hard
-
-"postcss-calc@npm:^7.0.1":
-  version: 7.0.5
-  resolution: "postcss-calc@npm:7.0.5"
-  dependencies:
-    postcss: ^7.0.27
-    postcss-selector-parser: ^6.0.2
-    postcss-value-parser: ^4.0.2
-  checksum: 850aed0201c6a7aaf5c1b4161f3d90e607ae3513c2720de038b85749f7913ac3e31c75f42314815d75641883138d2ed4dbd399da0563acc50f008c63fe068e06
-  languageName: node
-  linkType: hard
-
-"postcss-colormin@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "postcss-colormin@npm:4.0.3"
-  dependencies:
-    browserslist: ^4.0.0
-    color: ^3.0.0
-    has: ^1.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: c2632c38a64e2f76b41eb58d97193c77ab71a3d206e8453377019ed8f42c9e94be1b9df66b1e86d44e5af1e2892e7f0316c1d039c83519065eec3824aac78d17
-  languageName: node
-  linkType: hard
-
-"postcss-convert-values@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-convert-values@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 8fc4a78787642d67faebbce5f80c3e1c2ec49ab57e52f6702079f6dd57caa2c7e1bf1472a8499e548b7c6b078bc6dab664580444d81ce723caf80f4b5240237a
-  languageName: node
-  linkType: hard
-
-"postcss-discard-comments@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-discard-comments@npm:4.0.2"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: 7b357a3a4bbb2601ec0c659ed389de4334e185cfebbd991bed4c69d83905ec49b5a988d4b4ee1ea8db5b6f8b66b93f8590c16cf5c22f7efe5bde2ed1cad4ccce
-  languageName: node
-  linkType: hard
-
-"postcss-discard-duplicates@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-discard-duplicates@npm:4.0.2"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: 128342e2b913f0dd6f844519049dfb9a7fd82e0680e28d8e8111314af2137fe6b6d8af3503e775b8df56727d18a1dfc76cdb9944c615bf00cecacbde915e199f
-  languageName: node
-  linkType: hard
-
-"postcss-discard-empty@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-discard-empty@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: f06a00331cef0ba05362060642b3661fff63a1a02803984ce071e3af71061ee40083953021ae0665e6c650193f25b9155dca8c94cfe78a4d1b667a5e2d3e738d
-  languageName: node
-  linkType: hard
-
-"postcss-discard-overridden@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-discard-overridden@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: be24bca265926d22af134ed3ede7a2a27d65e32c5e5ebe3b83603e84599fc2b5587e3e0344c01e4e660f9f4072100ee6d1b56bacd0a6d428f2e0e0acd9bd4046
   languageName: node
   linkType: hard
 
@@ -14717,105 +13011,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-merge-longhand@npm:^4.0.11":
-  version: 4.0.11
-  resolution: "postcss-merge-longhand@npm:4.0.11"
-  dependencies:
-    css-color-names: 0.0.4
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-    stylehacks: ^4.0.0
-  checksum: f6ae3d8f2b07d30de78b17d7f58828571bf161d1a1d99d9371a59e1f0b18f13b7b684b34bf2b4c0d5c28e2d0eb0901a57b8c69ad558660aa3c81b9af16702cf6
-  languageName: node
-  linkType: hard
-
-"postcss-merge-rules@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "postcss-merge-rules@npm:4.0.3"
-  dependencies:
-    browserslist: ^4.0.0
-    caniuse-api: ^3.0.0
-    cssnano-util-same-parent: ^4.0.0
-    postcss: ^7.0.0
-    postcss-selector-parser: ^3.0.0
-    vendors: ^1.0.0
-  checksum: 18907817119fa00c5b016631c5e623d59061a0ae2a5e54069b19af0c09cde66ed11db8f585f33be0231f55a925beb13edc17b5336c3421050ce8e7d5708b27b9
-  languageName: node
-  linkType: hard
-
-"postcss-minify-font-values@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-minify-font-values@npm:4.0.2"
-  dependencies:
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 9fc541821f5235f4ea38fdd2671bd1d624894375e044e3f4de3bb161217a4f1501da72f4485e130b8b750c0c6d32ba36cd82ec3d252a07943006b62308938a3c
-  languageName: node
-  linkType: hard
-
-"postcss-minify-gradients@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-minify-gradients@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-arguments: ^4.0.0
-    is-color-stop: ^1.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 4c54f4fa49c8b7568b92c2e29bb15602e384837f95f278efb1792f3d650a2b7ff0a2115f62d90b18bc77b94f0bab9a9035ce1fb73953d6046e14e754ae8680af
-  languageName: node
-  linkType: hard
-
-"postcss-minify-params@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-minify-params@npm:4.0.2"
-  dependencies:
-    alphanum-sort: ^1.0.0
-    browserslist: ^4.0.0
-    cssnano-util-get-arguments: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-    uniqs: ^2.0.0
-  checksum: dbcb82b7b16fece458fa677d1a9da5f5b4984a1880ef51a50f554d31e1825c52e33b08357fef3a4077faa06e78cdc765dc8757482ca18703e72e2826694d4937
-  languageName: node
-  linkType: hard
-
-"postcss-minify-selectors@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-minify-selectors@npm:4.0.2"
-  dependencies:
-    alphanum-sort: ^1.0.0
-    has: ^1.0.0
-    postcss: ^7.0.0
-    postcss-selector-parser: ^3.0.0
-  checksum: 8fde92b5561ceb5dfbede1000457a022b231634daccfec0afeda799aedf21cb0ab52e38dc4c16110aed557c4cbc91570f71c3d5f58de419fd662ccb0656cd43d
-  languageName: node
-  linkType: hard
-
-"postcss-modules-extract-imports@npm:1.1.0":
-  version: 1.1.0
-  resolution: "postcss-modules-extract-imports@npm:1.1.0"
-  dependencies:
-    postcss: ^6.0.1
-  checksum: 49e40c921f0c783998a8ea9757abdfcbd216823c5e9e1240a64fca993109937ddff6dc17719c4439194b14269a1902169abba610d23dee8cc25d6abf997079ef
-  languageName: node
-  linkType: hard
-
 "postcss-modules-extract-imports@npm:^2.0.0":
   version: 2.0.0
   resolution: "postcss-modules-extract-imports@npm:2.0.0"
   dependencies:
     postcss: ^7.0.5
   checksum: 82e59325814e133cfbef4a4237b68eba017c15a350dac938049cefa2d212b22037c54ec8adda7b6cc23c845ea9a47e0538caa3649f9f9ed527788826a1b17670
-  languageName: node
-  linkType: hard
-
-"postcss-modules-local-by-default@npm:1.2.0":
-  version: 1.2.0
-  resolution: "postcss-modules-local-by-default@npm:1.2.0"
-  dependencies:
-    css-selector-tokenizer: ^0.7.0
-    postcss: ^6.0.1
-  checksum: 221d2c2467bcb959c084f2c0ed746d5a312226393c80325096c00a7bbddaadee99c1ff5f8b037aa09b1f7a545e694725f8a2c991a9d543c04ce46f87adb44077
   languageName: node
   linkType: hard
 
@@ -14831,16 +13032,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-modules-scope@npm:1.1.0":
-  version: 1.1.0
-  resolution: "postcss-modules-scope@npm:1.1.0"
-  dependencies:
-    css-selector-tokenizer: ^0.7.0
-    postcss: ^6.0.1
-  checksum: 397b0942681953c46939537453fb9999d150845afd84dd97513fbe22702cd61f471110f5ae2b0d429be198cd1de87e98e76ca910cf02ecbdd07f558bdb551231
-  languageName: node
-  linkType: hard
-
 "postcss-modules-scope@npm:^2.2.0":
   version: 2.2.0
   resolution: "postcss-modules-scope@npm:2.2.0"
@@ -14851,16 +13042,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-modules-values@npm:1.3.0":
-  version: 1.3.0
-  resolution: "postcss-modules-values@npm:1.3.0"
-  dependencies:
-    icss-replace-symbols: ^1.1.0
-    postcss: ^6.0.1
-  checksum: 839cc932f76930548af1cef2d4cefb7d4833a71561aad0663c29359e083c31e1c5cddc9c5d4dc78d3a22f622453cdadd776138164a9efdc76c09e2a2828fc68c
-  languageName: node
-  linkType: hard
-
 "postcss-modules-values@npm:^3.0.0":
   version: 3.0.0
   resolution: "postcss-modules-values@npm:3.0.0"
@@ -14868,162 +13049,6 @@ fsevents@^1.2.7:
     icss-utils: ^4.0.0
     postcss: ^7.0.6
   checksum: 01dc4ea51ecc12654b9e46773180d2cf731b69ad7abf5e4b9368b653dbbbc28aa3e1db31027b50d8d7534c0c206e684ae2edaaedb120220871559e43ebe81c9c
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-charset@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-normalize-charset@npm:4.0.1"
-  dependencies:
-    postcss: ^7.0.0
-  checksum: 4e40b321c45c1d8428ac9e6d7bc63ca92be5d4f65747e9b2d34e8d59bcc42a6b1a6fa9f0781e45f29c8fa0221299a61dc8b2b2a7314653e9841c6512d7820e79
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-display-values@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-display-values@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-match: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 4bd5952f1c0a5cf2a731a84b1ce218f6d9df7d2304233449bb82aa7a54c5a150cbdcb4160297206b017dce03b170e7e1a5c85a75a470b878c85b3eeabf652626
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-positions@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-positions@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-arguments: ^4.0.0
-    has: ^1.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 9d7d79703adeede66302169559603ef314b02acada5f9ff99748d54d6b91386ca0d39ffc0d13c203e8b09fe106ee55504aa5b693d9928766ba2487dd67e0c48d
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-repeat-style@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-repeat-style@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-arguments: ^4.0.0
-    cssnano-util-get-match: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: dcb89339fd8e2411e0f14dec0b22976459b1ad8ced45d5e0a7cc9f8b4ce2a0562dc92f850192c089387541bc931d9cc7cac105cc85f6e5918b80c27669e3f68d
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-string@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-string@npm:4.0.2"
-  dependencies:
-    has: ^1.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 91116aa9c6c85b3b2ba09f85e31c1e23650e4204ce8936dfd3b46585d7c69e19b6359aa87415ad8b6041a87b7b218cd2c732e5a7b7b5be754e95a41ad6439696
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-timing-functions@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-timing-functions@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-match: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 92bca529aacd9cc0189cf809a2de77d3f4d035ceea6c63365cb6247516ab6cc6525b826a1288c8d77ed1ed21f2f24eb052dd570fb38e95f89e95d2c0eefa82b7
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-unicode@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-normalize-unicode@npm:4.0.1"
-  dependencies:
-    browserslist: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 84714ba7c1d0d304d7227ddf53f754b3dde4f6f00d7d4456d925e504e986c1210786a1a4b59e1d127b4a8d1786a9def716f13868b5a622d078f7950404c69392
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-url@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-normalize-url@npm:4.0.1"
-  dependencies:
-    is-absolute-url: ^2.0.0
-    normalize-url: ^3.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 76d75e27e95a563a6f698c83bff4254d7bae916f48ff1b28b4750dc7f07b4fd67699fb3737bc0c9b077ed5ed676a19993597d4208c20d773fcbfa48b39cd9066
-  languageName: node
-  linkType: hard
-
-"postcss-normalize-whitespace@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-normalize-whitespace@npm:4.0.2"
-  dependencies:
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 7093ca8313659807290f6b039e9064787e777002cf7c84f896667c2c9cf6d349c32b809153dcf5475145ae6a6c2d198a769681ec16321ca227db4b682a5f5344
-  languageName: node
-  linkType: hard
-
-"postcss-ordered-values@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "postcss-ordered-values@npm:4.1.2"
-  dependencies:
-    cssnano-util-get-arguments: ^4.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 6f394641453559d51aecbd61301293b9a274cb5774c47de7488d559597354924c7b11ea66ec009b960d80f0945fc92fde33c3380463b039e8d00b8a0e57037ab
-  languageName: node
-  linkType: hard
-
-"postcss-reduce-initial@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "postcss-reduce-initial@npm:4.0.3"
-  dependencies:
-    browserslist: ^4.0.0
-    caniuse-api: ^3.0.0
-    has: ^1.0.0
-    postcss: ^7.0.0
-  checksum: ed276a820860d13cccd794954ed759af1e2278bfa2c863bb120ebd307404b2f8a1525e307b5ef9295d2b02ee72b1a8b31bfc2cf33d377ec0c7ca77d225298c3e
-  languageName: node
-  linkType: hard
-
-"postcss-reduce-transforms@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-reduce-transforms@npm:4.0.2"
-  dependencies:
-    cssnano-util-get-match: ^4.0.0
-    has: ^1.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-  checksum: 2bf993ff44b4e7b1c242955cf437d502447b93dcadfd812cecca0b4aa7ed8779b8c27c09a8c244b957aaef54ebdcd525a3f67b800a0c9a081775a31b245340ba
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:6.0.2":
-  version: 6.0.2
-  resolution: "postcss-selector-parser@npm:6.0.2"
-  dependencies:
-    cssesc: ^3.0.0
-    indexes-of: ^1.0.1
-    uniq: ^1.0.1
-  checksum: 0c8bec00e966038572228df54782ef4eefcd76902e5fc3822e6ad8f144c097c48acd9d00376d95cbbd902bfc0ecdf078e3a42eaba2679e1e43b4f91660534121
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^3.0.0":
-  version: 3.1.2
-  resolution: "postcss-selector-parser@npm:3.1.2"
-  dependencies:
-    dot-prop: ^5.2.0
-    indexes-of: ^1.0.1
-    uniq: ^1.0.1
-  checksum: 021ffdeef1007d4ab24439fee8e2cba188681899eae8dbc882a0e860d2ff8392f232c87e3f69eadc0a3d630b897a9ceb9f49adbe30b954a23ed91e61d3ea248c
   languageName: node
   linkType: hard
 
@@ -15039,66 +13064,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-svgo@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "postcss-svgo@npm:4.0.2"
-  dependencies:
-    is-svg: ^3.0.0
-    postcss: ^7.0.0
-    postcss-value-parser: ^3.0.0
-    svgo: ^1.0.0
-  checksum: a2a6e324fc1d15523aa6b70649a6afa1bc31f7457ffc3819601508424e35d0b1369463a84b4845d7218463198e1ee1db0234bd48766f925278c9f8272c731ece
-  languageName: node
-  linkType: hard
-
-"postcss-unique-selectors@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-unique-selectors@npm:4.0.1"
-  dependencies:
-    alphanum-sort: ^1.0.0
-    postcss: ^7.0.0
-    uniqs: ^2.0.0
-  checksum: 1f1fdc108654b6d08e499b1b4227a8023f01376ca15f461fe5c62a07bc2b553e688ca2d7e60c7443ce372d09c8121d79a402272d6880785c8659067922622c2a
-  languageName: node
-  linkType: hard
-
-"postcss-value-parser@npm:^3.0.0":
-  version: 3.3.1
-  resolution: "postcss-value-parser@npm:3.3.1"
-  checksum: 834603f6bd822846cc20b1f95e648dea67353eb506898cc5fb540b32e9a956c1030754b9503270eb00c61c3734409d7ec94fba2b4f0a89954bc855bad7e9267c
-  languageName: node
-  linkType: hard
-
-"postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.1.0":
+"postcss-value-parser@npm:^4.1.0":
   version: 4.1.0
   resolution: "postcss-value-parser@npm:4.1.0"
   checksum: 70831403886859289f650550a38889857022c5bbe264fd5d39cfad5207b3e1d33422edc031c1a922f3ae29d0dff98837a8bf126c840374d2b0079e7d57cf7d71
   languageName: node
   linkType: hard
 
-"postcss@npm:6.0.1, postcss@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "postcss@npm:6.0.1"
-  dependencies:
-    chalk: ^1.1.3
-    source-map: ^0.5.6
-    supports-color: ^3.2.3
-  checksum: 3c87bd463e86e19077dc71ab1051a5831c6544479079db1dcf50b677876cbd79048f570669e3d58056e45d4bce9925eda4749b261bc096e16fde73342ac492b4
-  languageName: node
-  linkType: hard
-
-"postcss@npm:7.0.32":
-  version: 7.0.32
-  resolution: "postcss@npm:7.0.32"
-  dependencies:
-    chalk: ^2.4.2
-    source-map: ^0.6.1
-    supports-color: ^6.1.0
-  checksum: 340f4f6ca6bd37961927f68bf7e38d071a7cba0468240cbba64ccf78012b2acbec974491284cb200e438dd3e655314e6d9508562523cbf9a49d5b00fd7e769fa
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^7.0.0, postcss@npm:^7.0.1, postcss@npm:^7.0.14, postcss@npm:^7.0.17, postcss@npm:^7.0.26, postcss@npm:^7.0.27, postcss@npm:^7.0.32, postcss@npm:^7.0.5, postcss@npm:^7.0.6":
+"postcss@npm:^7.0.0, postcss@npm:^7.0.14, postcss@npm:^7.0.26, postcss@npm:^7.0.32, postcss@npm:^7.0.5, postcss@npm:^7.0.6":
   version: 7.0.35
   resolution: "postcss@npm:7.0.35"
   dependencies:
@@ -15106,63 +13079,6 @@ fsevents@^1.2.7:
     source-map: ^0.6.1
     supports-color: ^6.1.0
   checksum: 8a979ea9799dd48399337708a395ddb8cf0e328515201ed35c99f5ba5eaa7688eae65764c570bf49b5be0b106226e2f222abc210de068b3d3da9a9a3bbb70567
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.0.5":
-  version: 8.1.1
-  resolution: "postcss@npm:8.1.1"
-  dependencies:
-    colorette: ^1.2.1
-    line-column: ^1.0.2
-    nanoid: ^3.1.12
-    source-map: ^0.6.1
-  checksum: 9bdc9e51369ee35831589f0cfffcb996ed2b50aa23e54e3cf849c74361c17e7f7c1df3e0b993392818ede40f0731c458be134901ce9438bd38223e38781f52f5
-  languageName: node
-  linkType: hard
-
-"posthtml-parser@npm:^0.4.1":
-  version: 0.4.2
-  resolution: "posthtml-parser@npm:0.4.2"
-  dependencies:
-    htmlparser2: ^3.9.2
-  checksum: 94e5b1d7d21fdec5cfe7049551055a285e7dbbcbba61ea6e911ea32119583a64d7def18938fa5e1ea2578cf8d53a5c2952d016892c6b5e5a436b324afb7313c1
-  languageName: node
-  linkType: hard
-
-"posthtml-parser@npm:^0.5.0":
-  version: 0.5.2
-  resolution: "posthtml-parser@npm:0.5.2"
-  dependencies:
-    htmlparser2: ^5.0.1
-  checksum: 3f4255ac4d542ff0897b4847c21e1ee8ddb8bb9d827801c1256d32e7b27cfd81a7229853d61f3ef6d278b98a66b68c703caa3a3c8ad4b0576680cf425e3649e6
-  languageName: node
-  linkType: hard
-
-"posthtml-render@npm:^1.1.5, posthtml-render@npm:^1.2.2, posthtml-render@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "posthtml-render@npm:1.2.3"
-  checksum: 1b2f72ed83bd94ea24ef8830e2aec670e6af1775ff3b913d9281a7551f41db737c73513b82e722695a5a48dfc8caff3fa87ea4e6e7ef7f7f6e58b8f62d21664a
-  languageName: node
-  linkType: hard
-
-"posthtml@npm:^0.11.3":
-  version: 0.11.6
-  resolution: "posthtml@npm:0.11.6"
-  dependencies:
-    posthtml-parser: ^0.4.1
-    posthtml-render: ^1.1.5
-  checksum: 4894f114ccbdb739fb97520868a15b25c52f633cbbb0f754af2cce04020bd34d25260ff41039f5c171fb16684b5e51ef9bff88463ad6bfb639ce9f9eefe1f249
-  languageName: node
-  linkType: hard
-
-"posthtml@npm:^0.13.4":
-  version: 0.13.4
-  resolution: "posthtml@npm:0.13.4"
-  dependencies:
-    posthtml-parser: ^0.5.0
-    posthtml-render: ^1.2.3
-  checksum: 6986f1404a57efef592bc8a34a87c7690e414adac8dc981d2a31c84af9fe93e916e25be21bfba59dab230dd4845644a974f512f5a2a7c25fc6365837e8dc9ae6
   languageName: node
   linkType: hard
 
@@ -15243,6 +13159,7 @@ fsevents@^1.2.7:
   resolution: "primitives@workspace:."
   dependencies:
     "@babel/core": ^7.0.0
+    "@preconstruct/cli": ^2.0.1
     "@stitches/react": canary
     "@storybook/addon-storysource": 6.1.0-beta.4
     "@storybook/react": 6.1.0-beta.4
@@ -15458,7 +13375,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"punycode@npm:^1.2.4, punycode@npm:^1.3.2, punycode@npm:^1.4.1":
+"punycode@npm:^1.2.4":
   version: 1.4.1
   resolution: "punycode@npm:1.4.1"
   checksum: 5ce1e044cee2b12f1c65ccd523d7e71d6578f2c77f5c21c2e7a9d588535559c9508571d42638c131dab93cbe9a7b37bce1a7475d43fc8236c99dfe1efc36cfa5
@@ -15469,20 +13386,6 @@ fsevents@^1.2.7:
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 0202dc191cb35bfd88870ac99a1e824b03486d4cee20b543ef337a6dee8d8b11017da32a3e4c40b69b19976e982c030b62bd72bba42884acb691bc5ef91354c8
-  languageName: node
-  linkType: hard
-
-"purgecss@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "purgecss@npm:2.3.0"
-  dependencies:
-    commander: ^5.0.0
-    glob: ^7.0.0
-    postcss: 7.0.32
-    postcss-selector-parser: ^6.0.2
-  bin:
-    purgecss: bin/purgecss
-  checksum: 903351123a904d80b5377434148fdff5edf59187c32b9961297a18ce4ab4ef3033344684f9a90e3b02983aca0d6713092591ce22d5fb2a92b33226428882cd9b
   languageName: node
   linkType: hard
 
@@ -15514,7 +13417,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"querystring-es3@npm:^0.2.0, querystring-es3@npm:^0.2.1":
+"querystring-es3@npm:^0.2.0":
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
   checksum: 3c388906aa5644e55cdbede78f99a4d05a6e36a45b06929ad8713a2020a5cefeb6ec23adaa27584d968cf658e5d237b5e216f5e48930d040cd6b810679714741
@@ -15525,6 +13428,20 @@ fsevents@^1.2.7:
   version: 0.2.0
   resolution: "querystring@npm:0.2.0"
   checksum: 1e76c51462f0ffb148e0b2fdeb811f61377800298605229d32efcdaaaf0a8fd4314a4b4405e1fbf130a5ca421c0e51f926fab5bb9f8b9b3b8c394f4e2d33d3d1
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "quick-lru@npm:4.0.1"
+  checksum: 91847e4b07453655f73513b96a3b49e3bb8bf37de1ce2075d44e5dddb2f08050c5dc858d97884d61618bb44487945880b4b481fe93e94a3622b43036f8b94e11
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "quick-lru@npm:5.1.1"
+  checksum: fafb2b2fa1a948d6f2e88d4a60571be70b316d9b0be857d24fba0ac28fc31acebf535b643fe968473d689f8c655bcb2a0e4da67912f571059a4e4eb15740b021
   languageName: node
   linkType: hard
 
@@ -15551,13 +13468,6 @@ fsevents@^1.2.7:
     randombytes: ^2.0.5
     safe-buffer: ^5.1.0
   checksum: 24658ce99e0a325f27d157fbff9b111f9fa2f56876031ac9a09bcd6c5ae53d3c3f1b124d7e1b813803ee1b09e50dd1561ac7f7a8ba2930319cbcda5e827602ab
-  languageName: node
-  linkType: hard
-
-"range-parser@npm:1.2.0":
-  version: 1.2.0
-  resolution: "range-parser@npm:1.2.0"
-  checksum: 8260023192a5def4c6db4ced82e6546306937f1202417b846f2e8b565426e71697086f509a070f66fd23a57e9f96aba108f08d16d4be23d418c8c68a73b539bd
   languageName: node
   linkType: hard
 
@@ -15816,13 +13726,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-refresh@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "react-refresh@npm:0.9.0"
-  checksum: 300dc431389f4c532bdfec08d5bc59b591c8c440486a7d5770c8954adf3afe62501b659c5acbdb7831751e8be506eb90a6f72491fab40352f3b3fba16897acf6
-  languageName: node
-  linkType: hard
-
 "react-remove-scroll-bar@npm:^2.1.0":
   version: 2.1.0
   resolution: "react-remove-scroll-bar@npm:2.1.0"
@@ -16022,7 +13925,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.0, readable-stream@npm:^3.1.1, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -16242,7 +14145,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"request-promise-native@npm:^1.0.5, request-promise-native@npm:^1.0.8":
+"request-promise-native@npm:^1.0.8":
   version: 1.0.9
   resolution: "request-promise-native@npm:1.0.9"
   dependencies:
@@ -16255,7 +14158,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"request@npm:^2.88.0, request@npm:^2.88.2":
+"request@npm:^2.88.2":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:
@@ -16294,13 +14197,6 @@ fsevents@^1.2.7:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: 8d3633149a7fef67d14613146247137fe1dc4cc969bf2d1adcd40e3c28056de503229f41e78cba5efebad3a223cbfb4215fd220d879148df10c6d9a877099dbd
-  languageName: node
-  linkType: hard
-
-"requires-port@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "requires-port@npm:1.0.0"
-  checksum: 0db25fb2ac9b4f2345a350846b7ba99d1f25a6686b1728246d14f05450c8f2fc066bdfae4561b4be2627c184a030a27e17268cfefdf46836e271db13734bc49e
   languageName: node
   linkType: hard
 
@@ -16385,20 +14281,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rgb-regex@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "rgb-regex@npm:1.0.1"
-  checksum: 7701e22ec451e55a919c88f61a8006c70d004cc06d09a3e4806b0ffaff2ac0138fbbb3896d0e21f716c745e4ad6ae62114bf0920a78c7381e994e57b73575baf
-  languageName: node
-  linkType: hard
-
-"rgba-regex@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "rgba-regex@npm:1.0.0"
-  checksum: 4ffb946276ee7d7259a518eae89a3c6cce99736449ebed2c88ab26a076543766c62194c7dd06b8e4f5375e91c6e9bd21ebfc3ddf4b143f3688f260cafd9d466b
-  languageName: node
-  linkType: hard
-
 "rimraf@npm:2.6.3, rimraf@npm:^2.2.8, rimraf@npm:^2.5.4, rimraf@npm:^2.6.3":
   version: 2.6.3
   resolution: "rimraf@npm:2.6.3"
@@ -16428,6 +14310,20 @@ fsevents@^1.2.7:
     hash-base: ^3.0.0
     inherits: ^2.0.1
   checksum: e0370fbe779b1f15d74c3e7dffc0ce40b57b845fc7e431fab8a571958d5fd9c91eb0038a252604600e20786d117badea0cc4cf8816b8a6be6b9166b565ad6797
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^2.32.0":
+  version: 2.35.1
+  resolution: "rollup@npm:2.35.1"
+  dependencies:
+    fsevents: ~2.1.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 01e8b621baf3b35e1a28e3679cf9bdd4c22c2e999a895343e0b1e02dfe735f92a9fe439042e1b35c981663e9a8b75c1d707e6c27d786170febbb503b83dfed39
   languageName: node
   linkType: hard
 
@@ -16533,15 +14429,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"saxes@npm:^3.1.9":
-  version: 3.1.11
-  resolution: "saxes@npm:3.1.11"
-  dependencies:
-    xmlchars: ^2.1.1
-  checksum: dbdbd14f903e2a18c3efb422401ad0630dd25e4ed6a52fd01e42b205508ee70e5170da4d39ab2957eca54dc2934b9c8fa6f2f90292b136bfa935db7877177a08
-  languageName: node
-  linkType: hard
-
 "saxes@npm:^5.0.0":
   version: 5.0.1
   resolution: "saxes@npm:5.0.1"
@@ -16615,7 +14502,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -16691,22 +14578,6 @@ fsevents@^1.2.7:
     parseurl: ~1.3.2
     safe-buffer: 5.1.1
   checksum: d49e51c7f489785c4a0f824ab55238be9fab2308a74ca667469c4caff980ff53f0a423d6b05cdcddb7258a604971530b5ed7bb5cbd5d25d0cc61d102f066db9a
-  languageName: node
-  linkType: hard
-
-"serve-handler@npm:^6.0.0":
-  version: 6.1.3
-  resolution: "serve-handler@npm:6.1.3"
-  dependencies:
-    bytes: 3.0.0
-    content-disposition: 0.5.2
-    fast-url-parser: 1.1.3
-    mime-types: 2.1.18
-    minimatch: 3.0.4
-    path-is-inside: 1.0.2
-    path-to-regexp: 2.2.1
-    range-parser: 1.2.0
-  checksum: 493e7556ec53bc6c8616ffc58697d93c5ebc8ddeb38de39b5381140a8467bb720fbbd58fbe91de25ea9ccc98ce8b11131ccd7e160ddf891ca5199e7f1437cc18
   languageName: node
   linkType: hard
 
@@ -16859,15 +14730,6 @@ fsevents@^1.2.7:
   version: 3.0.3
   resolution: "signal-exit@npm:3.0.3"
   checksum: f8f3fec95c8d1f9ad7e3cce07e1195f84e7a85cdcb4e825e8a2b76aa5406a039083d2bc9662b3cf40e6948262f41277047d20e6fbd58c77edced0b18fab647d8
-  languageName: node
-  linkType: hard
-
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: ^0.3.1
-  checksum: a5a2c1c86cea94f42ab843508e7c68b5bbfd15acb08056d600ac2e9c7f7c41bc417e71160ea3034a5411d3cce186c801f7a56badfb3a854906ce163120318875
   languageName: node
   linkType: hard
 
@@ -17036,6 +14898,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"sourcemap-codec@npm:^1.4.4":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: 4d56d1232a45af813606d1755f11e7ae6b3542c615a7e3f904382f0134a9412ba8d090e83749254d78449eafdfcc62d5158b8f35e6241480b51b74b5c46b99f9
+  languageName: node
+  linkType: hard
+
 "space-separated-tokens@npm:^1.0.0":
   version: 1.1.5
   resolution: "space-separated-tokens@npm:1.1.5"
@@ -17083,15 +14952,6 @@ fsevents@^1.2.7:
   dependencies:
     extend-shallow: ^3.0.0
   checksum: 9b610d1509f8213dad7d38b5f0b49109ab53c2a93e7886c370a66b9eeb723706cd01b04b61b3d906ff6369314429412f8fad54b93d57fa50103d85884f0c175f
-  languageName: node
-  linkType: hard
-
-"split2@npm:^3.1.1":
-  version: 3.2.2
-  resolution: "split2@npm:3.2.2"
-  dependencies:
-    readable-stream: ^3.0.0
-  checksum: 04bf20af25bfe917edbb7f719cc9dbd2ca16633e4e6a5e343a8c834310aafd802c74b3aceb96acf3571545b0340d55d2d3273dbee8f9bc6a811371dcfbe0c8a7
   languageName: node
   linkType: hard
 
@@ -17228,18 +15088,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"stream-http@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "stream-http@npm:3.1.1"
-  dependencies:
-    builtin-status-codes: ^3.0.0
-    inherits: ^2.0.4
-    readable-stream: ^3.6.0
-    xtend: ^4.0.2
-  checksum: 59334d615fdd774d1a8ac73ed5f348986c96ebfc0c3679a162a37838f07839ba3607e3e1a042ea78a1d920a8cf2c3ccacbb91ff9538975e9dfdcadae2ca7eb42
-  languageName: node
-  linkType: hard
-
 "stream-shift@npm:^1.0.0":
   version: 1.0.1
   resolution: "stream-shift@npm:1.0.1"
@@ -17351,7 +15199,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.0.0, string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
+"string_decoder@npm:^1.0.0, string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -17472,30 +15320,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"stylehacks@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "stylehacks@npm:4.0.3"
-  dependencies:
-    browserslist: ^4.0.0
-    postcss: ^7.0.0
-    postcss-selector-parser: ^3.0.0
-  checksum: 1345ad348db3c98f7d0423762e13e816a8c1ba0b1d90d79f3528513be429f1cf68b7fa9c9d379870208586e7ff4cfb68b4121bbd904df03b17e84d62efcff288
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
   checksum: 5d6fb449e29f779cc639756f0d6b9ab6138048e753683cd2c647f36a9254714051909a5f569e6aa83c5310c8dfe8a1f481967e02bef401ac8eed46ee0950d779
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "supports-color@npm:3.2.3"
-  dependencies:
-    has-flag: ^1.0.0
-  checksum: d26b4f5f7ab4408e3ecf5809896a399a0d388b948701a8958bb6610ca30aa837e75d56d7dfb5e175f8ffd92431dc1e149faa6183cf166178ea63c74e974a87ce
   languageName: node
   linkType: hard
 
@@ -17543,7 +15371,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"svgo@npm:^1.0.0, svgo@npm:^1.2.2, svgo@npm:^1.3.2":
+"svgo@npm:^1.2.2":
   version: 1.3.2
   resolution: "svgo@npm:1.3.2"
   dependencies:
@@ -17566,7 +15394,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"symbol-tree@npm:^3.2.2, symbol-tree@npm:^3.2.4":
+"symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 0b9af4e5f005f9f0b9c916d91a1b654422ffa49ef09c5c4b6efa7a778f63976be9f410e57db1e9ea7576eea0631a34b69a5622674aa92a60a896ccf2afca87a7
@@ -17632,7 +15460,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"term-size@npm:^2.1.0, term-size@npm:^2.1.1":
+"term-size@npm:^2.1.0":
   version: 2.2.1
   resolution: "term-size@npm:2.2.1"
   checksum: a013f688f6fc1b6410be3b2f7a04c3a9169e97186949b0bc33cc7c1943b0c88d9a943f81e518d9227cb817803e7a18c702f2971eafd6d8659ce4a1df94094246
@@ -17700,16 +15528,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.2.0":
-  version: 5.3.8
-  resolution: "terser@npm:5.3.8"
+"terser@npm:^5.2.1":
+  version: 5.5.1
+  resolution: "terser@npm:5.5.1"
   dependencies:
     commander: ^2.20.0
     source-map: ~0.7.2
     source-map-support: ~0.5.19
   bin:
     terser: bin/terser
-  checksum: 3fc070378ba9981d8088a4012060f16428a97dc8f98d5a731b2ab51b8c9bc8cb651ca068aef499faad863584ae4d4883872c4f51db053bc2575c2e0bc11ab411
+  checksum: f96abd0fb4595a1cbc875df661eceb7ae97cf05996f5327e38f16b5bf0c685296ab81d00a34059f6ca292bbba5eeed31ed7e51d2bf5d7cf6534a1a31aff0db86
   languageName: node
   linkType: hard
 
@@ -17762,19 +15590,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"timers-browserify@npm:^2.0.11, timers-browserify@npm:^2.0.4":
+"timers-browserify@npm:^2.0.4":
   version: 2.0.12
   resolution: "timers-browserify@npm:2.0.12"
   dependencies:
     setimmediate: ^1.0.4
   checksum: 9e10d036d61b81eef9679b8ed452000eecbc309ea67067120a124a451b58ac4e5d348ca24152351770b5058117732dc8c665fff0b984f8eb0d857b9e13c33f42
-  languageName: node
-  linkType: hard
-
-"timsort@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "timsort@npm:0.3.0"
-  checksum: d8300c3ecf1a3751413de82b04ad283b461ab6fb1041820c825d13b4ae74526e2101ab5fb84c57a0c6e1f4d7f67173b5d8754ed8bb7447c6a9ce1db8562eb82c
   languageName: node
   linkType: hard
 
@@ -17876,7 +15697,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^2.3.3, tough-cookie@npm:^2.5.0, tough-cookie@npm:~2.5.0":
+"tough-cookie@npm:^2.3.3, tough-cookie@npm:~2.5.0":
   version: 2.5.0
   resolution: "tough-cookie@npm:2.5.0"
   dependencies:
@@ -17894,15 +15715,6 @@ fsevents@^1.2.7:
     psl: ^1.1.28
     punycode: ^2.1.1
   checksum: dc1eee69c61a6d5598144ff41c9b5e758207130d92d2b89facad075140a99c10d674a6278764b9edfe8e074cb7840c15e7b786b93d0672875026c2ce5172d774
-  languageName: node
-  linkType: hard
-
-"tr46@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "tr46@npm:1.0.1"
-  dependencies:
-    punycode: ^2.1.0
-  checksum: 66e2e4d6799d3c2fcc56ad6084e8ab7b3e744f138babc86100e5e2bfaf011231d00d229cfccfaf338da953b96c3ea9128d182274915c1516c5189ee75b7c0ad9
   languageName: node
   linkType: hard
 
@@ -17929,6 +15741,13 @@ fsevents@^1.2.7:
     uuid: ^3.3.2
     xdg-trashdir: ^2.1.1
   checksum: bf58b52290837a87d7282db47dee7cb22afb5e07b8218eddadb6a2958ea52236cbb0b61b4274072d8e38066575787dacec45bf5a01ada1fcf8a946e9900930e6
+  languageName: node
+  linkType: hard
+
+"trim-newlines@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "trim-newlines@npm:3.0.0"
+  checksum: 51bfbec0014ae58cdbf3c55e34cfe7f1a92a77d362990bb4cc8d6edf51f1c21f28b92e442adec3ef9cef69194b532b28c1a0a06d9ee78b2b0fd28d191a2b738e
   languageName: node
   linkType: hard
 
@@ -18026,13 +15845,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"tty-browserify@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "tty-browserify@npm:0.0.1"
-  checksum: 397de97534c831e136fb32170a7a7b5a21438e98751fdff5c49d0d0c889b14642da102919259f23560b8584cd918a20f1116a4caf0a9fe80414c5f8d6fb70637
-  languageName: node
-  linkType: hard
-
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -18069,6 +15881,13 @@ fsevents@^1.2.7:
   version: 0.11.0
   resolution: "type-fest@npm:0.11.0"
   checksum: 02e5cadf13590a5724cacf8d9133320efd173f6fb1b695fcb29e56551a315bf0f07ca988a780a1999b7b55bb3eaaa7f37223615207236d393af17bba6749dc95
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "type-fest@npm:0.13.1"
+  checksum: 11acce4f34c75a838914bdc4a0133d2dd0864e313897471974880df82624159521bae691a6100ff99f93be2d0f8871ecdab18573d2c67e61905cf2f5cbfa52a6
   languageName: node
   linkType: hard
 
@@ -18146,25 +15965,6 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"uncss@npm:^0.17.3":
-  version: 0.17.3
-  resolution: "uncss@npm:0.17.3"
-  dependencies:
-    commander: ^2.20.0
-    glob: ^7.1.4
-    is-absolute-url: ^3.0.1
-    is-html: ^1.1.0
-    jsdom: ^14.1.0
-    lodash: ^4.17.15
-    postcss: ^7.0.17
-    postcss-selector-parser: 6.0.2
-    request: ^2.88.0
-  bin:
-    uncss: bin/uncss
-  checksum: 03b87df23b1f63479eae3bcc8a0a20120b527960dcedefad404e7228741d8a3ed763ec39dea89d8b6505a2d315d0f86cdd87ba45ba638b8931c9dfb311b49fbd
-  languageName: node
-  linkType: hard
-
 "unfetch@npm:^4.1.0":
   version: 4.2.0
   resolution: "unfetch@npm:4.2.0"
@@ -18219,13 +16019,6 @@ typescript@^3.9.7:
   version: 1.0.1
   resolution: "uniq@npm:1.0.1"
   checksum: a5603a5b3128616f268e7695e47cd1eb8d583cf8ee1278434140cd83d2f3f98e5d65a22cf4187f0345ca8d8a0a9f1d07e1f06cb46312135ad4a6303fd28fc317
-  languageName: node
-  linkType: hard
-
-"uniqs@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "uniqs@npm:2.0.0"
-  checksum: f6467e9cb94e25d40e25dc600bec69ec5c6c3ba58ec168fecfd2a74cd8a92f54383dfbcbb9f8a50ba389c7e6e9cfd08e03ae80391792357d6a4e616f907af3f6
   languageName: node
   linkType: hard
 
@@ -18450,20 +16243,6 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.0, util@npm:^0.12.3":
-  version: 0.12.3
-  resolution: "util@npm:0.12.3"
-  dependencies:
-    inherits: ^2.0.3
-    is-arguments: ^1.0.4
-    is-generator-function: ^1.0.7
-    is-typed-array: ^1.1.3
-    safe-buffer: ^5.1.2
-    which-typed-array: ^1.1.2
-  checksum: 684f2f586db12c86b2c2800e5d4963fe2e95a85ece1e52f25344e54c29d62e985c716ec53b817970121e0ea47f99a971299998848e35a5d1c5953e182852d6fe
-  languageName: node
-  linkType: hard
-
 "utila@npm:~0.4":
   version: 0.4.0
   resolution: "utila@npm:0.4.0"
@@ -18496,7 +16275,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"v8-compile-cache@npm:^2.0.0, v8-compile-cache@npm:^2.0.3":
+"v8-compile-cache@npm:^2.0.3, v8-compile-cache@npm:^2.1.1":
   version: 2.2.0
   resolution: "v8-compile-cache@npm:2.2.0"
   checksum: 1efc9946401fcad7a67619b520d8d12e31c7138090ffd9f98af9b919461fa23d947ecef0eab89cca4037c01d29d25a389ab6c0fac70ee4ed030443b08cdf6cff
@@ -18531,13 +16310,6 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"vendors@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "vendors@npm:1.0.4"
-  checksum: f49cf918e866901eb36e0dc85970fde99929a3f298e1c55b4e20517eda18e16fb57da3eee72801e7d371f9b33684492879ed5ceebae4d1bed48c6e1a62ef6e58
-  languageName: node
-  linkType: hard
-
 "verror@npm:1.10.0":
   version: 1.10.0
   resolution: "verror@npm:1.10.0"
@@ -18549,30 +16321,19 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"vm-browserify@npm:^1.0.1, vm-browserify@npm:^1.1.2":
+"vm-browserify@npm:^1.0.1":
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: fc571a62d2cf797ae8773ebb3cb0d2bea50ed02059e128dd9087975929fce4c80a6485ce1aaf7d44ef69db99dfdcde50b6be5d5eb73b296660d761c32fb544fe
   languageName: node
   linkType: hard
 
-"w3c-hr-time@npm:^1.0.1, w3c-hr-time@npm:^1.0.2":
+"w3c-hr-time@npm:^1.0.2":
   version: 1.0.2
   resolution: "w3c-hr-time@npm:1.0.2"
   dependencies:
     browser-process-hrtime: ^1.0.0
   checksum: bb021b4c4b15acc26a7b0de5b6f4c02d829b458345af162713685e84698380fabffc7856f4a85ba368f23c8419d3a7a726b628b993ffeb0d5a83d0d57d4cbf72
-  languageName: node
-  linkType: hard
-
-"w3c-xmlserializer@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "w3c-xmlserializer@npm:1.1.2"
-  dependencies:
-    domexception: ^1.0.1
-    webidl-conversions: ^4.0.2
-    xml-name-validator: ^3.0.0
-  checksum: 9a7b5c7e32d4fa3d272a38e62595ff43169a9aa1b000d27a6b2613df759071034a8e870f7e6ebae8d0024d3056eeff1cad0fdab118ad4430c3d1cac3384dcd29
   languageName: node
   linkType: hard
 
@@ -18626,22 +16387,6 @@ typescript@^3.9.7:
     watchpack-chokidar2:
       optional: true
   checksum: 61876d6e60ddb1e9b0a6143c65a4453543bb1a27638254635d179d4681f15af200de9a61c1a3faec220a29e41ca37381e604345ffa9d48c064a29cff4cb25732
-  languageName: node
-  linkType: hard
-
-"wcwidth@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "wcwidth@npm:1.0.1"
-  dependencies:
-    defaults: ^1.0.3
-  checksum: abf8ba432dd19a95af63895de6af932900a9451e175745551aeca0fd2d46604bc72ff80aa83adc3f67fb8389191329340e2864aefcf20655ffe91f0dbee5d953
-  languageName: node
-  linkType: hard
-
-"webidl-conversions@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "webidl-conversions@npm:4.0.2"
-  checksum: 75c2ada4262cda41410ec898178f4f2a31419a905415a98a0bd1b93441ce4a2b942bae2d0ac6d637b749b9d3b309be5a49dbc3b06aae9d9e65280554268a2c94
   languageName: node
   linkType: hard
 
@@ -18777,7 +16522,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"whatwg-encoding@npm:^1.0.1, whatwg-encoding@npm:^1.0.5":
+"whatwg-encoding@npm:^1.0.5":
   version: 1.0.5
   resolution: "whatwg-encoding@npm:1.0.5"
   dependencies:
@@ -18786,21 +16531,10 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"whatwg-mimetype@npm:^2.2.0, whatwg-mimetype@npm:^2.3.0":
+"whatwg-mimetype@npm:^2.3.0":
   version: 2.3.0
   resolution: "whatwg-mimetype@npm:2.3.0"
   checksum: 926e6ef8c7e53d158e501ce5e3c0e491d343c3c97e71b3d30451ffe4b1d6f81844c336b46a446a0b4f3fe4f327d76e3451d53ee8055344a0f5f2f35b84518011
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "whatwg-url@npm:7.1.0"
-  dependencies:
-    lodash.sortby: ^4.7.0
-    tr46: ^1.0.1
-    webidl-conversions: ^4.0.2
-  checksum: ccbf75d3dfa6d97a7705acc250a43041dfcfa0c9695a5148cac844c39a29657d7c07b3c4533ebabb2401fedcd5eb98626256add2760403b0889c9983ea1a76aa
   languageName: node
   linkType: hard
 
@@ -18826,20 +16560,6 @@ typescript@^3.9.7:
   version: 1.0.0
   resolution: "which-pm-runs@npm:1.0.0"
   checksum: 0bb79a782e98955afec8f35a3ae95c4711fdd3d0743772ee98211da67c2421fdd4c92c95c93532cc0b4dcc085d8e27f3ad2f8a9173cb632692379bd3d2818821
-  languageName: node
-  linkType: hard
-
-"which-typed-array@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "which-typed-array@npm:1.1.2"
-  dependencies:
-    available-typed-arrays: ^1.0.2
-    es-abstract: ^1.17.5
-    foreach: ^2.0.5
-    function-bind: ^1.1.1
-    has-symbols: ^1.0.1
-    is-typed-array: ^1.1.3
-  checksum: 577bfb6457f70f8c9ee117ef243c69d00fa0c92ffb82f1700c6fd8bf0a85de5f0582555f6259f250e2fb712d6dab04d3d140362555ccf116cdcfcf6b9bc41a99
   languageName: node
   linkType: hard
 
@@ -18947,15 +16667,6 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"ws@npm:^6.1.2, ws@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "ws@npm:6.2.1"
-  dependencies:
-    async-limiter: ~1.0.0
-  checksum: 35d32b09e28f799f04708c3a7bd9eff469ae63e60543d7e18335f28689228a42ee21210f48de680aad6e5317df76b5b1183d1a1ea4b4d14cb6e0943528f40e76
-  languageName: node
-  linkType: hard
-
 "ws@npm:^7.2.3":
   version: 7.4.0
   resolution: "ws@npm:7.4.0"
@@ -19000,14 +16711,14 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"xmlchars@npm:^2.1.1, xmlchars@npm:^2.2.0":
+"xmlchars@npm:^2.2.0":
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 69bbb61e8d939873c8aa7d006d082944de2eb6f12f55e53fdfc670d544e677736b59e498ece303f264bd1dc39b77557eef1c1c9bfb09eb5e1e30ac552420d81e
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:^4.0.2, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 37ee522a3e9fb9b143a400c30b21dc122aa8c9c9411c6afae1005a4617dc20a21765c114d544e37a6bb60c2733dd8ee0a44ed9e80d884ac78cccd30b5e0ab0da
@@ -19056,7 +16767,7 @@ typescript@^3.9.7:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^18.1.2":
+"yargs-parser@npm:^18.1.2, yargs-parser@npm:^18.1.3":
   version: 18.1.3
   resolution: "yargs-parser@npm:18.1.3"
   dependencies:


### PR DESCRIPTION
This PR explores using [Preconstruct](https://preconstruct.tools/) in place of Parcel for building packages. I'm leaving this is draft mode for now because I'm not even 100% sure if it's a net win for us, but I wanted to open it for discussion. Here's my initial thoughts:

- Preconstruct is specifically designed for monorepos, whereas Parcel is not. This is evident to me in improved DX on the command line + optimized build speed. This build runs super fast compared to running Parcel independently on every package. This was also dead simple to set up and use. The few error messages I've seen have been far more readable and actionable so far.
- Preconstruct uses Rollup under the hood, which is simpler and less magical than Parcel. It uses Babel as well but doesn't pre-configure anything there, so that's now exposed to us directly.
- Hopefully we never see a Yarn dependency graph issue again. 🤞