### PR TITLE
[Popover][DropdownMenu] Fix race condition when dismissing via click outside and `disableOutsidePointerEvents` is off. 

### DIFF
--- a/.yarn/versions/f17394b2.yml
+++ b/.yarn/versions/f17394b2.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/f17394b2.yml
+++ b/.yarn/versions/f17394b2.yml
@@ -1,5 +1,7 @@
 releases:
+  "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
   "@radix-ui/react-popover": patch
 
 declined:

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -136,7 +136,7 @@ const DropdownMenuContent = forwardRefWithAs<
       open={context.open}
       onOpenChange={context.setOpen}
       anchorRef={anchorRef || context.triggerRef}
-      trapFocus
+      trapFocus={skipCloseAutoFocus ? false : true}
       onCloseAutoFocus={(event) => {
         if (skipCloseAutoFocus) {
           event.preventDefault();
@@ -145,7 +145,7 @@ const DropdownMenuContent = forwardRefWithAs<
         }
       }}
       disableOutsidePointerEvents={disableOutsidePointerEvents}
-      onPointerDownOutside={(event) => {
+      onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
         const wasTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
 
         // skip autofocus on close if clicking outside is allowed and it happened
@@ -155,15 +155,13 @@ const DropdownMenuContent = forwardRefWithAs<
         // as it's already setup to close, otherwise it would close and immediately open.
         if (wasTrigger) {
           event.preventDefault();
-        } else {
-          onInteractOutside?.(event);
         }
 
         if (event.defaultPrevented) {
           // reset this because the event was prevented
           setSkipCloseAutoFocus(false);
         }
-      }}
+      })}
       onInteractOutside={onInteractOutside}
       disableOutsideScroll={disableOutsideScroll}
       portalled={portalled}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -121,7 +121,6 @@ const DropdownMenuContent = forwardRefWithAs<
     ...contentProps
   } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
-  const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
   return (
     <MenuPrimitive.Root
       ref={forwardedRef}
@@ -136,32 +135,25 @@ const DropdownMenuContent = forwardRefWithAs<
       open={context.open}
       onOpenChange={context.setOpen}
       anchorRef={anchorRef || context.triggerRef}
-      trapFocus={skipCloseAutoFocus ? false : true}
+      trapFocus
       onCloseAutoFocus={(event) => {
-        if (skipCloseAutoFocus) {
-          event.preventDefault();
-        } else {
-          context.triggerRef.current?.focus();
-        }
+        event.preventDefault();
+        context.triggerRef.current?.focus();
       }}
       disableOutsidePointerEvents={disableOutsidePointerEvents}
-      onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
-        const wasTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+      onPointerDownOutside={composeEventHandlers(
+        onPointerDownOutside,
+        (event) => {
+          const wasTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
 
-        // skip autofocus on close if clicking outside is allowed and it happened
-        setSkipCloseAutoFocus(!disableOutsidePointerEvents);
-
-        // prevent dismissing when clicking the trigger
-        // as it's already setup to close, otherwise it would close and immediately open.
-        if (wasTrigger) {
-          event.preventDefault();
-        }
-
-        if (event.defaultPrevented) {
-          // reset this because the event was prevented
-          setSkipCloseAutoFocus(false);
-        }
-      })}
+          // prevent dismissing when clicking the trigger
+          // as it's already setup to close, otherwise it would close and immediately open.
+          if (wasTrigger) {
+            event.preventDefault();
+          }
+        },
+        { checkForDefaultPrevented: false }
+      )}
       onInteractOutside={onInteractOutside}
       disableOutsideScroll={disableOutsideScroll}
       portalled={portalled}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -214,10 +214,9 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
                 onPointerDownOutside={composeEventHandlers(
                   onPointerDownOutside,
                   (event) => {
-                    const isNotRightClick =
+                    const isLeftClick =
                       (event as MouseEvent).button === 0 && event.ctrlKey === false;
-
-                    const isPermitted = !disableOutsidePointerEvents && isNotRightClick;
+                    const isPermitted = !disableOutsidePointerEvents && isLeftClick;
                     setIsPermittedPointerDownOutsideEvent(isPermitted);
 
                     if (event.defaultPrevented) {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -172,6 +172,11 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
       setMenuTabIndex(itemsReachable ? -1 : 0);
     }, [itemsReachable]);
 
+    const [
+      isPermittedPointerDownOutsideEvent,
+      setIsPermittedPointerDownOutsideEvent,
+    ] = React.useState(false);
+
     const PortalWrapper = portalled ? Portal : React.Fragment;
     const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
 
@@ -189,15 +194,39 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
       <PortalWrapper>
         <ScrollLockWrapper>
           <FocusScope
-            trapped={trapFocus}
+            // clicking outside may raise a focusout event, which may get trapped.
+            // in cases where outside pointer events are permitted, we stop trapping.
+            trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
             onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={onCloseAutoFocus}
+            onUnmountAutoFocus={(event) => {
+              // skip autofocus on unmount if clicking outside is permitted and it happened
+              if (isPermittedPointerDownOutsideEvent) {
+                event.preventDefault();
+              } else {
+                onCloseAutoFocus?.(event);
+              }
+            }}
           >
             {(focusScopeProps) => (
               <DismissableLayer
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
                 onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={onPointerDownOutside}
+                onPointerDownOutside={composeEventHandlers(
+                  onPointerDownOutside,
+                  (event) => {
+                    const isNotRightClick =
+                      (event as MouseEvent).button === 0 && event.ctrlKey === false;
+
+                    const isPermitted = !disableOutsidePointerEvents && isNotRightClick;
+                    setIsPermittedPointerDownOutsideEvent(isPermitted);
+
+                    if (event.defaultPrevented) {
+                      // reset this because the event was prevented
+                      setIsPermittedPointerDownOutsideEvent(false);
+                    }
+                  },
+                  { checkForDefaultPrevented: false }
+                )}
                 onFocusOutside={composeEventHandlers(
                   onFocusOutside,
                   (event) => {

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -17,6 +17,7 @@ export const Styled = () => {
           <PopoverArrow as={StyledArrow} width={20} height={10} />
         </PopoverContent>
       </Popover>
+      <input />
     </div>
   );
 };

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -251,7 +251,9 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
                       event.target as HTMLElement
                     );
 
-                    const isPermitted = !disableOutsidePointerEvents;
+                    const isLeftClick =
+                      (event as MouseEvent).button === 0 && event.ctrlKey === false;
+                    const isPermitted = !disableOutsidePointerEvents && isLeftClick;
                     setIsPermittedPointerDownOutsideEvent(isPermitted);
 
                     // prevent dismissing when clicking the trigger

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -224,7 +224,7 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
       <PortalWrapper>
         <ScrollLockWrapper>
           <FocusScope
-            trapped={trapFocus}
+            trapped={skipCloseAutoFocus ? false : trapFocus}
             onMountAutoFocus={onOpenAutoFocus}
             onUnmountAutoFocus={(event) => {
               if (skipCloseAutoFocus) {
@@ -238,7 +238,7 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
               <DismissableLayer
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
                 onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={(event) => {
+                onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
                   const wasTrigger = context.triggerRef.current?.contains(
                     event.target as HTMLElement
                   );
@@ -250,15 +250,13 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
                   // as it's already setup to close, otherwise it would close and immediately open.
                   if (wasTrigger) {
                     event.preventDefault();
-                  } else {
-                    onInteractOutside?.(event);
                   }
 
                   if (event.defaultPrevented) {
                     // reset this because the event was prevented
                     setSkipCloseAutoFocus(false);
                   }
-                }}
+                })}
                 onFocusOutside={composeEventHandlers(
                   onFocusOutside,
                   (event) => {


### PR DESCRIPTION
I finally managed to fix this one! 🎉 

## Background

This was an issue that was reported by Lucas with regards to the `DropdownMenu`.
He was trying to turn off `disableOutsidePointerEvents` on `DropdownMenu.Content` so you can click through to things, and although it did work (for example button actions would be called), it wouldn't let him focus inside an input straight up.

I was sure I made this work with all the work I did on `DismissableLayer` and `FocusScope`, I even had some stories.

After reviewing this all with him, I realised that we had the same problem in `Popover` too.
But then I could see that my stories in `DismissableLayer.stories` which cover this specifically were working fine…

> **NOTE**: we have fake `Dialog` and fake `Popover` in this story file (basically crude versions of them to see how `DismissableLayer` and `FocusScope` interacted with each other).

So, considering the pieces were the same, there would have been some difference somewhere… 🤔

After a few days going through this, I realised the difference was `Presence` which is in our real components but not in these crude ones. and sure enough removing it fixed the issue.

So basically, because unmount has to be slightly delayed because of `Presence`, it gives us a race condition, which is basically that the focus trap is still active for a little bit longer than normal and so traps the focus when trying to focus the outside input.

## Solution

This solution I propose here is that I basically use the fact that we know when we want to `skipCloseAutoFocus`, and when that is the case, I disable the focus trap (effectively in proper time, rather than delayed unmount time). This works really well given that we have declarative access to whether the focus trap is active or not.

Let me know your thoughts on this, feels a little bit like a patch, but I think @jjenzz and I have been over this before and I don't think there would be any way for us to remove the delay from `Presence`.