### PR TITLE
[react-accordion] Allow disabled `AccordionItem` when `Accordion` is `disabled={false}`

### DIFF
--- a/.yarn/versions/77e1fa7a.yml
+++ b/.yarn/versions/77e1fa7a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-accordion": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.test.tsx
+++ b/packages/react/accordion/src/Accordion.test.tsx
@@ -156,6 +156,64 @@ describe('given an Accordion with a change callback', () => {
   });
 });
 
+describe('given an Accordion with a false `disabled` prop', () => {
+  describe('and a disabled item', () => {
+    let rendered: RenderResult;
+
+    beforeEach(() => {
+      rendered = render(
+        <DisabledAccordionTest>
+          <Accordion.Item value="disabled" data-testid="item-disabled" disabled={true}>
+            <Accordion.Header>
+              <Accordion.Button data-testid="button-disabled">Button disabled</Accordion.Button>
+            </Accordion.Header>
+            <Accordion.Panel>Panel disabled</Accordion.Panel>
+          </Accordion.Item>
+        </DisabledAccordionTest>
+      );
+    });
+
+    it('should disable the disabled item', () => {
+      const item = rendered.queryByTestId('item-disabled');
+      expect(item).toHaveAttribute('data-disabled');
+    });
+
+    it('should disable the disabled item button', () => {
+      const button = rendered.queryByTestId('button-disabled');
+      expect(button).toHaveAttribute('disabled');
+    });
+
+    it('should enable all other items', () => {
+      const items = rendered.queryAllByTestId('item');
+      const disabled = items.some((item) => item.getAttribute('data-disabled'));
+      expect(disabled).toBe(false);
+    });
+
+    it('should enable all other item buttons', () => {
+      const buttons = rendered.queryAllByTestId('button');
+      const disabled = buttons.some((button) => button.getAttribute('disabled'));
+      expect(disabled).toBe(false);
+    });
+  });
+});
+
+function DisabledAccordionTest(props: React.ComponentProps<typeof Accordion.Root>) {
+  const { children, ...rootProps } = props;
+  return (
+    <Accordion.Root {...rootProps} disabled={false}>
+      {ITEMS.map((val) => (
+        <Accordion.Item value={val} key={val} data-testid="item">
+          <Accordion.Header>
+            <Accordion.Button data-testid="button">Button</Accordion.Button>
+          </Accordion.Header>
+          <Accordion.Panel>Panel</Accordion.Panel>
+        </Accordion.Item>
+      ))}
+      {children}
+    </Accordion.Root>
+  );
+}
+
 function AccordionTest(props: React.ComponentProps<typeof Accordion.Root>) {
   return (
     <Accordion.Root data-testid="container" {...props}>

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -65,7 +65,7 @@ const AccordionItem = forwardRefWithAs<typeof Collapsible, AccordionItemOwnProps
     const generatedButtonId = `accordion-button-${useId()}`;
     const buttonId = props.id || generatedButtonId;
     const open = (value && value === accordionContext.value) || false;
-    const disabled = accordionContext.disabled ?? props.disabled;
+    const disabled = accordionContext.disabled || props.disabled;
 
     const itemContext: AccordionItemContextValue = React.useMemo(() => ({ open, buttonId }), [
       open,


### PR DESCRIPTION
This was raised on Discord.

If the `Accordion.Root` had `disabled={false}`, the `Accordion.Item`s would all be enabled regardless of whether they explicitly had a `disabled={true}` prop themselves.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
