### PR TITLE
[Dialog][AlertDialog] Fix regression

### DIFF
--- a/.yarn/versions/e7611a1d.yml
+++ b/.yarn/versions/e7611a1d.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -248,6 +248,9 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
               disableOutsidePointerEvents
               onEscapeKeyDown={onEscapeKeyDown}
               onPointerDownOutside={onPointerDownOutside}
+              // When focus is trapped, a focusout event may still happen.
+              // We make sure we don't trigger our `onDismiss` in such case.
+              onFocusOutside={(event) => event.preventDefault()}
               onDismiss={() => context.setOpen(false)}
             >
               {(dismissableLayerProps) => (


### PR DESCRIPTION
I've spotted a small regression with `Dialog` 0.0.2 (and therefore `AlertDialog)` (closing when tabbing even though focus is trapped).

It was introduced introduced after we made the changes in `FocusScope` to not cancel out `focusout` event.
We had made the necessary changes in `Popover` and `Menu`, etc (to `preventDefault` when `trapFocus` was true) but forgot to do it always in the case of `Dialog` because focus is always trapped.