### PR TITLE
FocusScope blur fix

### DIFF
--- a/.yarn/versions/52c80af8.yml
+++ b/.yarn/versions/52c80af8.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@storybook/react": "6.1.0-beta.4",
     "@testing-library/jest-dom": "^5.11.3",
     "@testing-library/react": "^10.4.8",
+    "@testing-library/user-event": "^12.6.0",
     "@types/eslint": "^7",
     "@types/jest": "^26.0.10",
     "@types/jest-axe": "^3.5.0",

--- a/packages/react/focus-scope/src/FocusScope.test.tsx
+++ b/packages/react/focus-scope/src/FocusScope.test.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, act } from '@testing-library/react';
+import { FocusScope } from './FocusScope';
+import type { RenderResult } from '@testing-library/react';
+
+const INNER_NAME_INPUT_LABEL = 'Name';
+const INNER_EMAIL_INPUT_LABEL = 'Email';
+const INNER_SUBMIT_LABEL = 'Submit';
+
+describe('FocusScope', () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(1);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  describe('given a default FocusScope', () => {
+    let rendered: RenderResult;
+    let tabbableFirst: HTMLInputElement;
+    let tabbableSecond: HTMLInputElement;
+    let tabbableLast: HTMLButtonElement;
+
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope trapped>
+            {(props) => (
+              <div {...props}>
+                <form>
+                  <TestField label={INNER_NAME_INPUT_LABEL} />
+                  <TestField label={INNER_EMAIL_INPUT_LABEL} />
+                  <button>{INNER_SUBMIT_LABEL}</button>
+                </form>
+              </div>
+            )}
+          </FocusScope>
+          <TestField label="other" />
+          <button>some outer button</button>
+        </div>
+      );
+      tabbableFirst = rendered.getByLabelText(INNER_NAME_INPUT_LABEL) as HTMLInputElement;
+      tabbableSecond = rendered.getByLabelText(INNER_EMAIL_INPUT_LABEL) as HTMLInputElement;
+      tabbableLast = rendered.getByText(INNER_SUBMIT_LABEL) as HTMLButtonElement;
+    });
+
+    it('should focus the next element in the scope on tab', () => {
+      focus(tabbableFirst);
+      userEvent.tab();
+      expect(tabbableSecond).toHaveFocus();
+    });
+
+    it('should focus the last element in the scope on shift+tab from the first element in scope', () => {
+      focus(tabbableFirst);
+      userEvent.tab({ shift: true });
+      expect(tabbableLast).toHaveFocus();
+    });
+
+    it('should focus the first element in scope on tab from the last element in scope', async () => {
+      focus(tabbableLast);
+      userEvent.tab();
+      expect(tabbableFirst).toHaveFocus();
+    });
+  });
+
+  describe('given a FocusScope where the first focusable has a negative tabindex', () => {
+    let rendered: RenderResult;
+    let tabbableSecond: HTMLInputElement;
+    let tabbableLast: HTMLButtonElement;
+
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope trapped>
+            {(props) => (
+              <div {...props}>
+                <form>
+                  <TestField label={INNER_NAME_INPUT_LABEL} tabIndex={-1} />
+                  <TestField label={INNER_EMAIL_INPUT_LABEL} />
+                  <button>{INNER_SUBMIT_LABEL}</button>
+                </form>
+              </div>
+            )}
+          </FocusScope>
+          <TestField label="other" />
+          <button>some outer button</button>
+        </div>
+      );
+      tabbableSecond = rendered.getByLabelText(INNER_EMAIL_INPUT_LABEL) as HTMLInputElement;
+      tabbableLast = rendered.getByText(INNER_SUBMIT_LABEL) as HTMLButtonElement;
+    });
+
+    it('should skip the element with a negative tabindex on tab', () => {
+      focus(tabbableLast);
+      userEvent.tab();
+      expect(tabbableSecond).toHaveFocus();
+    });
+
+    it('should skip the element with a negative tabindex on shift+tab', () => {
+      focus(tabbableSecond);
+      userEvent.tab({ shift: true });
+      expect(tabbableLast).toHaveFocus();
+    });
+  });
+
+  describe('given a FocusScope with internal focus handlers', () => {
+    const handleLastFocusableElementBlur = jest.fn();
+    let rendered: RenderResult;
+    let tabbableFirst: HTMLInputElement;
+
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope trapped>
+            {(props) => (
+              <div {...props}>
+                <form>
+                  <TestField label={INNER_NAME_INPUT_LABEL} />
+                  <button onBlur={handleLastFocusableElementBlur}>{INNER_SUBMIT_LABEL}</button>
+                </form>
+              </div>
+            )}
+          </FocusScope>
+        </div>
+      );
+      tabbableFirst = rendered.getByLabelText(INNER_NAME_INPUT_LABEL) as HTMLInputElement;
+    });
+
+    it('should properly blur the last element in the scope before cycling back', async () => {
+      // Tab back and then tab forward to cycle through the scope
+      focus(tabbableFirst);
+      userEvent.tab({ shift: true });
+      userEvent.tab();
+      expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function focus(element: HTMLElement) {
+  act(() => {
+    element.focus();
+  });
+}
+
+function TestField({ label, ...props }: { label: string } & React.ComponentProps<'input'>) {
+  return (
+    <label>
+      <span>{label}</span>
+      <input type="text" name={label.toLowerCase()} {...props} />
+    </label>
+  );
+}

--- a/packages/react/focus-scope/src/createFocusScope.tsx
+++ b/packages/react/focus-scope/src/createFocusScope.tsx
@@ -52,9 +52,7 @@ function createFocusScope(container: HTMLElement) {
     if (focusScope.paused) return;
 
     requestAnimationFrame(() => {
-      // Use document.activeElement instead of event.relatedTarget because it is more reliable if an
-      // iframe receives focus.
-      const elementReceivingFocus = document.activeElement;
+      const elementReceivingFocus = event.relatedTarget as Element | null;
       if (!container.contains(elementReceivingFocus)) {
         trapFocus(container, elementReceivingFocus);
       }

--- a/packages/react/focus-scope/src/createFocusScope.tsx
+++ b/packages/react/focus-scope/src/createFocusScope.tsx
@@ -27,26 +27,38 @@ function createFocusScope(container: HTMLElement) {
   }
 
   function addListeners() {
-    document.addEventListener('focusout', handleFocusInOrFocusOut, { capture: true });
-    document.addEventListener('focusin', handleFocusInOrFocusOut, { capture: true });
+    document.addEventListener('focusout', handleFocusOut, { capture: true });
+    document.addEventListener('focusin', handleFocusIn, { capture: true });
   }
 
   function removeListeners() {
-    document.removeEventListener('focusout', handleFocusInOrFocusOut, { capture: true });
-    document.removeEventListener('focusin', handleFocusInOrFocusOut, { capture: true });
+    document.removeEventListener('focusout', handleFocusOut, { capture: true });
+    document.removeEventListener('focusin', handleFocusIn, { capture: true });
   }
 
-  function handleFocusInOrFocusOut(event: FocusEvent) {
+  function handleFocusIn(event: FocusEvent) {
     if (focusScope.paused) return;
 
-    const isFocusOut = event.type === 'focusout';
-    const focusedTarget = (isFocusOut ? event.relatedTarget : event.target) as Element | null;
+    const focusedTarget = event.target as Element | null;
     if (!container.contains(focusedTarget)) {
       // we're intercepting the event and will re-focus in
       // so we also pretend that the event didn't happen by stopping propagation.
       event.stopImmediatePropagation();
       trapFocus(container, focusedTarget);
     }
+  }
+
+  function handleFocusOut(event: FocusEvent) {
+    if (focusScope.paused) return;
+
+    requestAnimationFrame(() => {
+      // Use document.activeElement instead of event.relatedTarget because it is more reliable if an
+      // iframe receives focus.
+      const elementReceivingFocus = document.activeElement;
+      if (!container.contains(elementReceivingFocus)) {
+        trapFocus(container, elementReceivingFocus);
+      }
+    });
   }
 
   // create focus scope instance

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,6 +4249,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/user-event@npm:^12.6.0":
+  version: 12.6.0
+  resolution: "@testing-library/user-event@npm:12.6.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: d6ad1876131b934137794a2b910f3f875ade748c3f6bd6e210089f740937d6ab8aa7d80201dcdaacdc7e208a69a807fbbe64cbd2c849449c23afa34dd5742f54
+  languageName: node
+  linkType: hard
+
 "@types/anymatch@npm:*":
   version: 1.3.1
   resolution: "@types/anymatch@npm:1.3.1"
@@ -15248,6 +15259,7 @@ fsevents@^1.2.7:
     "@storybook/react": 6.1.0-beta.4
     "@testing-library/jest-dom": ^5.11.3
     "@testing-library/react": ^10.4.8
+    "@testing-library/user-event": ^12.6.0
     "@types/eslint": ^7
     "@types/jest": ^26.0.10
     "@types/jest-axe": ^3.5.0


### PR DESCRIPTION
Fixes #365. I tested across all our stories that use `FocusScope` under the hood and, as far as I can tell, everything still works as expected. @benoitgrelard will definitely want to have a look at this as he may be aware of some edge cases I'm not as it relates to the changes made in the `focusout` handler.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Add or edit tests to reflect the change (run `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
