### PR TITLE
[Popper + dependents] Add wrapper data attribute

### DIFF
--- a/.yarn/versions/9673d3b6.yml
+++ b/.yarn/versions/9673d3b6.yml
@@ -1,0 +1,10 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/9673d3b6.yml
+++ b/.yarn/versions/9673d3b6.yml
@@ -5,6 +5,30 @@ releases:
   "@radix-ui/react-popover": patch
   "@radix-ui/react-popper": patch
   "@radix-ui/react-tooltip": patch
+  "@radix-ui/utils": patch
 
 declined:
   - primitives
+  - "@radix-ui/popper"
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-announce"
+  - "@radix-ui/react-arrow"
+  - "@radix-ui/react-aspect-ratio"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-focus-scope"
+  - "@radix-ui/react-label"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-scroll-area"
+  - "@radix-ui/react-separator"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toggle-button"
+  - "@radix-ui/react-utils"
+  - "@radix-ui/react-visually-hidden"

--- a/packages/core/utils/src/domUtils.ts
+++ b/packages/core/utils/src/domUtils.ts
@@ -18,6 +18,10 @@ function getPartDataAttrObj(componentPart: string) {
   return { [getPartDataAttr(componentPart)]: '' };
 }
 
+function getSelectorObj(selector: string | null) {
+  return selector ? { [`data-${selector}`]: '' } : undefined;
+}
+
 function canUseDOM() {
   return !!(typeof window !== 'undefined' && window.document && window.document.createElement);
 }
@@ -47,6 +51,7 @@ function getResizeObserverEntryBorderBoxSize(entry: ResizeObserverEntry): Resize
 export {
   getPartDataAttr,
   getPartDataAttrObj,
+  getSelectorObj,
   canUseDOM,
   makeId,
   namespaced,

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { composeEventHandlers, createContext, extendComponent } from '@radix-ui/react-utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
-import { getPartDataAttrObj, makeRect } from '@radix-ui/utils';
+import { getPartDataAttrObj, makeRect, namespaced } from '@radix-ui/utils';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 
 import type { Point, MeasurableElement } from '@radix-ui/utils';
@@ -89,6 +89,7 @@ const ContextMenuContent = forwardRefWithAs<typeof MenuPrimitive.Root, ContextMe
       disableOutsidePointerEvents = true,
       side = 'bottom',
       align = 'start',
+      wrapperSelector = namespaced(CONTENT_NAME + 'Wrapper'),
       ...contentProps
     } = props;
     const context = useContextMenuContext(CONTENT_NAME);
@@ -98,7 +99,7 @@ const ContextMenuContent = forwardRefWithAs<typeof MenuPrimitive.Root, ContextMe
         ref={forwardedRef}
         {...contentProps}
         {...getPartDataAttrObj(CONTENT_NAME)}
-        wrapperPartName={CONTENT_NAME + 'Wrapper'}
+        wrapperSelector={wrapperSelector}
         open={context.open}
         onOpenChange={context.setOpen}
         style={{

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -98,6 +98,7 @@ const ContextMenuContent = forwardRefWithAs<typeof MenuPrimitive.Root, ContextMe
         ref={forwardedRef}
         {...contentProps}
         {...getPartDataAttrObj(CONTENT_NAME)}
+        wrapperPartName={CONTENT_NAME + 'Wrapper'}
         open={context.open}
         onOpenChange={context.setOpen}
         style={{

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -127,6 +127,7 @@ const DropdownMenuContent = forwardRefWithAs<
       ref={forwardedRef}
       {...contentProps}
       {...getPartDataAttrObj(CONTENT_NAME)}
+      wrapperPartName={CONTENT_NAME + 'Wrapper'}
       id={context.id}
       style={{
         ...contentProps.style,

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -8,7 +8,7 @@ import {
   useId,
 } from '@radix-ui/react-utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
-import { getPartDataAttrObj } from '@radix-ui/utils';
+import { getPartDataAttrObj, namespaced } from '@radix-ui/utils';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 
 /* -------------------------------------------------------------------------------------------------
@@ -118,6 +118,7 @@ const DropdownMenuContent = forwardRefWithAs<
     onInteractOutside,
     disableOutsideScroll = true,
     portalled = true,
+    wrapperSelector = namespaced(CONTENT_NAME + 'Wrapper'),
     ...contentProps
   } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
@@ -127,7 +128,7 @@ const DropdownMenuContent = forwardRefWithAs<
       ref={forwardedRef}
       {...contentProps}
       {...getPartDataAttrObj(CONTENT_NAME)}
-      wrapperPartName={CONTENT_NAME + 'Wrapper'}
+      wrapperSelector={wrapperSelector}
       id={context.id}
       style={{
         ...contentProps.style,

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -214,6 +214,7 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
                   <PopperPrimitive.Root
                     role="menu"
                     {...getPartDataAttrObj(MENU_NAME)}
+                    wrapperPartName={MENU_NAME + 'Wrapper'}
                     {...menuProps}
                     ref={composeRefs(
                       forwardedRef,

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -7,7 +7,7 @@ import {
   useCallbackRef,
   useComposedRefs,
 } from '@radix-ui/react-utils';
-import { getPartDataAttr, getPartDataAttrObj } from '@radix-ui/utils';
+import { getPartDataAttr, getPartDataAttrObj, namespaced } from '@radix-ui/utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Presence } from '@radix-ui/react-presence';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
@@ -154,6 +154,7 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
       onDismiss,
       disableOutsideScroll,
       portalled,
+      wrapperSelector = namespaced(MENU_NAME + 'Wrapper'),
       ...menuProps
     } = props;
 
@@ -214,7 +215,7 @@ const MenuImpl = forwardRefWithAs<typeof PopperPrimitive.Root, MenuImplOwnProps>
                   <PopperPrimitive.Root
                     role="menu"
                     {...getPartDataAttrObj(MENU_NAME)}
-                    wrapperPartName={MENU_NAME + 'Wrapper'}
+                    wrapperSelector={wrapperSelector}
                     {...menuProps}
                     ref={composeRefs(
                       forwardedRef,

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getPartDataAttrObj } from '@radix-ui/utils';
+import { getPartDataAttrObj, namespaced } from '@radix-ui/utils';
 import {
   createContext,
   useComposedRefs,
@@ -201,6 +201,7 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
       onInteractOutside,
       disableOutsideScroll = false,
       portalled = true,
+      wrapperSelector = namespaced(CONTENT_NAME + 'Wrapper'),
       ...contentProps
     } = props;
     const context = usePopoverContext(CONTENT_NAME);
@@ -274,7 +275,7 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
                 {(dismissableLayerProps) => (
                   <PopperPrimitive.Root
                     {...getPartDataAttrObj(CONTENT_NAME)}
-                    wrapperPartName={CONTENT_NAME + 'Wrapper'}
+                    wrapperSelector={wrapperSelector}
                     role="dialog"
                     aria-modal
                     {...contentProps}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -274,6 +274,7 @@ const PopoverContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Popover
                 {(dismissableLayerProps) => (
                   <PopperPrimitive.Root
                     {...getPartDataAttrObj(CONTENT_NAME)}
+                    wrapperPartName={CONTENT_NAME + 'Wrapper'}
                     role="dialog"
                     aria-modal
                     {...contentProps}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -3,7 +3,7 @@ import { getPlacementData } from '@radix-ui/popper';
 import { createContext, useRect, useSize, useComposedRefs } from '@radix-ui/react-utils';
 import { forwardRefWithAs } from '@radix-ui/react-polymorphic';
 import { Arrow as ArrowPrimitive } from '@radix-ui/react-arrow';
-import { getPartDataAttrObj, makeRect } from '@radix-ui/utils';
+import { namespaced, getPartDataAttrObj, getSelectorObj, makeRect } from '@radix-ui/utils';
 
 import type { Side, Align, Size, MeasurableElement } from '@radix-ui/utils';
 
@@ -37,7 +37,7 @@ type PopperOwnProps = {
   alignOffset?: number;
   collisionTolerance?: number;
   avoidCollisions?: boolean;
-  wrapperPartName?: string;
+  wrapperSelector?: string | null;
 };
 
 const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
@@ -52,7 +52,7 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
       alignOffset,
       collisionTolerance,
       avoidCollisions = true,
-      wrapperPartName = POPPER_NAME + 'Wrapper',
+      wrapperSelector = namespaced(POPPER_NAME + 'Wrapper'),
       ...popperProps
     } = props;
 
@@ -88,7 +88,7 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
     const context = React.useMemo(() => ({ arrowRef, arrowStyles, setArrowOffset }), [arrowStyles]);
 
     return (
-      <div style={popperStyles} {...getPartDataAttrObj(wrapperPartName)}>
+      <div style={popperStyles} {...getSelectorObj(wrapperSelector)}>
         <Comp
           {...getPartDataAttrObj(POPPER_NAME)}
           {...popperProps}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -37,6 +37,7 @@ type PopperOwnProps = {
   alignOffset?: number;
   collisionTolerance?: number;
   avoidCollisions?: boolean;
+  wrapperPartName?: string;
 };
 
 const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
@@ -51,6 +52,7 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
       alignOffset,
       collisionTolerance,
       avoidCollisions = true,
+      wrapperPartName = POPPER_NAME + 'Wrapper',
       ...popperProps
     } = props;
 
@@ -86,7 +88,7 @@ const Popper = forwardRefWithAs<typeof POPPER_DEFAULT_TAG, PopperOwnProps>(
     const context = React.useMemo(() => ({ arrowRef, arrowStyles, setArrowOffset }), [arrowStyles]);
 
     return (
-      <div style={popperStyles}>
+      <div style={popperStyles} {...getPartDataAttrObj(wrapperPartName)}>
         <Comp
           {...getPartDataAttrObj(POPPER_NAME)}
           {...popperProps}

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getPartDataAttrObj } from '@radix-ui/utils';
+import { getPartDataAttrObj, namespaced } from '@radix-ui/utils';
 import {
   createContext,
   useComposedRefs,
@@ -224,6 +224,7 @@ const TooltipContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Tooltip
       'aria-label': ariaLabel,
       anchorRef,
       portalled = true,
+      wrapperSelector = namespaced(CONTENT_NAME + 'Wrapper'),
       ...contentProps
     } = props;
     const context = useTooltipContext(CONTENT_NAME);
@@ -234,7 +235,7 @@ const TooltipContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Tooltip
         <CheckTriggerMoved />
         <PopperPrimitive.Root
           {...getPartDataAttrObj(CONTENT_NAME)}
-          wrapperPartName={CONTENT_NAME + 'Wrapper'}
+          wrapperSelector={wrapperSelector}
           {...contentProps}
           data-state={context.stateAttribute}
           ref={forwardedRef}

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -234,6 +234,7 @@ const TooltipContentImpl = forwardRefWithAs<typeof PopperPrimitive.Root, Tooltip
         <CheckTriggerMoved />
         <PopperPrimitive.Root
           {...getPartDataAttrObj(CONTENT_NAME)}
+          wrapperPartName={CONTENT_NAME + 'Wrapper'}
           {...contentProps}
           data-state={context.stateAttribute}
           ref={forwardedRef}


### PR DESCRIPTION
Closes #368 

This PR adds a `data-radix-*` attribute to the non-exposed part of `Popper` (the positioning wrapper).
This is in response to what we have discussed over on this issue: [Portalled tooltips appear behind modals/overlays that have z-index #368](https://github.com/radix-ui/primitives/issues/368#issuecomment-754195352)

I have passed the right name to each dependent component too so you end up with `data-radix-tooltip-content-wrapper` for example. This way users can precisely target only certain components.

A few questions here:

- is this enough? What if they only need to set some rules to only "some" tooltips, or "some" menus, etc
- we could provide a `wrapperClassname` escape hatch for that I suppose, or even do just that and not bother with the data attribute

Also, doing all this with the part name passed as a prop and the `{...getPartDataAttrObj(partName) }` internally made me think that perhaps this is a better solution to this issue: [[react-*]: Remove extended internal data attributes #347](https://github.com/radix-ui/primitives/pull/347)

Thoughts?

