### PR TITLE
Remove parcel cache

### DIFF
--- a/.yarn/versions/937739d3.yml
+++ b/.yarn/versions/937739d3.yml
@@ -1,0 +1,42 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-guards": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+  "@radix-ui/utils": patch
+
+declined:
+  - primitives

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "// build": "For context on tsconfig replacements in build scripts, see https://github.com/radix-ui/primitives/pull/361#discussion_r555004944",
     "build": "yarn build:config && yarn build:packages && yarn build:cleanup",
     "build:config": "mv tsconfig.json tsconfig.tmp.json && mv tsconfig.production.json tsconfig.json",
-    "build:packages": "parcel build 'packages/*/*/'",
+    "build:packages": "parcel build 'packages/*/*/' --no-cache",
     "build:cleanup": "mv tsconfig.json tsconfig.production.json && mv tsconfig.tmp.json tsconfig.json",
     "publish": "yarn bump && yarn build && yarn workspaces foreach -pv --exclude primitives npm publish --tolerate-republish --access public",
     "clean": "yarn workspaces foreach -pv --exclude primitives run clean",
-    "reset": "yarn clean && rm -rf .yarn/cache node_modules",
+    "reset": "yarn clean && rm -rf node_modules .yarn/cache .parcel-cache",
     "bump": "yarn version apply --all",
     "bump:check": "yarn version check"
   },

--- a/packages/core/popper/package.json
+++ b/packages/core/popper/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/utils": "workspace:*",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-visually-hidden": "workspace:*"

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "workspace:*",

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "workspace:*",

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-label": "workspace:*",

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*"

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-menu": "workspace:*",

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-dismissable-layer": "workspace:*",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*"

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-menu": "workspace:*",

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-dismissable-layer": "workspace:*",

--- a/packages/react/polymorphic/package.json
+++ b/packages/react/polymorphic/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "devDependencies": {
     "@testing-library/react": "^10.4.8"

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-dismissable-layer": "workspace:*",

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/popper": "workspace:*",

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*"

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",

--- a/packages/react/primitive/package.json
+++ b/packages/react/primitive/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-label": "workspace:*",

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-utils": "workspace:*",

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-collection": "workspace:*",

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-label": "workspace:*",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/utils/package.json
+++ b/packages/react/utils/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -12,10 +12,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "parcel build src/index.ts --no-cache",
     "clean": "rm -rf dist",
-    "version": "yarn version",
-    "prepublish": "yarn clean && yarn build"
+    "prepublish": "yarn clean"
   },
   "dependencies": {
     "@radix-ui/react-polymorphic": "workspace:*",


### PR DESCRIPTION
Closes #406 

I have left the clean tasks as normal because `rm -rf **/dist` isn't really safe as it'll also delete `dist` folders from `node_modules` where some packages might be having the built artefacts (like us for example).