### PR TITLE
[ContextMenu][DropdownMenu] Fix issue introduced by new `selector` prop

### DIFF
--- a/.yarn/versions/c778bbee.yml
+++ b/.yarn/versions/c778bbee.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -370,6 +370,7 @@ MenuLabel.displayName = LABEL_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const ITEM_NAME = 'MenuItem';
+// HERE: 👇
 const ENABLED_ITEM_SELECTOR = `[data-${getSelector(ITEM_NAME)}]:not([data-disabled])`;
 const ITEM_SELECT = 'menu.itemSelect';
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -304,10 +304,6 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
                       }
                     }
                   })}
-                  // focus the menu if the mouse is moved over anything else than an item
-                  onMouseMove={composeEventHandlers(menuProps.onMouseMove, (event) => {
-                    if (!isItemOrInsideItem(event.target)) menuRef.current?.focus();
-                  })}
                 >
                   <RovingFocusGroup
                     reachable={itemsReachable}
@@ -370,8 +366,8 @@ MenuLabel.displayName = LABEL_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const ITEM_NAME = 'MenuItem';
-// HERE: 👇
-const ENABLED_ITEM_SELECTOR = `[data-${getSelector(ITEM_NAME)}]:not([data-disabled])`;
+const ITEM_ATTR = `data-${getSelector(ITEM_NAME)}`;
+const ENABLED_ITEM_SELECTOR = `[${ITEM_ATTR}]:not([data-disabled])`;
 const ITEM_SELECT = 'menu.itemSelect';
 
 type MenuItemOwnProps = Merge<
@@ -436,6 +432,12 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
       {...itemProps}
       {...rovingFocusProps}
       {...menuTypeaheadItemProps}
+      /**
+       * Because `Menu` is not used directly but rather used through dependent implementations
+       * (like `DropdownMenu` and `ContextMenu`), we cannot rely on the usual `selector` at this level.
+       * We make sure there's always a generic `data-radix-menu-item` available to query from here.
+       */
+      {...{ [ITEM_ATTR]: '' }}
       ref={composedRef}
       data-disabled={disabled ? '' : undefined}
       onFocus={composeEventHandlers(itemProps.onFocus, rovingFocusProps.onFocus)}
@@ -671,11 +673,6 @@ MenuSeparator.displayName = SEPARATOR_NAME;
 const MenuArrow = extendComponent(PopperPrimitive.Arrow, 'MenuArrow');
 
 /* -----------------------------------------------------------------------------------------------*/
-
-function isItemOrInsideItem(target: EventTarget) {
-  const item = (target as HTMLElement).closest(ENABLED_ITEM_SELECTOR);
-  return item !== null;
-}
 
 function getOpenState(open: boolean) {
   return open ? 'open' : 'closed';


### PR DESCRIPTION
Closes #402 

After checking a reported issue #402, I realised we have introduced a bug in dependents of `Menu` (`ContextMenu`, `DropdownMenu`) when we added the `selector` prop.

This is because the expectation on what attributes are present changed, and we didn't account for it here.
Namely, before we were expecting the `data-radix-menu-item` to be present even in dependents of `Menu`.
This is no longer a safe assumption to make obviously, therefore we cannot rely on this selector.

Looking at other places we build selectors like this (roving focus behaviour, or typeahead behaviour) they both add their own data attribute to ensure they can safely select items. So it seems in this case we should be doing the same somehow. It feels a bit more annoying given that we know there is already a default selectors for items… but obviously now specific to each dependent of `Menu`).

I haven't made any change yet, wondering what your thoughts were.