### PR TITLE
Remove unnecessary package resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,8 +140,5 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --quiet --fix --cache"
-  },
-  "resolutions": {
-    "@types/styled-system__core": "npm:@peduarte/styled-system__core@*"
   }
 }


### PR DESCRIPTION
Just removing an unnecessary `@types/styled-system__core` resolution in the package.json. This has been there since the first days of Radix but that dependency is no longer used by the project itself or any sub-dependency. Everything seems to work fine after deleting it.