### PR TITLE
ScrollArea: Temporary workaround for double render (#351)

### DIFF
--- a/.yarn/versions/257b7174.yml
+++ b/.yarn/versions/257b7174.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-scroll-area": patch
+
+declined:
+  - primitives

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -10,6 +10,7 @@ import {
   ScrollAreaCorner,
   ScrollAreaTrack,
   ScrollAreaThumb,
+  unstable_ScrollAreaNoNativeFallback as ScrollAreaNoNativeFallback,
   SCROLL_AREA_CSS_PROPS,
 } from './ScrollArea';
 import { Popover, PopoverContent, PopoverTrigger, PopoverArrow } from '@radix-ui/react-popover';
@@ -202,6 +203,88 @@ export function InsidePopover() {
           <PopoverArrow width={50} height={20} />
         </PopoverContent>
       </Popover>
+    </React.Fragment>
+  );
+}
+
+// We'll likely remove this eventually
+// See https://github.com/radix-ui/primitives/issues/351
+export function WithoutNativeFallback() {
+  const { unstable_forceNative, ...scrollAreaControlProps } = useScrollAreaControlProps();
+  const divRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const div = divRef.current;
+    function handleMouseEnter() {
+      console.log('Hello, you have entered the div zone!');
+    }
+    div?.addEventListener('mouseenter', handleMouseEnter);
+    return () => {
+      div?.removeEventListener('mouseenter', handleMouseEnter);
+    };
+  }, []);
+  return (
+    <React.Fragment>
+      <ScrollPropControls disableForceNative />
+      <hr />
+      <Resizable>
+        <ScrollAreaNoNativeFallback
+          as={Win98StyledRoot}
+          overflowX="scroll"
+          {...scrollAreaControlProps}
+          css={{ width: '400px', height: '400px' }}
+        >
+          <ScrollAreaScrollbarY as={Win98StyledScrollbarY}>
+            <ScrollAreaButtonStart as={Win98StyledScrollButton}>
+              <Arrow direction="up" />
+            </ScrollAreaButtonStart>
+
+            <ScrollAreaTrack as={Win98StyledScrollTrack}>
+              <ScrollAreaThumb as={Win98StyledScrollThumb} />
+            </ScrollAreaTrack>
+            <ScrollAreaButtonEnd as={Win98StyledScrollButton}>
+              <Arrow direction="down" />
+            </ScrollAreaButtonEnd>
+          </ScrollAreaScrollbarY>
+
+          <ScrollAreaScrollbarX as={Win98StyledScrollbarX}>
+            <ScrollAreaButtonStart as={Win98StyledScrollButton}>
+              <Arrow direction="left" />
+            </ScrollAreaButtonStart>
+
+            <ScrollAreaTrack as={Win98StyledScrollTrack}>
+              <ScrollAreaThumb as={Win98StyledScrollThumb} />
+            </ScrollAreaTrack>
+            <ScrollAreaButtonEnd as={Win98StyledScrollButton}>
+              <Arrow direction="right" />
+            </ScrollAreaButtonEnd>
+          </ScrollAreaScrollbarX>
+
+          <ScrollAreaCorner as={Win98StyledCorner} />
+
+          <ScrollAreaViewport
+            as={BaseStyledViewport}
+            css={{
+              width: '1000px',
+              padding: 20,
+
+              '& > :first-child': {
+                marginTop: 0,
+              },
+
+              '& > :last-child': {
+                marginBottom: 0,
+              },
+            }}
+          >
+            <div ref={divRef} style={{ padding: '10px', border: '1px solid crimson' }}>
+              Mouse over me and check your logs!
+            </div>
+            <LongContent />
+            <LongContent />
+            <LongContent />
+          </ScrollAreaViewport>
+        </ScrollAreaNoNativeFallback>
+      </Resizable>
     </React.Fragment>
   );
 }
@@ -595,7 +678,7 @@ function useScrollAreaControlProps() {
   };
 }
 
-function ScrollPropControls() {
+function ScrollPropControls({ disableForceNative }: { disableForceNative?: boolean }) {
   const {
     forceNative,
     setForceNative,
@@ -621,13 +704,15 @@ function ScrollPropControls() {
       <Box>
         <Fieldset>
           <Legend>Simulation options:</Legend>
-          <Checkbox
-            name="forceNative"
-            checked={forceNative}
-            onChange={(e) => setForceNative(e.target.checked)}
-          >
-            Force native scrollbars
-          </Checkbox>
+          {!disableForceNative ? (
+            <Checkbox
+              name="forceNative"
+              checked={forceNative}
+              onChange={(e) => setForceNative(e.target.checked)}
+            >
+              Force native scrollbars
+            </Checkbox>
+          ) : null}
           <Checkbox
             name="prefersReducedMotion"
             checked={prefersReducedMotion}

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -301,7 +301,7 @@ const ScrollAreaNative = forwardRefWithAs<typeof ROOT_DEFAULT_TAG, ScrollAreaNat
 );
 
 type ScrollAreaImplProps = ScrollAreaInternalProps &
-  Required<Omit<ScrollAreaOwnProps, 'unstable_forceNative'>>;
+  Omit<ScrollAreaOwnProps, 'unstable_forceNative'>;
 
 const initialSize = { width: 0, height: 0 };
 const initialState: ScrollAreaReducerState = {

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -1587,6 +1587,7 @@ const ButtonEnd = ScrollAreaButtonEnd;
 const Track = ScrollAreaTrack;
 const Thumb = ScrollAreaThumb;
 const Corner = ScrollAreaCorner;
+const unstable_ScrollAreaNoNativeFallback = ScrollAreaNoNativeFallback;
 
 export {
   ScrollArea,
@@ -1598,7 +1599,7 @@ export {
   ScrollAreaTrack,
   ScrollAreaThumb,
   ScrollAreaCorner,
-  ScrollAreaNoNativeFallback as unstable_ScrollAreaNoNativeFallback,
+  unstable_ScrollAreaNoNativeFallback,
   //
   Root,
   Viewport,

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -50,14 +50,6 @@ const SCROLL_AREA_CSS_PROPS_LIST = [
   'cornerHeight',
 ] as const;
 const SCROLL_AREA_CSS_PROPS = SCROLL_AREA_CSS_PROPS_LIST.reduce(reduceToCssProperties, {} as any);
-const AUTO = 'auto';
-const HOVER = 'hover';
-const ALWAYS = 'always';
-const SCROLL = 'scroll';
-const NONE = 'none';
-const RELATIVE = 'relative';
-const LTR = 'ltr';
-const RTL = 'rtl';
 
 enum ScrollAreaState {
   Idle = 'Idle',
@@ -87,12 +79,12 @@ const ROOT_DEFAULT_TAG = 'div';
 const ROOT_NAME = 'ScrollArea';
 const ROOT_DEFAULT_PROPS = {
   as: ROOT_DEFAULT_TAG,
-  overflowX: AUTO,
-  overflowY: AUTO,
-  scrollbarVisibility: HOVER,
+  overflowX: 'auto',
+  overflowY: 'auto',
+  scrollbarVisibility: 'hover',
   scrollbarVisibilityRestTimeout: 600,
-  dir: LTR,
-  trackClickBehavior: RELATIVE,
+  dir: 'ltr',
+  trackClickBehavior: 'relative',
   unstable_prefersReducedMotion: false,
 } as const;
 
@@ -301,7 +293,7 @@ const ScrollAreaNative = forwardRefWithAs<typeof ROOT_DEFAULT_TAG, ScrollAreaNat
 
           // Set this inline since we don't currently support resizable scroll areas. This feature
           // will come later.
-          resize: NONE,
+          resize: 'none',
         }}
       />
     );
@@ -387,8 +379,8 @@ const ScrollAreaImpl = forwardRefWithAs<typeof ROOT_DEFAULT_TAG, ScrollAreaImplP
 
     const [reducerState, dispatch] = React.useReducer(scrollAreaStateReducer, {
       ...initialState,
-      scrollbarIsVisibleX: scrollbarVisibility === ALWAYS,
-      scrollbarIsVisibleY: scrollbarVisibility === ALWAYS,
+      scrollbarIsVisibleX: scrollbarVisibility === 'always',
+      scrollbarIsVisibleY: scrollbarVisibility === 'always',
     });
 
     const {
@@ -448,25 +440,25 @@ const ScrollAreaImpl = forwardRefWithAs<typeof ROOT_DEFAULT_TAG, ScrollAreaImplP
     //  - overflow is `auto` and scrollbar autohide is `never`
     //  - overflow is `hidden` or `visible` (scrollbars are hidden no matter what in either case)
     const shouldOffsetX =
-      scrollbarVisibility === ALWAYS &&
-      (overflowX === SCROLL || (overflowX === AUTO && reducerState.contentIsOverflowingX));
+      scrollbarVisibility === 'always' &&
+      (overflowX === 'scroll' || (overflowX === 'auto' && reducerState.contentIsOverflowingX));
     const shouldOffsetY =
-      scrollbarVisibility === ALWAYS &&
-      (overflowY === SCROLL || (overflowY === AUTO && reducerState.contentIsOverflowingY));
+      scrollbarVisibility === 'always' &&
+      (overflowY === 'scroll' || (overflowY === 'auto' && reducerState.contentIsOverflowingY));
 
     const { domSizes } = reducerState;
 
     const style: any = {
       [SCROLL_AREA_CSS_PROPS.scrollbarXOffset]:
-        shouldOffsetX && domSizes.scrollbarX.height ? toPixelString(domSizes.scrollbarX.height) : 0,
+        shouldOffsetX && domSizes.scrollbarX.height ? domSizes.scrollbarX.height + 'px' : 0,
       [SCROLL_AREA_CSS_PROPS.scrollbarYOffset]:
-        shouldOffsetY && domSizes.scrollbarY.width ? toPixelString(domSizes.scrollbarY.width) : 0,
+        shouldOffsetY && domSizes.scrollbarY.width ? domSizes.scrollbarY.width + 'px' : 0,
       [SCROLL_AREA_CSS_PROPS.positionWidth]: domSizes.position.width
-        ? toPixelString(domSizes.position.width)
-        : AUTO,
+        ? domSizes.position.width + 'px'
+        : 'auto',
       [SCROLL_AREA_CSS_PROPS.positionHeight]: domSizes.position.height
-        ? toPixelString(domSizes.position.height)
-        : AUTO,
+        ? domSizes.position.height + 'px'
+        : 'auto',
     };
 
     return (
@@ -633,12 +625,12 @@ const ScrollAreaViewportImpl = forwardRefWithAs<typeof VIEWPORT_DEFAULT_TAG>(
         onScroll={handleScroll}
         style={{
           zIndex: 1,
-          width: toCssCustomProp(SCROLL_AREA_CSS_PROPS.positionWidth),
-          height: toCssCustomProp(SCROLL_AREA_CSS_PROPS.positionHeight),
-          scrollbarWidth: NONE,
+          width: `var(${SCROLL_AREA_CSS_PROPS.positionWidth})`,
+          height: `var(${SCROLL_AREA_CSS_PROPS.positionHeight})`,
+          scrollbarWidth: 'none',
           // @ts-ignore
           overflowScrolling: 'touch',
-          resize: NONE,
+          resize: 'none',
           overflowX,
           overflowY,
         }}
@@ -652,8 +644,8 @@ const ScrollAreaViewportImpl = forwardRefWithAs<typeof VIEWPORT_DEFAULT_TAG>(
             // https://blog.alexandergottlieb.com/overflow-scroll-and-the-right-padding-problem-a-css-only-solution-6d442915b3f4
             display: 'table',
             width: '100%',
-            paddingBottom: toCssCustomProp(SCROLL_AREA_CSS_PROPS.scrollbarXOffset),
-            paddingRight: toCssCustomProp(SCROLL_AREA_CSS_PROPS.scrollbarYOffset),
+            paddingBottom: `var(${SCROLL_AREA_CSS_PROPS.scrollbarXOffset})`,
+            paddingRight: `var(${SCROLL_AREA_CSS_PROPS.scrollbarYOffset})`,
           }}
         >
           <Comp {...getPartDataAttrObj(VIEWPORT_NAME)} ref={ref} {...domProps} />
@@ -801,24 +793,24 @@ const ScrollAreaScrollbarImpl = forwardRefWithAs<
   const opacity = (function () {
     const defaultVisible = domProps.style?.opacity || 1;
     switch (scrollbarVisibility) {
-      case ALWAYS:
+      case 'always':
         return domProps.style?.opacity;
-      case SCROLL:
+      case 'scroll':
         return scrollbarIsVisible ? defaultVisible : 0;
-      case HOVER:
+      case 'hover':
         return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 0;
     }
   })();
 
   const pointerEvents = (function () {
-    const defaultVisible = domProps.style?.pointerEvents || AUTO;
+    const defaultVisible = domProps.style?.pointerEvents || 'auto';
     switch (scrollbarVisibility) {
-      case ALWAYS:
+      case 'always':
         return domProps.style?.pointerEvents;
-      case SCROLL:
-        return scrollbarIsVisible ? defaultVisible : NONE;
-      case HOVER:
-        return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : NONE;
+      case 'scroll':
+        return scrollbarIsVisible ? defaultVisible : 'none';
+      case 'hover':
+        return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 'none';
     }
   })();
 
@@ -836,7 +828,7 @@ const ScrollAreaScrollbarImpl = forwardRefWithAs<
         {...domProps}
         style={{
           ...domProps.style,
-          display: !contentIsOverflowing ? NONE : domProps.style?.display,
+          display: !contentIsOverflowing ? 'none' : domProps.style?.display,
           opacity,
           pointerEvents,
         }}
@@ -863,7 +855,7 @@ const ScrollAreaScrollbarX = forwardRefWithAs<typeof SCROLLBAR_DEFAULT_TAG>(
           ...props.style,
           // @ts-ignore
           [SCROLL_AREA_CSS_PROPS.scrollbarXSize]: domSizes.scrollbarX.height
-            ? toPixelString(domSizes.scrollbarX.height)
+            ? domSizes.scrollbarX.height + 'px'
             : 0,
         }}
       />
@@ -886,7 +878,7 @@ const ScrollAreaScrollbarY = forwardRefWithAs<typeof SCROLLBAR_DEFAULT_TAG>(
           ...props.style,
           // @ts-ignore
           [SCROLL_AREA_CSS_PROPS.scrollbarYSize]: domSizes.scrollbarY.width
-            ? toPixelString(domSizes.scrollbarY.width)
+            ? domSizes.scrollbarY.width + 'px'
             : 0,
         }}
       />
@@ -1290,11 +1282,11 @@ const ScrollAreaThumb = forwardRefWithAs<typeof THUMB_DEFAULT_TAG>(function Scro
           ? {
               [SCROLL_AREA_CSS_PROPS.scrollbarThumbWillChange]: 'left',
               [SCROLL_AREA_CSS_PROPS.scrollbarThumbHeight]: '100%',
-              [SCROLL_AREA_CSS_PROPS.scrollbarThumbWidth]: AUTO,
+              [SCROLL_AREA_CSS_PROPS.scrollbarThumbWidth]: 'auto',
             }
           : {
               [SCROLL_AREA_CSS_PROPS.scrollbarThumbWillChange]: 'top',
-              [SCROLL_AREA_CSS_PROPS.scrollbarThumbHeight]: AUTO,
+              [SCROLL_AREA_CSS_PROPS.scrollbarThumbHeight]: 'auto',
               [SCROLL_AREA_CSS_PROPS.scrollbarThumbWidth]: '100%',
             }),
       }}
@@ -1520,7 +1512,7 @@ const ScrollAreaCornerImpl = forwardRefWithAs<typeof CORNER_DEFAULT_TAG>(
     const dispatch = useDispatchContext(CORNER_NAME);
     const { dir } = useScrollAreaContext(CORNER_NAME);
     const { domSizes } = useScrollAreaStateContext();
-    const isRTL = dir === RTL;
+    const isRTL = dir === 'rtl';
 
     const style: any = {
       // The resize handle is placed, by default, in the bottom right corner of the scroll area. In
@@ -1530,14 +1522,14 @@ const ScrollAreaCornerImpl = forwardRefWithAs<typeof CORNER_DEFAULT_TAG>(
       [SCROLL_AREA_CSS_PROPS.cornerRight]: isRTL ? 'unset' : 0,
 
       [SCROLL_AREA_CSS_PROPS.cornerHeight]: domSizes.scrollbarX.height
-        ? toPixelString(domSizes.scrollbarX.height)
+        ? domSizes.scrollbarX.height + 'px'
         : domSizes.scrollbarY.width
-        ? toPixelString(domSizes.scrollbarY.width)
+        ? domSizes.scrollbarY.width + 'px'
         : '16px',
       [SCROLL_AREA_CSS_PROPS.cornerWidth]: domSizes.scrollbarY.width
-        ? toPixelString(domSizes.scrollbarY.width)
+        ? domSizes.scrollbarY.width + 'px'
         : domSizes.scrollbarX.height
-        ? toPixelString(domSizes.scrollbarX.height)
+        ? domSizes.scrollbarX.height + 'px'
         : '16px',
 
       position: 'absolute',
@@ -1677,7 +1669,7 @@ function scrollAreaStateReducer(
       };
     }
     case ScrollAreaEvents.SetScrollbarIsVisible: {
-      if (event.scrollbarVisibility === ALWAYS) {
+      if (event.scrollbarVisibility === 'always') {
         return {
           ...context,
           scrollbarIsVisibleX: true,
@@ -1822,11 +1814,11 @@ function useExtendedScrollAreaRef(
       },
       addScrollListener(...args: any[]) {
         // @ts-ignore
-        elementToHandle.addEventListener(SCROLL, ...args);
+        elementToHandle.addEventListener('scroll', ...args);
       },
       removeScrollListener(...args: any[]) {
         // @ts-ignore
-        elementToHandle.removeEventListener(SCROLL, ...args);
+        elementToHandle.removeEventListener('scroll', ...args);
       },
     };
 
@@ -2131,7 +2123,7 @@ function getThumbSize(args: {
   if (!shouldOverflow(positionElement, { axis })) {
     // We're at 100% visible area, no need to show the scroll thumb:
     return {
-      display: NONE,
+      display: 'none',
       width: 0,
       height: 0,
     };
@@ -2328,14 +2320,6 @@ function updateThumbPosition(args: {
   } else if (axis === 'y') {
     thumbElement.style.top = `${thumbPos * 100}%`;
   }
-}
-
-function toPixelString(value: number) {
-  return value + 'px';
-}
-
-function toCssCustomProp(value: number | string) {
-  return `var(${value})`;
 }
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR exports a wrapper component that will bypass the double render caused by our `ScrollArea` implementation. This is intended as a stop-gap solution to an issue @StephenHaney is having with internal event listeners not running because we throw away the initially rendered DOM.

Long term I'm leaning towards removing the native fallback altogether and exposing a hook to detect compatibility instead, leaving it to the consumer to handle feature detection so they can wrap it however they'd like. That would let us get rid of the weird ref issues in the simplest way IMO. I'd like to wait for @jjenzz to get back to review and offer feedback as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
