### PR TITLE
ToggleButton: Add ToggleButtonGroup and ToggleButtonGroupExclusive components

### DIFF
--- a/packages/react/toggle-button/src/ToggleButton.stories.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ToggleButton, ToggleButtonGroup } from './ToggleButton';
+import { ToggleButton, ToggleButtonGroup, ToggleButtonGroupExclusive } from './ToggleButton';
 import { styled } from '../../../../stitches.config';
 
 export default { title: 'Components/ToggleButton' };
@@ -18,7 +18,7 @@ export const Controlled = () => {
 
 export const Grouped = () => {
   return (
-    <ToggleButtonGroup defaultValue={['1']}>
+    <ToggleButtonGroup aria-label="Options" defaultValue={['1']}>
       <ToggleButton value="1" as={StyledRoot}>
         Option 1
       </ToggleButton>
@@ -36,7 +36,11 @@ export const GroupedControlled = () => {
   const [value, setValue] = React.useState<string[]>(['1']);
 
   return (
-    <ToggleButtonGroup value={value} onValueChange={setValue}>
+    <ToggleButtonGroup
+      aria-label="Options"
+      value={value}
+      onValueChange={(val) => setValue(val as any)}
+    >
       <ToggleButton value="1" as={StyledRoot}>
         Option 1
       </ToggleButton>
@@ -47,6 +51,35 @@ export const GroupedControlled = () => {
         Option 3
       </ToggleButton>
     </ToggleButtonGroup>
+  );
+};
+
+export const GroupedControlledExclusive = () => {
+  const [value, setValue] = React.useState<string | null>(null);
+  function handleValueChange(newValue: string | null) {
+    if (newValue === value) {
+      setValue(null);
+    } else {
+      setValue(newValue);
+    }
+  }
+
+  return (
+    <ToggleButtonGroupExclusive
+      aria-label="Options"
+      value={value}
+      onValueChange={handleValueChange}
+    >
+      <ToggleButton value="1" as={StyledRoot}>
+        Option 1
+      </ToggleButton>
+      <ToggleButton value="2" as={StyledRoot}>
+        Option 2
+      </ToggleButton>
+      <ToggleButton value="3" as={StyledRoot}>
+        Option 3
+      </ToggleButton>
+    </ToggleButtonGroupExclusive>
   );
 };
 

--- a/packages/react/toggle-button/src/ToggleButton.stories.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ToggleButton } from './ToggleButton';
+import { ToggleButton, ToggleButtonGroup } from './ToggleButton';
 import { styled } from '../../../../stitches.config';
 
 export default { title: 'Components/ToggleButton' };
@@ -13,6 +13,40 @@ export const Controlled = () => {
     <ToggleButton as={StyledRoot} toggled={toggled} onToggledChange={setToggled}>
       {toggled ? 'On' : 'Off'}
     </ToggleButton>
+  );
+};
+
+export const Grouped = () => {
+  return (
+    <ToggleButtonGroup defaultValue={['1']}>
+      <ToggleButton value="1" as={StyledRoot}>
+        Option 1
+      </ToggleButton>
+      <ToggleButton value="2" as={StyledRoot}>
+        Option 2
+      </ToggleButton>
+      <ToggleButton value="3" as={StyledRoot}>
+        Option 3
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+};
+
+export const GroupedControlled = () => {
+  const [value, setValue] = React.useState<string[]>(['1']);
+
+  return (
+    <ToggleButtonGroup value={value} onValueChange={setValue}>
+      <ToggleButton value="1" as={StyledRoot}>
+        Option 1
+      </ToggleButton>
+      <ToggleButton value="2" as={StyledRoot}>
+        Option 2
+      </ToggleButton>
+      <ToggleButton value="3" as={StyledRoot}>
+        Option 3
+      </ToggleButton>
+    </ToggleButtonGroup>
   );
 };
 

--- a/packages/react/toggle-button/src/ToggleButton.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.tsx
@@ -1,10 +1,90 @@
 import * as React from 'react';
-import { useControlledState, composeEventHandlers } from '@radix-ui/react-utils';
-import { getPartDataAttrObj } from '@radix-ui/utils';
+import { useControlledState, composeEventHandlers, useId } from '@radix-ui/react-utils';
+import { getPartDataAttrObj, warning, makeId } from '@radix-ui/utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 
-const NAME = 'ToggleButton';
-const DEFAULT_TAG = 'button';
+/* -------------------------------------------------------------------------------------------------
+ * ToggleButtonGroup
+ * -----------------------------------------------------------------------------------------------*/
+
+const GROUP_NAME = 'ToggleButtonGroup';
+const GROUP_DEFAULT_TAG = 'div';
+
+type SelectionMode = 'multiple' | 'exclusive';
+
+type ToggleButtonGroupContextValue = {
+  value: string[] | undefined;
+  setValue: React.Dispatch<React.SetStateAction<string[] | undefined>>;
+  selectionMode: SelectionMode;
+};
+
+const ToggleButtonGroupContext = React.createContext<ToggleButtonGroupContextValue>(null as any);
+ToggleButtonGroupContext.displayName = GROUP_NAME + 'Context';
+
+type ToggleButtonGroupOwnProps = {
+  /**
+   * Controls how buttons within a group are selected. If set to `"multiple"`, any number of buttons
+   * in a group may be toggled at a time (similar to a checkbox). If `"exclusive"`, only a single
+   * button within a group can be toggled at a time (similar to a radio group).
+   *
+   * (default: `"multiple"`)
+   * */
+  selectionMode?: SelectionMode;
+  /** The controlled value of the toggled button */
+  value?: string[];
+  /** The uncontrolled value of the toggled button */
+  defaultValue?: string[];
+  /** A function called when the value of the toggled buttons changes */
+  onValueChange?(value: string[]): void;
+};
+
+const ToggleButtonGroup = forwardRefWithAs<typeof GROUP_DEFAULT_TAG, ToggleButtonGroupOwnProps>(
+  (props, forwardedRef) => {
+    const {
+      as: Comp = GROUP_DEFAULT_TAG,
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+      children,
+      selectionMode = 'multiple',
+      ...groupProps
+    } = props;
+
+    const [value, setValue] = useControlledState<string[]>({
+      prop: valueProp,
+      defaultProp: defaultValue,
+      onChange: onValueChange,
+    });
+
+    const context: ToggleButtonGroupContextValue = React.useMemo(
+      () => ({
+        selectionMode,
+        setValue,
+        value,
+      }),
+      [selectionMode, setValue, value]
+    );
+
+    useGroupSelectionModeWarning({ selectionMode, valueProp, defaultValue });
+
+    return (
+      <Comp {...getPartDataAttrObj(GROUP_NAME)} role="group" ref={forwardedRef} {...groupProps}>
+        <ToggleButtonGroupContext.Provider value={context}>
+          {children}
+        </ToggleButtonGroupContext.Provider>
+      </Comp>
+    );
+  }
+);
+
+ToggleButtonGroup.displayName = GROUP_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * ToggleButton
+ * -----------------------------------------------------------------------------------------------*/
+
+const BUTTON_NAME = 'ToggleButton';
+const BUTTON_DEFAULT_TAG = 'button';
 
 type ToggleButtonOwnProps = {
   /** Whether the button is toggled or not, if controlled */
@@ -16,29 +96,53 @@ type ToggleButtonOwnProps = {
   defaultToggled?: boolean;
   /** A function called when the button is toggled */
   onToggledChange?(toggled: boolean): void;
+  /**
+   * A string value for the toggle button. Optional unless the button is inside of a
+   * `ToggleButtonGroup`. All items within a `ToggleButtonGroup` should use a unique value.
+   */
+  value?: string;
 };
 
-const ToggleButton = forwardRefWithAs<typeof DEFAULT_TAG, ToggleButtonOwnProps>(
+const ToggleButton = forwardRefWithAs<typeof BUTTON_DEFAULT_TAG, ToggleButtonOwnProps>(
   (props, forwardedRef) => {
     const {
-      as: Comp = DEFAULT_TAG,
+      as: Comp = BUTTON_DEFAULT_TAG,
       toggled: toggledProp,
       defaultToggled = false,
       onClick,
       onToggledChange,
       children,
+      value: valueProp,
       ...buttonProps
     } = props;
 
-    const [toggled = false, setToggled] = useControlledState({
+    const [_toggled = false, _setToggled] = useControlledState<boolean>({
       prop: toggledProp,
       onChange: onToggledChange,
       defaultProp: defaultToggled,
     });
 
+    const generatedValue = makeId(`toggle-button`, useId());
+    const value = valueProp || generatedValue;
+
+    const groupContext = React.useContext(ToggleButtonGroupContext);
+    const toggled = groupContext ? groupContext.value?.includes(value) : _toggled;
+    const setToggled = groupContext
+      ? (toggled: boolean) =>
+          groupContext.setValue((prevValues) =>
+            toggled
+              ? (prevValues || []).filter((val) => val !== value)
+              : groupContext.selectionMode === 'exclusive'
+              ? [value]
+              : (prevValues || []).concat(value)
+          )
+      : _setToggled;
+
+    useButtonStateInGroupWarning({ toggledProp, defaultToggled, groupContext });
+
     return (
       <Comp
-        {...getPartDataAttrObj(NAME)}
+        {...getPartDataAttrObj(BUTTON_NAME)}
         type="button"
         aria-pressed={toggled}
         data-state={toggled ? 'on' : 'off'}
@@ -57,12 +161,55 @@ const ToggleButton = forwardRefWithAs<typeof DEFAULT_TAG, ToggleButtonOwnProps>(
   }
 );
 
-ToggleButton.displayName = NAME;
+ToggleButton.displayName = BUTTON_NAME;
 
 const Root = ToggleButton;
+const Group = ToggleButtonGroup;
 
-export {
-  ToggleButton,
-  //
-  Root,
-};
+export { ToggleButton, ToggleButtonGroup, Group, Root };
+
+function useGroupSelectionModeWarning({
+  valueProp,
+  defaultValue,
+  selectionMode,
+}: {
+  valueProp: string[] | undefined;
+  defaultValue: string[] | undefined;
+  selectionMode: SelectionMode;
+}) {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      const isControlled = valueProp !== undefined;
+      const propName = isControlled ? '`value`' : '`defaultValue`';
+      const value = isControlled ? valueProp : defaultValue;
+      warning(
+        !(selectionMode === 'exclusive' && value?.length && value.length > 1),
+        `When \`selectionMode\` is set to \`'exclusive'\`, only a single value can be passed to the ${propName} prop in ${GROUP_NAME}. Check to make sure multiple values are not included in the ${propName} array, or change \`selectionMode\` to \`'inclusive'\` to allow multiple toggled buttons in a ${GROUP_NAME}.`
+      );
+    }, [defaultValue, selectionMode, valueProp]);
+  }
+}
+
+function useButtonStateInGroupWarning({
+  toggledProp,
+  defaultToggled,
+  groupContext,
+}: {
+  toggledProp: boolean | undefined;
+  defaultToggled: boolean | undefined;
+  groupContext: ToggleButtonGroupContextValue | null;
+}) {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      const isControlled = toggledProp !== undefined;
+      const propName = isControlled ? '`toggled`' : '`defaultToggled`';
+      const toggled = isControlled ? toggledProp : defaultToggled;
+      warning(
+        !(groupContext && toggled !== undefined),
+        `A ${BUTTON_NAME} with an explicit ${propName} prop was used inside of a ${GROUP_NAME}. When ${BUTTON_NAME} is used inside of a ${GROUP_NAME}, the ${GROUP_NAME} component is responsible for managing the toggled state of its nested ${BUTTON_NAME} components. Either remove the ${propName} from ${BUTTON_NAME} or remove the ${GROUP_NAME} component if the ${BUTTON_NAME} is unrelated to other surrounding buttons.`
+      );
+    }, [groupContext, toggledProp, defaultToggled]);
+  }
+}


### PR DESCRIPTION
Instead of creating a new package, I added `ToggleButtonGroup` and `ToggleButtonGroupExclusive` components to the existing `ToggleButton` package. I think this makes sense, but let me know if anyone has any strong feelings why we'd need a separate package.

A few notes:
- There is no ARIA pattern for toggle button groups specifically. In many cases, toggle button groups in many native contexts use a roving tabindex and use keyboard controls similar to radio buttons, but this is not universally expected necessarily (for example, in a larger menubar, the menu itself manages focus of its children, and groups are irrelevant in that context). Further, I'm not sure it would be intuitive or expected for assistive tech unless there was an `aria-description` with keyboard instructions. As far as screen readers go, they just know they are in a group on a toggle button, and one would expect tab to move to the next item in the group.
- `ToggleButtonGroupExclusive` was used in lieu of a prop to determine whether or not not multiple items in a group can be selected simultaneously (like a radio group). The main reason for this is because the prop typing changes depending on this setting, and I don't believe we can create generic components with `forwardRefWithAs`. I tried playing with it for a while and didn't get anywhere with it, but I figure this approach simplifies implementation regardless. Consumers can wrap this and create that API if they need support for both and would prefer a prop to determine the selection mode.



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`). -- *NOTE:* I will add tests after getting feedback on the API
- [x] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features. *NOTE:* See testing note, same goes for docs

This pull request:

- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
