### PR TITLE
[react-polymorphic] Replace `forwardRefWithAs` util with type

### DIFF
--- a/.yarn/versions/42f4f3b9.yml
+++ b/.yarn/versions/42f4f3b9.yml
@@ -1,0 +1,41 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+  "@radix-ui/utils": patch
+
+declined:
+  - primitives

--- a/packages/core/utils/src/types.ts
+++ b/packages/core/utils/src/types.ts
@@ -4,3 +4,5 @@
  */
 export type ElementTagNameMap = HTMLElementTagNameMap &
   Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;
+
+export type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2;

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { getSelector } from '@radix-ui/utils';
 import { useComposedRefs, useLayoutEffect } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 type RegionType = 'polite' | 'assertive' | 'off';
 type RegionRole = 'status' | 'alert' | 'log' | 'none';
@@ -23,66 +25,74 @@ const listenerMap = new Map<Element, number>();
 
 const NAME = 'Announce';
 
-type AnnounceOwnProps = {
-  /**
-   * Mirrors the `aria-atomic` DOM attribute for live regions. It is an optional attribute that
-   * indicates whether assistive technologies will present all, or only parts of, the changed region
-   * based on the change notifications defined by the `aria-relevant` attribute.
-   *
-   * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-atomic
-   * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
-   */
-  'aria-atomic'?: boolean;
-  /**
-   * Mirrors the `aria-relevant` DOM attribute for live regions. It is an optional attribute used to
-   * describe what types of changes have occurred to the region, and which changes are relevant and
-   * should be announced. Any change that is not relevant acts in the same manner it would if the
-   * `aria-live` attribute were set to off.
-   *
-   * Unfortunately, `aria-relevant` doesn't behave as expected across all device/screen reader
-   * combinations. It's important to test its implementation before relying on it to work for your
-   * users. The attribute is omitted by default.
-   *
-   * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-relevant
-   * @see MDN      https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute
-   * @see Opinion  https://medium.com/dev-channel/why-authors-should-avoid-aria-relevant-5d3164fab1e3
-   * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
-   */
-  'aria-relevant'?: string | AriaRelevantOptions[];
-  /**
-   * React children of your component. Children can be mirrored directly or modified to optimize for
-   * screen reader user experience.
-   */
-  children: React.ReactNode;
-  /**
-   * An optional unique identifier for the live region.
-   *
-   * By default, `Announce` components create, at most, two unique `aria-live` regions in the
-   * document (one for all `polite` notifications, one for all `assertive` notifications). In some
-   * cases you may wish to append additional `aria-live` regions for distinct purposes (for example,
-   * simple status updates may need to be separated from a stack of toast-style notifications). By
-   * passing an id, you indicate that any content rendered by components with the same identifier
-   * should be mirrored in a separate `aria-live` region.
-   */
-  regionIdentifier?: string;
-  /**
-   * Mirrors the `role` DOM attribute. This is optional and may be useful as an override in some
-   * cases. By default, the role is determined by the `type` prop.
-   *
-   * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Preferring_specialized_live_region_roles
-   */
-  role?: RegionRole;
-  /**
-   * Mirrors the `aria-live` DOM attribute. The `aria-live=POLITENESS_SETTING` is used to set the
-   * priority with which screen reader should treat updates to live regions. Its possible settings
-   * are: off, polite or assertive. Defaults to `polite`.
-   *
-   * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
-   */
-  type?: RegionType;
-};
+type AnnounceOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Mirrors the `aria-atomic` DOM attribute for live regions. It is an optional attribute that
+     * indicates whether assistive technologies will present all, or only parts of, the changed region
+     * based on the change notifications defined by the `aria-relevant` attribute.
+     *
+     * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-atomic
+     * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
+     */
+    'aria-atomic'?: boolean;
+    /**
+     * Mirrors the `aria-relevant` DOM attribute for live regions. It is an optional attribute used to
+     * describe what types of changes have occurred to the region, and which changes are relevant and
+     * should be announced. Any change that is not relevant acts in the same manner it would if the
+     * `aria-live` attribute were set to off.
+     *
+     * Unfortunately, `aria-relevant` doesn't behave as expected across all device/screen reader
+     * combinations. It's important to test its implementation before relying on it to work for your
+     * users. The attribute is omitted by default.
+     *
+     * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-relevant
+     * @see MDN      https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute
+     * @see Opinion  https://medium.com/dev-channel/why-authors-should-avoid-aria-relevant-5d3164fab1e3
+     * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
+     */
+    'aria-relevant'?: string | AriaRelevantOptions[];
+    /**
+     * React children of your component. Children can be mirrored directly or modified to optimize for
+     * screen reader user experience.
+     */
+    children: React.ReactNode;
+    /**
+     * An optional unique identifier for the live region.
+     *
+     * By default, `Announce` components create, at most, two unique `aria-live` regions in the
+     * document (one for all `polite` notifications, one for all `assertive` notifications). In some
+     * cases you may wish to append additional `aria-live` regions for distinct purposes (for example,
+     * simple status updates may need to be separated from a stack of toast-style notifications). By
+     * passing an id, you indicate that any content rendered by components with the same identifier
+     * should be mirrored in a separate `aria-live` region.
+     */
+    regionIdentifier?: string;
+    /**
+     * Mirrors the `role` DOM attribute. This is optional and may be useful as an override in some
+     * cases. By default, the role is determined by the `type` prop.
+     *
+     * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Preferring_specialized_live_region_roles
+     */
+    role?: RegionRole;
+    /**
+     * Mirrors the `aria-live` DOM attribute. The `aria-live=POLITENESS_SETTING` is used to set the
+     * priority with which screen reader should treat updates to live regions. Its possible settings
+     * are: off, polite or assertive. Defaults to `polite`.
+     *
+     * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
+     */
+    type?: RegionType;
+  }
+>;
 
-const Announce = forwardRefWithAs<typeof Primitive, AnnounceOwnProps>((props, forwardedRef) => {
+type AnnouncePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  AnnounceOwnProps
+>;
+
+const Announce = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-relevant': ariaRelevant,
     children,
@@ -174,7 +184,7 @@ const Announce = forwardRefWithAs<typeof Primitive, AnnounceOwnProps>((props, fo
       {region && ReactDOM.createPortal(<div>{children}</div>, region)}
     </React.Fragment>
   );
-});
+}) as AnnouncePrimitive;
 
 Announce.displayName = NAME;
 

--- a/packages/react/arrow/src/Arrow.tsx
+++ b/packages/react/arrow/src/Arrow.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { getSelector } from '@radix-ui/utils';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 const NAME = 'Arrow';
 const DEFAULT_TAG = 'svg';
+
+type ArrowOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ArrowPrimitive = Polymorphic.ForwardRefComponent<typeof DEFAULT_TAG, ArrowOwnProps>;
 
 /**
  * We pass `ArrowImpl` in the `as` prop so that the whole svg
  * is replaced when consumer passes an `as` prop
  */
-const Arrow = forwardRefWithAs<typeof DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    return <Primitive as={ArrowImpl} selector={getSelector(NAME)} {...props} ref={forwardedRef} />;
-  }
-);
+const Arrow = React.forwardRef((props, forwardedRef) => {
+  return <Primitive as={ArrowImpl} selector={getSelector(NAME)} {...props} ref={forwardedRef} />;
+}) as ArrowPrimitive;
 
 const ArrowImpl = React.forwardRef<SVGSVGElement, React.ComponentProps<typeof DEFAULT_TAG>>(
   (props, forwardedRef) => (

--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { getSelector } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * AspectRatio
@@ -9,43 +11,43 @@ import { Primitive } from '@radix-ui/react-primitive';
 
 const NAME = 'AspectRatio';
 
-type AspectRatioOwnProps = {
-  ratio?: number;
-};
+type AspectRatioOwnProps = Merge<Polymorphic.OwnProps<typeof Primitive>, { ratio?: number }>;
+type AspectRatioPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  AspectRatioOwnProps
+>;
 
-const AspectRatio = forwardRefWithAs<typeof Primitive, AspectRatioOwnProps>(
-  (props, forwardedRef) => {
-    const { ratio = 1 / 1, style, children, ...aspectRatioProps } = props;
-    return (
-      <div
+const AspectRatio = React.forwardRef((props, forwardedRef) => {
+  const { ratio = 1 / 1, style, children, ...aspectRatioProps } = props;
+  return (
+    <div
+      style={{
+        // ensures inner element is contained
+        position: 'relative',
+        // ensures padding bottom trick maths works
+        width: '100%',
+        paddingBottom: `${100 / ratio}%`,
+      }}
+    >
+      <Primitive
+        selector={getSelector(NAME)}
+        {...aspectRatioProps}
+        ref={forwardedRef}
         style={{
-          // ensures inner element is contained
-          position: 'relative',
-          // ensures padding bottom trick maths works
-          width: '100%',
-          paddingBottom: `${100 / ratio}%`,
+          ...style,
+          // ensures children expand in ratio
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
         }}
       >
-        <Primitive
-          selector={getSelector(NAME)}
-          {...aspectRatioProps}
-          ref={forwardedRef}
-          style={{
-            ...style,
-            // ensures children expand in ratio
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-          }}
-        >
-          {children}
-        </Primitive>
-      </div>
-    );
-  }
-);
+        {children}
+      </Primitive>
+    </div>
+  );
+}) as AspectRatioPrimitive;
 
 AspectRatio.displayName = NAME;
 

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { getSelector } from '@radix-ui/utils';
 import { createContext, useCallbackRef, useLayoutEffect } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 
-import type { OwnProps, MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Avatar
@@ -14,6 +14,8 @@ const AVATAR_NAME = 'Avatar';
 const AVATAR_DEFAULT_TAG = 'span';
 
 type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
+type AvatarOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type AvatarPrimitive = Polymorphic.ForwardRefComponent<typeof AVATAR_DEFAULT_TAG, AvatarOwnProps>;
 type AvatarContextValue = [
   ImageLoadingStatus,
   React.Dispatch<React.SetStateAction<ImageLoadingStatus>>
@@ -24,22 +26,20 @@ const [AvatarContext, useAvatarContext] = createContext<AvatarContextValue>(
   AVATAR_NAME
 );
 
-const Avatar = forwardRefWithAs<typeof AVATAR_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const { children, ...avatarProps } = props;
-    const context = React.useState<ImageLoadingStatus>('idle');
-    return (
-      <Primitive
-        as={AVATAR_DEFAULT_TAG}
-        selector={getSelector(AVATAR_NAME)}
-        {...avatarProps}
-        ref={forwardedRef}
-      >
-        <AvatarContext.Provider value={context}>{children}</AvatarContext.Provider>
-      </Primitive>
-    );
-  }
-);
+const Avatar = React.forwardRef((props, forwardedRef) => {
+  const { children, ...avatarProps } = props;
+  const context = React.useState<ImageLoadingStatus>('idle');
+  return (
+    <Primitive
+      as={AVATAR_DEFAULT_TAG}
+      selector={getSelector(AVATAR_NAME)}
+      {...avatarProps}
+      ref={forwardedRef}
+    >
+      <AvatarContext.Provider value={context}>{children}</AvatarContext.Provider>
+    </Primitive>
+  );
+}) as AvatarPrimitive;
 
 Avatar.displayName = AVATAR_NAME;
 
@@ -50,14 +50,17 @@ Avatar.displayName = AVATAR_NAME;
 const IMAGE_NAME = 'AvatarImage';
 const IMAGE_DEFAULT_TAG = 'img';
 
-type AvatarImageOwnProps = {
-  onLoadingStatusChange?: (status: ImageLoadingStatus) => void;
-};
+type AvatarImageOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  { onLoadingStatusChange?: (status: ImageLoadingStatus) => void }
+>;
 
-const AvatarImage = forwardRefWithAs<
+type AvatarImagePrimitive = Polymorphic.ForwardRefComponent<
   typeof IMAGE_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, AvatarImageOwnProps>
->((props, forwardedRef) => {
+  AvatarImageOwnProps
+>;
+
+const AvatarImage = React.forwardRef((props, forwardedRef) => {
   const { src, onLoadingStatusChange: onLoadingStatusChangeProp = () => {}, ...imageProps } = props;
   const [, setImageLoadingStatus] = useAvatarContext(IMAGE_NAME);
   const imageLoadingStatus = useImageLoadingStatus(src);
@@ -79,7 +82,7 @@ const AvatarImage = forwardRefWithAs<
       ref={forwardedRef}
     />
   ) : null;
-});
+}) as AvatarImagePrimitive;
 
 AvatarImage.displayName = IMAGE_NAME;
 
@@ -90,14 +93,13 @@ AvatarImage.displayName = IMAGE_NAME;
 const FALLBACK_NAME = 'AvatarFallback';
 const FALLBACK_DEFAULT_TAG = 'span';
 
-type AvatarFallbackOwnProps = {
-  delayMs?: number;
-};
-
-const AvatarFallback = forwardRefWithAs<
+type AvatarFallbackOwnProps = Merge<Polymorphic.OwnProps<typeof Primitive>, { delayMs?: number }>;
+type AvatarFallbackPrimitive = Polymorphic.ForwardRefComponent<
   typeof FALLBACK_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, AvatarFallbackOwnProps>
->((props, forwardedRef) => {
+  AvatarFallbackOwnProps
+>;
+
+const AvatarFallback = React.forwardRef((props, forwardedRef) => {
   const { delayMs, ...fallbackProps } = props;
   const [imageLoadingStatus] = useAvatarContext(FALLBACK_NAME);
   const [canRender, setCanRender] = React.useState(delayMs === undefined);
@@ -117,7 +119,7 @@ const AvatarFallback = forwardRefWithAs<
       ref={forwardedRef}
     />
   ) : null;
-});
+}) as AvatarFallbackPrimitive;
 
 AvatarFallback.displayName = FALLBACK_NAME;
 

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -6,12 +6,12 @@ import {
   useControlledState,
   useComposedRefs,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { useLabelContext } from '@radix-ui/react-label';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 
-import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Checkbox
@@ -22,24 +22,28 @@ const CHECKBOX_DEFAULT_TAG = 'button';
 
 type CheckedState = boolean | 'indeterminate';
 type InputDOMProps = React.ComponentProps<'input'>;
-type CheckboxOwnProps = {
-  checked?: CheckedState;
-  defaultChecked?: CheckedState;
-  required?: InputDOMProps['required'];
-  readOnly?: InputDOMProps['readOnly'];
-  onCheckedChange?: InputDOMProps['onChange'];
-  onChange: never;
-};
+type CheckboxOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    checked?: CheckedState;
+    defaultChecked?: CheckedState;
+    required?: InputDOMProps['required'];
+    readOnly?: InputDOMProps['readOnly'];
+    onCheckedChange?: InputDOMProps['onChange'];
+  }
+>;
+
+type CheckboxPrimitive = Polymorphic.ForwardRefComponent<
+  typeof CHECKBOX_DEFAULT_TAG,
+  CheckboxOwnProps
+>;
 
 const [CheckboxContext, useCheckboxContext] = createContext<CheckedState>(
   CHECKBOX_NAME + 'Context',
   CHECKBOX_NAME
 );
 
-const Checkbox = forwardRefWithAs<
-  typeof CHECKBOX_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, CheckboxOwnProps>
->((props, forwardedRef) => {
+const Checkbox = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-labelledby': ariaLabelledby,
     children,
@@ -115,7 +119,7 @@ const Checkbox = forwardRefWithAs<
       </Primitive>
     </>
   );
-});
+}) as CheckboxPrimitive;
 
 Checkbox.displayName = CHECKBOX_NAME;
 
@@ -126,18 +130,23 @@ Checkbox.displayName = CHECKBOX_NAME;
 const INDICATOR_NAME = 'CheckboxIndicator';
 const INDICATOR_DEFAULT_TAG = 'span';
 
-type CheckboxIndicatorOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
+type CheckboxIndicatorOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
 
-const CheckboxIndicator = forwardRefWithAs<
+type CheckboxIndicatorPrimitive = Polymorphic.ForwardRefComponent<
   typeof INDICATOR_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, CheckboxIndicatorOwnProps>
->((props, forwardedRef) => {
+  CheckboxIndicatorOwnProps
+>;
+
+const CheckboxIndicator = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...indicatorProps } = props;
   const checked = useCheckboxContext(INDICATOR_NAME);
   return (
@@ -151,7 +160,7 @@ const CheckboxIndicator = forwardRefWithAs<
       />
     </Presence>
   );
-});
+}) as CheckboxIndicatorPrimitive;
 
 CheckboxIndicator.displayName = INDICATOR_NAME;
 

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -6,11 +6,11 @@ import {
   useControlledState,
 } from '@radix-ui/react-utils';
 import { getSelector } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Presence } from '@radix-ui/react-presence';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Collapsible
@@ -18,12 +18,20 @@ import type { OwnProps } from '@radix-ui/react-polymorphic';
 
 const COLLAPSIBLE_NAME = 'Collapsible';
 
-type CollapsibleOwnProps = {
-  defaultOpen?: boolean;
-  open?: boolean;
-  disabled?: boolean;
-  onOpenChange?(open?: boolean): void;
-};
+type CollapsibleOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    defaultOpen?: boolean;
+    open?: boolean;
+    disabled?: boolean;
+    onOpenChange?(open?: boolean): void;
+  }
+>;
+
+type CollapsiblePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  CollapsibleOwnProps
+>;
 
 type CollapsibleContextValue = {
   contentId?: string;
@@ -38,47 +46,45 @@ const [CollapsibleContext, useCollapsibleContext] = createContext<CollapsibleCon
   COLLAPSIBLE_NAME
 );
 
-const Collapsible = forwardRefWithAs<typeof Primitive, CollapsibleOwnProps>(
-  (props, forwardedRef) => {
-    const {
-      id: idProp,
-      children,
-      open: openProp,
-      defaultOpen,
+const Collapsible = React.forwardRef((props, forwardedRef) => {
+  const {
+    id: idProp,
+    children,
+    open: openProp,
+    defaultOpen,
+    disabled,
+    onOpenChange,
+    ...collapsibleProps
+  } = props;
+
+  const [open = false, setOpen] = useControlledState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+  const [contentId, setContentId] = React.useState<string>();
+  const context = React.useMemo(
+    () => ({
+      contentId,
+      open,
       disabled,
-      onOpenChange,
-      ...collapsibleProps
-    } = props;
+      toggle: () => setOpen((prevOpen) => !prevOpen),
+      setContentId,
+    }),
+    [contentId, disabled, open, setOpen]
+  );
 
-    const [open = false, setOpen] = useControlledState({
-      prop: openProp,
-      defaultProp: defaultOpen,
-      onChange: onOpenChange,
-    });
-    const [contentId, setContentId] = React.useState<string>();
-    const context = React.useMemo(
-      () => ({
-        contentId,
-        open,
-        disabled,
-        toggle: () => setOpen((prevOpen) => !prevOpen),
-        setContentId,
-      }),
-      [contentId, disabled, open, setOpen]
-    );
-
-    return (
-      <Primitive
-        selector={getSelector(COLLAPSIBLE_NAME)}
-        {...collapsibleProps}
-        data-state={getState(context.open)}
-        ref={forwardedRef}
-      >
-        <CollapsibleContext.Provider value={context}>{children}</CollapsibleContext.Provider>
-      </Primitive>
-    );
-  }
-);
+  return (
+    <Primitive
+      selector={getSelector(COLLAPSIBLE_NAME)}
+      {...collapsibleProps}
+      data-state={getState(context.open)}
+      ref={forwardedRef}
+    >
+      <CollapsibleContext.Provider value={context}>{children}</CollapsibleContext.Provider>
+    </Primitive>
+  );
+}) as CollapsiblePrimitive;
 
 Collapsible.displayName = COLLAPSIBLE_NAME;
 
@@ -89,26 +95,30 @@ Collapsible.displayName = COLLAPSIBLE_NAME;
 const BUTTON_NAME = 'CollapsibleButton';
 const BUTTON_DEFAULT_TAG = 'button';
 
-const CollapsibleButton = forwardRefWithAs<typeof BUTTON_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const { onClick, ...buttonProps } = props;
-    const context = useCollapsibleContext(BUTTON_NAME);
+type CollapsibleButtonOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type CollapsibleButtonPrimitive = Polymorphic.ForwardRefComponent<
+  typeof BUTTON_DEFAULT_TAG,
+  CollapsibleButtonOwnProps
+>;
 
-    return (
-      <Primitive
-        as={BUTTON_DEFAULT_TAG}
-        selector={getSelector(BUTTON_NAME)}
-        aria-controls={context.contentId}
-        aria-expanded={context.open || false}
-        data-state={getState(context.open)}
-        {...buttonProps}
-        ref={forwardedRef}
-        onClick={composeEventHandlers(onClick, context.toggle)}
-        disabled={context.disabled}
-      />
-    );
-  }
-);
+const CollapsibleButton = React.forwardRef((props, forwardedRef) => {
+  const { onClick, ...buttonProps } = props;
+  const context = useCollapsibleContext(BUTTON_NAME);
+
+  return (
+    <Primitive
+      as={BUTTON_DEFAULT_TAG}
+      selector={getSelector(BUTTON_NAME)}
+      aria-controls={context.contentId}
+      aria-expanded={context.open || false}
+      data-state={getState(context.open)}
+      {...buttonProps}
+      ref={forwardedRef}
+      onClick={composeEventHandlers(onClick, context.toggle)}
+      disabled={context.disabled}
+    />
+  );
+}) as CollapsibleButtonPrimitive;
 
 CollapsibleButton.displayName = BUTTON_NAME;
 
@@ -118,43 +128,49 @@ CollapsibleButton.displayName = BUTTON_NAME;
 
 const CONTENT_NAME = 'CollapsibleContent';
 
-type CollapsibleContentOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
-
-const CollapsibleContent = forwardRefWithAs<typeof Primitive, CollapsibleContentOwnProps>(
-  (props, forwardedRef) => {
-    const { id: idProp, forceMount, children, ...contentProps } = props;
-    const { setContentId, open } = useCollapsibleContext(CONTENT_NAME);
-    const generatedId = `collapsible-${useId()}`;
-    const id = idProp || generatedId;
-
-    React.useEffect(() => {
-      setContentId(id);
-    }, [id, setContentId]);
-
-    return (
-      <Presence present={forceMount || open}>
-        {({ present }) => (
-          <Primitive
-            selector={getSelector(CONTENT_NAME)}
-            {...contentProps}
-            ref={forwardedRef}
-            id={id}
-            hidden={!present}
-            data-state={getState(open)}
-          >
-            {present && children}
-          </Primitive>
-        )}
-      </Presence>
-    );
+type CollapsibleContentOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
   }
-);
+>;
+
+type CollapsibleContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  CollapsibleContentOwnProps
+>;
+
+const CollapsibleContent = React.forwardRef((props, forwardedRef) => {
+  const { id: idProp, forceMount, children, ...contentProps } = props;
+  const { setContentId, open } = useCollapsibleContext(CONTENT_NAME);
+  const generatedId = `collapsible-${useId()}`;
+  const id = idProp || generatedId;
+
+  React.useEffect(() => {
+    setContentId(id);
+  }, [id, setContentId]);
+
+  return (
+    <Presence present={forceMount || open}>
+      {({ present }) => (
+        <Primitive
+          selector={getSelector(CONTENT_NAME)}
+          {...contentProps}
+          ref={forwardedRef}
+          id={id}
+          hidden={!present}
+          data-state={getState(open)}
+        >
+          {present && children}
+        </Primitive>
+      )}
+    </Presence>
+  );
+}) as CollapsibleContentPrimitive;
 
 CollapsibleContent.displayName = CONTENT_NAME;
 

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { composeEventHandlers, createContext, extendComponent } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { makeRect, getSelector } from '@radix-ui/utils';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 import type { Point, MeasurableElement } from '@radix-ui/utils';
-import type { OwnProps } from '@radix-ui/react-polymorphic';
 
 /* -------------------------------------------------------------------------------------------------
  * ContextMenu
@@ -47,25 +46,29 @@ ContextMenu.displayName = CONTEXT_MENU_NAME;
 const TRIGGER_NAME = 'ContextMenuTrigger';
 const TRIGGER_DEFAULT_TAG = 'span';
 
-const ContextMenuTrigger = forwardRefWithAs<typeof TRIGGER_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = useContextMenuContext(TRIGGER_NAME);
-    return (
-      <Primitive
-        as={TRIGGER_DEFAULT_TAG}
-        selector={getSelector(TRIGGER_NAME)}
-        {...props}
-        ref={forwardedRef}
-        onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
-          event.preventDefault();
-          const point = { x: event.clientX, y: event.clientY };
-          context.setOpen(true);
-          context.anchorPointRef.current = point;
-        })}
-      />
-    );
-  }
-);
+type ContextMenuTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ContextMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof TRIGGER_DEFAULT_TAG,
+  ContextMenuTriggerOwnProps
+>;
+
+const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
+  const context = useContextMenuContext(TRIGGER_NAME);
+  return (
+    <Primitive
+      as={TRIGGER_DEFAULT_TAG}
+      selector={getSelector(TRIGGER_NAME)}
+      {...props}
+      ref={forwardedRef}
+      onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
+        event.preventDefault();
+        const point = { x: event.clientX, y: event.clientY };
+        context.setOpen(true);
+        context.anchorPointRef.current = point;
+      })}
+    />
+  );
+}) as ContextMenuTriggerPrimitive;
 
 ContextMenuTrigger.displayName = TRIGGER_NAME;
 
@@ -75,44 +78,47 @@ ContextMenuTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'ContextMenuContent';
 
-type ContextMenuContentOwnProps = {
-  anchorRef: never;
-  trapFocus: never;
-  disableOutsideScroll: never;
-  portalled: never;
-  onCloseAutoFocus: never;
-  onOpenAutoFocus: never;
-  onDismiss: never;
-};
+type ContextMenuContentOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuPrimitive.Root>,
+  | 'anchorRef'
+  | 'trapFocus'
+  | 'disableOutsideScroll'
+  | 'portalled'
+  | 'onCloseAutoFocus'
+  | 'onOpenAutoFocus'
+  | 'onDismiss'
+>;
 
-const ContextMenuContent = forwardRefWithAs<typeof MenuPrimitive.Root, ContextMenuContentOwnProps>(
-  (props, forwardedRef) => {
-    const context = useContextMenuContext(CONTENT_NAME);
+type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Root>,
+  ContextMenuContentOwnProps
+>;
 
-    return (
-      <MenuPrimitive.Root
-        selector={getSelector(CONTENT_NAME)}
-        disableOutsidePointerEvents
-        side="bottom"
-        align="start"
-        {...props}
-        ref={forwardedRef}
-        open={context.open}
-        onOpenChange={context.setOpen}
-        style={{
-          ...props.style,
-          // re-namespace exposed content custom property
-          ['--radix-context-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-        }}
-        anchorRef={context.anchorRef}
-        trapFocus
-        disableOutsideScroll
-        portalled
-        onDismiss={() => context.setOpen(false)}
-      />
-    );
-  }
-);
+const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
+  const context = useContextMenuContext(CONTENT_NAME);
+  return (
+    <MenuPrimitive.Root
+      selector={getSelector(CONTENT_NAME)}
+      disableOutsidePointerEvents
+      side="bottom"
+      align="start"
+      {...props}
+      ref={forwardedRef}
+      open={context.open}
+      onOpenChange={context.setOpen}
+      style={{
+        ...props.style,
+        // re-namespace exposed content custom property
+        ['--radix-context-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+      }}
+      anchorRef={context.anchorRef}
+      trapFocus
+      disableOutsideScroll
+      portalled
+      onDismiss={() => context.setOpen(false)}
+    />
+  );
+}) as ContextMenuContentPrimitive;
 
 ContextMenuContent.displayName = CONTENT_NAME;
 

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -7,7 +7,6 @@ import {
   useId,
   composeRefs,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { getSelector, makeId } from '@radix-ui/utils';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
@@ -18,7 +17,8 @@ import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
 type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
@@ -76,25 +76,29 @@ Dialog.displayName = DIALOG_NAME;
 const TRIGGER_NAME = 'DialogTrigger';
 const TRIGGER_DEFAULT_TAG = 'button';
 
-const DialogTrigger = forwardRefWithAs<typeof TRIGGER_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = useDialogContext(TRIGGER_NAME);
-    const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
-    return (
-      <Primitive
-        as={TRIGGER_DEFAULT_TAG}
-        selector={getSelector(TRIGGER_NAME)}
-        type="button"
-        aria-haspopup="dialog"
-        aria-expanded={context.open}
-        aria-controls={context.id}
-        {...props}
-        ref={composedTriggerRef}
-        onClick={composeEventHandlers(props.onClick, () => context.setOpen(true))}
-      />
-    );
-  }
-);
+type DialogTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type DialogTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof TRIGGER_DEFAULT_TAG,
+  DialogTriggerOwnProps
+>;
+
+const DialogTrigger = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(TRIGGER_NAME);
+  const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+  return (
+    <Primitive
+      as={TRIGGER_DEFAULT_TAG}
+      selector={getSelector(TRIGGER_NAME)}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={context.open}
+      aria-controls={context.id}
+      {...props}
+      ref={composedTriggerRef}
+      onClick={composeEventHandlers(props.onClick, () => context.setOpen(true))}
+    />
+  );
+}) as DialogTriggerPrimitive;
 
 DialogTrigger.displayName = TRIGGER_NAME;
 
@@ -104,35 +108,43 @@ DialogTrigger.displayName = TRIGGER_NAME;
 
 const OVERLAY_NAME = 'DialogOverlay';
 
-type DialogOverlayOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
-
-const DialogOverlay = forwardRefWithAs<typeof DialogOverlayImpl, DialogOverlayOwnProps>(
-  (props, forwardedRef) => {
-    const { forceMount, ...overlayProps } = props;
-    const context = useDialogContext(OVERLAY_NAME);
-    return (
-      <Presence present={forceMount || context.open}>
-        <DialogOverlayImpl
-          {...overlayProps}
-          data-state={getState(context.open)}
-          ref={forwardedRef}
-        />
-      </Presence>
-    );
+type DialogOverlayOwnProps = Merge<
+  Polymorphic.OwnProps<typeof DialogOverlayImpl>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
   }
-);
+>;
 
-const DialogOverlayImpl = forwardRefWithAs<typeof Primitive>((props, forwardedRef) => (
+type DialogOverlayPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof DialogOverlayImpl>,
+  DialogOverlayOwnProps
+>;
+
+const DialogOverlay = React.forwardRef((props, forwardedRef) => {
+  const { forceMount, ...overlayProps } = props;
+  const context = useDialogContext(OVERLAY_NAME);
+  return (
+    <Presence present={forceMount || context.open}>
+      <DialogOverlayImpl {...overlayProps} data-state={getState(context.open)} ref={forwardedRef} />
+    </Presence>
+  );
+}) as DialogOverlayPrimitive;
+
+type DialogOverlayImplOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  DialogOverlayImplOwnProps
+>;
+
+const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => (
   <Portal>
     <Primitive selector={getSelector(OVERLAY_NAME)} {...props} ref={forwardedRef} />
   </Portal>
-));
+)) as DialogOverlayImplPrimitive;
 
 DialogOverlay.displayName = OVERLAY_NAME;
 
@@ -142,140 +154,148 @@ DialogOverlay.displayName = OVERLAY_NAME;
 
 const CONTENT_NAME = 'DialogContent';
 
-type DialogContentOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
-
-const DialogContent = forwardRefWithAs<typeof DialogContentImpl, DialogContentOwnProps>(
-  (props, forwardedRef) => {
-    const { forceMount, ...contentProps } = props;
-    const context = useDialogContext(CONTENT_NAME);
-    return (
-      <Presence present={forceMount || context.open}>
-        <DialogContentImpl
-          {...contentProps}
-          data-state={getState(context.open)}
-          ref={forwardedRef}
-        />
-      </Presence>
-    );
+type DialogContentOwnProps = Merge<
+  Polymorphic.OwnProps<typeof DialogContentImpl>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
   }
-);
+>;
 
-type DialogContentImplOwnProps = {
-  /**
-   * Event handler called when auto-focusing on open.
-   * Can be prevented.
-   */
-  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+type DialogContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof DialogContentImpl>,
+  DialogContentOwnProps
+>;
 
-  /**
-   * Event handler called when auto-focusing on close.
-   * Can be prevented.
-   */
-  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+const DialogContent = React.forwardRef((props, forwardedRef) => {
+  const { forceMount, ...contentProps } = props;
+  const context = useDialogContext(CONTENT_NAME);
+  return (
+    <Presence present={forceMount || context.open}>
+      <DialogContentImpl {...contentProps} data-state={getState(context.open)} ref={forwardedRef} />
+    </Presence>
+  );
+}) as DialogContentPrimitive;
 
-  /**
-   * Event handler called when the escape key is down.
-   * Can be prevented.
-   */
-  onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
+type DialogContentImplOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Event handler called when auto-focusing on open.
+     * Can be prevented.
+     */
+    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
 
-  /**
-   * Event handler called when the a pointer event happens outside of the `Dialog`.
-   * Can be prevented.
-   */
-  onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
-};
+    /**
+     * Event handler called when auto-focusing on close.
+     * Can be prevented.
+     */
+    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
 
-const DialogContentImpl = forwardRefWithAs<typeof Primitive, DialogContentImplOwnProps>(
-  (props, forwardedRef) => {
-    const {
-      onOpenAutoFocus,
-      onCloseAutoFocus,
-      onEscapeKeyDown,
-      onPointerDownOutside,
-      ...contentProps
-    } = props;
-    const context = useDialogContext(CONTENT_NAME);
+    /**
+     * Event handler called when the escape key is down.
+     * Can be prevented.
+     */
+    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
 
-    // Make sure the whole tree has focus guards as our `Dialog` will be
-    // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
-
-    // Hide everything from ARIA except the content
-    const contentRef = React.useRef<HTMLDivElement>(null);
-    React.useEffect(() => {
-      const content = contentRef.current;
-      if (content) return hideOthers(content);
-    }, []);
-
-    return (
-      <Portal>
-        <RemoveScroll>
-          <FocusScope
-            trapped
-            onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={onCloseAutoFocus}
-          >
-            {(focusScopeProps) => (
-              <DismissableLayer
-                disableOutsidePointerEvents
-                onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={onPointerDownOutside}
-                onDismiss={() => context.setOpen(false)}
-              >
-                {(dismissableLayerProps) => (
-                  <Primitive
-                    selector={getSelector(CONTENT_NAME)}
-                    role="dialog"
-                    aria-modal
-                    {...contentProps}
-                    ref={composeRefs(
-                      forwardedRef,
-                      contentRef,
-                      focusScopeProps.ref,
-                      dismissableLayerProps.ref
-                    )}
-                    id={context.id}
-                    style={{
-                      ...dismissableLayerProps.style,
-                      ...contentProps.style,
-                    }}
-                    onBlurCapture={composeEventHandlers(
-                      contentProps.onBlurCapture,
-                      dismissableLayerProps.onBlurCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onFocusCapture={composeEventHandlers(
-                      contentProps.onFocusCapture,
-                      dismissableLayerProps.onFocusCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onMouseDownCapture={composeEventHandlers(
-                      contentProps.onMouseDownCapture,
-                      dismissableLayerProps.onMouseDownCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onTouchStartCapture={composeEventHandlers(
-                      contentProps.onTouchStartCapture,
-                      dismissableLayerProps.onTouchStartCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                  />
-                )}
-              </DismissableLayer>
-            )}
-          </FocusScope>
-        </RemoveScroll>
-      </Portal>
-    );
+    /**
+     * Event handler called when the a pointer event happens outside of the `Dialog`.
+     * Can be prevented.
+     */
+    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
   }
-);
+>;
+
+type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  DialogContentImplOwnProps
+>;
+
+const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
+  const {
+    onOpenAutoFocus,
+    onCloseAutoFocus,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    ...contentProps
+  } = props;
+  const context = useDialogContext(CONTENT_NAME);
+
+  // Make sure the whole tree has focus guards as our `Dialog` will be
+  // the last element in the DOM (beacuse of the `Portal`)
+  useFocusGuards();
+
+  // Hide everything from ARIA except the content
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <Portal>
+      <RemoveScroll>
+        <FocusScope
+          trapped
+          onMountAutoFocus={onOpenAutoFocus}
+          onUnmountAutoFocus={onCloseAutoFocus}
+        >
+          {(focusScopeProps) => (
+            <DismissableLayer
+              disableOutsidePointerEvents
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={onPointerDownOutside}
+              onDismiss={() => context.setOpen(false)}
+            >
+              {(dismissableLayerProps) => (
+                <Primitive
+                  selector={getSelector(CONTENT_NAME)}
+                  role="dialog"
+                  aria-modal
+                  {...contentProps}
+                  ref={composeRefs(
+                    forwardedRef,
+                    contentRef,
+                    focusScopeProps.ref,
+                    dismissableLayerProps.ref
+                  )}
+                  id={context.id}
+                  style={{
+                    ...dismissableLayerProps.style,
+                    ...contentProps.style,
+                  }}
+                  onBlurCapture={composeEventHandlers(
+                    contentProps.onBlurCapture,
+                    dismissableLayerProps.onBlurCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onFocusCapture={composeEventHandlers(
+                    contentProps.onFocusCapture,
+                    dismissableLayerProps.onFocusCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onMouseDownCapture={composeEventHandlers(
+                    contentProps.onMouseDownCapture,
+                    dismissableLayerProps.onMouseDownCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onTouchStartCapture={composeEventHandlers(
+                    contentProps.onTouchStartCapture,
+                    dismissableLayerProps.onTouchStartCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                />
+              )}
+            </DismissableLayer>
+          )}
+        </FocusScope>
+      </RemoveScroll>
+    </Portal>
+  );
+}) as DialogContentImplPrimitive;
 
 DialogContent.displayName = CONTENT_NAME;
 
@@ -286,21 +306,25 @@ DialogContent.displayName = CONTENT_NAME;
 const CLOSE_NAME = 'DialogClose';
 const CLOSE_DEFAULT_TAG = 'button';
 
-const DialogClose = forwardRefWithAs<typeof CLOSE_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = useDialogContext(CLOSE_NAME);
-    return (
-      <Primitive
-        as={CLOSE_DEFAULT_TAG}
-        selector={getSelector(CLOSE_NAME)}
-        type="button"
-        {...props}
-        ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
-      />
-    );
-  }
-);
+type DialogCloseOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type DialogClosePrimitive = Polymorphic.ForwardRefComponent<
+  typeof CLOSE_DEFAULT_TAG,
+  DialogCloseOwnProps
+>;
+
+const DialogClose = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(CLOSE_NAME);
+  return (
+    <Primitive
+      as={CLOSE_DEFAULT_TAG}
+      selector={getSelector(CLOSE_NAME)}
+      type="button"
+      {...props}
+      ref={forwardedRef}
+      onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
+    />
+  );
+}) as DialogClosePrimitive;
 
 DialogClose.displayName = CLOSE_NAME;
 

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -7,12 +7,12 @@ import {
   useControlledState,
   useId,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { getSelector } from '@radix-ui/utils';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * DropdownMenu
@@ -63,10 +63,13 @@ DropdownMenu.displayName = DROPDOWN_MENU_NAME;
 const TRIGGER_NAME = 'DropdownMenuTrigger';
 const TRIGGER_DEFAULT_TAG = 'button';
 
-const DropdownMenuTrigger = forwardRefWithAs<
+type DropdownMenuTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type DropdownMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
   typeof TRIGGER_DEFAULT_TAG,
-  OwnProps<typeof Primitive>
->((props, forwardedRef) => {
+  DropdownMenuTriggerOwnProps
+>;
+
+const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
   const context = useDropdownMenuContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 
@@ -95,7 +98,7 @@ const DropdownMenuTrigger = forwardRefWithAs<
       })}
     />
   );
-});
+}) as DropdownMenuTriggerPrimitive;
 
 DropdownMenuTrigger.displayName = TRIGGER_NAME;
 
@@ -105,18 +108,18 @@ DropdownMenuTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'DropdownMenuContent';
 
-type DropdownMenuContentOwnProps = {
-  anchorRef?: React.ComponentProps<typeof MenuPrimitive.Root>['anchorRef'];
-  trapFocus: never;
-  onCloseAutoFocus: never;
-  onOpenAutoFocus: never;
-  onDismiss: never;
-};
+type MenuPrimitiveOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.Root>;
+type DropdownMenuContentOwnProps = Merge<
+  Omit<MenuPrimitiveOwnProps, 'trapFocus' | 'onCloseAutoFocus' | 'onOpenAutoFocus' | 'onDismiss'>,
+  { anchorRef?: MenuPrimitiveOwnProps['anchorRef'] }
+>;
 
-const DropdownMenuContent = forwardRefWithAs<
-  typeof MenuPrimitive.Root,
+type DropdownMenuContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Root>,
   DropdownMenuContentOwnProps
->((props, forwardedRef) => {
+>;
+
+const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
   const context = useDropdownMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Root
@@ -156,7 +159,7 @@ const DropdownMenuContent = forwardRefWithAs<
       onDismiss={() => context.setOpen(false)}
     />
   );
-});
+}) as DropdownMenuContentPrimitive;
 
 DropdownMenuContent.displayName = CONTENT_NAME;
 

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { getSelector } from '@radix-ui/utils';
 import { useId, useComposedRefs } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 
-import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Label
@@ -13,79 +13,76 @@ import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
 const NAME = 'Label';
 const DEFAULT_TAG = 'span';
 
-type LabelOwnProps = {
-  htmlFor?: string;
-};
+type LabelOwnProps = Merge<Polymorphic.OwnProps<typeof Primitive>, { htmlFor?: string }>;
+type LabelPrimitive = Polymorphic.ForwardRefComponent<typeof DEFAULT_TAG, LabelOwnProps>;
 
 type LabelContextValue = { id: string; ref: React.RefObject<HTMLSpanElement> };
 const LabelContext = React.createContext<LabelContextValue | undefined>(undefined);
 
-const Label = forwardRefWithAs<typeof DEFAULT_TAG, MergeOwnProps<typeof Primitive, LabelOwnProps>>(
-  (props, forwardedRef) => {
-    const { htmlFor, id: idProp, children, ...labelProps } = props;
-    const labelRef = React.useRef<HTMLSpanElement>(null);
-    const ref = useComposedRefs(forwardedRef, labelRef);
-    const generatedId = `label-${useId()}`;
-    const id = idProp || generatedId;
+const Label = React.forwardRef((props, forwardedRef) => {
+  const { htmlFor, id: idProp, children, ...labelProps } = props;
+  const labelRef = React.useRef<HTMLSpanElement>(null);
+  const ref = useComposedRefs(forwardedRef, labelRef);
+  const generatedId = `label-${useId()}`;
+  const id = idProp || generatedId;
 
-    React.useEffect(() => {
+  React.useEffect(() => {
+    const label = labelRef.current;
+
+    if (label) {
+      const handleMouseDown = (event: MouseEvent) => {
+        if (event.detail > 1) event.preventDefault();
+      };
+
+      // prevent text selection when double clicking label
+      label.addEventListener('mousedown', handleMouseDown);
+      return () => label.removeEventListener('mousedown', handleMouseDown);
+    }
+  }, [labelRef]);
+
+  React.useEffect(() => {
+    if (htmlFor) {
+      const element = document.getElementById(htmlFor);
       const label = labelRef.current;
 
-      if (label) {
-        const handleMouseDown = (event: MouseEvent) => {
-          if (event.detail > 1) event.preventDefault();
+      if (label && element) {
+        const removeLabelClickEventListener = addLabelClickEventListener(label, element);
+        const getAriaLabel = () => element.getAttribute('aria-labelledby');
+        const ariaLabelledBy = [getAriaLabel(), id].filter(Boolean).join(' ');
+        element.setAttribute('aria-labelledby', ariaLabelledBy);
+
+        return () => {
+          removeLabelClickEventListener();
+          /**
+           * We get the latest attribute value because at the time that this cleanup fires,
+           * the values from the closure may have changed.
+           */
+          const ariaLabelledBy = getAriaLabel()?.replace(id, '');
+          if (ariaLabelledBy === '') {
+            element.removeAttribute('aria-labelledby');
+          } else if (ariaLabelledBy) {
+            element.setAttribute('aria-labelledby', ariaLabelledBy);
+          }
         };
-
-        // prevent text selection when double clicking label
-        label.addEventListener('mousedown', handleMouseDown);
-        return () => label.removeEventListener('mousedown', handleMouseDown);
       }
-    }, [labelRef]);
+    }
+  }, [id, htmlFor]);
 
-    React.useEffect(() => {
-      if (htmlFor) {
-        const element = document.getElementById(htmlFor);
-        const label = labelRef.current;
-
-        if (label && element) {
-          const removeLabelClickEventListener = addLabelClickEventListener(label, element);
-          const getAriaLabel = () => element.getAttribute('aria-labelledby');
-          const ariaLabelledBy = [getAriaLabel(), id].filter(Boolean).join(' ');
-          element.setAttribute('aria-labelledby', ariaLabelledBy);
-
-          return () => {
-            removeLabelClickEventListener();
-            /**
-             * We get the latest attribute value because at the time that this cleanup fires,
-             * the values from the closure may have changed.
-             */
-            const ariaLabelledBy = getAriaLabel()?.replace(id, '');
-            if (ariaLabelledBy === '') {
-              element.removeAttribute('aria-labelledby');
-            } else if (ariaLabelledBy) {
-              element.setAttribute('aria-labelledby', ariaLabelledBy);
-            }
-          };
-        }
-      }
-    }, [id, htmlFor]);
-
-    return (
-      <Primitive
-        as={DEFAULT_TAG}
-        selector={getSelector(NAME)}
-        {...labelProps}
-        ref={ref}
-        id={id}
-        role="label"
-      >
-        <LabelContext.Provider value={React.useMemo(() => ({ id, ref: labelRef }), [id])}>
-          {children}
-        </LabelContext.Provider>
-      </Primitive>
-    );
-  }
-);
+  return (
+    <Primitive
+      as={DEFAULT_TAG}
+      selector={getSelector(NAME)}
+      {...labelProps}
+      ref={ref}
+      id={id}
+      role="label"
+    >
+      <LabelContext.Provider value={React.useMemo(() => ({ id, ref: labelRef }), [id])}>
+        {children}
+      </LabelContext.Provider>
+    </Primitive>
+  );
+}) as LabelPrimitive;
 
 Label.displayName = 'Label';
 

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -12,7 +12,8 @@ import {
 } from './Menu';
 import { styled, css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 export default { title: 'Components/Menu', excludeStories: ['styledComponents'] };
 
@@ -247,18 +248,24 @@ export const Animated = () => {
   );
 };
 
-type MenuOwnProps = {
-  onOpenChange: never;
-  anchorRef: never;
-  portalled: never;
-  trapFocus: never;
-  onOpenAutoFocus: never;
-  onCloseAutoFocus: never;
-  disableOutsidePointerEvents: never;
-  disableOutsideScroll: never;
-};
+type MenuOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuPrimitive>,
+  | 'onOpenChange'
+  | 'anchorRef'
+  | 'portalled'
+  | 'trapFocus'
+  | 'onOpenAutoFocus'
+  | 'onCloseAutoFocus'
+  | 'disableOutsidePointerEvents'
+  | 'disableOutsideScroll'
+>;
 
-const Menu = forwardRefWithAs<typeof MenuPrimitive, MenuOwnProps>((props, forwardedRef) => {
+type MenuPrimitiveType = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive>,
+  MenuOwnProps
+>;
+
+const Menu = React.forwardRef((props, forwardedRef) => {
   const { open = true } = props;
   const ref = React.useRef<HTMLDivElement>(null);
   return (
@@ -281,7 +288,7 @@ const Menu = forwardRefWithAs<typeof MenuPrimitive, MenuOwnProps>((props, forwar
       />
     </>
   );
-});
+}) as MenuPrimitiveType;
 
 const StyledRoot = styled('div', {
   display: 'inline-block',

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -79,7 +79,6 @@ const Menu = React.forwardRef((props, forwardedRef) => {
 type MenuImplOwnProps = Merge<
   Polymorphic.OwnProps<typeof PopperPrimitive.Root>,
   {
-    anchorRef: React.ComponentProps<typeof PopperPrimitive.Root>['anchorRef'];
     onOpenChange?: (open: boolean) => void;
     loop?: boolean;
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -8,7 +8,6 @@ import {
   useComposedRefs,
 } from '@radix-ui/react-utils';
 import { getSelector } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
@@ -21,7 +20,8 @@ import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 import { useMenuTypeahead, useMenuTypeaheadItem } from './useMenuTypeahead';
 
-import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
 type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
@@ -46,17 +46,25 @@ const [MenuContext, useMenuContext] = createContext<MenuContextValue>(
   MENU_NAME
 );
 
-type MenuOwnProps = {
-  open?: boolean;
+type MenuOwnProps = Merge<
+  Polymorphic.OwnProps<typeof MenuImpl>,
+  {
+    open?: boolean;
 
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
 
-const Menu = forwardRefWithAs<typeof MenuImpl, MenuOwnProps>((props, forwardedRef) => {
+type MenuPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuImpl>,
+  MenuOwnProps
+>;
+
+const Menu = React.forwardRef((props, forwardedRef) => {
   const { children, forceMount, open = false, ...menuProps } = props;
 
   return (
@@ -66,256 +74,259 @@ const Menu = forwardRefWithAs<typeof MenuImpl, MenuOwnProps>((props, forwardedRe
       </MenuImpl>
     </Presence>
   );
-});
+}) as MenuPrimitive;
 
-type MenuImplOwnProps = {
-  anchorRef: React.ComponentProps<typeof PopperPrimitive.Root>['anchorRef'];
-  onOpenChange?: (open: boolean) => void;
-  loop?: boolean;
+type MenuImplOwnProps = Merge<
+  Polymorphic.OwnProps<typeof PopperPrimitive.Root>,
+  {
+    anchorRef: React.ComponentProps<typeof PopperPrimitive.Root>['anchorRef'];
+    onOpenChange?: (open: boolean) => void;
+    loop?: boolean;
 
-  /**
-   * Whether focus should be trapped within the `Menu`
-   * (default: false)
-   */
-  trapFocus?: FocusScopeProps['trapped'];
+    /**
+     * Whether focus should be trapped within the `Menu`
+     * (default: false)
+     */
+    trapFocus?: FocusScopeProps['trapped'];
 
-  /**
-   * Event handler called when auto-focusing on open.
-   * Can be prevented.
-   */
-  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+    /**
+     * Event handler called when auto-focusing on open.
+     * Can be prevented.
+     */
+    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
 
-  /**
-   * Event handler called when auto-focusing on close.
-   * Can be prevented.
-   */
-  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+    /**
+     * Event handler called when auto-focusing on close.
+     * Can be prevented.
+     */
+    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
 
-  /**
-   * When `true`, hover/focus/click interactions will be disabled on elements outside the `Menu`.
-   * Users will need to click twice on outside elements to interact with them:
-   * Once to close the `Menu`, and again to trigger the element.
-   */
-  disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
+    /**
+     * When `true`, hover/focus/click interactions will be disabled on elements outside the `Menu`.
+     * Users will need to click twice on outside elements to interact with them:
+     * Once to close the `Menu`, and again to trigger the element.
+     */
+    disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
 
-  /**
-   * Event handler called when the escape key is down.
-   * Can be prevented.
-   */
-  onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
+    /**
+     * Event handler called when the escape key is down.
+     * Can be prevented.
+     */
+    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
 
-  /**
-   * Event handler called when the a pointer event happens outside of the `Menu`.
-   * Can be prevented.
-   */
-  onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
+    /**
+     * Event handler called when the a pointer event happens outside of the `Menu`.
+     * Can be prevented.
+     */
+    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
 
-  /**
-   * Event handler called when the focus moves outside of the `Menu`.
-   * Can be prevented.
-   */
-  onFocusOutside?: DismissableLayerProps['onFocusOutside'];
+    /**
+     * Event handler called when the focus moves outside of the `Menu`.
+     * Can be prevented.
+     */
+    onFocusOutside?: DismissableLayerProps['onFocusOutside'];
 
-  /**
-   * Event handler called when an interaction happens outside the `Menu`.
-   * Specifically, when a pointer event happens outside of the `Menu` or focus moves outside of it.
-   * Can be prevented.
-   */
-  onInteractOutside?: DismissableLayerProps['onInteractOutside'];
+    /**
+     * Event handler called when an interaction happens outside the `Menu`.
+     * Specifically, when a pointer event happens outside of the `Menu` or focus moves outside of it.
+     * Can be prevented.
+     */
+    onInteractOutside?: DismissableLayerProps['onInteractOutside'];
 
-  /** Callback called when the `DismissableLayer` should be dismissed */
-  onDismiss?: DismissableLayerProps['onDismiss'];
+    /** Callback called when the `DismissableLayer` should be dismissed */
+    onDismiss?: DismissableLayerProps['onDismiss'];
 
-  /**
-   * Whether scrolling outside the `Menu` should be prevented
-   * (default: `false`)
-   */
-  disableOutsideScroll?: boolean;
+    /**
+     * Whether scrolling outside the `Menu` should be prevented
+     * (default: `false`)
+     */
+    disableOutsideScroll?: boolean;
 
-  /**
-   * Whether the `Menu` should render in a `Portal`
-   * (default: `true`)
-   */
-  portalled?: boolean;
-};
-
-const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>(
-  (props, forwardedRef) => {
-    const {
-      children,
-      onOpenChange,
-      anchorRef,
-      loop,
-      trapFocus,
-      onOpenAutoFocus,
-      onCloseAutoFocus,
-      disableOutsidePointerEvents,
-      onEscapeKeyDown,
-      onPointerDownOutside,
-      onFocusOutside,
-      onInteractOutside,
-      onDismiss,
-      disableOutsideScroll,
-      portalled,
-      ...menuProps
-    } = props;
-
-    const handleOpenChange = useCallbackRef(onOpenChange);
-    const menuRef = React.useRef<HTMLDivElement>(null);
-    const [menuTabIndex, setMenuTabIndex] = React.useState(0);
-    const [itemsReachable, setItemsReachable] = React.useState(false);
-    const menuTypeaheadProps = useMenuTypeahead();
-
-    const context = React.useMemo(
-      () => ({ menuRef, setItemsReachable, onOpenChange: handleOpenChange }),
-      [handleOpenChange]
-    );
-
-    React.useEffect(() => {
-      setMenuTabIndex(itemsReachable ? -1 : 0);
-    }, [itemsReachable]);
-
-    const [
-      isPermittedPointerDownOutsideEvent,
-      setIsPermittedPointerDownOutsideEvent,
-    ] = React.useState(false);
-
-    const PortalWrapper = portalled ? Portal : React.Fragment;
-    const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
-
-    // Make sure the whole tree has focus guards as our `Menu` may be
-    // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
-
-    // Hide everything from ARIA except the `Menu`
-    React.useEffect(() => {
-      const menu = menuRef.current;
-      if (menu) return hideOthers(menu);
-    }, []);
-
-    return (
-      <PortalWrapper>
-        <ScrollLockWrapper>
-          <FocusScope
-            // clicking outside may raise a focusout event, which may get trapped.
-            // in cases where outside pointer events are permitted, we stop trapping.
-            trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
-            onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={(event) => {
-              // skip autofocus on unmount if clicking outside is permitted and it happened
-              if (isPermittedPointerDownOutsideEvent) {
-                event.preventDefault();
-              } else {
-                onCloseAutoFocus?.(event);
-              }
-            }}
-          >
-            {(focusScopeProps) => (
-              <DismissableLayer
-                disableOutsidePointerEvents={disableOutsidePointerEvents}
-                onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={composeEventHandlers(
-                  onPointerDownOutside,
-                  (event) => {
-                    const isLeftClick =
-                      (event as MouseEvent).button === 0 && event.ctrlKey === false;
-                    const isPermitted = !disableOutsidePointerEvents && isLeftClick;
-                    setIsPermittedPointerDownOutsideEvent(isPermitted);
-
-                    if (event.defaultPrevented) {
-                      // reset this because the event was prevented
-                      setIsPermittedPointerDownOutsideEvent(false);
-                    }
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onFocusOutside={composeEventHandlers(
-                  onFocusOutside,
-                  (event) => {
-                    // When focus is trapped, a focusout event may still happen.
-                    // We make sure we don't trigger our `onDismiss` in such case.
-                    if (trapFocus) event.preventDefault();
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onInteractOutside={onInteractOutside}
-                onDismiss={onDismiss}
-              >
-                {(dismissableLayerProps) => (
-                  <PopperPrimitive.Root
-                    role="menu"
-                    selector={getSelector(MENU_NAME)}
-                    {...menuProps}
-                    ref={composeRefs(
-                      forwardedRef,
-                      menuRef,
-                      focusScopeProps.ref,
-                      dismissableLayerProps.ref
-                    )}
-                    anchorRef={anchorRef}
-                    tabIndex={menuTabIndex}
-                    style={{ ...dismissableLayerProps.style, outline: 'none', ...menuProps.style }}
-                    onBlurCapture={composeEventHandlers(
-                      menuProps.onBlurCapture,
-                      dismissableLayerProps.onBlurCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onFocusCapture={composeEventHandlers(
-                      menuProps.onFocusCapture,
-                      dismissableLayerProps.onFocusCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onMouseDownCapture={composeEventHandlers(
-                      menuProps.onMouseDownCapture,
-                      dismissableLayerProps.onMouseDownCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onTouchStartCapture={composeEventHandlers(
-                      menuProps.onTouchStartCapture,
-                      dismissableLayerProps.onTouchStartCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onKeyDownCapture={composeEventHandlers(
-                      menuProps.onKeyDownCapture,
-                      menuTypeaheadProps.onKeyDownCapture
-                    )}
-                    // focus first/last item based on key pressed
-                    onKeyDown={composeEventHandlers(menuProps.onKeyDown, (event) => {
-                      const menu = menuRef.current;
-                      if (event.target === menu) {
-                        if (ALL_KEYS.includes(event.key)) {
-                          event.preventDefault();
-                          const items = Array.from(menu.querySelectorAll(ENABLED_ITEM_SELECTOR));
-                          const item = FIRST_KEYS.includes(event.key)
-                            ? items[0]
-                            : items.reverse()[0];
-                          (item as HTMLElement | undefined)?.focus();
-                        }
-                      }
-                    })}
-                    // focus the menu if the mouse is moved over anything else than an item
-                    onMouseMove={composeEventHandlers(menuProps.onMouseMove, (event) => {
-                      if (!isItemOrInsideItem(event.target)) menuRef.current?.focus();
-                    })}
-                  >
-                    <RovingFocusGroup
-                      reachable={itemsReachable}
-                      onReachableChange={setItemsReachable}
-                      orientation="vertical"
-                      loop={loop}
-                    >
-                      <MenuContext.Provider value={context}>{children}</MenuContext.Provider>
-                    </RovingFocusGroup>
-                  </PopperPrimitive.Root>
-                )}
-              </DismissableLayer>
-            )}
-          </FocusScope>
-        </ScrollLockWrapper>
-      </PortalWrapper>
-    );
+    /**
+     * Whether the `Menu` should render in a `Portal`
+     * (default: `true`)
+     */
+    portalled?: boolean;
   }
-);
+>;
+
+type MenuImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Root>,
+  MenuImplOwnProps
+>;
+
+const MenuImpl = React.forwardRef((props, forwardedRef) => {
+  const {
+    children,
+    onOpenChange,
+    anchorRef,
+    loop,
+    trapFocus,
+    onOpenAutoFocus,
+    onCloseAutoFocus,
+    disableOutsidePointerEvents,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    onFocusOutside,
+    onInteractOutside,
+    onDismiss,
+    disableOutsideScroll,
+    portalled,
+    ...menuProps
+  } = props;
+
+  const handleOpenChange = useCallbackRef(onOpenChange);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const [menuTabIndex, setMenuTabIndex] = React.useState(0);
+  const [itemsReachable, setItemsReachable] = React.useState(false);
+  const menuTypeaheadProps = useMenuTypeahead();
+
+  const context = React.useMemo(
+    () => ({ menuRef, setItemsReachable, onOpenChange: handleOpenChange }),
+    [handleOpenChange]
+  );
+
+  React.useEffect(() => {
+    setMenuTabIndex(itemsReachable ? -1 : 0);
+  }, [itemsReachable]);
+
+  const [
+    isPermittedPointerDownOutsideEvent,
+    setIsPermittedPointerDownOutsideEvent,
+  ] = React.useState(false);
+
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+  const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
+
+  // Make sure the whole tree has focus guards as our `Menu` may be
+  // the last element in the DOM (beacuse of the `Portal`)
+  useFocusGuards();
+
+  // Hide everything from ARIA except the `Menu`
+  React.useEffect(() => {
+    const menu = menuRef.current;
+    if (menu) return hideOthers(menu);
+  }, []);
+
+  return (
+    <PortalWrapper>
+      <ScrollLockWrapper>
+        <FocusScope
+          // clicking outside may raise a focusout event, which may get trapped.
+          // in cases where outside pointer events are permitted, we stop trapping.
+          trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
+          onMountAutoFocus={onOpenAutoFocus}
+          onUnmountAutoFocus={(event) => {
+            // skip autofocus on unmount if clicking outside is permitted and it happened
+            if (isPermittedPointerDownOutsideEvent) {
+              event.preventDefault();
+            } else {
+              onCloseAutoFocus?.(event);
+            }
+          }}
+        >
+          {(focusScopeProps) => (
+            <DismissableLayer
+              disableOutsidePointerEvents={disableOutsidePointerEvents}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={composeEventHandlers(
+                onPointerDownOutside,
+                (event) => {
+                  const isLeftClick = (event as MouseEvent).button === 0 && event.ctrlKey === false;
+                  const isPermitted = !disableOutsidePointerEvents && isLeftClick;
+                  setIsPermittedPointerDownOutsideEvent(isPermitted);
+
+                  if (event.defaultPrevented) {
+                    // reset this because the event was prevented
+                    setIsPermittedPointerDownOutsideEvent(false);
+                  }
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onFocusOutside={composeEventHandlers(
+                onFocusOutside,
+                (event) => {
+                  // When focus is trapped, a focusout event may still happen.
+                  // We make sure we don't trigger our `onDismiss` in such case.
+                  if (trapFocus) event.preventDefault();
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onInteractOutside={onInteractOutside}
+              onDismiss={onDismiss}
+            >
+              {(dismissableLayerProps) => (
+                <PopperPrimitive.Root
+                  role="menu"
+                  selector={getSelector(MENU_NAME)}
+                  {...menuProps}
+                  ref={composeRefs(
+                    forwardedRef,
+                    menuRef,
+                    focusScopeProps.ref,
+                    dismissableLayerProps.ref
+                  )}
+                  anchorRef={anchorRef}
+                  tabIndex={menuTabIndex}
+                  style={{ ...dismissableLayerProps.style, outline: 'none', ...menuProps.style }}
+                  onBlurCapture={composeEventHandlers(
+                    menuProps.onBlurCapture,
+                    dismissableLayerProps.onBlurCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onFocusCapture={composeEventHandlers(
+                    menuProps.onFocusCapture,
+                    dismissableLayerProps.onFocusCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onMouseDownCapture={composeEventHandlers(
+                    menuProps.onMouseDownCapture,
+                    dismissableLayerProps.onMouseDownCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onTouchStartCapture={composeEventHandlers(
+                    menuProps.onTouchStartCapture,
+                    dismissableLayerProps.onTouchStartCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onKeyDownCapture={composeEventHandlers(
+                    menuProps.onKeyDownCapture,
+                    menuTypeaheadProps.onKeyDownCapture
+                  )}
+                  // focus first/last item based on key pressed
+                  onKeyDown={composeEventHandlers(menuProps.onKeyDown, (event) => {
+                    const menu = menuRef.current;
+                    if (event.target === menu) {
+                      if (ALL_KEYS.includes(event.key)) {
+                        event.preventDefault();
+                        const items = Array.from(menu.querySelectorAll(ENABLED_ITEM_SELECTOR));
+                        const item = FIRST_KEYS.includes(event.key) ? items[0] : items.reverse()[0];
+                        (item as HTMLElement | undefined)?.focus();
+                      }
+                    }
+                  })}
+                  // focus the menu if the mouse is moved over anything else than an item
+                  onMouseMove={composeEventHandlers(menuProps.onMouseMove, (event) => {
+                    if (!isItemOrInsideItem(event.target)) menuRef.current?.focus();
+                  })}
+                >
+                  <RovingFocusGroup
+                    reachable={itemsReachable}
+                    onReachableChange={setItemsReachable}
+                    orientation="vertical"
+                    loop={loop}
+                  >
+                    <MenuContext.Provider value={context}>{children}</MenuContext.Provider>
+                  </RovingFocusGroup>
+                </PopperPrimitive.Root>
+              )}
+            </DismissableLayer>
+          )}
+        </FocusScope>
+      </ScrollLockWrapper>
+    </PortalWrapper>
+  );
+}) as MenuImplPrimitive;
 
 Menu.displayName = MENU_NAME;
 
@@ -325,9 +336,15 @@ Menu.displayName = MENU_NAME;
 
 const GROUP_NAME = 'MenuGroup';
 
-const MenuGroup = forwardRefWithAs<typeof Primitive>((props, forwardedRef) => (
+type MenuGroupOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type MenuGroupPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  MenuGroupOwnProps
+>;
+
+const MenuGroup = React.forwardRef((props, forwardedRef) => (
   <Primitive role="group" selector={getSelector(GROUP_NAME)} {...props} ref={forwardedRef} />
-));
+)) as MenuGroupPrimitive;
 
 MenuGroup.displayName = GROUP_NAME;
 
@@ -337,9 +354,15 @@ MenuGroup.displayName = GROUP_NAME;
 
 const LABEL_NAME = 'MenuLabel';
 
-const MenuLabel = forwardRefWithAs<typeof Primitive>((props, forwardedRef) => (
+type MenuLabelOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type MenuLabelPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  MenuLabelOwnProps
+>;
+
+const MenuLabel = React.forwardRef((props, forwardedRef) => (
   <Primitive selector={getSelector(LABEL_NAME)} {...props} ref={forwardedRef} />
-));
+)) as MenuLabelPrimitive;
 
 MenuLabel.displayName = LABEL_NAME;
 
@@ -351,14 +374,21 @@ const ITEM_NAME = 'MenuItem';
 const ENABLED_ITEM_SELECTOR = `[data-${getSelector(ITEM_NAME)}]:not([data-disabled])`;
 const ITEM_SELECT = 'menu.itemSelect';
 
-type MenuItemOwnProps = {
-  disabled?: boolean;
-  textValue?: string;
-  onSelect?: (event: Event) => void;
-  onSelectCapture: never;
-};
+type MenuItemOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    disabled?: boolean;
+    textValue?: string;
+    onSelect?: (event: Event) => void;
+  }
+>;
 
-const MenuItem = forwardRefWithAs<typeof Primitive, MenuItemOwnProps>((props, forwardedRef) => {
+type MenuItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  MenuItemOwnProps
+>;
+
+const MenuItem = React.forwardRef((props, forwardedRef) => {
   const { disabled, textValue, onSelect, ...itemProps } = props;
   const menuItemRef = React.useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs(forwardedRef, menuItemRef);
@@ -449,7 +479,7 @@ const MenuItem = forwardRefWithAs<typeof Primitive, MenuItemOwnProps>((props, fo
       })}
     />
   );
-});
+}) as MenuItemPrimitive;
 
 MenuItem.displayName = ITEM_NAME;
 
@@ -459,33 +489,39 @@ MenuItem.displayName = ITEM_NAME;
 
 const CHECKBOX_ITEM_NAME = 'MenuCheckboxItem';
 
-type MenuCheckboxItemOwnProps = {
-  checked?: boolean;
-  onCheckedChange?: (checked: boolean) => void;
-};
-
-const MenuCheckboxItem = forwardRefWithAs<typeof MenuItem, MenuCheckboxItemOwnProps>(
-  (props, forwardedRef) => {
-    const { checked = false, onCheckedChange, children, ...checkboxItemProps } = props;
-    return (
-      <MenuItem
-        role="menuitemcheckbox"
-        selector={getSelector(CHECKBOX_ITEM_NAME)}
-        aria-checked={checked}
-        {...checkboxItemProps}
-        data-state={getCheckedState(checked)}
-        ref={forwardedRef}
-        onSelect={composeEventHandlers(
-          checkboxItemProps.onSelect,
-          () => onCheckedChange?.(!checked),
-          { checkForDefaultPrevented: false }
-        )}
-      >
-        <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
-      </MenuItem>
-    );
+type MenuCheckboxItemOwnProps = Merge<
+  Polymorphic.OwnProps<typeof MenuItem>,
+  {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
   }
-);
+>;
+
+type MenyCheckboxItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuItem>,
+  MenuCheckboxItemOwnProps
+>;
+
+const MenuCheckboxItem = React.forwardRef((props, forwardedRef) => {
+  const { checked = false, onCheckedChange, children, ...checkboxItemProps } = props;
+  return (
+    <MenuItem
+      role="menuitemcheckbox"
+      selector={getSelector(CHECKBOX_ITEM_NAME)}
+      aria-checked={checked}
+      {...checkboxItemProps}
+      data-state={getCheckedState(checked)}
+      ref={forwardedRef}
+      onSelect={composeEventHandlers(
+        checkboxItemProps.onSelect,
+        () => onCheckedChange?.(!checked),
+        { checkForDefaultPrevented: false }
+      )}
+    >
+      <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
+    </MenuItem>
+  );
+}) as MenyCheckboxItemPrimitive;
 
 MenuCheckboxItem.displayName = CHECKBOX_ITEM_NAME;
 
@@ -497,26 +533,32 @@ const RADIO_GROUP_NAME = 'MenuRadioGroup';
 
 const RadioGroupContext = React.createContext<MenuRadioGroupOwnProps>({} as any);
 
-type MenuRadioGroupOwnProps = {
-  value?: string;
-  onValueChange?: (value: string) => void;
-};
-
-const MenuRadioGroup = forwardRefWithAs<typeof MenuGroup, MenuRadioGroupOwnProps>(
-  (props, forwardedRef) => {
-    const { children, value, onValueChange, ...groupProps } = props;
-    const handleValueChange = useCallbackRef(onValueChange);
-    const context = React.useMemo(() => ({ value, onValueChange: handleValueChange }), [
-      value,
-      handleValueChange,
-    ]);
-    return (
-      <MenuGroup selector={getSelector(RADIO_GROUP_NAME)} {...groupProps} ref={forwardedRef}>
-        <RadioGroupContext.Provider value={context}>{children}</RadioGroupContext.Provider>
-      </MenuGroup>
-    );
+type MenuRadioGroupOwnProps = Merge<
+  Polymorphic.OwnProps<typeof MenuGroup>,
+  {
+    value?: string;
+    onValueChange?: (value: string) => void;
   }
-);
+>;
+
+type MenuRadioGroupPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuGroup>,
+  MenuRadioGroupOwnProps
+>;
+
+const MenuRadioGroup = React.forwardRef((props, forwardedRef) => {
+  const { children, value, onValueChange, ...groupProps } = props;
+  const handleValueChange = useCallbackRef(onValueChange);
+  const context = React.useMemo(() => ({ value, onValueChange: handleValueChange }), [
+    value,
+    handleValueChange,
+  ]);
+  return (
+    <MenuGroup selector={getSelector(RADIO_GROUP_NAME)} {...groupProps} ref={forwardedRef}>
+      <RadioGroupContext.Provider value={context}>{children}</RadioGroupContext.Provider>
+    </MenuGroup>
+  );
+}) as MenuRadioGroupPrimitive;
 
 MenuRadioGroup.displayName = RADIO_GROUP_NAME;
 
@@ -526,34 +568,34 @@ MenuRadioGroup.displayName = RADIO_GROUP_NAME;
 
 const RADIO_ITEM_NAME = 'MenuRadioItem';
 
-type MenuRadioItemOwnProps = {
-  value: string;
-};
+type MenuRadioItemOwnProps = Merge<Polymorphic.OwnProps<typeof MenuItem>, { value: string }>;
+type MenuRadioItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuItem>,
+  MenuRadioItemOwnProps
+>;
 
-const MenuRadioItem = forwardRefWithAs<typeof MenuItem, MenuRadioItemOwnProps>(
-  (props, forwardedRef) => {
-    const { value, children, ...radioItemProps } = props;
-    const context = React.useContext(RadioGroupContext);
-    const checked = value === context.value;
-    return (
-      <MenuItem
-        role="menuitemradio"
-        selector={getSelector(RADIO_ITEM_NAME)}
-        aria-checked={checked}
-        {...radioItemProps}
-        data-state={getCheckedState(checked)}
-        ref={forwardedRef}
-        onSelect={composeEventHandlers(
-          radioItemProps.onSelect,
-          () => context.onValueChange?.(value),
-          { checkForDefaultPrevented: false }
-        )}
-      >
-        <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
-      </MenuItem>
-    );
-  }
-);
+const MenuRadioItem = React.forwardRef((props, forwardedRef) => {
+  const { value, children, ...radioItemProps } = props;
+  const context = React.useContext(RadioGroupContext);
+  const checked = value === context.value;
+  return (
+    <MenuItem
+      role="menuitemradio"
+      selector={getSelector(RADIO_ITEM_NAME)}
+      aria-checked={checked}
+      {...radioItemProps}
+      data-state={getCheckedState(checked)}
+      ref={forwardedRef}
+      onSelect={composeEventHandlers(
+        radioItemProps.onSelect,
+        () => context.onValueChange?.(value),
+        { checkForDefaultPrevented: false }
+      )}
+    >
+      <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
+    </MenuItem>
+  );
+}) as MenuRadioItemPrimitive;
 
 MenuRadioItem.displayName = RADIO_ITEM_NAME;
 
@@ -566,18 +608,23 @@ const ITEM_INDICATOR_DEFAULT_TAG = 'span';
 
 const ItemIndicatorContext = React.createContext(false);
 
-type MenuItemIndicatorOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
+type MenuItemIndicatorOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
 
-const MenuItemIndicator = forwardRefWithAs<
+type MenuItemIndicatorPrimitive = Polymorphic.ForwardRefComponent<
   typeof ITEM_INDICATOR_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, MenuItemIndicatorOwnProps>
->((props, forwardedRef) => {
+  MenuItemIndicatorOwnProps
+>;
+
+const MenuItemIndicator = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...indicatorProps } = props;
   const checked = React.useContext(ItemIndicatorContext);
   return (
@@ -591,7 +638,7 @@ const MenuItemIndicator = forwardRefWithAs<
       />
     </Presence>
   );
-});
+}) as MenuItemIndicatorPrimitive;
 
 MenuItemIndicator.displayName = ITEM_INDICATOR_NAME;
 
@@ -601,7 +648,13 @@ MenuItemIndicator.displayName = ITEM_INDICATOR_NAME;
 
 const SEPARATOR_NAME = 'MenuSeparator';
 
-const MenuSeparator = forwardRefWithAs<typeof Primitive>((props, forwardedRef) => (
+type MenuSeparatorOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type MenuSeparatorPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  MenuSeparatorOwnProps
+>;
+
+const MenuSeparator = React.forwardRef((props, forwardedRef) => (
   <Primitive
     role="separator"
     selector={getSelector(SEPARATOR_NAME)}
@@ -609,7 +662,7 @@ const MenuSeparator = forwardRefWithAs<typeof Primitive>((props, forwardedRef) =
     {...props}
     ref={forwardedRef}
   />
-));
+)) as MenuSeparatorPrimitive;
 
 MenuSeparator.displayName = SEPARATOR_NAME;
 

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -18,6 +18,7 @@
     "prepublish": "yarn clean && yarn build"
   },
   "devDependencies": {
+    "@radix-ui/react-primitive": "workspace:*",
     "@testing-library/react": "^10.4.8"
   },
   "peerDependencies": {

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -18,7 +18,6 @@
     "prepublish": "yarn clean && yarn build"
   },
   "devDependencies": {
-    "@radix-ui/react-primitive": "workspace:*",
     "@testing-library/react": "^10.4.8"
   },
   "peerDependencies": {

--- a/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
+++ b/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Primitive } from '@radix-ui/react-primitive';
-import { forwardRefWithAs } from './forwardRefWithAs';
 
-import type { MergeOwnProps } from './forwardRefWithAs';
+import type * as Polymorphic from './forwardRefWithAs';
 import type { RenderResult } from '@testing-library/react';
 
 /* -------------------------------------------------------------------------------------------------
@@ -15,12 +14,13 @@ type ButtonProps = {
   another?: number;
 };
 
-const Button = forwardRefWithAs<'button', MergeOwnProps<typeof Primitive, ButtonProps>>(
-  (props, forwardedRef) => {
-    const { isDisabled, ...buttonProps } = props;
-    return <Primitive as="button" {...buttonProps} ref={forwardedRef} />;
-  }
-);
+const Button = React.forwardRef((props, forwardedRef) => {
+  const { isDisabled, ...buttonProps } = props;
+  return <Primitive as="button" {...buttonProps} ref={forwardedRef} />;
+}) as Polymorphic.ForwardRefComponent<
+  'button',
+  Polymorphic.OwnProps<typeof Primitive> & ButtonProps
+>;
 
 /* -------------------------------------------------------------------------------------------------
  * Extended Button using react utilities without polymorphism
@@ -49,15 +49,20 @@ export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(
 
 type ExtendedButtonProps = {
   isExtended?: boolean;
-  another: never;
 };
 
-const ExtendedButton = forwardRefWithAs<typeof Button, ExtendedButtonProps>(
-  (props, forwardedRef) => {
-    const { isExtended, ...extendedButtonProps } = props;
-    return <Button {...extendedButtonProps} ref={forwardedRef} />;
-  }
-);
+type ExtendedButtonButtonOwnProps = Omit<
+  Polymorphic.OwnProps<typeof Button>,
+  keyof ExtendedButtonProps | 'another'
+>;
+
+const ExtendedButton = React.forwardRef((props, forwardedRef) => {
+  const { isExtended, ...extendedButtonProps } = props;
+  return <Button {...extendedButtonProps} ref={forwardedRef} />;
+}) as Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Button>,
+  ExtendedButtonProps & ExtendedButtonButtonOwnProps
+>;
 
 /* -------------------------------------------------------------------------------------------------
  * Normal Link
@@ -85,11 +90,11 @@ type BoldProps = {
   requiredProp: boolean;
 };
 
-const Bold = forwardRefWithAs<'a', BoldProps>((props, forwardedRef) => {
+const Bold = React.forwardRef((props, forwardedRef) => {
   const { as: Comp = 'a', requiredProp, ...boldProps } = props;
   /* Does not expect requiredProp */
   return <Comp {...boldProps} ref={forwardedRef} />;
-});
+}) as Polymorphic.ForwardRefComponent<'a', BoldProps>;
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
+++ b/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
@@ -39,8 +39,17 @@ const ExtendedButtonUsingReactUtils = React.forwardRef<
 export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(
   props: React.ComponentProps<typeof Button>
 ) {
+  /* Should complain about implicit `any` for inline props */
+  /* @ts-expect-error */
+  const implicitAnyProps = <Button as={(props) => <button {...props} />} {...props} />;
   /* Should not error with inline `as` component */
-  return <Button as={(props) => <button {...props} />} {...props} />;
+  const explicitAnyProps = <Button as={(props: any) => <button {...props} />} {...props} />;
+  return (
+    <>
+      {implicitAnyProps}
+      {explicitAnyProps}
+    </>
+  );
 }
 
 /* -------------------------------------------------------------------------------------------------
@@ -83,18 +92,18 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
 });
 
 /* -------------------------------------------------------------------------------------------------
- * Polymorphic Bold with required prop
+ * Polymorphic Anchor with required prop
  * -----------------------------------------------------------------------------------------------*/
 
-type BoldProps = {
+type AnchorProps = {
   requiredProp: boolean;
 };
 
-const Bold = React.forwardRef((props, forwardedRef) => {
-  const { as: Comp = 'a', requiredProp, ...boldProps } = props;
+const Anchor = React.forwardRef((props, forwardedRef) => {
+  const { as: Comp = 'a', requiredProp, ...anchorProps } = props;
   /* Does not expect requiredProp */
-  return <Comp {...boldProps} ref={forwardedRef} />;
-}) as Polymorphic.ForwardRefComponent<'a', BoldProps>;
+  return <Comp {...anchorProps} ref={forwardedRef} />;
+}) as Polymorphic.ForwardRefComponent<'a', AnchorProps>;
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -134,7 +143,7 @@ export function Test() {
       <Button as={Link} isPrimary />
 
       {/* Button as Link accepts isDisabled prop */}
-      <Button as={Link} isDisabled />
+      <Button as={Link} />
 
       {/* Button as Link does not accept form prop */}
       {/* @ts-expect-error */}
@@ -184,9 +193,16 @@ export function Test() {
       {/* @ts-expect-error */}
       <ExtendedButtonUsingReactUtils as="a" isDisabled />
 
-      {/* Bold expects requiredProp prop */}
+      {/* Anchor expects requiredProp prop */}
       {/* @ts-expect-error */}
-      <Bold />
+      <Anchor />
+
+      {/* Button as Anchor (Polymorphic.ForwardRefComponent) expects required prop */}
+      {/* @ts-expect-error */}
+      <Button as={Anchor} />
+
+      {/* Button as Anchor (Polymorphic.ForwardRefComponent) accepts requiredProp */}
+      <Button as={Anchor} requiredProp />
     </>
   );
 }

--- a/packages/react/polymorphic/src/forwardRefWithAs.ts
+++ b/packages/react/polymorphic/src/forwardRefWithAs.ts
@@ -18,12 +18,6 @@ type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : {};
  */
 type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : never;
 
-/**
- * Gets the HTML element type from an intrinsic element
- * @example ElementRef<'div'> // HTMLDivElement
- */
-type ElementRef<E> = E extends keyof JSX.IntrinsicElements ? React.ElementRef<E> : never;
-
 /* -------------------------------------------------------------------------------------------------
  * ForwardRefComponent
  * -----------------------------------------------------------------------------------------------*/
@@ -48,7 +42,7 @@ interface ForwardRefComponent<
    */
   <As extends keyof JSX.IntrinsicElements>(
     props: MergeProps<As, OwnProps & { as: As }>
-  ): JSX.Element;
+  ): React.ReactElement | null;
 
   /**
    * When passing an `as` prop as a component, use this overload.
@@ -58,14 +52,13 @@ interface ForwardRefComponent<
    * We don't use `React.ComponentType` here as we get type errors
    * when consumers try to do inline `as` components.
    */
-  <As extends React.ElementType>(props: MergeProps<As, OwnProps & { as: As }>): JSX.Element;
-
-  /**
-   * ForwardRefRenderFunction
-   */
-  (
-    props: MergeProps<IntrinsicElementString, OwnProps & { as?: IntrinsicElementString }>,
-    ref: React.ForwardedRef<ElementRef<IntrinsicElementString>>
+  <
+    As extends React.ElementType<any>,
+    // Inferring with props so inline `as` components get implicit `any` errors
+    // e.g. `as={(props) => {}}` <-- `props` errors
+    _AsWithProps = As extends React.ElementType<infer P> ? React.ElementType<P> : never
+  >(
+    props: MergeProps<_AsWithProps, OwnProps & { as: _AsWithProps }>
   ): React.ReactElement | null;
 }
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -9,7 +9,6 @@ import {
   composeRefs,
   extendComponent,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
@@ -20,7 +19,8 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
 type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
@@ -76,27 +76,29 @@ Popover.displayName = POPOVER_NAME;
 const TRIGGER_NAME = 'PopoverTrigger';
 const TRIGGER_DEFAULT_TAG = 'button';
 
-const PopoverTrigger = forwardRefWithAs<typeof TRIGGER_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = usePopoverContext(TRIGGER_NAME);
-    const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
-    return (
-      <Primitive
-        as={TRIGGER_DEFAULT_TAG}
-        selector={getSelector(TRIGGER_NAME)}
-        type="button"
-        aria-haspopup="dialog"
-        aria-expanded={context.open}
-        aria-controls={context.id}
-        {...props}
-        ref={composedTriggerRef}
-        onClick={composeEventHandlers(props.onClick, () =>
-          context.setOpen((prevOpen) => !prevOpen)
-        )}
-      />
-    );
-  }
-);
+type PopoverTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type PopoverTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof TRIGGER_DEFAULT_TAG,
+  PopoverTriggerOwnProps
+>;
+
+const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
+  const context = usePopoverContext(TRIGGER_NAME);
+  const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+  return (
+    <Primitive
+      as={TRIGGER_DEFAULT_TAG}
+      selector={getSelector(TRIGGER_NAME)}
+      type="button"
+      aria-haspopup="dialog"
+      aria-expanded={context.open}
+      aria-controls={context.id}
+      {...props}
+      ref={composedTriggerRef}
+      onClick={composeEventHandlers(props.onClick, () => context.setOpen((prevOpen) => !prevOpen))}
+    />
+  );
+}) as PopoverTriggerPrimitive;
 
 PopoverTrigger.displayName = TRIGGER_NAME;
 
@@ -106,79 +108,13 @@ PopoverTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'PopoverContent';
 
-type PopoverContentOwnProps = {
-  /**
-   * Whether focus should be trapped within the `Popover`
-   * (default: false)
-   */
-  trapFocus?: FocusScopeProps['trapped'];
+type PopoverContentOwnProps = Polymorphic.OwnProps<typeof PopoverContentImpl>;
+type PopoverContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
+  PopoverContentOwnProps
+>;
 
-  /**
-   * Event handler called when auto-focusing on open.
-   * Can be prevented.
-   */
-  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
-
-  /**
-   * Event handler called when auto-focusing on close.
-   * Can be prevented.
-   */
-  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-
-  /**
-   * When `true`, hover/focus/click interactions will be disabled on elements outside the `Popover`.
-   * Users will need to click twice on outside elements to interact with them:
-   * Once to close the `Popover`, and again to trigger the element.
-   */
-  disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
-
-  /**
-   * Event handler called when the escape key is down.
-   * Can be prevented.
-   */
-  onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
-
-  /**
-   * Event handler called when the a pointer event happens outside of the `Popover`.
-   * Can be prevented.
-   */
-  onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
-
-  /**
-   * Event handler called when the focus moves outside of the `Popover`.
-   * Can be prevented.
-   */
-  onFocusOutside?: DismissableLayerProps['onFocusOutside'];
-
-  /**
-   * Event handler called when an interaction happens outside the `Popover`.
-   * Specifically, when a pointer event happens outside of the `Popover` or focus moves outside of it.
-   * Can be prevented.
-   */
-  onInteractOutside?: DismissableLayerProps['onInteractOutside'];
-
-  /**
-   * Whether scrolling outside the `Popover` should be prevented
-   * (default: `false`)
-   */
-  disableOutsideScroll?: boolean;
-
-  /**
-   * Whether the `Popover` should render in a `Portal`
-   * (default: `true`)
-   */
-  portalled?: boolean;
-
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-
-  anchorRef?: React.ComponentProps<typeof PopperPrimitive.Root>['anchorRef'];
-};
-
-const PopoverContent = forwardRefWithAs<typeof PopoverContentImpl>((props, forwardedRef) => {
+const PopoverContent = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...contentProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
   return (
@@ -190,155 +126,233 @@ const PopoverContent = forwardRefWithAs<typeof PopoverContentImpl>((props, forwa
       />
     </Presence>
   );
-});
+}) as PopoverContentPrimitive;
 
-const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, PopoverContentOwnProps>(
-  (props, forwardedRef) => {
-    const {
-      children,
-      anchorRef,
-      trapFocus = true,
-      onOpenAutoFocus,
-      onCloseAutoFocus,
-      disableOutsidePointerEvents = false,
-      onEscapeKeyDown,
-      onPointerDownOutside,
-      onFocusOutside,
-      onInteractOutside,
-      disableOutsideScroll = false,
-      portalled = true,
-      ...contentProps
-    } = props;
-    const context = usePopoverContext(CONTENT_NAME);
-    const [
-      isPermittedPointerDownOutsideEvent,
-      setIsPermittedPointerDownOutsideEvent,
-    ] = React.useState(false);
+type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Root>;
+type PopoverContentImplOwnProps = Merge<
+  PopperPrimitiveOwnProps,
+  {
+    /**
+     * Whether focus should be trapped within the `Popover`
+     * (default: false)
+     */
+    trapFocus?: FocusScopeProps['trapped'];
 
-    const PortalWrapper = portalled ? Portal : React.Fragment;
-    const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
+    /**
+     * Event handler called when auto-focusing on open.
+     * Can be prevented.
+     */
+    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
 
-    // Make sure the whole tree has focus guards as our `Popover` may be
-    // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
+    /**
+     * Event handler called when auto-focusing on close.
+     * Can be prevented.
+     */
+    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
 
-    // Hide everything from ARIA except the content
-    const contentRef = React.useRef<HTMLDivElement>(null);
-    React.useEffect(() => {
-      const content = contentRef.current;
-      if (content) return hideOthers(content);
-    }, []);
+    /**
+     * When `true`, hover/focus/click interactions will be disabled on elements outside the `Popover`.
+     * Users will need to click twice on outside elements to interact with them:
+     * Once to close the `Popover`, and again to trigger the element.
+     */
+    disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
 
-    return (
-      <PortalWrapper>
-        <ScrollLockWrapper>
-          <FocusScope
-            // clicking outside may raise a focusout event, which may get trapped.
-            // in cases where outside pointer events are permitted, we stop trapping.
-            trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
-            onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={(event) => {
-              // skip autofocus on close if clicking outside is permitted and it happened
-              if (isPermittedPointerDownOutsideEvent) {
-                event.preventDefault();
-              } else {
-                onCloseAutoFocus?.(event);
-              }
-            }}
-          >
-            {(focusScopeProps) => (
-              <DismissableLayer
-                disableOutsidePointerEvents={disableOutsidePointerEvents}
-                onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={composeEventHandlers(
-                  onPointerDownOutside,
-                  (event) => {
-                    const wasTrigger = context.triggerRef.current?.contains(
-                      event.target as HTMLElement
-                    );
+    /**
+     * Event handler called when the escape key is down.
+     * Can be prevented.
+     */
+    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
 
-                    const isLeftClick =
-                      (event as MouseEvent).button === 0 && event.ctrlKey === false;
-                    const isPermitted = !disableOutsidePointerEvents && isLeftClick;
-                    setIsPermittedPointerDownOutsideEvent(isPermitted);
+    /**
+     * Event handler called when the a pointer event happens outside of the `Popover`.
+     * Can be prevented.
+     */
+    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
 
-                    // prevent dismissing when clicking the trigger
-                    // as it's already setup to close, otherwise it would close and immediately open.
-                    if (wasTrigger) {
-                      event.preventDefault();
-                    }
+    /**
+     * Event handler called when the focus moves outside of the `Popover`.
+     * Can be prevented.
+     */
+    onFocusOutside?: DismissableLayerProps['onFocusOutside'];
 
-                    if (event.defaultPrevented) {
-                      // reset this because the event was prevented
-                      setIsPermittedPointerDownOutsideEvent(false);
-                    }
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onFocusOutside={composeEventHandlers(
-                  onFocusOutside,
-                  (event) => {
-                    // When focus is trapped, a focusout event may still happen.
-                    // We make sure we don't trigger our `onDismiss` in such case.
-                    if (trapFocus) event.preventDefault();
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onInteractOutside={onInteractOutside}
-                onDismiss={() => context.setOpen(false)}
-              >
-                {(dismissableLayerProps) => (
-                  <PopperPrimitive.Root
-                    role="dialog"
-                    selector={getSelector(CONTENT_NAME)}
-                    aria-modal
-                    {...contentProps}
-                    ref={composeRefs(
-                      forwardedRef,
-                      contentRef,
-                      focusScopeProps.ref,
-                      dismissableLayerProps.ref
-                    )}
-                    id={context.id}
-                    anchorRef={anchorRef || context.triggerRef}
-                    style={{
-                      ...dismissableLayerProps.style,
-                      ...contentProps.style,
-                      // re-namespace exposed content custom property
-                      ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-                    }}
-                    onBlurCapture={composeEventHandlers(
-                      contentProps.onBlurCapture,
-                      dismissableLayerProps.onBlurCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onFocusCapture={composeEventHandlers(
-                      contentProps.onFocusCapture,
-                      dismissableLayerProps.onFocusCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onMouseDownCapture={composeEventHandlers(
-                      contentProps.onMouseDownCapture,
-                      dismissableLayerProps.onMouseDownCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                    onTouchStartCapture={composeEventHandlers(
-                      contentProps.onTouchStartCapture,
-                      dismissableLayerProps.onTouchStartCapture,
-                      { checkForDefaultPrevented: false }
-                    )}
-                  >
-                    {children}
-                  </PopperPrimitive.Root>
-                )}
-              </DismissableLayer>
-            )}
-          </FocusScope>
-        </ScrollLockWrapper>
-      </PortalWrapper>
-    );
+    /**
+     * Event handler called when an interaction happens outside the `Popover`.
+     * Specifically, when a pointer event happens outside of the `Popover` or focus moves outside of it.
+     * Can be prevented.
+     */
+    onInteractOutside?: DismissableLayerProps['onInteractOutside'];
+
+    /**
+     * Whether scrolling outside the `Popover` should be prevented
+     * (default: `false`)
+     */
+    disableOutsideScroll?: boolean;
+
+    /**
+     * Whether the `Popover` should render in a `Portal`
+     * (default: `true`)
+     */
+    portalled?: boolean;
+
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+
+    anchorRef?: PopperPrimitiveOwnProps['anchorRef'];
   }
-);
+>;
+
+type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Root>,
+  PopoverContentImplOwnProps
+>;
+
+const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
+  const {
+    children,
+    anchorRef,
+    trapFocus = true,
+    onOpenAutoFocus,
+    onCloseAutoFocus,
+    disableOutsidePointerEvents = false,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    onFocusOutside,
+    onInteractOutside,
+    disableOutsideScroll = false,
+    portalled = true,
+    ...contentProps
+  } = props;
+  const context = usePopoverContext(CONTENT_NAME);
+  const [
+    isPermittedPointerDownOutsideEvent,
+    setIsPermittedPointerDownOutsideEvent,
+  ] = React.useState(false);
+
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+  const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
+
+  // Make sure the whole tree has focus guards as our `Popover` may be
+  // the last element in the DOM (beacuse of the `Portal`)
+  useFocusGuards();
+
+  // Hide everything from ARIA except the content
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <PortalWrapper>
+      <ScrollLockWrapper>
+        <FocusScope
+          // clicking outside may raise a focusout event, which may get trapped.
+          // in cases where outside pointer events are permitted, we stop trapping.
+          trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
+          onMountAutoFocus={onOpenAutoFocus}
+          onUnmountAutoFocus={(event) => {
+            // skip autofocus on close if clicking outside is permitted and it happened
+            if (isPermittedPointerDownOutsideEvent) {
+              event.preventDefault();
+            } else {
+              onCloseAutoFocus?.(event);
+            }
+          }}
+        >
+          {(focusScopeProps) => (
+            <DismissableLayer
+              disableOutsidePointerEvents={disableOutsidePointerEvents}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={composeEventHandlers(
+                onPointerDownOutside,
+                (event) => {
+                  const wasTrigger = context.triggerRef.current?.contains(
+                    event.target as HTMLElement
+                  );
+
+                  const isLeftClick = (event as MouseEvent).button === 0 && event.ctrlKey === false;
+                  const isPermitted = !disableOutsidePointerEvents && isLeftClick;
+                  setIsPermittedPointerDownOutsideEvent(isPermitted);
+
+                  // prevent dismissing when clicking the trigger
+                  // as it's already setup to close, otherwise it would close and immediately open.
+                  if (wasTrigger) {
+                    event.preventDefault();
+                  }
+
+                  if (event.defaultPrevented) {
+                    // reset this because the event was prevented
+                    setIsPermittedPointerDownOutsideEvent(false);
+                  }
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onFocusOutside={composeEventHandlers(
+                onFocusOutside,
+                (event) => {
+                  // When focus is trapped, a focusout event may still happen.
+                  // We make sure we don't trigger our `onDismiss` in such case.
+                  if (trapFocus) event.preventDefault();
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onInteractOutside={onInteractOutside}
+              onDismiss={() => context.setOpen(false)}
+            >
+              {(dismissableLayerProps) => (
+                <PopperPrimitive.Root
+                  role="dialog"
+                  selector={getSelector(CONTENT_NAME)}
+                  aria-modal
+                  {...contentProps}
+                  ref={composeRefs(
+                    forwardedRef,
+                    contentRef,
+                    focusScopeProps.ref,
+                    dismissableLayerProps.ref
+                  )}
+                  id={context.id}
+                  anchorRef={anchorRef || context.triggerRef}
+                  style={{
+                    ...dismissableLayerProps.style,
+                    ...contentProps.style,
+                    // re-namespace exposed content custom property
+                    ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+                  }}
+                  onBlurCapture={composeEventHandlers(
+                    contentProps.onBlurCapture,
+                    dismissableLayerProps.onBlurCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onFocusCapture={composeEventHandlers(
+                    contentProps.onFocusCapture,
+                    dismissableLayerProps.onFocusCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onMouseDownCapture={composeEventHandlers(
+                    contentProps.onMouseDownCapture,
+                    dismissableLayerProps.onMouseDownCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                  onTouchStartCapture={composeEventHandlers(
+                    contentProps.onTouchStartCapture,
+                    dismissableLayerProps.onTouchStartCapture,
+                    { checkForDefaultPrevented: false }
+                  )}
+                >
+                  {children}
+                </PopperPrimitive.Root>
+              )}
+            </DismissableLayer>
+          )}
+        </FocusScope>
+      </ScrollLockWrapper>
+    </PortalWrapper>
+  );
+}) as PopoverContentImplPrimitive;
 
 PopoverContent.displayName = CONTENT_NAME;
 
@@ -349,21 +363,25 @@ PopoverContent.displayName = CONTENT_NAME;
 const CLOSE_NAME = 'PopoverClose';
 const CLOSE_DEFAULT_TAG = 'button';
 
-const PopoverClose = forwardRefWithAs<typeof CLOSE_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = usePopoverContext(CLOSE_NAME);
-    return (
-      <Primitive
-        as={CLOSE_DEFAULT_TAG}
-        selector={getSelector(CLOSE_NAME)}
-        type="button"
-        {...props}
-        ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
-      />
-    );
-  }
-);
+type PopoverCloseOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type PopoverClosePrimitive = Polymorphic.ForwardRefComponent<
+  typeof CLOSE_DEFAULT_TAG,
+  PopoverCloseOwnProps
+>;
+
+const PopoverClose = React.forwardRef((props, forwardedRef) => {
+  const context = usePopoverContext(CLOSE_NAME);
+  return (
+    <Primitive
+      as={CLOSE_DEFAULT_TAG}
+      selector={getSelector(CLOSE_NAME)}
+      type="button"
+      {...props}
+      ref={forwardedRef}
+      onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
+    />
+  );
+}) as PopoverClosePrimitive;
 
 PopoverClose.displayName = CLOSE_NAME;
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -108,7 +108,17 @@ PopoverTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'PopoverContent';
 
-type PopoverContentOwnProps = Polymorphic.OwnProps<typeof PopoverContentImpl>;
+type PopoverContentOwnProps = Merge<
+  Polymorphic.OwnProps<typeof PopoverContentImpl>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
+
 type PopoverContentPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
   PopoverContentOwnProps
@@ -193,12 +203,6 @@ type PopoverContentImplOwnProps = Merge<
      * (default: `true`)
      */
     portalled?: boolean;
-
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
 
     anchorRef?: PopperPrimitiveOwnProps['anchorRef'];
   }

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { getPlacementData } from '@radix-ui/popper';
 import { createContext, useRect, useSize, useComposedRefs } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Arrow as ArrowPrimitive } from '@radix-ui/react-arrow';
 import { getSelector, getSelectorObj, makeRect } from '@radix-ui/utils';
 
-import type { Side, Align, Size, MeasurableElement } from '@radix-ui/utils';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Side, Align, Size, MeasurableElement, Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Root level context
@@ -29,17 +29,25 @@ const [PopperContext, usePopperContext] = createContext<PopperContextValue>(
 
 const POPPER_NAME = 'Popper';
 
-type PopperOwnProps = {
-  anchorRef: React.RefObject<MeasurableElement>;
-  side?: Side;
-  sideOffset?: number;
-  align?: Align;
-  alignOffset?: number;
-  collisionTolerance?: number;
-  avoidCollisions?: boolean;
-};
+type PopperOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    anchorRef: React.RefObject<MeasurableElement>;
+    side?: Side;
+    sideOffset?: number;
+    align?: Align;
+    alignOffset?: number;
+    collisionTolerance?: number;
+    avoidCollisions?: boolean;
+  }
+>;
 
-const Popper = forwardRefWithAs<typeof Primitive, PopperOwnProps>((props, forwardedRef) => {
+type PopperPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  PopperOwnProps
+>;
+
+const Popper = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(POPPER_NAME),
     children,
@@ -103,7 +111,7 @@ const Popper = forwardRefWithAs<typeof Primitive, PopperOwnProps>((props, forwar
       </Primitive>
     </div>
   );
-});
+}) as PopperPrimitive;
 
 Popper.displayName = POPPER_NAME;
 
@@ -113,46 +121,47 @@ Popper.displayName = POPPER_NAME;
 
 const ARROW_NAME = 'PopperArrow';
 
-type PopperArrowOwnProps = {
-  offset?: number;
-};
+type PopperArrowOwnProps = Merge<Polymorphic.OwnProps<typeof ArrowPrimitive>, { offset?: number }>;
 
-const PopperArrow = forwardRefWithAs<typeof ArrowPrimitive, PopperArrowOwnProps>(
-  function PopperArrow(props, forwardedRef) {
-    const { offset, ...arrowProps } = props;
-    const { arrowRef, setArrowOffset, arrowStyles } = usePopperContext(ARROW_NAME);
+type PopperArrowPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ArrowPrimitive>,
+  PopperArrowOwnProps
+>;
 
-    // send the Arrow's offset up to Popper
-    React.useEffect(() => setArrowOffset(offset), [setArrowOffset, offset]);
+const PopperArrow = React.forwardRef(function PopperArrow(props, forwardedRef) {
+  const { offset, ...arrowProps } = props;
+  const { arrowRef, setArrowOffset, arrowStyles } = usePopperContext(ARROW_NAME);
 
-    return (
-      <span style={{ ...arrowStyles, pointerEvents: 'none' }}>
-        <span
-          // we have to use an extra wrapper because `ResizeObserver` (used by `useSize`)
-          // doesn't report size as we'd expect on SVG elements.
-          // it reports their bounding box which is effectively the largest path inside the SVG.
-          ref={arrowRef}
+  // send the Arrow's offset up to Popper
+  React.useEffect(() => setArrowOffset(offset), [setArrowOffset, offset]);
+
+  return (
+    <span style={{ ...arrowStyles, pointerEvents: 'none' }}>
+      <span
+        // we have to use an extra wrapper because `ResizeObserver` (used by `useSize`)
+        // doesn't report size as we'd expect on SVG elements.
+        // it reports their bounding box which is effectively the largest path inside the SVG.
+        ref={arrowRef}
+        style={{
+          display: 'inline-block',
+          verticalAlign: 'top',
+          pointerEvents: 'auto',
+        }}
+      >
+        <ArrowPrimitive
+          selector={getSelector(ARROW_NAME)}
+          {...arrowProps}
+          ref={forwardedRef}
           style={{
-            display: 'inline-block',
-            verticalAlign: 'top',
-            pointerEvents: 'auto',
+            ...arrowProps.style,
+            // ensures the element can be measured correctly (mostly for if SVG)
+            display: 'block',
           }}
-        >
-          <ArrowPrimitive
-            selector={getSelector(ARROW_NAME)}
-            {...arrowProps}
-            ref={forwardedRef}
-            style={{
-              ...arrowProps.style,
-              // ensures the element can be measured correctly (mostly for if SVG)
-              display: 'block',
-            }}
-          />
-        </span>
+        />
       </span>
-    );
-  }
-);
+    </span>
+  );
+}) as PopperArrowPrimitive;
 
 PopperArrow.displayName = ARROW_NAME;
 

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getSelector, getSelectorObj } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 /* -------------------------------------------------------------------------------------------------
  * Primitive
@@ -24,10 +25,10 @@ type PrimitiveOwnProps = {
   selector?: string | null;
 };
 
-const Primitive = forwardRefWithAs<typeof DEFAULT_TAG, PrimitiveOwnProps>((props, forwardedRef) => {
+const Primitive = React.forwardRef((props, forwardedRef) => {
   const { as: Comp = DEFAULT_TAG, selector = getSelector(NAME), ...primitiveProps } = props;
   return <Comp {...primitiveProps} {...getSelectorObj(selector)} ref={forwardedRef} />;
-});
+}) as Polymorphic.ForwardRefComponent<typeof DEFAULT_TAG, PrimitiveOwnProps>;
 
 Primitive.displayName = 'Primitive';
 

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { createContext } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { getSelector } from '@radix-ui/utils';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Progress
@@ -18,13 +20,21 @@ const [ProgressContext, useProgressContext] = createContext<ProgressContextValue
   PROGRESS_NAME
 );
 
-type ProgressOwnProps = {
-  value?: number | null | undefined;
-  max?: number;
-  getValueLabel?(value: number, max: number): string;
-};
+type ProgressOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    value?: number | null | undefined;
+    max?: number;
+    getValueLabel?(value: number, max: number): string;
+  }
+>;
 
-const Progress = forwardRefWithAs<typeof Primitive, ProgressOwnProps>((props, forwardedRef) => {
+type ProgressPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ProgressOwnProps
+>;
+
+const Progress = React.forwardRef((props, forwardedRef) => {
   const {
     children,
     value: valueProp,
@@ -55,7 +65,7 @@ const Progress = forwardRefWithAs<typeof Primitive, ProgressOwnProps>((props, fo
       <ProgressContext.Provider value={ctx}>{children}</ProgressContext.Provider>
     </Primitive>
   );
-});
+}) as ProgressPrimitive;
 
 Progress.displayName = PROGRESS_NAME;
 
@@ -85,7 +95,13 @@ Progress.propTypes = {
 
 const INDICATOR_NAME = 'ProgressIndicator';
 
-const ProgressIndicator = forwardRefWithAs<typeof Primitive>((props, forwardedRef) => {
+type ProgressIndicatorOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ProgressIndicatorPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ProgressIndicatorOwnProps
+>;
+
+const ProgressIndicator = React.forwardRef((props, forwardedRef) => {
   const { value, max } = useProgressContext(INDICATOR_NAME);
   return (
     <Primitive
@@ -97,7 +113,7 @@ const ProgressIndicator = forwardRefWithAs<typeof Primitive>((props, forwardedRe
       ref={forwardedRef}
     />
   );
-});
+}) as ProgressIndicatorPrimitive;
 
 ProgressIndicator.displayName = INDICATOR_NAME;
 

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -5,13 +5,13 @@ import {
   useControlledState,
   useComposedRefs,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLabelContext } from '@radix-ui/react-label';
 import { getSelector } from '@radix-ui/utils';
 
-import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Radio
@@ -21,21 +21,22 @@ const RADIO_NAME = 'Radio';
 const RADIO_DEFAULT_TAG = 'button';
 
 type InputDOMProps = React.ComponentProps<'input'>;
-type RadioOwnProps = {
-  checked?: boolean;
-  defaultChecked?: boolean;
-  required?: InputDOMProps['required'];
-  readOnly?: InputDOMProps['readOnly'];
-  onCheckedChange?: InputDOMProps['onChange'];
-  onChange: never;
-};
+type RadioOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    checked?: boolean;
+    defaultChecked?: boolean;
+    required?: InputDOMProps['required'];
+    readOnly?: InputDOMProps['readOnly'];
+    onCheckedChange?: InputDOMProps['onChange'];
+  }
+>;
+
+type RadioPrimitive = Polymorphic.ForwardRefComponent<typeof RADIO_DEFAULT_TAG, RadioOwnProps>;
 
 const [RadioContext, useRadioContext] = createContext<boolean>(RADIO_NAME + 'Context', RADIO_NAME);
 
-const Radio = forwardRefWithAs<
-  typeof RADIO_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, RadioOwnProps>
->((props, forwardedRef) => {
+const Radio = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-labelledby': ariaLabelledby,
     children,
@@ -105,7 +106,7 @@ const Radio = forwardRefWithAs<
       </Primitive>
     </>
   );
-});
+}) as RadioPrimitive;
 
 Radio.displayName = RADIO_NAME;
 
@@ -116,18 +117,23 @@ Radio.displayName = RADIO_NAME;
 const INDICATOR_NAME = 'RadioIndicator';
 const INDICATOR_DEFAULT_TAG = 'span';
 
-type RadioIndicatorOwnProps = {
-  /**
-   * Used to force mounting when more control is needed. Useful when
-   * controlling animation with React animation libraries.
-   */
-  forceMount?: true;
-};
+type RadioIndicatorOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
 
-const RadioIndicator = forwardRefWithAs<
+type RadioIndicatorPrimitive = Polymorphic.ForwardRefComponent<
   typeof INDICATOR_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, RadioIndicatorOwnProps>
->((props, forwardedRef) => {
+  RadioIndicatorOwnProps
+>;
+
+const RadioIndicator = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...indicatorProps } = props;
   const checked = useRadioContext(INDICATOR_NAME);
   return (
@@ -141,7 +147,7 @@ const RadioIndicator = forwardRefWithAs<
       />
     </Presence>
   );
-});
+}) as RadioIndicatorPrimitive;
 
 RadioIndicator.displayName = INDICATOR_NAME;
 

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -7,24 +7,34 @@ import {
   useComposedRefs,
   extendComponent,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Radio, RadioIndicator } from './Radio';
 import { useLabelContext } from '@radix-ui/react-label';
 import { getSelector } from '@radix-ui/utils';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
+
 /* -------------------------------------------------------------------------------------------------
  * RadioGroup
  * -----------------------------------------------------------------------------------------------*/
 const RADIO_GROUP_NAME = 'RadioGroup';
 
-type RadioGroupOwnProps = {
-  value?: string;
-  defaultValue?: string;
-  required?: React.ComponentProps<typeof Radio>['required'];
-  onValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-};
+type RadioGroupOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    value?: string;
+    defaultValue?: string;
+    required?: React.ComponentProps<typeof Radio>['required'];
+    onValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  }
+>;
+
+type RadioGroupPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  RadioGroupOwnProps
+>;
 
 type RadioGroupContextValue = {
   value: RadioGroupOwnProps['value'];
@@ -37,7 +47,7 @@ const [RadioGroupContext, useRadioGroupContext] = createContext<RadioGroupContex
   RADIO_GROUP_NAME
 );
 
-const RadioGroup = forwardRefWithAs<typeof Primitive, RadioGroupOwnProps>((props, forwardedRef) => {
+const RadioGroup = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-labelledby': ariaLabelledby,
     defaultValue,
@@ -79,7 +89,7 @@ const RadioGroup = forwardRefWithAs<typeof Primitive, RadioGroupOwnProps>((props
       </RadioGroupContext.Provider>
     </Primitive>
   );
-});
+}) as RadioGroupPrimitive;
 
 RadioGroup.displayName = RADIO_GROUP_NAME;
 
@@ -89,54 +99,53 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 
 const ITEM_NAME = 'RadioGroupItem';
 
-type RadioGroupItemOwnProps = { value: string };
+type RadioGroupItemOwnProps = Merge<Polymorphic.OwnProps<typeof Radio>, { value: string }>;
+type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Radio>,
+  RadioGroupItemOwnProps
+>;
 
-const RadioGroupItem = forwardRefWithAs<typeof Radio, RadioGroupItemOwnProps>(
-  (props, forwardedRef) => {
-    const { disabled, required, ...itemProps } = props;
-    const context = useRadioGroupContext(ITEM_NAME);
-    const radioRef = React.useRef<React.ElementRef<typeof Radio>>(null);
-    const ref = useComposedRefs(forwardedRef, radioRef);
-    const isChecked = context.value === props.value;
-    const rovingFocusProps = useRovingFocus({ disabled, active: isChecked });
-    const handleChange = composeEventHandlers(itemProps.onCheckedChange, context.onValueChange);
-    const handleKeyDown = composeEventHandlers(itemProps.onKeyDown, rovingFocusProps.onKeyDown);
-    const handleMouseDown = composeEventHandlers(
-      itemProps.onMouseDown,
-      rovingFocusProps.onMouseDown
-    );
-    const handleFocus = composeEventHandlers(
-      itemProps.onFocus,
-      composeEventHandlers(rovingFocusProps.onFocus, () => {
-        /**
-         * Roving index will focus the radio and we need to check it when this happens.
-         * We do this imperatively instead of updating `context.value` because changing via
-         * state would not trigger change events (e.g. when in a form).
-         */
-        if (context.value !== undefined) {
-          radioRef.current?.click();
-        }
-      })
-    );
+const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
+  const { disabled, required, ...itemProps } = props;
+  const context = useRadioGroupContext(ITEM_NAME);
+  const radioRef = React.useRef<React.ElementRef<typeof Radio>>(null);
+  const ref = useComposedRefs(forwardedRef, radioRef);
+  const isChecked = context.value === props.value;
+  const rovingFocusProps = useRovingFocus({ disabled, active: isChecked });
+  const handleChange = composeEventHandlers(itemProps.onCheckedChange, context.onValueChange);
+  const handleKeyDown = composeEventHandlers(itemProps.onKeyDown, rovingFocusProps.onKeyDown);
+  const handleMouseDown = composeEventHandlers(itemProps.onMouseDown, rovingFocusProps.onMouseDown);
+  const handleFocus = composeEventHandlers(
+    itemProps.onFocus,
+    composeEventHandlers(rovingFocusProps.onFocus, () => {
+      /**
+       * Roving index will focus the radio and we need to check it when this happens.
+       * We do this imperatively instead of updating `context.value` because changing via
+       * state would not trigger change events (e.g. when in a form).
+       */
+      if (context.value !== undefined) {
+        radioRef.current?.click();
+      }
+    })
+  );
 
-    return (
-      <Radio
-        selector={getSelector(ITEM_NAME)}
-        {...itemProps}
-        {...rovingFocusProps}
-        disabled={disabled}
-        data-disabled={disabled ? '' : undefined}
-        required={required ?? context.required}
-        checked={isChecked}
-        ref={ref}
-        onCheckedChange={handleChange}
-        onKeyDown={handleKeyDown}
-        onMouseDown={handleMouseDown}
-        onFocus={handleFocus}
-      />
-    );
-  }
-);
+  return (
+    <Radio
+      selector={getSelector(ITEM_NAME)}
+      {...itemProps}
+      {...rovingFocusProps}
+      disabled={disabled}
+      data-disabled={disabled ? '' : undefined}
+      required={required ?? context.required}
+      checked={isChecked}
+      ref={ref}
+      onCheckedChange={handleChange}
+      onKeyDown={handleKeyDown}
+      onMouseDown={handleMouseDown}
+      onFocus={handleFocus}
+    />
+  );
+}) as RadioGroupItemPrimitive;
 
 RadioGroupItem.displayName = ITEM_NAME;
 

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -18,7 +18,6 @@ import {
   useLayoutEffect,
   usePrefersReducedMotion,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import {
   canUseDOM,
@@ -34,7 +33,8 @@ import { bezier } from './bezier-easing';
 import { Queue } from './queue';
 import { useHover } from './useHover';
 
-import type { Axis, Size } from '@radix-ui/utils';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge, Axis, Size } from '@radix-ui/utils';
 
 const SCROLL_AREA_CSS_PROPS_LIST = [
   'positionWidth',
@@ -149,60 +149,65 @@ const [DispatchContext, useDispatchContext] = createContext<React.Dispatch<Scrol
  * ScrollArea
  * -----------------------------------------------------------------------------------------------*/
 
-type ScrollAreaOwnProps = {
-  children: React.ReactNode;
-  /**
-   * Overflow behavior for the x axis. Mirrors the `overflow-x` CSS property.
-   *
-   * (default: `"auto"`)
-   */
-  overflowX?: OverflowBehavior;
-  /**
-   * Overflow behavior for the y axis. Mirrors the `overflow-y` CSS property.
-   *
-   * (default: `"auto"`)
-   */
-  overflowY?: OverflowBehavior;
-  /**
-   * Describes the nature of scrollbar visibility, similar to how the scrollbar preferences in MacOS
-   * control visibility of native scrollbars.
-   * - `"always"`: Scrollbars are always visible when content is overflowing
-   * - `"scroll"`: Scrollbars are visible when the user is scrolling along its corresponding axis
-   * - `"hover"`: Scrollbars are visible when the user is scrolling along its corresponding axis and
-   *   when the user is hovering over scrollable area
-   *
-   * (default: `"hover"`)
-   */
-  scrollbarVisibility?: ScrollbarVisibility;
-  /**
-   * If `scrollbarVisibility` is set to either `"scroll"`, this prop determines the length of time,
-   * in milliseconds, before the scrollbars are hidden after the user stops interacting with
-   * scrollbars.
-   *
-   * (default: 600)
-   */
-  scrollbarVisibilityRestTimeout?: number;
-  /**
-   * Describes the action that occurs when a user clicks on the scroll track. When `"relative"`, the
-   * scroll area will jump to a spot relative to where the user has clicked in relation to the
-   * track. When `"page"`, the scroll area will initially jump to the next or previous page of
-   * the viewable area, depending on which direction on the track is clicked.
-   *
-   * (default: `"relative"`)
-   */
-  trackClickBehavior?: TrackClickBehavior;
-  /**
-   * Mostly here for debugging, but these might be useful for consumers
-   */
-  unstable_forceNative?: boolean;
-  unstable_prefersReducedMotion?: boolean;
-  dir?: TextDirection;
-};
+type ScrollAreaOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    children: React.ReactNode;
+    /**
+     * Overflow behavior for the x axis. Mirrors the `overflow-x` CSS property.
+     *
+     * (default: `"auto"`)
+     */
+    overflowX?: OverflowBehavior;
+    /**
+     * Overflow behavior for the y axis. Mirrors the `overflow-y` CSS property.
+     *
+     * (default: `"auto"`)
+     */
+    overflowY?: OverflowBehavior;
+    /**
+     * Describes the nature of scrollbar visibility, similar to how the scrollbar preferences in MacOS
+     * control visibility of native scrollbars.
+     * - `"always"`: Scrollbars are always visible when content is overflowing
+     * - `"scroll"`: Scrollbars are visible when the user is scrolling along its corresponding axis
+     * - `"hover"`: Scrollbars are visible when the user is scrolling along its corresponding axis and
+     *   when the user is hovering over scrollable area
+     *
+     * (default: `"hover"`)
+     */
+    scrollbarVisibility?: ScrollbarVisibility;
+    /**
+     * If `scrollbarVisibility` is set to either `"scroll"`, this prop determines the length of time,
+     * in milliseconds, before the scrollbars are hidden after the user stops interacting with
+     * scrollbars.
+     *
+     * (default: 600)
+     */
+    scrollbarVisibilityRestTimeout?: number;
+    /**
+     * Describes the action that occurs when a user clicks on the scroll track. When `"relative"`, the
+     * scroll area will jump to a spot relative to where the user has clicked in relation to the
+     * track. When `"page"`, the scroll area will initially jump to the next or previous page of
+     * the viewable area, depending on which direction on the track is clicked.
+     *
+     * (default: `"relative"`)
+     */
+    trackClickBehavior?: TrackClickBehavior;
+    /**
+     * Mostly here for debugging, but these might be useful for consumers
+     */
+    unstable_forceNative?: boolean;
+    unstable_prefersReducedMotion?: boolean;
+    dir?: TextDirection;
+  }
+>;
 
-const ScrollArea = forwardRefWithAs<typeof Primitive, ScrollAreaOwnProps>(function ScrollArea(
-  props,
-  forwardedRef
-) {
+type ScrollAreaPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaOwnProps
+>;
+
+const ScrollArea = React.forwardRef(function ScrollArea(props, forwardedRef) {
   const { unstable_forceNative: forceNative = false, children, ...restProps } = {
     ...ROOT_DEFAULT_PROPS,
     ...props,
@@ -231,12 +236,19 @@ const ScrollArea = forwardRefWithAs<typeof Primitive, ScrollAreaOwnProps>(functi
       <NativeScrollContext.Provider value={usesNative}>{children}</NativeScrollContext.Provider>
     </ScrollAreaCustomOrNative>
   );
-});
+}) as ScrollAreaPrimitive;
 
-const ScrollAreaNoNativeFallback = forwardRefWithAs<
-  typeof Primitive,
+type ScrollAreaNoNativeFallbackOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
   Omit<ScrollAreaOwnProps, 'unstable_forceNative'>
->(function ScrollArea(props, forwardedRef) {
+>;
+
+type ScrollAreaNoNativeFallbackPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaNoNativeFallbackOwnProps
+>;
+
+const ScrollAreaNoNativeFallback = React.forwardRef(function ScrollArea(props, forwardedRef) {
   const { children, ...restProps } = {
     ...ROOT_DEFAULT_PROPS,
     ...props,
@@ -253,57 +265,69 @@ const ScrollAreaNoNativeFallback = forwardRefWithAs<
       <NativeScrollContext.Provider value={false}>{children}</NativeScrollContext.Provider>
     </ScrollAreaImpl>
   );
-});
+}) as ScrollAreaNoNativeFallbackPrimitive;
 
 type ScrollAreaInternalProps = {
   positionRef: React.RefObject<HTMLDivElement>;
   scrollAreaRef: React.RefObject<HTMLDivElement>;
 };
 
-type ScrollAreaNativeProps = ScrollAreaInternalProps &
-  Omit<ScrollAreaOwnProps, 'unstable_forceNative'> & {
+type ScrollAreaNativeOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  (ScrollAreaInternalProps & Omit<ScrollAreaOwnProps, 'unstable_forceNative'>) & {
     overflowX: NonNullable<ScrollAreaOwnProps['overflowX']>;
     overflowY: NonNullable<ScrollAreaOwnProps['overflowY']>;
-  };
-
-const ScrollAreaNative = forwardRefWithAs<typeof Primitive, ScrollAreaNativeProps>(
-  function ScrollAreaNative(props, forwardedRef) {
-    const {
-      overflowX,
-      overflowY,
-      scrollbarVisibility,
-      scrollbarVisibilityRestTimeout,
-      trackClickBehavior,
-      unstable_prefersReducedMotion,
-      scrollAreaRef,
-      positionRef,
-      ...domProps
-    } = { ...ROOT_DEFAULT_PROPS, ...props };
-
-    const ref = useComposedRefs(scrollAreaRef, forwardedRef);
-
-    return (
-      <Primitive
-        selector={getSelector(ROOT_NAME)}
-        {...domProps}
-        ref={ref}
-        style={{
-          ...domProps.style,
-          // For native fallback, the scroll area wrapper itself is scrollable
-          overflowX,
-          overflowY,
-
-          // Set this inline since we don't currently support resizable scroll areas. This feature
-          // will come later.
-          resize: 'none',
-        }}
-      />
-    );
   }
-);
+>;
 
-type ScrollAreaImplProps = ScrollAreaInternalProps &
-  Omit<ScrollAreaOwnProps, 'unstable_forceNative'>;
+type ScrollAreaNativePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaNativeOwnProps
+>;
+
+const ScrollAreaNative = React.forwardRef(function ScrollAreaNative(props, forwardedRef) {
+  const {
+    overflowX,
+    overflowY,
+    scrollbarVisibility,
+    scrollbarVisibilityRestTimeout,
+    trackClickBehavior,
+    unstable_prefersReducedMotion,
+    scrollAreaRef,
+    positionRef,
+    ...domProps
+  } = { ...ROOT_DEFAULT_PROPS, ...props };
+
+  const ref = useComposedRefs(scrollAreaRef, forwardedRef);
+
+  return (
+    <Primitive
+      selector={getSelector(ROOT_NAME)}
+      {...domProps}
+      ref={ref}
+      style={{
+        ...domProps.style,
+        // For native fallback, the scroll area wrapper itself is scrollable
+        overflowX,
+        overflowY,
+
+        // Set this inline since we don't currently support resizable scroll areas. This feature
+        // will come later.
+        resize: 'none',
+      }}
+    />
+  );
+}) as ScrollAreaNativePrimitive;
+
+type ScrollAreaImplProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  ScrollAreaInternalProps & Omit<ScrollAreaOwnProps, 'unstable_forceNative'>
+>;
+
+type ScrollAreaImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaImplProps
+>;
 
 const initialSize = { width: 0, height: 0 };
 const initialState: ScrollAreaReducerState = {
@@ -324,169 +348,167 @@ const initialState: ScrollAreaReducerState = {
   },
 };
 
-const ScrollAreaImpl = forwardRefWithAs<typeof Primitive, ScrollAreaImplProps>(
-  function ScrollAreaImpl(props, forwardedRef) {
-    const {
-      children,
-      onScroll,
-      overflowX,
-      overflowY,
-      scrollbarVisibility,
-      scrollbarVisibilityRestTimeout,
-      trackClickBehavior,
-      unstable_prefersReducedMotion,
+const ScrollAreaImpl = React.forwardRef(function ScrollAreaImpl(props, forwardedRef) {
+  const {
+    children,
+    onScroll,
+    overflowX,
+    overflowY,
+    scrollbarVisibility,
+    scrollbarVisibilityRestTimeout,
+    trackClickBehavior,
+    unstable_prefersReducedMotion,
+    positionRef,
+    scrollAreaRef,
+    ...domProps
+  } = { ...ROOT_DEFAULT_PROPS, ...props };
+
+  // That we call `onScroll` in the viewport component is an implementation detail that the
+  // consumer probably shouldn't need to think about. Passing it down from the top means that the
+  // event handler would work the same way in the native fallback as well.
+  const handleScroll = useCallbackRef(onScroll);
+
+  const buttonDownRef = React.useRef<HTMLDivElement>(null);
+  const buttonLeftRef = React.useRef<HTMLDivElement>(null);
+  const buttonRightRef = React.useRef<HTMLDivElement>(null);
+  const buttonUpRef = React.useRef<HTMLDivElement>(null);
+  const viewportRef = React.useRef<HTMLDivElement>(null);
+  const scrollbarXRef = React.useRef<HTMLDivElement>(null);
+  const scrollbarYRef = React.useRef<HTMLDivElement>(null);
+  const thumbXRef = React.useRef<HTMLDivElement>(null);
+  const thumbYRef = React.useRef<HTMLDivElement>(null);
+  const trackXRef = React.useRef<HTMLDivElement>(null);
+  const trackYRef = React.useRef<HTMLDivElement>(null);
+  const refs: ScrollAreaRefs = React.useMemo(() => {
+    return {
+      buttonDownRef,
+      buttonLeftRef,
+      buttonRightRef,
+      buttonUpRef,
+      viewportRef,
       positionRef,
       scrollAreaRef,
-      ...domProps
-    } = { ...ROOT_DEFAULT_PROPS, ...props };
+      scrollbarXRef,
+      scrollbarYRef,
+      thumbXRef,
+      thumbYRef,
+      trackXRef,
+      trackYRef,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    // That we call `onScroll` in the viewport component is an implementation detail that the
-    // consumer probably shouldn't need to think about. Passing it down from the top means that the
-    // event handler would work the same way in the native fallback as well.
-    const handleScroll = useCallbackRef(onScroll);
+  const _prefersReducedMotion = usePrefersReducedMotion(scrollAreaRef);
+  const prefersReducedMotion = unstable_prefersReducedMotion ?? _prefersReducedMotion;
 
-    const buttonDownRef = React.useRef<HTMLDivElement>(null);
-    const buttonLeftRef = React.useRef<HTMLDivElement>(null);
-    const buttonRightRef = React.useRef<HTMLDivElement>(null);
-    const buttonUpRef = React.useRef<HTMLDivElement>(null);
-    const viewportRef = React.useRef<HTMLDivElement>(null);
-    const scrollbarXRef = React.useRef<HTMLDivElement>(null);
-    const scrollbarYRef = React.useRef<HTMLDivElement>(null);
-    const thumbXRef = React.useRef<HTMLDivElement>(null);
-    const thumbYRef = React.useRef<HTMLDivElement>(null);
-    const trackXRef = React.useRef<HTMLDivElement>(null);
-    const trackYRef = React.useRef<HTMLDivElement>(null);
-    const refs: ScrollAreaRefs = React.useMemo(() => {
-      return {
-        buttonDownRef,
-        buttonLeftRef,
-        buttonRightRef,
-        buttonUpRef,
-        viewportRef,
-        positionRef,
-        scrollAreaRef,
-        scrollbarXRef,
-        scrollbarYRef,
-        thumbXRef,
-        thumbYRef,
-        trackXRef,
-        trackYRef,
-      };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+  const [reducerState, dispatch] = React.useReducer(scrollAreaStateReducer, {
+    ...initialState,
+    scrollbarIsVisibleX: scrollbarVisibility === 'always',
+    scrollbarIsVisibleY: scrollbarVisibility === 'always',
+  });
 
-    const _prefersReducedMotion = usePrefersReducedMotion(scrollAreaRef);
-    const prefersReducedMotion = unstable_prefersReducedMotion ?? _prefersReducedMotion;
+  const {
+    hoverProps: { onPointerEnter, onPointerLeave },
+    isHovered,
+  } = useHover();
 
-    const [reducerState, dispatch] = React.useReducer(scrollAreaStateReducer, {
-      ...initialState,
-      scrollbarIsVisibleX: scrollbarVisibility === 'always',
-      scrollbarIsVisibleY: scrollbarVisibility === 'always',
-    });
-
-    const {
-      hoverProps: { onPointerEnter, onPointerLeave },
+  const context: ScrollAreaContextValue = React.useMemo(() => {
+    return {
+      dir: props.dir,
       isHovered,
-    } = useHover();
-
-    const context: ScrollAreaContextValue = React.useMemo(() => {
-      return {
-        dir: props.dir,
-        isHovered,
-        onScroll: handleScroll,
-        overflowX,
-        overflowY,
-        prefersReducedMotion,
-        scrollbarVisibility,
-        scrollbarVisibilityRestTimeout,
-        trackClickBehavior,
-      };
-    }, [
-      props.dir,
-      handleScroll,
-      isHovered,
+      onScroll: handleScroll,
       overflowX,
       overflowY,
       prefersReducedMotion,
       scrollbarVisibility,
       scrollbarVisibilityRestTimeout,
       trackClickBehavior,
-    ]);
-
-    const ref = useComposedRefs(forwardedRef, scrollAreaRef);
-
-    useBorderBoxResizeObserver(scrollAreaRef, (size, scrollAreaElement) => {
-      const { ownerWindow } = getOwnerGlobals(scrollAreaRef);
-      const scrollAreaComputedStyle = ownerWindow.getComputedStyle(scrollAreaElement);
-      dispatch({
-        type: ScrollAreaEvents.HandleScrollAreaResize,
-        scrollAreaComputedStyle,
-        width: size.inlineSize,
-        height: size.blockSize,
-      });
-    });
-
-    // Defined CSS custom properties to determine styles based on sizes and positioning of child
-    // elements.
-    //
-    // We need an offset value to determine whether or not the content area should add padding to
-    // account for the size of the scrollbar.
-    //
-    // Only offset if:
-    //  - overflow is `scroll` and scrollbar autohide is `never`
-    //  - overflow is `auto`, scrollbar autohide is `never`, and the axis has overflowing content
-    //
-    // Do not offset if:
-    //  - scrollbar autohide is `scroll` (scrollbars overlap content in this case)
-    //  - overflow is `auto` and scrollbar autohide is `never`
-    //  - overflow is `hidden` or `visible` (scrollbars are hidden no matter what in either case)
-    const shouldOffsetX =
-      scrollbarVisibility === 'always' &&
-      (overflowX === 'scroll' || (overflowX === 'auto' && reducerState.contentIsOverflowingX));
-    const shouldOffsetY =
-      scrollbarVisibility === 'always' &&
-      (overflowY === 'scroll' || (overflowY === 'auto' && reducerState.contentIsOverflowingY));
-
-    const { domSizes } = reducerState;
-
-    const style: any = {
-      [SCROLL_AREA_CSS_PROPS.scrollbarXOffset]:
-        shouldOffsetX && domSizes.scrollbarX.height ? domSizes.scrollbarX.height + 'px' : 0,
-      [SCROLL_AREA_CSS_PROPS.scrollbarYOffset]:
-        shouldOffsetY && domSizes.scrollbarY.width ? domSizes.scrollbarY.width + 'px' : 0,
-      [SCROLL_AREA_CSS_PROPS.positionWidth]: domSizes.position.width
-        ? domSizes.position.width + 'px'
-        : 'auto',
-      [SCROLL_AREA_CSS_PROPS.positionHeight]: domSizes.position.height
-        ? domSizes.position.height + 'px'
-        : 'auto',
     };
+  }, [
+    props.dir,
+    handleScroll,
+    isHovered,
+    overflowX,
+    overflowY,
+    prefersReducedMotion,
+    scrollbarVisibility,
+    scrollbarVisibilityRestTimeout,
+    trackClickBehavior,
+  ]);
 
-    return (
-      <DispatchContext.Provider value={dispatch}>
-        <ScrollAreaRefsContext.Provider value={refs}>
-          <ScrollAreaContext.Provider value={context}>
-            <ScrollAreaStateContext.Provider value={reducerState}>
-              <Primitive
-                selector={getSelector(ROOT_NAME)}
-                {...domProps}
-                ref={ref}
-                style={{
-                  ...domProps.style,
-                  ...style,
-                }}
-                onPointerEnter={composeEventHandlers(props.onPointerEnter, onPointerEnter)}
-                onPointerLeave={composeEventHandlers(props.onPointerLeave, onPointerLeave)}
-              >
-                {children}
-              </Primitive>
-            </ScrollAreaStateContext.Provider>
-          </ScrollAreaContext.Provider>
-        </ScrollAreaRefsContext.Provider>
-      </DispatchContext.Provider>
-    );
-  }
-);
+  const ref = useComposedRefs(forwardedRef, scrollAreaRef);
+
+  useBorderBoxResizeObserver(scrollAreaRef, (size, scrollAreaElement) => {
+    const { ownerWindow } = getOwnerGlobals(scrollAreaRef);
+    const scrollAreaComputedStyle = ownerWindow.getComputedStyle(scrollAreaElement);
+    dispatch({
+      type: ScrollAreaEvents.HandleScrollAreaResize,
+      scrollAreaComputedStyle,
+      width: size.inlineSize,
+      height: size.blockSize,
+    });
+  });
+
+  // Defined CSS custom properties to determine styles based on sizes and positioning of child
+  // elements.
+  //
+  // We need an offset value to determine whether or not the content area should add padding to
+  // account for the size of the scrollbar.
+  //
+  // Only offset if:
+  //  - overflow is `scroll` and scrollbar autohide is `never`
+  //  - overflow is `auto`, scrollbar autohide is `never`, and the axis has overflowing content
+  //
+  // Do not offset if:
+  //  - scrollbar autohide is `scroll` (scrollbars overlap content in this case)
+  //  - overflow is `auto` and scrollbar autohide is `never`
+  //  - overflow is `hidden` or `visible` (scrollbars are hidden no matter what in either case)
+  const shouldOffsetX =
+    scrollbarVisibility === 'always' &&
+    (overflowX === 'scroll' || (overflowX === 'auto' && reducerState.contentIsOverflowingX));
+  const shouldOffsetY =
+    scrollbarVisibility === 'always' &&
+    (overflowY === 'scroll' || (overflowY === 'auto' && reducerState.contentIsOverflowingY));
+
+  const { domSizes } = reducerState;
+
+  const style: any = {
+    [SCROLL_AREA_CSS_PROPS.scrollbarXOffset]:
+      shouldOffsetX && domSizes.scrollbarX.height ? domSizes.scrollbarX.height + 'px' : 0,
+    [SCROLL_AREA_CSS_PROPS.scrollbarYOffset]:
+      shouldOffsetY && domSizes.scrollbarY.width ? domSizes.scrollbarY.width + 'px' : 0,
+    [SCROLL_AREA_CSS_PROPS.positionWidth]: domSizes.position.width
+      ? domSizes.position.width + 'px'
+      : 'auto',
+    [SCROLL_AREA_CSS_PROPS.positionHeight]: domSizes.position.height
+      ? domSizes.position.height + 'px'
+      : 'auto',
+  };
+
+  return (
+    <DispatchContext.Provider value={dispatch}>
+      <ScrollAreaRefsContext.Provider value={refs}>
+        <ScrollAreaContext.Provider value={context}>
+          <ScrollAreaStateContext.Provider value={reducerState}>
+            <Primitive
+              selector={getSelector(ROOT_NAME)}
+              {...domProps}
+              ref={ref}
+              style={{
+                ...domProps.style,
+                ...style,
+              }}
+              onPointerEnter={composeEventHandlers(props.onPointerEnter, onPointerEnter)}
+              onPointerLeave={composeEventHandlers(props.onPointerLeave, onPointerLeave)}
+            >
+              {children}
+            </Primitive>
+          </ScrollAreaStateContext.Provider>
+        </ScrollAreaContext.Provider>
+      </ScrollAreaRefsContext.Provider>
+    </DispatchContext.Provider>
+  );
+}) as ScrollAreaImplPrimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * ScrollAreaViewport
@@ -494,7 +516,13 @@ const ScrollAreaImpl = forwardRefWithAs<typeof Primitive, ScrollAreaImplProps>(
 
 const VIEWPORT_NAME = 'ScrollAreaViewport';
 
-const ScrollAreaViewportImpl = forwardRefWithAs<typeof Primitive>(function ScrollAreaViewportImpl(
+type ScrollAreaViewportImplOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaViewportImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaViewportImplOwnProps
+>;
+
+const ScrollAreaViewportImpl = React.forwardRef(function ScrollAreaViewportImpl(
   props,
   forwardedRef
 ) {
@@ -655,17 +683,21 @@ const ScrollAreaViewportImpl = forwardRefWithAs<typeof Primitive>(function Scrol
       </div>
     </div>
   );
-});
+}) as ScrollAreaViewportImplPrimitive;
 
-const ScrollAreaViewport = forwardRefWithAs<typeof ScrollAreaViewportImpl>(
-  function ScrollAreaViewport(props, forwardedRef) {
-    return useNativeScrollArea() ? (
-      <Primitive selector={getSelector(VIEWPORT_NAME)} {...props} ref={forwardedRef} />
-    ) : (
-      <ScrollAreaViewportImpl {...props} ref={forwardedRef} />
-    );
-  }
-);
+type ScrollAreaViewportOwnProps = Polymorphic.OwnProps<typeof ScrollAreaViewportImpl>;
+type ScrollAreaViewportPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ScrollAreaViewportImpl>,
+  ScrollAreaViewportOwnProps
+>;
+
+const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(props, forwardedRef) {
+  return useNativeScrollArea() ? (
+    <Primitive selector={getSelector(VIEWPORT_NAME)} {...props} ref={forwardedRef} />
+  ) : (
+    <ScrollAreaViewportImpl {...props} ref={forwardedRef} />
+  );
+}) as ScrollAreaViewportPrimitive;
 
 ScrollAreaViewport.displayName = VIEWPORT_NAME;
 
@@ -676,10 +708,18 @@ ScrollAreaViewport.displayName = VIEWPORT_NAME;
 const SCROLLBAR_X_NAME = 'ScrollAreaScrollbarX';
 const SCROLLBAR_Y_NAME = 'ScrollAreaScrollbarY';
 
-interface ScrollAreaScrollbarOwnProps {
-  axis: Axis;
-  name: string;
-}
+type ScrollAreaScrollbarOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    axis: Axis;
+    name: string;
+  }
+>;
+
+type ScrollAreaScrollbarPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaScrollbarOwnProps
+>;
 
 interface ScrollbarContextValue {
   axis: Axis;
@@ -691,67 +731,51 @@ const [ScrollbarContext, useScrollbarContext] = createContext<ScrollbarContextVa
   'ScrollAreaScrollbar'
 );
 
-const ScrollAreaScrollbar = forwardRefWithAs<typeof Primitive, ScrollAreaScrollbarOwnProps>(
-  function ScrollAreaScrollbar(props, forwardedRef) {
-    const { axis, name, onWheel, onPointerDown, onPointerUp, onPointerMove, ...domProps } = props;
-    const dispatch = useDispatchContext(name);
-    const { scrollbarVisibility, scrollbarVisibilityRestTimeout, isHovered } = useScrollAreaContext(
-      name
-    );
-    const {
-      [axis === 'x' ? 'contentIsOverflowingX' : 'contentIsOverflowingY']: contentIsOverflowing,
-      [axis === 'x' ? 'scrollbarIsVisibleX' : 'scrollbarIsVisibleY']: scrollbarIsVisible,
-    } = useScrollAreaStateContext();
-    const refsContext = useScrollAreaRefs(name);
-    const { positionRef } = refsContext;
-    const scrollbarRef = getScrollbarRef(axis, refsContext);
-    const ref = useComposedRefs(scrollbarRef, forwardedRef);
+const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar(props, forwardedRef) {
+  const { axis, name, onWheel, onPointerDown, onPointerUp, onPointerMove, ...domProps } = props;
+  const dispatch = useDispatchContext(name);
+  const { scrollbarVisibility, scrollbarVisibilityRestTimeout, isHovered } = useScrollAreaContext(
+    name
+  );
+  const {
+    [axis === 'x' ? 'contentIsOverflowingX' : 'contentIsOverflowingY']: contentIsOverflowing,
+    [axis === 'x' ? 'scrollbarIsVisibleX' : 'scrollbarIsVisibleY']: scrollbarIsVisible,
+  } = useScrollAreaStateContext();
+  const refsContext = useScrollAreaRefs(name);
+  const { positionRef } = refsContext;
+  const scrollbarRef = getScrollbarRef(axis, refsContext);
+  const ref = useComposedRefs(scrollbarRef, forwardedRef);
 
-    // Animation effects triggered by button and track clicks are managed in a queue to prevent race
-    // conditions and invalid DOM measurements when the user clicks faster than the animation is
-    // able to be completed
-    const scrollAnimationQueue = useConstant(() => new Queue<any>());
+  // Animation effects triggered by button and track clicks are managed in a queue to prevent race
+  // conditions and invalid DOM measurements when the user clicks faster than the animation is
+  // able to be completed
+  const scrollAnimationQueue = useConstant(() => new Queue<any>());
 
-    useBorderBoxResizeObserver(scrollbarRef, (size: ResizeObserverSize) => {
-      dispatch({
-        type: ScrollAreaEvents.HandleScrollbarResize,
-        width: size.inlineSize,
-        height: size.blockSize,
-        axis,
-      });
+  useBorderBoxResizeObserver(scrollbarRef, (size: ResizeObserverSize) => {
+    dispatch({
+      type: ScrollAreaEvents.HandleScrollbarResize,
+      width: size.inlineSize,
+      height: size.blockSize,
+      axis,
     });
+  });
 
-    const handleWheel = composeEventHandlers(onWheel, function handleWheel(event) {
-      const absoluteDeltaX = Math.abs(event.deltaX);
-      const absoluteDeltaY = Math.abs(event.deltaY);
-      if (positionRef.current) {
-        if (absoluteDeltaX > 0 && absoluteDeltaX > absoluteDeltaY) {
-          positionRef.current.scrollLeft += event.deltaX;
-        }
-        if (absoluteDeltaY > 0 && absoluteDeltaY > absoluteDeltaX) {
-          positionRef.current.scrollTop += event.deltaY;
-        }
+  const handleWheel = composeEventHandlers(onWheel, function handleWheel(event) {
+    const absoluteDeltaX = Math.abs(event.deltaX);
+    const absoluteDeltaY = Math.abs(event.deltaY);
+    if (positionRef.current) {
+      if (absoluteDeltaX > 0 && absoluteDeltaX > absoluteDeltaY) {
+        positionRef.current.scrollLeft += event.deltaX;
       }
-    });
-
-    const timeoutId = React.useRef<any>();
-    React.useEffect(() => {
-      if (scrollbarIsVisible) {
-        timeoutId.current = setTimeout(() => {
-          dispatch({
-            type: ScrollAreaEvents.SetScrollbarIsVisible,
-            scrollbarVisibility,
-            [axis]: false,
-          });
-        }, scrollbarVisibilityRestTimeout);
-        return function () {
-          clearTimeout(timeoutId.current);
-        };
+      if (absoluteDeltaY > 0 && absoluteDeltaY > absoluteDeltaX) {
+        positionRef.current.scrollTop += event.deltaY;
       }
-    }, [axis, dispatch, scrollbarIsVisible, scrollbarVisibility, scrollbarVisibilityRestTimeout]);
+    }
+  });
 
-    function resetInteractiveTimer() {
-      clearTimeout(timeoutId.current);
+  const timeoutId = React.useRef<any>();
+  React.useEffect(() => {
+    if (scrollbarIsVisible) {
       timeoutId.current = setTimeout(() => {
         dispatch({
           type: ScrollAreaEvents.SetScrollbarIsVisible,
@@ -759,84 +783,101 @@ const ScrollAreaScrollbar = forwardRefWithAs<typeof Primitive, ScrollAreaScrollb
           [axis]: false,
         });
       }, scrollbarVisibilityRestTimeout);
-    }
-
-    // Not capturing the pointer because the user may be clicking on the thumb, but we need to know
-    // whether or not it's down on pointer move so we just use a ref.
-    const pointerDown = React.useRef(false);
-
-    const handlePointerDown = composeEventHandlers(onPointerDown, (event) => {
-      pointerDown.current = true;
-      clearTimeout(timeoutId.current);
-    });
-
-    const handlePointerUp = composeEventHandlers(onPointerUp, (event) => {
-      pointerDown.current = false;
-      resetInteractiveTimer();
-    });
-
-    const handlePointerMove = composeEventHandlers(onPointerMove, (event) => {
-      if (!pointerDown.current) {
-        resetInteractiveTimer();
-      }
-    });
-
-    const opacity = (function () {
-      const defaultVisible = domProps.style?.opacity || 1;
-      switch (scrollbarVisibility) {
-        case 'always':
-          return domProps.style?.opacity;
-        case 'scroll':
-          return scrollbarIsVisible ? defaultVisible : 0;
-        case 'hover':
-          return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 0;
-      }
-    })();
-
-    const pointerEvents = (function () {
-      const defaultVisible = domProps.style?.pointerEvents || 'auto';
-      switch (scrollbarVisibility) {
-        case 'always':
-          return domProps.style?.pointerEvents;
-        case 'scroll':
-          return scrollbarIsVisible ? defaultVisible : 'none';
-        case 'hover':
-          return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 'none';
-      }
-    })();
-
-    const context: ScrollbarContextValue = React.useMemo(() => {
-      return {
-        axis,
-        scrollAnimationQueue,
+      return function () {
+        clearTimeout(timeoutId.current);
       };
-    }, [axis, scrollAnimationQueue]);
+    }
+  }, [axis, dispatch, scrollbarIsVisible, scrollbarVisibility, scrollbarVisibilityRestTimeout]);
 
-    return (
-      <ScrollbarContext.Provider value={context}>
-        <Primitive
-          {...domProps}
-          ref={ref}
-          style={{
-            ...domProps.style,
-            display: !contentIsOverflowing ? 'none' : domProps.style?.display,
-            opacity,
-            pointerEvents,
-          }}
-          onPointerDown={handlePointerDown}
-          onPointerUp={handlePointerUp}
-          onPointerMove={handlePointerMove}
-          onWheel={handleWheel}
-        />
-      </ScrollbarContext.Provider>
-    );
+  function resetInteractiveTimer() {
+    clearTimeout(timeoutId.current);
+    timeoutId.current = setTimeout(() => {
+      dispatch({
+        type: ScrollAreaEvents.SetScrollbarIsVisible,
+        scrollbarVisibility,
+        [axis]: false,
+      });
+    }, scrollbarVisibilityRestTimeout);
   }
-);
 
-const ScrollAreaScrollbarX = forwardRefWithAs<typeof Primitive>(function ScrollAreaScrollbarX(
-  props,
-  forwardedRef
-) {
+  // Not capturing the pointer because the user may be clicking on the thumb, but we need to know
+  // whether or not it's down on pointer move so we just use a ref.
+  const pointerDown = React.useRef(false);
+
+  const handlePointerDown = composeEventHandlers(onPointerDown, (event) => {
+    pointerDown.current = true;
+    clearTimeout(timeoutId.current);
+  });
+
+  const handlePointerUp = composeEventHandlers(onPointerUp, (event) => {
+    pointerDown.current = false;
+    resetInteractiveTimer();
+  });
+
+  const handlePointerMove = composeEventHandlers(onPointerMove, (event) => {
+    if (!pointerDown.current) {
+      resetInteractiveTimer();
+    }
+  });
+
+  const opacity = (function () {
+    const defaultVisible = domProps.style?.opacity || 1;
+    switch (scrollbarVisibility) {
+      case 'always':
+        return domProps.style?.opacity;
+      case 'scroll':
+        return scrollbarIsVisible ? defaultVisible : 0;
+      case 'hover':
+        return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 0;
+    }
+  })();
+
+  const pointerEvents = (function () {
+    const defaultVisible = domProps.style?.pointerEvents || 'auto';
+    switch (scrollbarVisibility) {
+      case 'always':
+        return domProps.style?.pointerEvents;
+      case 'scroll':
+        return scrollbarIsVisible ? defaultVisible : 'none';
+      case 'hover':
+        return isHovered ? defaultVisible : scrollbarIsVisible ? defaultVisible : 'none';
+    }
+  })();
+
+  const context: ScrollbarContextValue = React.useMemo(() => {
+    return {
+      axis,
+      scrollAnimationQueue,
+    };
+  }, [axis, scrollAnimationQueue]);
+
+  return (
+    <ScrollbarContext.Provider value={context}>
+      <Primitive
+        {...domProps}
+        ref={ref}
+        style={{
+          ...domProps.style,
+          display: !contentIsOverflowing ? 'none' : domProps.style?.display,
+          opacity,
+          pointerEvents,
+        }}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerMove={handlePointerMove}
+        onWheel={handleWheel}
+      />
+    </ScrollbarContext.Provider>
+  );
+}) as ScrollAreaScrollbarPrimitive;
+
+type ScrollAreaScrollbarXOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaScrollbarXPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaScrollbarXOwnProps
+>;
+
+const ScrollAreaScrollbarX = React.forwardRef(function ScrollAreaScrollbarX(props, forwardedRef) {
   const { domSizes } = useScrollAreaStateContext();
   return useNativeScrollArea() ? null : (
     <ScrollAreaScrollbar
@@ -854,13 +895,17 @@ const ScrollAreaScrollbarX = forwardRefWithAs<typeof Primitive>(function ScrollA
       }}
     />
   );
-});
+}) as ScrollAreaScrollbarXPrimitive;
+
 ScrollAreaScrollbarX.displayName = SCROLLBAR_X_NAME;
 
-const ScrollAreaScrollbarY = forwardRefWithAs<typeof Primitive>(function ScrollAreaScrollbarY(
-  props,
-  forwardedRef
-) {
+type ScrollAreaScrollbarYOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaScrollbarYPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaScrollbarYOwnProps
+>;
+
+const ScrollAreaScrollbarY = React.forwardRef(function ScrollAreaScrollbarY(props, forwardedRef) {
   const { domSizes } = useScrollAreaStateContext();
   return useNativeScrollArea() ? null : (
     <ScrollAreaScrollbar
@@ -878,7 +923,8 @@ const ScrollAreaScrollbarY = forwardRefWithAs<typeof Primitive>(function ScrollA
       }}
     />
   );
-});
+}) as ScrollAreaScrollbarYPrimitive;
+
 ScrollAreaScrollbarY.displayName = SCROLLBAR_Y_NAME;
 
 /* -------------------------------------------------------------------------------------------------
@@ -887,10 +933,13 @@ ScrollAreaScrollbarY.displayName = SCROLLBAR_Y_NAME;
 
 const TRACK_NAME = 'ScrollAreaTrack';
 
-const ScrollAreaTrack = forwardRefWithAs<typeof Primitive>(function ScrollAreaTrack(
-  props,
-  forwardedRef
-) {
+type ScrollAreaTrackOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaTrackPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaTrackOwnProps
+>;
+
+const ScrollAreaTrack = React.forwardRef(function ScrollAreaTrack(props, forwardedRef) {
   const { onPointerDown: onPointerDownProp, ...domProps } = props;
   const { axis, scrollAnimationQueue } = useScrollbarContext(TRACK_NAME);
   const dispatch = useDispatchContext(TRACK_NAME);
@@ -1097,7 +1146,7 @@ const ScrollAreaTrack = forwardRefWithAs<typeof Primitive>(function ScrollAreaTr
   ]);
 
   return <Primitive selector={getSelector(TRACK_NAME)} {...domProps} ref={ref} data-axis={axis} />;
-});
+}) as ScrollAreaTrackPrimitive;
 
 ScrollAreaTrack.displayName = TRACK_NAME;
 
@@ -1107,10 +1156,13 @@ ScrollAreaTrack.displayName = TRACK_NAME;
 
 const THUMB_NAME = 'ScrollAreaThumb';
 
-const ScrollAreaThumb = forwardRefWithAs<typeof Primitive>(function ScrollAreaThumb(
-  props,
-  forwardedRef
-) {
+type ScrollAreaThumbOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaThumbPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaThumbOwnProps
+>;
+
+const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(props, forwardedRef) {
   const { onPointerDown: onPointerDownProp, ...domProps } = props;
   const { axis } = useScrollbarContext(THUMB_NAME);
   const refsContext = useScrollAreaRefs(THUMB_NAME);
@@ -1284,7 +1336,7 @@ const ScrollAreaThumb = forwardRefWithAs<typeof Primitive>(function ScrollAreaTh
       }}
     />
   );
-});
+}) as ScrollAreaThumbPrimitive;
 
 ScrollAreaThumb.displayName = THUMB_NAME;
 
@@ -1303,161 +1355,168 @@ const BUTTON_END_NAME = 'ScrollAreaButtonEnd';
 // We are concerned more about the bezier curve effect this creates vs. the actual values.
 const BUTTON_SCROLL_TIME = 135;
 
-interface ScrollAreaButtonProps {
-  direction: LogicalDirection;
-  name: string;
-}
+type ScrollAreaButtonProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    direction: LogicalDirection;
+    name: string;
+  }
+>;
 
-const ScrollAreaButton = forwardRefWithAs<typeof Primitive, ScrollAreaButtonProps>(
-  function ScrollAreaButton(props, forwardedRef) {
-    const { direction, name, onPointerDown: onPointerDownProp, ...domProps } = props;
-    const { axis, scrollAnimationQueue } = useScrollbarContext(name);
-    const dispatch = useDispatchContext(name);
-    const refsContext = useScrollAreaRefs(name);
-    const { prefersReducedMotion } = useScrollAreaContext(name);
-    const { positionRef } = refsContext;
-    const buttonRef = getButtonRef(direction, axis, refsContext);
-    const ref = useComposedRefs(buttonRef, forwardedRef);
-    const rafIdRef = React.useRef<number>();
-    const onPointerDown = useCallbackRef(onPointerDownProp);
+type ScrollAreaButtonPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaButtonProps
+>;
 
-    React.useEffect(() => {
-      const buttonElement = getButtonElementFromRef(buttonRef, direction);
-      const positionElement = getPositionElementFromRef(positionRef);
-      const { ownerDocument } = getOwnerGlobals(positionRef);
+const ScrollAreaButton = React.forwardRef(function ScrollAreaButton(props, forwardedRef) {
+  const { direction, name, onPointerDown: onPointerDownProp, ...domProps } = props;
+  const { axis, scrollAnimationQueue } = useScrollbarContext(name);
+  const dispatch = useDispatchContext(name);
+  const refsContext = useScrollAreaRefs(name);
+  const { prefersReducedMotion } = useScrollAreaContext(name);
+  const { positionRef } = refsContext;
+  const buttonRef = getButtonRef(direction, axis, refsContext);
+  const ref = useComposedRefs(buttonRef, forwardedRef);
+  const rafIdRef = React.useRef<number>();
+  const onPointerDown = useCallbackRef(onPointerDownProp);
 
-      let buttonPointerDownTimeoutId: any;
+  React.useEffect(() => {
+    const buttonElement = getButtonElementFromRef(buttonRef, direction);
+    const positionElement = getPositionElementFromRef(positionRef);
+    const { ownerDocument } = getOwnerGlobals(positionRef);
 
-      let buttonIntervalId: any = null;
-      const handlePointerDown = composeEventHandlers(
-        onPointerDown as any,
-        function handlePointerDown(event: PointerEvent) {
-          if (!isMainClick(event)) return;
+    let buttonPointerDownTimeoutId: any;
 
-          buttonElement.setPointerCapture(event.pointerId);
-          ownerDocument.addEventListener('pointerup', handlePointerUp);
-          ownerDocument.addEventListener('pointermove', handlePointerMove);
-          dispatch({ type: ScrollAreaEvents.StartButtonPress });
+    let buttonIntervalId: any = null;
+    const handlePointerDown = composeEventHandlers(onPointerDown as any, function handlePointerDown(
+      event: PointerEvent
+    ) {
+      if (!isMainClick(event)) return;
 
-          const delta = direction === 'start' ? -1 : 1;
-          if (prefersReducedMotion) {
-            scrollBy(positionElement, { axis, value: 51 * delta });
-          } else {
-            if (
-              canScroll(positionElement, { axis, delta }) //  &&
-              // Only queue new animation if the queue's state isn't already adding to the queue or
-              // pending a current animation. The prevents fast button clicks from creating an effect
-              // where the last queued animation stops too long after the user has stopped clicking.
-              // !scrollAnimationQueue.isBusy
-            ) {
+      buttonElement.setPointerCapture(event.pointerId);
+      ownerDocument.addEventListener('pointerup', handlePointerUp);
+      ownerDocument.addEventListener('pointermove', handlePointerMove);
+      dispatch({ type: ScrollAreaEvents.StartButtonPress });
+
+      const delta = direction === 'start' ? -1 : 1;
+      if (prefersReducedMotion) {
+        scrollBy(positionElement, { axis, value: 51 * delta });
+      } else {
+        if (
+          canScroll(positionElement, { axis, delta }) //  &&
+          // Only queue new animation if the queue's state isn't already adding to the queue or
+          // pending a current animation. The prevents fast button clicks from creating an effect
+          // where the last queued animation stops too long after the user has stopped clicking.
+          // !scrollAnimationQueue.isBusy
+        ) {
+          scrollAnimationQueue.enqueue(() =>
+            animate({
+              duration: BUTTON_SCROLL_TIME,
+              timing: bezier(0.16, 0, 0.73, 1),
+              draw(progress) {
+                scrollBy(positionElement, { axis, value: progress * 15 * delta });
+              },
+              rafIdRef,
+            })
+          );
+        }
+      }
+
+      // Handle case for user holding down the button, in which case we will repeat the
+      // `scrollAfterButtonPress` call on a ~300 ms interval until they release the pointer.
+      // Scrolling will also need to pause if the pointer leaves the button, but it should resume
+      // should they mouse back over it before releasing the pointer. After some time (~400ms?),
+      // if the user still has the pointer down we'll start to scroll further to some relative
+      // distance near the pointer in relation to the track.
+      buttonPointerDownTimeoutId = setTimeout(() => {
+        if (prefersReducedMotion) {
+          buttonIntervalId = setInterval(() => {
+            if (canScroll(positionElement, { axis, delta })) {
+              scrollBy(positionElement, { axis, value: 60 * delta });
+            } else {
+              clearInterval(buttonIntervalId);
+            }
+          }, BUTTON_SCROLL_TIME);
+        } else {
+          const pointerId = event.pointerId;
+          (function keepScrolling() {
+            if (canScroll(positionElement, { axis, delta })) {
               scrollAnimationQueue.enqueue(() =>
                 animate({
                   duration: BUTTON_SCROLL_TIME,
-                  timing: bezier(0.16, 0, 0.73, 1),
+                  timing: (n) => n,
                   draw(progress) {
-                    scrollBy(positionElement, { axis, value: progress * 15 * delta });
+                    scrollBy(positionElement, { axis, value: progress * (15 * delta) });
                   },
+                  done: buttonElement.hasPointerCapture(pointerId) ? keepScrolling : undefined,
                   rafIdRef,
                 })
               );
             }
-          }
-
-          // Handle case for user holding down the button, in which case we will repeat the
-          // `scrollAfterButtonPress` call on a ~300 ms interval until they release the pointer.
-          // Scrolling will also need to pause if the pointer leaves the button, but it should resume
-          // should they mouse back over it before releasing the pointer. After some time (~400ms?),
-          // if the user still has the pointer down we'll start to scroll further to some relative
-          // distance near the pointer in relation to the track.
-          buttonPointerDownTimeoutId = setTimeout(() => {
-            if (prefersReducedMotion) {
-              buttonIntervalId = setInterval(() => {
-                if (canScroll(positionElement, { axis, delta })) {
-                  scrollBy(positionElement, { axis, value: 60 * delta });
-                } else {
-                  clearInterval(buttonIntervalId);
-                }
-              }, BUTTON_SCROLL_TIME);
-            } else {
-              const pointerId = event.pointerId;
-              (function keepScrolling() {
-                if (canScroll(positionElement, { axis, delta })) {
-                  scrollAnimationQueue.enqueue(() =>
-                    animate({
-                      duration: BUTTON_SCROLL_TIME,
-                      timing: (n) => n,
-                      draw(progress) {
-                        scrollBy(positionElement, { axis, value: progress * (15 * delta) });
-                      },
-                      done: buttonElement.hasPointerCapture(pointerId) ? keepScrolling : undefined,
-                      rafIdRef,
-                    })
-                  );
-                }
-              })();
-            }
-            clearTimeout(buttonPointerDownTimeoutId!);
-          }, 400);
+          })();
         }
-      );
+        clearTimeout(buttonPointerDownTimeoutId!);
+      }, 400);
+    });
 
-      buttonElement.addEventListener('pointerdown', handlePointerDown);
+    buttonElement.addEventListener('pointerdown', handlePointerDown);
 
-      return function () {
-        buttonElement.removeEventListener('pointerdown', handlePointerDown);
-        ownerDocument.removeEventListener('pointerup', handlePointerUp);
+    return function () {
+      buttonElement.removeEventListener('pointerdown', handlePointerDown);
+      ownerDocument.removeEventListener('pointerup', handlePointerUp);
+      ownerDocument.removeEventListener('pointermove', handlePointerMove);
+      clearTimeout(buttonPointerDownTimeoutId!);
+      clearInterval(buttonIntervalId);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      cancelAnimationFrame(rafIdRef.current!);
+      dispatch({ type: ScrollAreaEvents.StopButtonPress });
+    };
+
+    /**
+     * If a mouse pointer leaves the bounds of the button before the track pointer timeout has been
+     * executed, we need to clear the timeout as if the pointer was released.
+     * @param event
+     */
+    function handlePointerMove(event: PointerEvent) {
+      if (event.pointerType === 'mouse' && pointerIsOutsideElement(event, buttonElement)) {
+        clearTimeout(buttonPointerDownTimeoutId!);
         ownerDocument.removeEventListener('pointermove', handlePointerMove);
-        clearTimeout(buttonPointerDownTimeoutId!);
-        clearInterval(buttonIntervalId);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        cancelAnimationFrame(rafIdRef.current!);
-        dispatch({ type: ScrollAreaEvents.StopButtonPress });
-      };
-
-      /**
-       * If a mouse pointer leaves the bounds of the button before the track pointer timeout has been
-       * executed, we need to clear the timeout as if the pointer was released.
-       * @param event
-       */
-      function handlePointerMove(event: PointerEvent) {
-        if (event.pointerType === 'mouse' && pointerIsOutsideElement(event, buttonElement)) {
-          clearTimeout(buttonPointerDownTimeoutId!);
-          ownerDocument.removeEventListener('pointermove', handlePointerMove);
-        }
       }
+    }
 
-      function handlePointerUp(event: PointerEvent) {
-        clearTimeout(buttonPointerDownTimeoutId!);
-        clearInterval(buttonIntervalId);
-        buttonElement.releasePointerCapture(event.pointerId);
-        buttonElement.removeEventListener('pointerup', handlePointerUp);
-        dispatch({ type: ScrollAreaEvents.StopButtonPress });
-      }
-    }, [
-      axis,
-      direction,
-      prefersReducedMotion,
-      // these should be stable references
-      buttonRef,
-      dispatch,
-      onPointerDown,
-      scrollAnimationQueue,
-      positionRef,
-    ]);
+    function handlePointerUp(event: PointerEvent) {
+      clearTimeout(buttonPointerDownTimeoutId!);
+      clearInterval(buttonIntervalId);
+      buttonElement.releasePointerCapture(event.pointerId);
+      buttonElement.removeEventListener('pointerup', handlePointerUp);
+      dispatch({ type: ScrollAreaEvents.StopButtonPress });
+    }
+  }, [
+    axis,
+    direction,
+    prefersReducedMotion,
+    // these should be stable references
+    buttonRef,
+    dispatch,
+    onPointerDown,
+    scrollAnimationQueue,
+    positionRef,
+  ]);
 
-    return <Primitive {...domProps} ref={ref} data-axis={axis} />;
-  }
-);
+  return <Primitive {...domProps} ref={ref} data-axis={axis} />;
+}) as ScrollAreaButtonPrimitive;
 
-type ScrollAreaButtonStartOwnProps = {
-  direction: never;
-  name: never;
-};
+type ScrollAreaButtonStartOwnProps = Omit<
+  Polymorphic.OwnProps<typeof ScrollAreaButton>,
+  'direction' | 'name'
+>;
 
-const ScrollAreaButtonStart = forwardRefWithAs<
-  typeof ScrollAreaButton,
+type ScrollAreaButtonStartPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ScrollAreaButton>,
   ScrollAreaButtonStartOwnProps
->(function ScrollAreaButtonStart(props, forwardedRef) {
+>;
+
+const ScrollAreaButtonStart = React.forwardRef(function ScrollAreaButtonStart(props, forwardedRef) {
   return (
     <ScrollAreaButton
       selector={getSelector(BUTTON_START_NAME)}
@@ -1467,28 +1526,31 @@ const ScrollAreaButtonStart = forwardRefWithAs<
       direction="start"
     />
   );
-});
+}) as ScrollAreaButtonStartPrimitive;
 
 ScrollAreaButtonStart.displayName = BUTTON_START_NAME;
 
-type ScrollAreaButtonEndOwnProps = {
-  direction: never;
-  name: never;
-};
+type ScrollAreaButtonEndOwnProps = Omit<
+  Polymorphic.OwnProps<typeof ScrollAreaButton>,
+  'direction' | 'name'
+>;
 
-const ScrollAreaButtonEnd = forwardRefWithAs<typeof ScrollAreaButton, ScrollAreaButtonEndOwnProps>(
-  function ScrollAreaButtonEnd(props, forwardedRef) {
-    return (
-      <ScrollAreaButton
-        selector={getSelector(BUTTON_END_NAME)}
-        {...props}
-        ref={forwardedRef}
-        name={BUTTON_END_NAME}
-        direction="end"
-      />
-    );
-  }
-);
+type ScrollAreaButtonEndPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ScrollAreaButton>,
+  ScrollAreaButtonEndOwnProps
+>;
+
+const ScrollAreaButtonEnd = React.forwardRef(function ScrollAreaButtonEnd(props, forwardedRef) {
+  return (
+    <ScrollAreaButton
+      selector={getSelector(BUTTON_END_NAME)}
+      {...props}
+      ref={forwardedRef}
+      name={BUTTON_END_NAME}
+      direction="end"
+    />
+  );
+}) as ScrollAreaButtonEndPrimitive;
 
 ScrollAreaButtonEnd.displayName = BUTTON_END_NAME;
 
@@ -1498,10 +1560,13 @@ ScrollAreaButtonEnd.displayName = BUTTON_END_NAME;
 
 const CORNER_NAME = 'ScrollAreaCorner';
 
-const ScrollAreaCornerImpl = forwardRefWithAs<typeof Primitive>(function ScrollAreaCornerImpl(
-  props,
-  forwardedRef
-) {
+type ScrollAreaCornerImplOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type ScrollAreaCornerImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  ScrollAreaCornerImplOwnProps
+>;
+
+const ScrollAreaCornerImpl = React.forwardRef(function ScrollAreaCornerImpl(props, forwardedRef) {
   const { positionRef } = useScrollAreaRefs(CORNER_NAME);
   const dispatch = useDispatchContext(CORNER_NAME);
   const { dir } = useScrollAreaContext(CORNER_NAME);
@@ -1560,14 +1625,18 @@ const ScrollAreaCornerImpl = forwardRefWithAs<typeof Primitive>(function ScrollA
       }}
     />
   );
-});
+}) as ScrollAreaCornerImplPrimitive;
 
-const ScrollAreaCorner = forwardRefWithAs<typeof ScrollAreaCornerImpl>(function ScrollAreaCorner(
-  props,
-  forwardedRef
-) {
+type ScrollAreaCornerOwnProps = Polymorphic.OwnProps<typeof ScrollAreaCornerImpl>;
+type ScrollAreaCornerPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ScrollAreaCornerImpl>,
+  ScrollAreaCornerOwnProps
+>;
+
+const ScrollAreaCorner = React.forwardRef(function ScrollAreaCorner(props, forwardedRef) {
   return useNativeScrollArea() ? null : <ScrollAreaCornerImpl {...props} ref={forwardedRef} />;
-});
+}) as ScrollAreaCornerPrimitive;
+
 ScrollAreaCorner.displayName = CORNER_NAME;
 
 /* ------------------------------------------------------------------------------------------------*/

--- a/packages/react/separator/src/Separator.tsx
+++ b/packages/react/separator/src/Separator.tsx
@@ -1,26 +1,36 @@
 import * as React from 'react';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { getSelector } from '@radix-ui/utils';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 const NAME = 'Separator';
 const DEFAULT_ORIENTATION = 'horizontal';
 const ORIENTATIONS = ['horizontal', 'vertical'] as const;
 
 type Orientation = typeof ORIENTATIONS[number];
-type SeparatorOwnProps = {
-  /**
-   * Either `vertical` or `horizontal`. Defaults to `horizontal`.
-   */
-  orientation?: Orientation;
-  /**
-   * Whether or not the component is purely decorative. When true, accessibility-related attributes
-   * are updated so that that the rendered element is removed from the accessibility tree.
-   */
-  decorative?: boolean;
-};
+type SeparatorOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Either `vertical` or `horizontal`. Defaults to `horizontal`.
+     */
+    orientation?: Orientation;
+    /**
+     * Whether or not the component is purely decorative. When true, accessibility-related attributes
+     * are updated so that that the rendered element is removed from the accessibility tree.
+     */
+    decorative?: boolean;
+  }
+>;
 
-const Separator = forwardRefWithAs<typeof Primitive, SeparatorOwnProps>((props, forwardedRef) => {
+type SeparatorPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  SeparatorOwnProps
+>;
+
+const Separator = React.forwardRef((props, forwardedRef) => {
   const { decorative, orientation: orientationProp = DEFAULT_ORIENTATION, ...domProps } = props;
   const orientation = isValidOrientation(orientationProp) ? orientationProp : DEFAULT_ORIENTATION;
   // `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
@@ -38,7 +48,7 @@ const Separator = forwardRefWithAs<typeof Primitive, SeparatorOwnProps>((props, 
       ref={forwardedRef}
     />
   );
-});
+}) as SeparatorPrimitive;
 
 Separator.displayName = NAME;
 

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -5,12 +5,12 @@ import {
   useControlledState,
   useComposedRefs,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLabelContext } from '@radix-ui/react-label';
 import { getSelector } from '@radix-ui/utils';
 
-import type { MergeOwnProps, OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Switch
@@ -20,24 +20,25 @@ const SWITCH_NAME = 'Switch';
 const SWITCH_DEFAULT_TAG = 'button';
 
 type InputDOMProps = React.ComponentProps<'input'>;
-type SwitchOwnProps = {
-  checked?: boolean;
-  defaultChecked?: boolean;
-  required?: InputDOMProps['required'];
-  readOnly?: InputDOMProps['readOnly'];
-  onCheckedChange?: InputDOMProps['onChange'];
-  onChange: never;
-};
+type SwitchOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    checked?: boolean;
+    defaultChecked?: boolean;
+    required?: InputDOMProps['required'];
+    readOnly?: InputDOMProps['readOnly'];
+    onCheckedChange?: InputDOMProps['onChange'];
+  }
+>;
+
+type SwitchPrimitive = Polymorphic.ForwardRefComponent<typeof SWITCH_DEFAULT_TAG, SwitchOwnProps>;
 
 const [SwitchContext, useSwitchContext] = createContext<boolean>(
   SWITCH_NAME + 'Context',
   SWITCH_NAME
 );
 
-const Switch = forwardRefWithAs<
-  typeof SWITCH_DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, SwitchOwnProps>
->((props, forwardedRef) => {
+const Switch = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-labelledby': ariaLabelledby,
     children,
@@ -108,7 +109,7 @@ const Switch = forwardRefWithAs<
       </Primitive>
     </>
   );
-});
+}) as SwitchPrimitive;
 
 Switch.displayName = SWITCH_NAME;
 
@@ -119,20 +120,24 @@ Switch.displayName = SWITCH_NAME;
 const THUMB_NAME = 'SwitchThumb';
 const THUMB_DEFAULT_TAG = 'span';
 
-const SwitchThumb = forwardRefWithAs<typeof THUMB_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const checked = useSwitchContext(THUMB_NAME);
-    return (
-      <Primitive
-        as={THUMB_DEFAULT_TAG}
-        selector={getSelector(THUMB_NAME)}
-        {...props}
-        data-state={getState(checked)}
-        ref={forwardedRef}
-      />
-    );
-  }
-);
+type SwitchThumbOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type SwitchThumbPrimitive = Polymorphic.ForwardRefComponent<
+  typeof THUMB_DEFAULT_TAG,
+  SwitchThumbOwnProps
+>;
+
+const SwitchThumb = React.forwardRef((props, forwardedRef) => {
+  const checked = useSwitchContext(THUMB_NAME);
+  return (
+    <Primitive
+      as={THUMB_DEFAULT_TAG}
+      selector={getSelector(THUMB_NAME)}
+      {...props}
+      data-state={getState(checked)}
+      ref={forwardedRef}
+    />
+  );
+}) as SwitchThumbPrimitive;
 
 SwitchThumb.displayName = THUMB_NAME;
 

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -5,10 +5,12 @@ import {
   useControlledState,
   useId,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import { getSelector, makeId } from '@radix-ui/utils';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Root level context
@@ -30,24 +32,32 @@ const [TabsContext, useTabsContext] = createContext<TabsContextValue>('TabsConte
 
 const TABS_NAME = 'Tabs';
 
-type TabsOwnProps = {
-  /** The value for the selected tab, if controlled */
-  value?: string;
-  /** The value of the tab to select by default, if uncontrolled */
-  defaultValue?: string;
-  /** A function called when a new tab is selected */
-  onValueChange?: (value: string) => void;
-  /**
-   * The orientation the tabs are layed out.
-   * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
-   * (default: horizontal)
-   */
-  orientation?: React.AriaAttributes['aria-orientation'];
-  /** Whether a tab is activated automatically or manually (default: automatic) */
-  activationMode?: 'automatic' | 'manual';
-};
+type TabsOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /** The value for the selected tab, if controlled */
+    value?: string;
+    /** The value of the tab to select by default, if uncontrolled */
+    defaultValue?: string;
+    /** A function called when a new tab is selected */
+    onValueChange?: (value: string) => void;
+    /**
+     * The orientation the tabs are layed out.
+     * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
+     * (default: horizontal)
+     */
+    orientation?: React.AriaAttributes['aria-orientation'];
+    /** Whether a tab is activated automatically or manually (default: automatic) */
+    activationMode?: 'automatic' | 'manual';
+  }
+>;
 
-const Tabs = forwardRefWithAs<typeof Primitive, TabsOwnProps>((props, forwardedRef) => {
+type TabsPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  TabsOwnProps
+>;
+
+const Tabs = React.forwardRef((props, forwardedRef) => {
   const {
     children,
     id,
@@ -86,7 +96,7 @@ const Tabs = forwardRefWithAs<typeof Primitive, TabsOwnProps>((props, forwardedR
       </Primitive>
     </TabsContext.Provider>
   );
-});
+}) as TabsPrimitive;
 
 Tabs.displayName = TABS_NAME;
 
@@ -96,15 +106,23 @@ Tabs.displayName = TABS_NAME;
 
 const TAB_LIST_NAME = 'TabsList';
 
-type TabsListOwnProps = {
-  /**
-   * Whether keyboard navigation should loop focus
-   * @defaultValue true
-   */
-  loop?: boolean;
-};
+type TabsListOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Whether keyboard navigation should loop focus
+     * @defaultValue true
+     */
+    loop?: boolean;
+  }
+>;
 
-const TabsList = forwardRefWithAs<typeof Primitive, TabsListOwnProps>((props, forwardedRef) => {
+type TabsListPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  TabsListOwnProps
+>;
+
+const TabsList = React.forwardRef((props, forwardedRef) => {
   const { orientation } = useTabsContext(TAB_LIST_NAME);
   const { loop = true, children, ...otherProps } = props;
 
@@ -122,7 +140,7 @@ const TabsList = forwardRefWithAs<typeof Primitive, TabsListOwnProps>((props, fo
       </RovingFocusGroup>
     </Primitive>
   );
-});
+}) as TabsListPrimitive;
 
 TabsList.displayName = TAB_LIST_NAME;
 
@@ -132,12 +150,20 @@ TabsList.displayName = TAB_LIST_NAME;
 
 const TAB_NAME = 'TabsTab';
 
-type TabsTabOwnProps = {
-  value: string;
-  disabled?: boolean;
-};
+type TabsTabOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    value: string;
+    disabled?: boolean;
+  }
+>;
 
-const TabsTab = forwardRefWithAs<typeof Primitive, TabsTabOwnProps>((props, forwardedRef) => {
+type TabsTabPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  TabsTabOwnProps
+>;
+
+const TabsTab = React.forwardRef((props, forwardedRef) => {
   const { value, disabled, ...tabProps } = props;
   const context = useTabsContext(TAB_NAME);
   const tabId = makeTabId(context.tabsId, value);
@@ -197,7 +223,7 @@ const TabsTab = forwardRefWithAs<typeof Primitive, TabsTabOwnProps>((props, forw
       onFocus={handleFocus}
     />
   );
-});
+}) as TabsTabPrimitive;
 
 TabsTab.displayName = TAB_NAME;
 
@@ -207,34 +233,34 @@ TabsTab.displayName = TAB_NAME;
 
 const TAB_PANEL_NAME = 'TabsPanel';
 
-type TabsPanelPropsOwnProps = {
-  value: string;
-};
+type TabsPanelPropsOwnProps = Merge<Polymorphic.OwnProps<typeof Primitive>, { value: string }>;
+type TabsPanelPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  TabsPanelPropsOwnProps
+>;
 
-const TabsPanel = forwardRefWithAs<typeof Primitive, TabsPanelPropsOwnProps>(
-  (props, forwardedRef) => {
-    const { value, ...tabPanelProps } = props;
-    const context = useTabsContext(TAB_PANEL_NAME);
-    const tabId = makeTabId(context.tabsId, value);
-    const tabPanelId = makeTabsPanelId(context.tabsId, value);
-    const isSelected = value === context.value;
+const TabsPanel = React.forwardRef((props, forwardedRef) => {
+  const { value, ...tabPanelProps } = props;
+  const context = useTabsContext(TAB_PANEL_NAME);
+  const tabId = makeTabId(context.tabsId, value);
+  const tabPanelId = makeTabsPanelId(context.tabsId, value);
+  const isSelected = value === context.value;
 
-    return (
-      <Primitive
-        selector={getSelector(TAB_PANEL_NAME)}
-        data-state={isSelected ? 'active' : 'inactive'}
-        data-orientation={context.orientation}
-        id={tabPanelId}
-        role="tabpanel"
-        aria-labelledby={tabId}
-        tabIndex={0}
-        hidden={!isSelected}
-        {...tabPanelProps}
-        ref={forwardedRef}
-      />
-    );
-  }
-);
+  return (
+    <Primitive
+      selector={getSelector(TAB_PANEL_NAME)}
+      data-state={isSelected ? 'active' : 'inactive'}
+      data-orientation={context.orientation}
+      id={tabPanelId}
+      role="tabpanel"
+      aria-labelledby={tabId}
+      tabIndex={0}
+      hidden={!isSelected}
+      {...tabPanelProps}
+      ref={forwardedRef}
+    />
+  );
+}) as TabsPanelPrimitive;
 
 TabsPanel.displayName = TAB_PANEL_NAME;
 

--- a/packages/react/toggle-button/src/ToggleButton.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.tsx
@@ -1,30 +1,35 @@
 import * as React from 'react';
 import { useControlledState, composeEventHandlers } from '@radix-ui/react-utils';
 import { getSelector } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 
-import type { MergeOwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 const NAME = 'ToggleButton';
 const DEFAULT_TAG = 'button';
 
-type ToggleButtonOwnProps = {
-  /** Whether the button is toggled or not, if controlled */
-  toggled?: boolean;
-  /**
-   * Whether the button is toggled by default, if uncontrolled
-   * (default: false)
-   */
-  defaultToggled?: boolean;
-  /** A function called when the button is toggled */
-  onToggledChange?(toggled: boolean): void;
-};
+type ToggleButtonOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /** Whether the button is toggled or not, if controlled */
+    toggled?: boolean;
+    /**
+     * Whether the button is toggled by default, if uncontrolled
+     * (default: false)
+     */
+    defaultToggled?: boolean;
+    /** A function called when the button is toggled */
+    onToggledChange?(toggled: boolean): void;
+  }
+>;
 
-const ToggleButton = forwardRefWithAs<
+type ToggleButtonPrimitive = Polymorphic.ForwardRefComponent<
   typeof DEFAULT_TAG,
-  MergeOwnProps<typeof Primitive, ToggleButtonOwnProps>
->((props, forwardedRef) => {
+  ToggleButtonOwnProps
+>;
+
+const ToggleButton = React.forwardRef((props, forwardedRef) => {
   const {
     toggled: toggledProp,
     defaultToggled = false,
@@ -59,7 +64,7 @@ const ToggleButton = forwardRefWithAs<
       {children}
     </Primitive>
   );
-});
+}) as ToggleButtonPrimitive;
 
 ToggleButton.displayName = NAME;
 

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -11,14 +11,14 @@ import {
   useLayoutEffect,
   extendComponent,
 } from '@radix-ui/react-utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { createStateMachine, stateChart } from './machine';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Root level context
@@ -137,52 +137,56 @@ Tooltip.displayName = TOOLTIP_NAME;
 const TRIGGER_NAME = 'TooltipTrigger';
 const TRIGGER_DEFAULT_TAG = 'button';
 
-const TooltipTrigger = forwardRefWithAs<typeof TRIGGER_DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => {
-    const context = useTooltipContext(TRIGGER_NAME);
-    const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+type TooltipTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type TooltipTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof TRIGGER_DEFAULT_TAG,
+  TooltipTriggerOwnProps
+>;
 
-    return (
-      <Primitive
-        as={TRIGGER_DEFAULT_TAG}
-        selector={getSelector(TRIGGER_NAME)}
-        type="button"
-        aria-describedby={context.open ? context.id : undefined}
-        {...props}
-        ref={composedTriggerRef}
-        onMouseEnter={composeEventHandlers(props.onMouseEnter, () =>
-          stateMachine.transition('mouseEntered', { id: context.id })
-        )}
-        onMouseMove={composeEventHandlers(props.onMouseMove, () =>
-          stateMachine.transition('mouseMoved', { id: context.id })
-        )}
-        onMouseLeave={composeEventHandlers(props.onMouseLeave, () => {
-          const stateMachineContext = stateMachine.getContext();
-          if (stateMachineContext.id === context.id) {
-            stateMachine.transition('mouseLeft', { id: context.id });
-          }
-        })}
-        onFocus={composeEventHandlers(props.onFocus, () =>
-          stateMachine.transition('focused', { id: context.id })
-        )}
-        onBlur={composeEventHandlers(props.onBlur, () => {
-          const stateMachineContext = stateMachine.getContext();
-          if (stateMachineContext.id === context.id) {
-            stateMachine.transition('blurred', { id: context.id });
-          }
-        })}
-        onMouseDown={composeEventHandlers(props.onMouseDown, () =>
-          stateMachine.transition('activated', { id: context.id })
-        )}
-        onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-          if (event.key === 'Escape' || event.key === 'Enter' || event.key === ' ') {
-            stateMachine.transition('activated', { id: context.id });
-          }
-        })}
-      />
-    );
-  }
-);
+const TooltipTrigger = React.forwardRef((props, forwardedRef) => {
+  const context = useTooltipContext(TRIGGER_NAME);
+  const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+
+  return (
+    <Primitive
+      as={TRIGGER_DEFAULT_TAG}
+      selector={getSelector(TRIGGER_NAME)}
+      type="button"
+      aria-describedby={context.open ? context.id : undefined}
+      {...props}
+      ref={composedTriggerRef}
+      onMouseEnter={composeEventHandlers(props.onMouseEnter, () =>
+        stateMachine.transition('mouseEntered', { id: context.id })
+      )}
+      onMouseMove={composeEventHandlers(props.onMouseMove, () =>
+        stateMachine.transition('mouseMoved', { id: context.id })
+      )}
+      onMouseLeave={composeEventHandlers(props.onMouseLeave, () => {
+        const stateMachineContext = stateMachine.getContext();
+        if (stateMachineContext.id === context.id) {
+          stateMachine.transition('mouseLeft', { id: context.id });
+        }
+      })}
+      onFocus={composeEventHandlers(props.onFocus, () =>
+        stateMachine.transition('focused', { id: context.id })
+      )}
+      onBlur={composeEventHandlers(props.onBlur, () => {
+        const stateMachineContext = stateMachine.getContext();
+        if (stateMachineContext.id === context.id) {
+          stateMachine.transition('blurred', { id: context.id });
+        }
+      })}
+      onMouseDown={composeEventHandlers(props.onMouseDown, () =>
+        stateMachine.transition('activated', { id: context.id })
+      )}
+      onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        if (event.key === 'Escape' || event.key === 'Enter' || event.key === ' ') {
+          stateMachine.transition('activated', { id: context.id });
+        }
+      })}
+    />
+  );
+}) as TooltipTriggerPrimitive;
 
 TooltipTrigger.displayName = TRIGGER_NAME;
 
@@ -192,62 +196,69 @@ TooltipTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'TooltipContent';
 
-type TooltipContentOwnProps = {
-  /**
-   * A more descriptive label for accessibility purpose
-   */
-  'aria-label'?: string;
+type TooltipContentOwnProps = Polymorphic.OwnProps<typeof TooltipContentImpl>;
+type TooltipContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof TooltipContentImpl>,
+  TooltipContentOwnProps
+>;
 
-  anchorRef?: React.ComponentProps<typeof PopperPrimitive.Root>['anchorRef'];
-
-  /**
-   * Whether the Tooltip should render in a Portal
-   * (default: `true`)
-   */
-  portalled?: boolean;
-};
-
-const TooltipContent = forwardRefWithAs<typeof TooltipContentImpl>((props, forwardedRef) => {
+const TooltipContent = React.forwardRef((props, forwardedRef) => {
   const context = useTooltipContext(CONTENT_NAME);
   return context.open ? <TooltipContentImpl ref={forwardedRef} {...props} /> : null;
-});
+}) as TooltipContentPrimitive;
 
-const TooltipContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, TooltipContentOwnProps>(
-  (props, forwardedRef) => {
-    const {
-      children,
-      'aria-label': ariaLabel,
-      anchorRef,
-      portalled = true,
-      ...contentProps
-    } = props;
-    const context = useTooltipContext(CONTENT_NAME);
-    const PortalWrapper = portalled ? Portal : React.Fragment;
+type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Root>;
+type TooltipContentImplOwnProps = Merge<
+  PopperPrimitiveOwnProps,
+  {
+    /**
+     * A more descriptive label for accessibility purpose
+     */
+    'aria-label'?: string;
 
-    return (
-      <PortalWrapper>
-        <CheckTriggerMoved />
-        <PopperPrimitive.Root
-          selector={getSelector(CONTENT_NAME)}
-          {...contentProps}
-          data-state={context.stateAttribute}
-          ref={forwardedRef}
-          anchorRef={anchorRef || context.triggerRef}
-          style={{
-            ...contentProps.style,
-            // re-namespace exposed content custom property
-            ['--radix-tooltip-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-          }}
-        >
-          {children}
-          <VisuallyHidden id={context.id} role="tooltip">
-            {ariaLabel || children}
-          </VisuallyHidden>
-        </PopperPrimitive.Root>
-      </PortalWrapper>
-    );
+    anchorRef?: PopperPrimitiveOwnProps['anchorRef'];
+
+    /**
+     * Whether the Tooltip should render in a Portal
+     * (default: `true`)
+     */
+    portalled?: boolean;
   }
-);
+>;
+
+type TooltipContentImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Root>,
+  TooltipContentImplOwnProps
+>;
+
+const TooltipContentImpl = React.forwardRef((props, forwardedRef) => {
+  const { children, 'aria-label': ariaLabel, anchorRef, portalled = true, ...contentProps } = props;
+  const context = useTooltipContext(CONTENT_NAME);
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+
+  return (
+    <PortalWrapper>
+      <CheckTriggerMoved />
+      <PopperPrimitive.Root
+        selector={getSelector(CONTENT_NAME)}
+        {...contentProps}
+        data-state={context.stateAttribute}
+        ref={forwardedRef}
+        anchorRef={anchorRef || context.triggerRef}
+        style={{
+          ...contentProps.style,
+          // re-namespace exposed content custom property
+          ['--radix-tooltip-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+        }}
+      >
+        {children}
+        <VisuallyHidden id={context.id} role="tooltip">
+          {ariaLabel || children}
+        </VisuallyHidden>
+      </PopperPrimitive.Root>
+    </PortalWrapper>
+  );
+}) as TooltipContentImplPrimitive;
 
 TooltipContent.displayName = CONTENT_NAME;
 

--- a/packages/react/utils/src/extendComponent.test.tsx
+++ b/packages/react/utils/src/extendComponent.test.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { extendComponent } from './extendComponent';
 
 import type { RenderResult } from '@testing-library/react';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 /* -------------------------------------------------------------------------------------------------
  * Polymorphic Button
  * -----------------------------------------------------------------------------------------------*/
 
-type ButtonProps = {
-  isDisabled?: boolean;
-};
+type ButtonProps = { isDisabled?: boolean };
+type ButtonPrimitive = Polymorphic.ForwardRefComponent<'button', ButtonProps>;
 
-const Button = forwardRefWithAs<'button', ButtonProps>((props, forwardedRef) => {
+const Button = React.forwardRef((props, forwardedRef) => {
   const { as: Comp = 'button', isDisabled, ...buttonProps } = props;
   return <Comp {...buttonProps} ref={forwardedRef} />;
-});
+}) as ButtonPrimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * Extended Polymorphic Button

--- a/packages/react/utils/src/extendComponent.tsx
+++ b/packages/react/utils/src/extendComponent.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
-import type { ForwardRefExoticComponentWithAs } from '@radix-ui/react-polymorphic';
 import { getSelector } from '@radix-ui/utils';
 
-function extendComponent<As extends ForwardRefExoticComponentWithAs<any, any>>(
-  Comp: As extends ForwardRefExoticComponentWithAs<infer I, infer P>
-    ? ForwardRefExoticComponentWithAs<I, P>
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+
+function extendComponent<As extends Polymorphic.ForwardRefComponent<any, any>>(
+  Comp: As extends Polymorphic.ForwardRefComponent<infer I, infer P>
+    ? Polymorphic.ForwardRefComponent<I, P>
     : As,
   displayName: string
 ) {
-  const Extended = forwardRefWithAs<typeof Comp>((props, forwardedRef) => {
+  const Extended = React.forwardRef((props, forwardedRef) => {
     const As = Comp as any;
     return <As selector={getSelector(displayName)} {...props} ref={forwardedRef} />;
-  });
+  }) as Polymorphic.ForwardRefComponent<
+    Polymorphic.IntrinsicElement<typeof Comp>,
+    Polymorphic.OwnProps<typeof Comp>
+  >;
   Extended.displayName = displayName;
   return Extended;
 }

--- a/packages/react/utils/src/extendComponent.tsx
+++ b/packages/react/utils/src/extendComponent.tsx
@@ -9,13 +9,14 @@ function extendComponent<As extends Polymorphic.ForwardRefComponent<any, any>>(
     : As,
   displayName: string
 ) {
-  const Extended = React.forwardRef((props, forwardedRef) => {
-    const As = Comp as any;
-    return <As selector={getSelector(displayName)} {...props} ref={forwardedRef} />;
-  }) as Polymorphic.ForwardRefComponent<
+  type ExtendedPrimitive = Polymorphic.ForwardRefComponent<
     Polymorphic.IntrinsicElement<typeof Comp>,
     Polymorphic.OwnProps<typeof Comp>
   >;
+  const Extended = React.forwardRef((props, forwardedRef) => {
+    const As = Comp as any;
+    return <As selector={getSelector(displayName)} {...props} ref={forwardedRef} />;
+  }) as ExtendedPrimitive;
   Extended.displayName = displayName;
   return Extended;
 }

--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -1,37 +1,40 @@
 import * as React from 'react';
 import { getSelector } from '@radix-ui/utils';
-import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Primitive } from '@radix-ui/react-primitive';
 
-import type { OwnProps } from '@radix-ui/react-polymorphic';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 const NAME = 'VisuallyHidden';
 const DEFAULT_TAG = 'span';
 
-const VisuallyHidden = forwardRefWithAs<typeof DEFAULT_TAG, OwnProps<typeof Primitive>>(
-  (props, forwardedRef) => (
-    <Primitive
-      as={DEFAULT_TAG}
-      selector={getSelector(NAME)}
-      {...props}
-      ref={forwardedRef}
-      style={{
-        ...props.style,
-        // See: https://github.com/twbs/bootstrap/blob/master/scss/mixins/_screen-reader.scss
-        position: 'absolute',
-        border: 0,
-        width: 1,
-        height: 1,
-        padding: 0,
-        margin: -1,
-        overflow: 'hidden',
-        clip: 'rect(0, 0, 0, 0)',
-        whiteSpace: 'nowrap',
-        wordWrap: 'normal',
-      }}
-    />
-  )
-);
+type VisuallyHiddenOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type VisuallyHiddenPrimitive = Polymorphic.ForwardRefComponent<
+  typeof DEFAULT_TAG,
+  VisuallyHiddenOwnProps
+>;
+
+const VisuallyHidden = React.forwardRef((props, forwardedRef) => (
+  <Primitive
+    as={DEFAULT_TAG}
+    selector={getSelector(NAME)}
+    {...props}
+    ref={forwardedRef}
+    style={{
+      ...props.style,
+      // See: https://github.com/twbs/bootstrap/blob/master/scss/mixins/_screen-reader.scss
+      position: 'absolute',
+      border: 0,
+      width: 1,
+      height: 1,
+      padding: 0,
+      margin: -1,
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      wordWrap: 'normal',
+    }}
+  />
+)) as VisuallyHiddenPrimitive;
 
 VisuallyHidden.displayName = NAME;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,6 +3280,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-polymorphic@workspace:packages/react/polymorphic"
   dependencies:
+    "@radix-ui/react-primitive": "workspace:*"
     "@testing-library/react": ^10.4.8
   peerDependencies:
     react: ^16.8 || ^17.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,7 +3280,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-polymorphic@workspace:packages/react/polymorphic"
   dependencies:
-    "@radix-ui/react-primitive": "workspace:*"
     "@testing-library/react": ^10.4.8
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
A while ago, Benoit and I were looking into tree-shaking for our components. We realised that Parcel will automatically annotate `React.forwardRef` as `PURE` for us to tree-shake them however, we have replaced this with our own `forwardRefWithAs` utility that breaks tree-shaking.

We could create our own babel plugin to annotate these for us (which we looked into and worked well) however, on my quest to figure out how to apply props with generic types for `ToggleButtonGroup` it dawned on me that we could just cast our components to this type instead of using the util and we would get `PURE` annotation without any plugins.

I personally prefer this approach because the `forwardRefWithAs` utility implies functionality, but it is purely for types. This more explicitly communicates that.

**Note: I've only applied this to `Accordion` and `Collapsible` for now to discuss. If we're happy I'll apply across the codebase.**

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [X] Fixes a bug in an existing package (tree-shaking)
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

