### PR TITLE
Explicitly declare default values for `as` and `selector` props

### DIFF
--- a/.yarn/versions/ef0bd797.yml
+++ b/.yarn/versions/ef0bd797.yml
@@ -1,0 +1,37 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -67,7 +67,7 @@ const [AccordionItemContext, useAccordionItemContext] = createContext<AccordionI
  * `AccordionItem` contains all of the parts of a collapsible section inside of an `Accordion`.
  */
 const AccordionItem = React.forwardRef((props, forwardedRef) => {
-  const { value, children, ...accordionItemProps } = props;
+  const { selector = getSelector(ITEM_NAME), value, children, ...accordionItemProps } = props;
   const accordionContext = useAccordionContext(ITEM_NAME);
   const generatedButtonId = `accordion-button-${useId()}`;
   const buttonId = props.id || generatedButtonId;
@@ -81,8 +81,8 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Collapsible
-      selector={getSelector(ITEM_NAME)}
       {...accordionItemProps}
+      selector={selector}
       ref={forwardedRef}
       data-state={open ? 'open' : 'closed'}
       data-disabled={disabled || undefined}
@@ -114,14 +114,10 @@ type AccordionHeaderPrimitive = Polymorphic.ForwardRefComponent<
  * `AccordionHeader` contains the content for the parts of an `AccordionItem` that will be visible
  * whether or not its content is collapsed.
  */
-const AccordionHeader = React.forwardRef((props, forwardedRef) => (
-  <Primitive
-    as={HEADER_DEFAULT_TAG}
-    selector={getSelector(HEADER_NAME)}
-    {...props}
-    ref={forwardedRef}
-  />
-)) as AccordionHeaderPrimitive;
+const AccordionHeader = React.forwardRef((props, forwardedRef) => {
+  const { as = HEADER_DEFAULT_TAG, selector = getSelector(HEADER_NAME), ...headerProps } = props;
+  return <Primitive {...headerProps} as={as} selector={selector} ref={forwardedRef} />;
+}) as AccordionHeaderPrimitive;
 
 AccordionHeader.displayName = HEADER_NAME;
 
@@ -142,6 +138,7 @@ type AccordionButtonPrimitive = Polymorphic.ForwardRefComponent<
  * should always be nested inside of an `AccordionHeader`.
  */
 const AccordionButton = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(BUTTON_NAME), ...buttonProps } = props;
   const { buttonNodesRef } = useAccordionContext(BUTTON_NAME);
   const itemContext = useAccordionItemContext(BUTTON_NAME);
 
@@ -163,8 +160,8 @@ const AccordionButton = React.forwardRef((props, forwardedRef) => {
 
   return (
     <CollapsibleButton
-      selector={getSelector(BUTTON_NAME)}
-      {...props}
+      {...buttonProps}
+      selector={selector}
       ref={composedRefs}
       aria-disabled={itemContext.open || undefined}
       id={itemContext.buttonId}
@@ -189,11 +186,12 @@ type AccordionPanelPrimitive = Polymorphic.ForwardRefComponent<
  * `AccordionPanel` contains the collapsible content for an `AccordionItem`.
  */
 const AccordionPanel = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(PANEL_NAME), ...panelProps } = props;
   const itemContext = useAccordionItemContext(PANEL_NAME);
   return (
     <CollapsibleContent
-      selector={getSelector(PANEL_NAME)}
-      {...props}
+      {...panelProps}
+      selector={selector}
       ref={forwardedRef}
       role="region"
       aria-labelledby={itemContext.buttonId}
@@ -245,6 +243,7 @@ type AccordionPrimitive = Polymorphic.ForwardRefComponent<
  */
 const Accordion = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(ACCORDION_NAME),
     value: valueProp,
     defaultValue,
     children,
@@ -315,8 +314,8 @@ const Accordion = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(ACCORDION_NAME)}
       {...accordionProps}
+      selector={selector}
       ref={composedRefs}
       onKeyDown={disabled ? undefined : handleKeyDown}
     >

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -81,9 +81,10 @@ type AlertDialogCancelPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AlertDialogCancel = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(CANCEL_NAME), ...cancelProps } = props;
   const { cancelRef } = useAlertDialogContentContext(CANCEL_NAME);
   const ref = useComposedRefs(forwardedRef, cancelRef);
-  return <DialogClose selector={getSelector(CANCEL_NAME)} {...props} ref={ref} />;
+  return <DialogClose {...cancelProps} selector={selector} ref={ref} />;
 }) as AlertDialogCancelPrimitive;
 
 AlertDialogCancel.displayName = CANCEL_NAME;
@@ -106,6 +107,7 @@ type AlertDialogContentPrimitive = Polymorphic.ForwardRefComponent<
 
 const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(CONTENT_NAME),
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     'aria-describedby': ariaDescribedBy,
@@ -120,7 +122,6 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
 
   return (
     <DialogContent
-      selector={getSelector(CONTENT_NAME)}
       role="alertdialog"
       aria-describedby={ariaDescribedBy || descriptionId}
       // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
@@ -129,6 +130,7 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
       aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || titleId}
       aria-label={ariaLabel || undefined}
       {...dialogContentProps}
+      selector={selector}
       ref={ref}
       onOpenAutoFocus={composeEventHandlers(dialogContentProps.onOpenAutoFocus, (event) => {
         event.preventDefault();
@@ -171,16 +173,9 @@ type AlertDialogTitlePrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AlertDialogTitle = React.forwardRef((props, forwardedRef) => {
+  const { as = TITLE_DEFAULT_TAG, selector = getSelector(TITLE_NAME), ...titleProps } = props;
   const { titleId } = useAlertDialogContext(TITLE_NAME);
-  return (
-    <Primitive
-      as={TITLE_DEFAULT_TAG}
-      selector={getSelector(TITLE_NAME)}
-      id={titleId}
-      {...props}
-      ref={forwardedRef}
-    />
-  );
+  return <Primitive id={titleId} {...titleProps} as={as} selector={selector} ref={forwardedRef} />;
 }) as AlertDialogTitlePrimitive;
 
 AlertDialogTitle.displayName = TITLE_NAME;
@@ -199,13 +194,18 @@ type AlertDialogDescriptionPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AlertDialogDescription = React.forwardRef((props, forwardedRef) => {
+  const {
+    as = DESCRIPTION_DEFAULT_TAG,
+    selector = getSelector(DESCRIPTION_NAME),
+    ...descriptionProps
+  } = props;
   const { descriptionId } = useAlertDialogContext(DESCRIPTION_NAME);
   return (
     <Primitive
-      as={DESCRIPTION_DEFAULT_TAG}
-      selector={getSelector(DESCRIPTION_NAME)}
       id={descriptionId}
-      {...props}
+      {...descriptionProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
     />
   );

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -94,6 +94,7 @@ type AnnouncePrimitive = Polymorphic.ForwardRefComponent<
 
 const Announce = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(NAME),
     'aria-relevant': ariaRelevant,
     children,
     type = 'polite',
@@ -176,7 +177,7 @@ const Announce = React.forwardRef((props, forwardedRef) => {
 
   return (
     <React.Fragment>
-      <Primitive selector={getSelector(NAME)} {...regionProps} ref={ref}>
+      <Primitive {...regionProps} selector={selector} ref={ref}>
         {children}
       </Primitive>
 

--- a/packages/react/arrow/src/Arrow.tsx
+++ b/packages/react/arrow/src/Arrow.tsx
@@ -20,18 +20,21 @@ const Arrow = React.forwardRef((props, forwardedRef) => {
 }) as ArrowPrimitive;
 
 const ArrowImpl = React.forwardRef<SVGSVGElement, React.ComponentProps<typeof DEFAULT_TAG>>(
-  (props, forwardedRef) => (
-    <svg
-      width={10}
-      height={5}
-      {...props}
-      ref={forwardedRef}
-      viewBox="0 0 30 10"
-      preserveAspectRatio="none"
-    >
-      <polygon points="0,0 30,0 15,10" />
-    </svg>
-  )
+  (props, forwardedRef) => {
+    const { width = 10, height = 5, ...arrowProps } = props;
+    return (
+      <svg
+        {...arrowProps}
+        ref={forwardedRef}
+        width={width}
+        height={height}
+        viewBox="0 0 30 10"
+        preserveAspectRatio="none"
+      >
+        <polygon points="0,0 30,0 15,10" />
+      </svg>
+    );
+  }
 );
 
 Arrow.displayName = NAME;

--- a/packages/react/arrow/src/Arrow.tsx
+++ b/packages/react/arrow/src/Arrow.tsx
@@ -15,7 +15,8 @@ type ArrowPrimitive = Polymorphic.ForwardRefComponent<typeof DEFAULT_TAG, ArrowO
  * is replaced when consumer passes an `as` prop
  */
 const Arrow = React.forwardRef((props, forwardedRef) => {
-  return <Primitive as={ArrowImpl} selector={getSelector(NAME)} {...props} ref={forwardedRef} />;
+  const { as = ArrowImpl, selector = getSelector(NAME), ...arrowProps } = props;
+  return <Primitive {...arrowProps} as={as} selector={selector} ref={forwardedRef} />;
 }) as ArrowPrimitive;
 
 const ArrowImpl = React.forwardRef<SVGSVGElement, React.ComponentProps<typeof DEFAULT_TAG>>(

--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -18,7 +18,13 @@ type AspectRatioPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AspectRatio = React.forwardRef((props, forwardedRef) => {
-  const { ratio = 1 / 1, style, children, ...aspectRatioProps } = props;
+  const {
+    selector = getSelector(NAME),
+    ratio = 1 / 1,
+    style,
+    children,
+    ...aspectRatioProps
+  } = props;
   return (
     <div
       style={{
@@ -30,8 +36,8 @@ const AspectRatio = React.forwardRef((props, forwardedRef) => {
       }}
     >
       <Primitive
-        selector={getSelector(NAME)}
         {...aspectRatioProps}
+        selector={selector}
         ref={forwardedRef}
         style={{
           ...style,

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -27,15 +27,15 @@ const [AvatarContext, useAvatarContext] = createContext<AvatarContextValue>(
 );
 
 const Avatar = React.forwardRef((props, forwardedRef) => {
-  const { children, ...avatarProps } = props;
+  const {
+    as = AVATAR_DEFAULT_TAG,
+    selector = getSelector(AVATAR_NAME),
+    children,
+    ...avatarProps
+  } = props;
   const context = React.useState<ImageLoadingStatus>('idle');
   return (
-    <Primitive
-      as={AVATAR_DEFAULT_TAG}
-      selector={getSelector(AVATAR_NAME)}
-      {...avatarProps}
-      ref={forwardedRef}
-    >
+    <Primitive {...avatarProps} as={as} selector={selector} ref={forwardedRef}>
       <AvatarContext.Provider value={context}>{children}</AvatarContext.Provider>
     </Primitive>
   );
@@ -61,7 +61,13 @@ type AvatarImagePrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AvatarImage = React.forwardRef((props, forwardedRef) => {
-  const { src, onLoadingStatusChange: onLoadingStatusChangeProp = () => {}, ...imageProps } = props;
+  const {
+    as = IMAGE_DEFAULT_TAG,
+    selector = getSelector(IMAGE_NAME),
+    src,
+    onLoadingStatusChange: onLoadingStatusChangeProp = () => {},
+    ...imageProps
+  } = props;
   const [, setImageLoadingStatus] = useAvatarContext(IMAGE_NAME);
   const imageLoadingStatus = useImageLoadingStatus(src);
   const onLoadingStatusChange = useCallbackRef(onLoadingStatusChangeProp);
@@ -74,13 +80,7 @@ const AvatarImage = React.forwardRef((props, forwardedRef) => {
   }, [imageLoadingStatus, setImageLoadingStatus, onLoadingStatusChange]);
 
   return imageLoadingStatus === 'loaded' ? (
-    <Primitive
-      as={IMAGE_DEFAULT_TAG}
-      selector={getSelector(IMAGE_NAME)}
-      {...imageProps}
-      src={src}
-      ref={forwardedRef}
-    />
+    <Primitive {...imageProps} as={as} selector={selector} ref={forwardedRef} src={src} />
   ) : null;
 }) as AvatarImagePrimitive;
 
@@ -100,7 +100,12 @@ type AvatarFallbackPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AvatarFallback = React.forwardRef((props, forwardedRef) => {
-  const { delayMs, ...fallbackProps } = props;
+  const {
+    as = FALLBACK_DEFAULT_TAG,
+    selector = getSelector(FALLBACK_NAME),
+    delayMs,
+    ...fallbackProps
+  } = props;
   const [imageLoadingStatus] = useAvatarContext(FALLBACK_NAME);
   const [canRender, setCanRender] = React.useState(delayMs === undefined);
 
@@ -112,12 +117,7 @@ const AvatarFallback = React.forwardRef((props, forwardedRef) => {
   }, [delayMs]);
 
   return canRender && imageLoadingStatus !== 'loaded' ? (
-    <Primitive
-      as={FALLBACK_DEFAULT_TAG}
-      selector={getSelector(FALLBACK_NAME)}
-      {...fallbackProps}
-      ref={forwardedRef}
-    />
+    <Primitive {...fallbackProps} as={as} selector={selector} ref={forwardedRef} />
   ) : null;
 }) as AvatarFallbackPrimitive;
 

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -45,6 +45,8 @@ const [CheckboxContext, useCheckboxContext] = createContext<CheckedState>(
 
 const Checkbox = React.forwardRef((props, forwardedRef) => {
   const {
+    as = CHECKBOX_DEFAULT_TAG,
+    selector = getSelector(CHECKBOX_NAME),
     'aria-labelledby': ariaLabelledby,
     children,
     name,
@@ -94,10 +96,10 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
         })}
       />
       <Primitive
-        as={CHECKBOX_DEFAULT_TAG}
-        selector={getSelector(CHECKBOX_NAME)}
         type="button"
         {...checkboxProps}
+        as={as}
+        selector={selector}
         ref={ref}
         role="checkbox"
         aria-checked={checked === 'indeterminate' ? 'mixed' : checked}
@@ -147,16 +149,21 @@ type CheckboxIndicatorPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const CheckboxIndicator = React.forwardRef((props, forwardedRef) => {
-  const { forceMount, ...indicatorProps } = props;
+  const {
+    as = INDICATOR_DEFAULT_TAG,
+    selector = getSelector(INDICATOR_NAME),
+    forceMount,
+    ...indicatorProps
+  } = props;
   const checked = useCheckboxContext(INDICATOR_NAME);
   return (
     <Presence present={forceMount || checked === 'indeterminate' || checked === true}>
       <Primitive
-        as={INDICATOR_DEFAULT_TAG}
-        selector={getSelector(INDICATOR_NAME)}
         {...indicatorProps}
-        data-state={getState(checked)}
+        as={as}
+        selector={selector}
         ref={forwardedRef}
+        data-state={getState(checked)}
       />
     </Presence>
   );

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -48,6 +48,7 @@ const [CollapsibleContext, useCollapsibleContext] = createContext<CollapsibleCon
 
 const Collapsible = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(COLLAPSIBLE_NAME),
     id: idProp,
     children,
     open: openProp,
@@ -76,8 +77,8 @@ const Collapsible = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(COLLAPSIBLE_NAME)}
       {...collapsibleProps}
+      selector={selector}
       data-state={getState(context.open)}
       ref={forwardedRef}
     >
@@ -102,17 +103,22 @@ type CollapsibleButtonPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const CollapsibleButton = React.forwardRef((props, forwardedRef) => {
-  const { onClick, ...buttonProps } = props;
+  const {
+    as = BUTTON_DEFAULT_TAG,
+    selector = getSelector(BUTTON_NAME),
+    onClick,
+    ...buttonProps
+  } = props;
   const context = useCollapsibleContext(BUTTON_NAME);
 
   return (
     <Primitive
-      as={BUTTON_DEFAULT_TAG}
-      selector={getSelector(BUTTON_NAME)}
       aria-controls={context.contentId}
       aria-expanded={context.open || false}
       data-state={getState(context.open)}
       {...buttonProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onClick={composeEventHandlers(onClick, context.toggle)}
       disabled={context.disabled}
@@ -145,7 +151,13 @@ type CollapsibleContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const CollapsibleContent = React.forwardRef((props, forwardedRef) => {
-  const { id: idProp, forceMount, children, ...contentProps } = props;
+  const {
+    selector = getSelector(CONTENT_NAME),
+    id: idProp,
+    forceMount,
+    children,
+    ...contentProps
+  } = props;
   const { setContentId, open } = useCollapsibleContext(CONTENT_NAME);
   const generatedId = `collapsible-${useId()}`;
   const id = idProp || generatedId;
@@ -158,8 +170,8 @@ const CollapsibleContent = React.forwardRef((props, forwardedRef) => {
     <Presence present={forceMount || open}>
       {({ present }) => (
         <Primitive
-          selector={getSelector(CONTENT_NAME)}
           {...contentProps}
+          selector={selector}
           ref={forwardedRef}
           id={id}
           hidden={!present}

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -96,16 +96,22 @@ type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
-  const { selector = getSelector(CONTENT_NAME), ...contentProps } = props;
+  const {
+    selector = getSelector(CONTENT_NAME),
+    side = 'bottom',
+    align = 'start',
+    disableOutsidePointerEvents = true,
+    ...contentProps
+  } = props;
   const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Root
-      disableOutsidePointerEvents
-      side="bottom"
-      align="start"
       {...contentProps}
       selector={selector}
       ref={forwardedRef}
+      side={side}
+      align={align}
+      disableOutsidePointerEvents={disableOutsidePointerEvents}
       open={context.open}
       onOpenChange={context.setOpen}
       style={{

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -53,12 +53,13 @@ type ContextMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, selector = getSelector(TRIGGER_NAME), ...triggerProps } = props;
   const context = useContextMenuContext(TRIGGER_NAME);
   return (
     <Primitive
-      as={TRIGGER_DEFAULT_TAG}
-      selector={getSelector(TRIGGER_NAME)}
-      {...props}
+      {...triggerProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
         event.preventDefault();
@@ -95,14 +96,15 @@ type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(CONTENT_NAME), ...contentProps } = props;
   const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Root
-      selector={getSelector(CONTENT_NAME)}
       disableOutsidePointerEvents
       side="bottom"
       align="start"
-      {...props}
+      {...contentProps}
+      selector={selector}
       ref={forwardedRef}
       open={context.open}
       onOpenChange={context.setOpen}

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -83,17 +83,18 @@ type DialogTriggerPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DialogTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, selector = getSelector(TRIGGER_NAME), ...triggerProps } = props;
   const context = useDialogContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
   return (
     <Primitive
-      as={TRIGGER_DEFAULT_TAG}
-      selector={getSelector(TRIGGER_NAME)}
       type="button"
       aria-haspopup="dialog"
       aria-expanded={context.open}
       aria-controls={context.id}
-      {...props}
+      {...triggerProps}
+      as={as}
+      selector={selector}
       ref={composedTriggerRef}
       onClick={composeEventHandlers(props.onClick, () => context.setOpen(true))}
     />
@@ -140,11 +141,14 @@ type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
   DialogOverlayImplOwnProps
 >;
 
-const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => (
-  <Portal>
-    <Primitive selector={getSelector(OVERLAY_NAME)} {...props} ref={forwardedRef} />
-  </Portal>
-)) as DialogOverlayImplPrimitive;
+const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(OVERLAY_NAME), ...overlayProps } = props;
+  return (
+    <Portal>
+      <Primitive {...overlayProps} selector={selector} ref={forwardedRef} />
+    </Portal>
+  );
+}) as DialogOverlayImplPrimitive;
 
 DialogOverlay.displayName = OVERLAY_NAME;
 
@@ -216,6 +220,7 @@ type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(CONTENT_NAME),
     onOpenAutoFocus,
     onCloseAutoFocus,
     onEscapeKeyDown,
@@ -255,10 +260,10 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
             >
               {(dismissableLayerProps) => (
                 <Primitive
-                  selector={getSelector(CONTENT_NAME)}
                   role="dialog"
                   aria-modal
                   {...contentProps}
+                  selector={selector}
                   ref={composeRefs(
                     forwardedRef,
                     contentRef,
@@ -316,13 +321,14 @@ type DialogClosePrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DialogClose = React.forwardRef((props, forwardedRef) => {
+  const { as = CLOSE_DEFAULT_TAG, selector = getSelector(CLOSE_NAME), ...closeProps } = props;
   const context = useDialogContext(CLOSE_NAME);
   return (
     <Primitive
-      as={CLOSE_DEFAULT_TAG}
-      selector={getSelector(CLOSE_NAME)}
       type="button"
-      {...props}
+      {...closeProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
     />

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -121,17 +121,23 @@ type DropdownMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
-  const { selector = getSelector(CONTENT_NAME), ...contentProps } = props;
+  const {
+    selector = getSelector(CONTENT_NAME),
+    disableOutsidePointerEvents = true,
+    disableOutsideScroll = true,
+    portalled = true,
+    ...contentProps
+  } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Root
-      disableOutsidePointerEvents
-      disableOutsideScroll
-      portalled
       {...contentProps}
       selector={selector}
       ref={forwardedRef}
       id={context.id}
+      disableOutsidePointerEvents={disableOutsidePointerEvents}
+      disableOutsideScroll={disableOutsideScroll}
+      portalled={portalled}
       style={{
         ...props.style,
         // re-namespace exposed content custom property

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -70,18 +70,19 @@ type DropdownMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, selector = getSelector(TRIGGER_NAME), ...triggerProps } = props;
   const context = useDropdownMenuContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 
   return (
     <Primitive
-      as={TRIGGER_DEFAULT_TAG}
-      selector={getSelector(TRIGGER_NAME)}
       type="button"
       aria-haspopup="menu"
       aria-expanded={context.open ? true : undefined}
       aria-controls={context.open ? context.id : undefined}
-      {...props}
+      {...triggerProps}
+      as={as}
+      selector={selector}
       ref={composedTriggerRef}
       onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
         // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
@@ -120,14 +121,15 @@ type DropdownMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(CONTENT_NAME), ...contentProps } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Root
-      selector={getSelector(CONTENT_NAME)}
       disableOutsidePointerEvents
       disableOutsideScroll
       portalled
-      {...props}
+      {...contentProps}
+      selector={selector}
       ref={forwardedRef}
       id={context.id}
       style={{

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -20,7 +20,14 @@ type LabelContextValue = { id: string; ref: React.RefObject<HTMLSpanElement> };
 const LabelContext = React.createContext<LabelContextValue | undefined>(undefined);
 
 const Label = React.forwardRef((props, forwardedRef) => {
-  const { htmlFor, id: idProp, children, ...labelProps } = props;
+  const {
+    as = DEFAULT_TAG,
+    selector = getSelector(NAME),
+    htmlFor,
+    id: idProp,
+    children,
+    ...labelProps
+  } = props;
   const labelRef = React.useRef<HTMLSpanElement>(null);
   const ref = useComposedRefs(forwardedRef, labelRef);
   const generatedId = `label-${useId()}`;
@@ -69,14 +76,7 @@ const Label = React.forwardRef((props, forwardedRef) => {
   }, [id, htmlFor]);
 
   return (
-    <Primitive
-      as={DEFAULT_TAG}
-      selector={getSelector(NAME)}
-      {...labelProps}
-      ref={ref}
-      id={id}
-      role="label"
-    >
+    <Primitive {...labelProps} as={as} selector={selector} ref={ref} id={id} role="label">
       <LabelContext.Provider value={React.useMemo(() => ({ id, ref: labelRef }), [id])}>
         {children}
       </LabelContext.Provider>

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -156,6 +156,7 @@ type MenuImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const MenuImpl = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(MENU_NAME),
     children,
     onOpenChange,
     anchorRef,
@@ -257,8 +258,8 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
               {(dismissableLayerProps) => (
                 <PopperPrimitive.Root
                   role="menu"
-                  selector={getSelector(MENU_NAME)}
                   {...menuProps}
+                  selector={selector}
                   ref={composeRefs(
                     forwardedRef,
                     menuRef,
@@ -337,9 +338,10 @@ type MenuGroupPrimitive = Polymorphic.ForwardRefComponent<
   MenuGroupOwnProps
 >;
 
-const MenuGroup = React.forwardRef((props, forwardedRef) => (
-  <Primitive role="group" selector={getSelector(GROUP_NAME)} {...props} ref={forwardedRef} />
-)) as MenuGroupPrimitive;
+const MenuGroup = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(GROUP_NAME), ...groupProps } = props;
+  return <Primitive role="group" {...groupProps} selector={selector} ref={forwardedRef} />;
+}) as MenuGroupPrimitive;
 
 MenuGroup.displayName = GROUP_NAME;
 
@@ -355,9 +357,10 @@ type MenuLabelPrimitive = Polymorphic.ForwardRefComponent<
   MenuLabelOwnProps
 >;
 
-const MenuLabel = React.forwardRef((props, forwardedRef) => (
-  <Primitive selector={getSelector(LABEL_NAME)} {...props} ref={forwardedRef} />
-)) as MenuLabelPrimitive;
+const MenuLabel = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(LABEL_NAME), ...labelProps } = props;
+  return <Primitive {...labelProps} selector={selector} ref={forwardedRef} />;
+}) as MenuLabelPrimitive;
 
 MenuLabel.displayName = LABEL_NAME;
 
@@ -385,7 +388,7 @@ type MenuItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuItem = React.forwardRef((props, forwardedRef) => {
-  const { disabled, textValue, onSelect, ...itemProps } = props;
+  const { selector = getSelector(ITEM_NAME), disabled, textValue, onSelect, ...itemProps } = props;
   const menuItemRef = React.useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs(forwardedRef, menuItemRef);
   const context = useMenuContext(ITEM_NAME);
@@ -427,7 +430,6 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
   return (
     <Primitive
       role="menuitem"
-      selector={getSelector(ITEM_NAME)}
       aria-disabled={disabled || undefined}
       {...itemProps}
       {...rovingFocusProps}
@@ -438,6 +440,7 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
        * We make sure there's always a generic `data-radix-menu-item` available to query from here.
        */
       {...{ [ITEM_ATTR]: '' }}
+      selector={selector}
       ref={composedRef}
       data-disabled={disabled ? '' : undefined}
       onFocus={composeEventHandlers(itemProps.onFocus, rovingFocusProps.onFocus)}
@@ -505,15 +508,21 @@ type MenyCheckboxItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuCheckboxItem = React.forwardRef((props, forwardedRef) => {
-  const { checked = false, onCheckedChange, children, ...checkboxItemProps } = props;
+  const {
+    selector = getSelector(CHECKBOX_ITEM_NAME),
+    checked = false,
+    onCheckedChange,
+    children,
+    ...checkboxItemProps
+  } = props;
   return (
     <MenuItem
       role="menuitemcheckbox"
-      selector={getSelector(CHECKBOX_ITEM_NAME)}
       aria-checked={checked}
       {...checkboxItemProps}
-      data-state={getCheckedState(checked)}
+      selector={selector}
       ref={forwardedRef}
+      data-state={getCheckedState(checked)}
       onSelect={composeEventHandlers(
         checkboxItemProps.onSelect,
         () => onCheckedChange?.(!checked),
@@ -549,14 +558,20 @@ type MenuRadioGroupPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuRadioGroup = React.forwardRef((props, forwardedRef) => {
-  const { children, value, onValueChange, ...groupProps } = props;
+  const {
+    selector = getSelector(RADIO_GROUP_NAME),
+    children,
+    value,
+    onValueChange,
+    ...groupProps
+  } = props;
   const handleValueChange = useCallbackRef(onValueChange);
   const context = React.useMemo(() => ({ value, onValueChange: handleValueChange }), [
     value,
     handleValueChange,
   ]);
   return (
-    <MenuGroup selector={getSelector(RADIO_GROUP_NAME)} {...groupProps} ref={forwardedRef}>
+    <MenuGroup {...groupProps} selector={selector} ref={forwardedRef}>
       <RadioGroupContext.Provider value={context}>{children}</RadioGroupContext.Provider>
     </MenuGroup>
   );
@@ -577,17 +592,17 @@ type MenuRadioItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuRadioItem = React.forwardRef((props, forwardedRef) => {
-  const { value, children, ...radioItemProps } = props;
+  const { selector = getSelector(RADIO_ITEM_NAME), value, children, ...radioItemProps } = props;
   const context = React.useContext(RadioGroupContext);
   const checked = value === context.value;
   return (
     <MenuItem
       role="menuitemradio"
-      selector={getSelector(RADIO_ITEM_NAME)}
       aria-checked={checked}
       {...radioItemProps}
-      data-state={getCheckedState(checked)}
+      selector={selector}
       ref={forwardedRef}
+      data-state={getCheckedState(checked)}
       onSelect={composeEventHandlers(
         radioItemProps.onSelect,
         () => context.onValueChange?.(value),
@@ -627,16 +642,21 @@ type MenuItemIndicatorPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuItemIndicator = React.forwardRef((props, forwardedRef) => {
-  const { forceMount, ...indicatorProps } = props;
+  const {
+    as = ITEM_INDICATOR_DEFAULT_TAG,
+    selector = getSelector(ITEM_INDICATOR_NAME),
+    forceMount,
+    ...indicatorProps
+  } = props;
   const checked = React.useContext(ItemIndicatorContext);
   return (
     <Presence present={forceMount || checked}>
       <Primitive
-        as={ITEM_INDICATOR_DEFAULT_TAG}
-        selector={getSelector(ITEM_INDICATOR_NAME)}
         {...indicatorProps}
-        data-state={getCheckedState(checked)}
+        as={as}
+        selector={selector}
         ref={forwardedRef}
+        data-state={getCheckedState(checked)}
       />
     </Presence>
   );
@@ -656,15 +676,18 @@ type MenuSeparatorPrimitive = Polymorphic.ForwardRefComponent<
   MenuSeparatorOwnProps
 >;
 
-const MenuSeparator = React.forwardRef((props, forwardedRef) => (
-  <Primitive
-    role="separator"
-    selector={getSelector(SEPARATOR_NAME)}
-    aria-orientation="horizontal"
-    {...props}
-    ref={forwardedRef}
-  />
-)) as MenuSeparatorPrimitive;
+const MenuSeparator = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(SEPARATOR_NAME), ...separatorProps } = props;
+  return (
+    <Primitive
+      role="separator"
+      aria-orientation="horizontal"
+      {...separatorProps}
+      selector={selector}
+      ref={forwardedRef}
+    />
+  );
+}) as MenuSeparatorPrimitive;
 
 MenuSeparator.displayName = SEPARATOR_NAME;
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -83,17 +83,18 @@ type PopoverTriggerPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, selector = getSelector(TRIGGER_NAME), ...triggerProps } = props;
   const context = usePopoverContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
   return (
     <Primitive
-      as={TRIGGER_DEFAULT_TAG}
-      selector={getSelector(TRIGGER_NAME)}
       type="button"
       aria-haspopup="dialog"
       aria-expanded={context.open}
       aria-controls={context.id}
-      {...props}
+      {...triggerProps}
+      as={as}
+      selector={selector}
       ref={composedTriggerRef}
       onClick={composeEventHandlers(props.onClick, () => context.setOpen((prevOpen) => !prevOpen))}
     />
@@ -215,6 +216,7 @@ type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(CONTENT_NAME),
     children,
     anchorRef,
     trapFocus = true,
@@ -309,9 +311,9 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
               {(dismissableLayerProps) => (
                 <PopperPrimitive.Root
                   role="dialog"
-                  selector={getSelector(CONTENT_NAME)}
                   aria-modal
                   {...contentProps}
+                  selector={selector}
                   ref={composeRefs(
                     forwardedRef,
                     contentRef,
@@ -374,13 +376,14 @@ type PopoverClosePrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const PopoverClose = React.forwardRef((props, forwardedRef) => {
+  const { as = CLOSE_DEFAULT_TAG, selector = getSelector(CLOSE_NAME), ...closeProps } = props;
   const context = usePopoverContext(CLOSE_NAME);
   return (
     <Primitive
-      as={CLOSE_DEFAULT_TAG}
-      selector={getSelector(CLOSE_NAME)}
       type="button"
-      {...props}
+      {...closeProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onClick={composeEventHandlers(props.onClick, () => context.setOpen(false))}
     />

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -129,7 +129,7 @@ type PopperArrowPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const PopperArrow = React.forwardRef(function PopperArrow(props, forwardedRef) {
-  const { offset, ...arrowProps } = props;
+  const { selector = getSelector(ARROW_NAME), offset, ...arrowProps } = props;
   const { arrowRef, setArrowOffset, arrowStyles } = usePopperContext(ARROW_NAME);
 
   // send the Arrow's offset up to Popper
@@ -149,8 +149,8 @@ const PopperArrow = React.forwardRef(function PopperArrow(props, forwardedRef) {
         }}
       >
         <ArrowPrimitive
-          selector={getSelector(ARROW_NAME)}
           {...arrowProps}
+          selector={selector}
           ref={forwardedRef}
           style={{
             ...arrowProps.style,

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -36,6 +36,7 @@ type ProgressPrimitive = Polymorphic.ForwardRefComponent<
 
 const Progress = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(PROGRESS_NAME),
     children,
     value: valueProp,
     max: maxProp,
@@ -50,17 +51,17 @@ const Progress = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(PROGRESS_NAME)}
       aria-valuemax={max}
       aria-valuemin={0}
       aria-valuenow={isNumber(value) ? value : undefined}
       aria-valuetext={valueLabel}
       role="progressbar"
       {...progressProps}
+      selector={selector}
+      ref={forwardedRef}
       data-state={getProgressState(value, max)}
       data-value={value ?? undefined}
       data-max={max}
-      ref={forwardedRef}
     >
       <ProgressContext.Provider value={ctx}>{children}</ProgressContext.Provider>
     </Primitive>
@@ -102,15 +103,16 @@ type ProgressIndicatorPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ProgressIndicator = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(INDICATOR_NAME), ...indicatorProps } = props;
   const { value, max } = useProgressContext(INDICATOR_NAME);
   return (
     <Primitive
-      selector={getSelector(INDICATOR_NAME)}
-      {...props}
+      {...indicatorProps}
+      selector={selector}
+      ref={forwardedRef}
       data-state={getProgressState(value, max)}
       data-value={value || undefined}
       data-max={max}
-      ref={forwardedRef}
     />
   );
 }) as ProgressIndicatorPrimitive;

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -38,6 +38,8 @@ const [RadioContext, useRadioContext] = createContext<boolean>(RADIO_NAME + 'Con
 
 const Radio = React.forwardRef((props, forwardedRef) => {
   const {
+    as = RADIO_DEFAULT_TAG,
+    selector = getSelector(RADIO_NAME),
     'aria-labelledby': ariaLabelledby,
     children,
     name,
@@ -82,10 +84,10 @@ const Radio = React.forwardRef((props, forwardedRef) => {
         })}
       />
       <Primitive
-        as={RADIO_DEFAULT_TAG}
-        selector={getSelector(RADIO_NAME)}
         type="button"
         {...radioProps}
+        as={as}
+        selector={selector}
         ref={ref}
         role="radio"
         aria-checked={checked}
@@ -134,16 +136,21 @@ type RadioIndicatorPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const RadioIndicator = React.forwardRef((props, forwardedRef) => {
-  const { forceMount, ...indicatorProps } = props;
+  const {
+    as = INDICATOR_DEFAULT_TAG,
+    selector = getSelector(INDICATOR_NAME),
+    forceMount,
+    ...indicatorProps
+  } = props;
   const checked = useRadioContext(INDICATOR_NAME);
   return (
     <Presence present={forceMount || checked}>
       <Primitive
-        as={INDICATOR_DEFAULT_TAG}
-        selector={getSelector(INDICATOR_NAME)}
         {...indicatorProps}
-        data-state={getState(checked)}
+        as={as}
+        selector={selector}
         ref={forwardedRef}
+        data-state={getState(checked)}
       />
     </Presence>
   );

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -49,6 +49,7 @@ const [RadioGroupContext, useRadioGroupContext] = createContext<RadioGroupContex
 
 const RadioGroup = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(RADIO_GROUP_NAME),
     'aria-labelledby': ariaLabelledby,
     defaultValue,
     children,
@@ -78,8 +79,8 @@ const RadioGroup = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(RADIO_GROUP_NAME)}
       {...groupProps}
+      selector={selector}
       ref={forwardedRef}
       role="radiogroup"
       aria-labelledby={labelledBy}
@@ -106,7 +107,7 @@ type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
-  const { disabled, required, ...itemProps } = props;
+  const { selector = getSelector(ITEM_NAME), disabled, required, ...itemProps } = props;
   const context = useRadioGroupContext(ITEM_NAME);
   const radioRef = React.useRef<React.ElementRef<typeof Radio>>(null);
   const ref = useComposedRefs(forwardedRef, radioRef);
@@ -131,14 +132,14 @@ const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Radio
-      selector={getSelector(ITEM_NAME)}
       {...itemProps}
       {...rovingFocusProps}
+      selector={selector}
+      ref={ref}
       disabled={disabled}
       data-disabled={disabled ? '' : undefined}
       required={required ?? context.required}
       checked={isChecked}
-      ref={ref}
       onCheckedChange={handleChange}
       onKeyDown={handleKeyDown}
       onMouseDown={handleMouseDown}

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -287,6 +287,7 @@ type ScrollAreaNativePrimitive = Polymorphic.ForwardRefComponent<
 
 const ScrollAreaNative = React.forwardRef(function ScrollAreaNative(props, forwardedRef) {
   const {
+    selector = getSelector(ROOT_NAME),
     overflowX,
     overflowY,
     scrollbarVisibility,
@@ -302,8 +303,8 @@ const ScrollAreaNative = React.forwardRef(function ScrollAreaNative(props, forwa
 
   return (
     <Primitive
-      selector={getSelector(ROOT_NAME)}
       {...domProps}
+      selector={selector}
       ref={ref}
       style={{
         ...domProps.style,
@@ -350,6 +351,7 @@ const initialState: ScrollAreaReducerState = {
 
 const ScrollAreaImpl = React.forwardRef(function ScrollAreaImpl(props, forwardedRef) {
   const {
+    selector = getSelector(ROOT_NAME),
     children,
     onScroll,
     overflowX,
@@ -491,8 +493,8 @@ const ScrollAreaImpl = React.forwardRef(function ScrollAreaImpl(props, forwarded
         <ScrollAreaContext.Provider value={context}>
           <ScrollAreaStateContext.Provider value={reducerState}>
             <Primitive
-              selector={getSelector(ROOT_NAME)}
               {...domProps}
+              selector={selector}
               ref={ref}
               style={{
                 ...domProps.style,
@@ -693,7 +695,11 @@ type ScrollAreaViewportPrimitive = Polymorphic.ForwardRefComponent<
 
 const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(props, forwardedRef) {
   return useNativeScrollArea() ? (
-    <Primitive selector={getSelector(VIEWPORT_NAME)} {...props} ref={forwardedRef} />
+    <Primitive
+      {...props}
+      selector={props.selector || getSelector(VIEWPORT_NAME)}
+      ref={forwardedRef}
+    />
   ) : (
     <ScrollAreaViewportImpl {...props} ref={forwardedRef} />
   );
@@ -878,11 +884,12 @@ type ScrollAreaScrollbarXPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaScrollbarX = React.forwardRef(function ScrollAreaScrollbarX(props, forwardedRef) {
+  const { selector = getSelector(SCROLLBAR_X_NAME), ...scrollbarXProps } = props;
   const { domSizes } = useScrollAreaStateContext();
   return useNativeScrollArea() ? null : (
     <ScrollAreaScrollbar
-      selector={getSelector(SCROLLBAR_X_NAME)}
-      {...props}
+      {...scrollbarXProps}
+      selector={selector}
       ref={forwardedRef}
       axis="x"
       name={SCROLLBAR_X_NAME}
@@ -906,11 +913,12 @@ type ScrollAreaScrollbarYPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaScrollbarY = React.forwardRef(function ScrollAreaScrollbarY(props, forwardedRef) {
+  const { selector = getSelector(SCROLLBAR_Y_NAME), ...scrollbarYProps } = props;
   const { domSizes } = useScrollAreaStateContext();
   return useNativeScrollArea() ? null : (
     <ScrollAreaScrollbar
-      selector={getSelector(SCROLLBAR_Y_NAME)}
-      {...props}
+      {...scrollbarYProps}
+      selector={selector}
       ref={forwardedRef}
       axis="y"
       name={SCROLLBAR_Y_NAME}
@@ -940,7 +948,11 @@ type ScrollAreaTrackPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaTrack = React.forwardRef(function ScrollAreaTrack(props, forwardedRef) {
-  const { onPointerDown: onPointerDownProp, ...domProps } = props;
+  const {
+    selector = getSelector(TRACK_NAME),
+    onPointerDown: onPointerDownProp,
+    ...domProps
+  } = props;
   const { axis, scrollAnimationQueue } = useScrollbarContext(TRACK_NAME);
   const dispatch = useDispatchContext(TRACK_NAME);
   const refsContext = useScrollAreaRefs(TRACK_NAME);
@@ -1145,7 +1157,7 @@ const ScrollAreaTrack = React.forwardRef(function ScrollAreaTrack(props, forward
     trackRef,
   ]);
 
-  return <Primitive selector={getSelector(TRACK_NAME)} {...domProps} ref={ref} data-axis={axis} />;
+  return <Primitive {...domProps} selector={selector} ref={ref} data-axis={axis} />;
 }) as ScrollAreaTrackPrimitive;
 
 ScrollAreaTrack.displayName = TRACK_NAME;
@@ -1163,7 +1175,11 @@ type ScrollAreaThumbPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(props, forwardedRef) {
-  const { onPointerDown: onPointerDownProp, ...domProps } = props;
+  const {
+    selector = getSelector(THUMB_NAME),
+    onPointerDown: onPointerDownProp,
+    ...domProps
+  } = props;
   const { axis } = useScrollbarContext(THUMB_NAME);
   const refsContext = useScrollAreaRefs(THUMB_NAME);
   const dispatch = useDispatchContext(THUMB_NAME);
@@ -1314,8 +1330,8 @@ const ScrollAreaThumb = React.forwardRef(function ScrollAreaThumb(props, forward
 
   return (
     <Primitive
-      selector={getSelector(THUMB_NAME)}
       {...domProps}
+      selector={selector}
       ref={ref}
       data-axis={axis}
       style={{
@@ -1517,10 +1533,11 @@ type ScrollAreaButtonStartPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaButtonStart = React.forwardRef(function ScrollAreaButtonStart(props, forwardedRef) {
+  const { selector = getSelector(BUTTON_START_NAME), ...buttonStartProps } = props;
   return (
     <ScrollAreaButton
-      selector={getSelector(BUTTON_START_NAME)}
-      {...props}
+      {...buttonStartProps}
+      selector={selector}
       ref={forwardedRef}
       name={BUTTON_START_NAME}
       direction="start"
@@ -1541,10 +1558,11 @@ type ScrollAreaButtonEndPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaButtonEnd = React.forwardRef(function ScrollAreaButtonEnd(props, forwardedRef) {
+  const { selector = getSelector(BUTTON_END_NAME), ...buttonEndProps } = props;
   return (
     <ScrollAreaButton
-      selector={getSelector(BUTTON_END_NAME)}
-      {...props}
+      {...buttonEndProps}
+      selector={selector}
       ref={forwardedRef}
       name={BUTTON_END_NAME}
       direction="end"
@@ -1567,6 +1585,7 @@ type ScrollAreaCornerImplPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaCornerImpl = React.forwardRef(function ScrollAreaCornerImpl(props, forwardedRef) {
+  const { selector = getSelector(CORNER_NAME), ...cornerProps } = props;
   const { positionRef } = useScrollAreaRefs(CORNER_NAME);
   const dispatch = useDispatchContext(CORNER_NAME);
   const { dir } = useScrollAreaContext(CORNER_NAME);
@@ -1616,8 +1635,8 @@ const ScrollAreaCornerImpl = React.forwardRef(function ScrollAreaCornerImpl(prop
 
   return (
     <Primitive
-      selector={getSelector(CORNER_NAME)}
-      {...props}
+      {...cornerProps}
+      selector={selector}
       ref={forwardedRef}
       style={{
         ...props.style,

--- a/packages/react/separator/src/Separator.tsx
+++ b/packages/react/separator/src/Separator.tsx
@@ -31,7 +31,12 @@ type SeparatorPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const Separator = React.forwardRef((props, forwardedRef) => {
-  const { decorative, orientation: orientationProp = DEFAULT_ORIENTATION, ...domProps } = props;
+  const {
+    selector = getSelector(NAME),
+    decorative,
+    orientation: orientationProp = DEFAULT_ORIENTATION,
+    ...domProps
+  } = props;
   const orientation = isValidOrientation(orientationProp) ? orientationProp : DEFAULT_ORIENTATION;
   // `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
   const ariaOrientation = orientation === 'vertical' ? orientation : undefined;
@@ -41,10 +46,10 @@ const Separator = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(NAME)}
       {...semanticProps}
       data-orientation={orientation}
       {...domProps}
+      selector={selector}
       ref={forwardedRef}
     />
   );

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -419,6 +419,8 @@ type SliderPartPrimitive = Polymorphic.ForwardRefComponent<
 
 const SliderPart = React.forwardRef((props, forwardedRef) => {
   const {
+    as = SLIDER_DEFAULT_TAG,
+    selector = getSelector(SLIDER_NAME),
     onSlideMouseDown,
     onSlideMouseMove,
     onSlideMouseUp,
@@ -453,9 +455,9 @@ const SliderPart = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      as={SLIDER_DEFAULT_TAG}
-      selector={getSelector(SLIDER_NAME)}
       {...sliderProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
         // Slide only if main mouse button was clicked
@@ -524,12 +526,13 @@ type SliderTrackPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const SliderTrack = React.forwardRef((props, forwardedRef) => {
+  const { as = TRACK_DEFAULT_TAG, selector = getSelector(TRACK_NAME), ...trackProps } = props;
   const context = useSliderContext(TRACK_NAME);
   return (
     <Primitive
-      as={TRACK_DEFAULT_TAG}
-      selector={getSelector(TRACK_NAME)}
-      {...props}
+      {...trackProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       data-orientation={context.orientation}
     />
@@ -552,6 +555,7 @@ type SliderRangePrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const SliderRange = React.forwardRef((props, forwardedRef) => {
+  const { as = RANGE_DEFAULT_TAG, selector = getSelector(RANGE_NAME), ...rangeProps } = props;
   const context = useSliderContext(RANGE_NAME);
   const orientation = React.useContext(SliderOrientationContext);
   const ref = React.useRef<HTMLSpanElement>(null);
@@ -565,9 +569,9 @@ const SliderRange = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      as={RANGE_DEFAULT_TAG}
-      selector={getSelector(RANGE_NAME)}
-      {...props}
+      {...rangeProps}
+      as={as}
+      selector={selector}
       ref={composedRefs}
       style={{
         ...props.style,
@@ -618,7 +622,13 @@ type SliderThumbImplPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const SliderThumbImpl = React.forwardRef((props, forwardedRef) => {
-  const { index, value, ...thumbProps } = props;
+  const {
+    as = THUMB_DEFAULT_TAG,
+    selector = getSelector(THUMB_NAME),
+    index,
+    value,
+    ...thumbProps
+  } = props;
   const context = useSliderContext(THUMB_NAME);
   const orientation = React.useContext(SliderOrientationContext);
   const thumbRef = React.useRef<HTMLSpanElement>(null);
@@ -650,9 +660,9 @@ const SliderThumbImpl = React.forwardRef((props, forwardedRef) => {
       }}
     >
       <Primitive
-        as={THUMB_DEFAULT_TAG}
-        selector={getSelector(THUMB_NAME)}
         {...thumbProps}
+        as={as}
+        selector={selector}
         ref={ref}
         aria-label={props['aria-label'] || label}
         aria-valuemin={context.min}

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -40,6 +40,8 @@ const [SwitchContext, useSwitchContext] = createContext<boolean>(
 
 const Switch = React.forwardRef((props, forwardedRef) => {
   const {
+    as = SWITCH_DEFAULT_TAG,
+    selector = getSelector(SWITCH_NAME),
     'aria-labelledby': ariaLabelledby,
     children,
     name,
@@ -84,10 +86,10 @@ const Switch = React.forwardRef((props, forwardedRef) => {
         })}
       />
       <Primitive
-        as={SWITCH_DEFAULT_TAG}
-        selector={getSelector(SWITCH_NAME)}
         type="button"
         {...switchProps}
+        as={as}
+        selector={selector}
         ref={ref}
         role="switch"
         aria-checked={checked}
@@ -127,14 +129,15 @@ type SwitchThumbPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const SwitchThumb = React.forwardRef((props, forwardedRef) => {
+  const { as = THUMB_DEFAULT_TAG, selector = getSelector(THUMB_NAME), ...thumbProps } = props;
   const checked = useSwitchContext(THUMB_NAME);
   return (
     <Primitive
-      as={THUMB_DEFAULT_TAG}
-      selector={getSelector(THUMB_NAME)}
-      {...props}
-      data-state={getState(checked)}
+      {...thumbProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
+      data-state={getState(checked)}
     />
   );
 }) as SwitchThumbPrimitive;

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -59,6 +59,7 @@ type TabsPrimitive = Polymorphic.ForwardRefComponent<
 
 const Tabs = React.forwardRef((props, forwardedRef) => {
   const {
+    selector = getSelector(TABS_NAME),
     children,
     id,
     value: valueProp,
@@ -87,9 +88,9 @@ const Tabs = React.forwardRef((props, forwardedRef) => {
     <TabsContext.Provider value={ctx}>
       <Primitive
         id={tabsId}
-        selector={getSelector(TABS_NAME)}
         data-orientation={orientation}
         {...tabsProps}
+        selector={selector}
         ref={forwardedRef}
       >
         {children}
@@ -123,16 +124,16 @@ type TabsListPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TabsList = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(TAB_LIST_NAME), loop = true, children, ...otherProps } = props;
   const { orientation } = useTabsContext(TAB_LIST_NAME);
-  const { loop = true, children, ...otherProps } = props;
 
   return (
     <Primitive
-      selector={getSelector(TAB_LIST_NAME)}
       data-orientation={orientation}
       role="tablist"
       aria-orientation={orientation}
       {...otherProps}
+      selector={selector}
       ref={forwardedRef}
     >
       <RovingFocusGroup orientation={orientation} loop={loop}>
@@ -164,7 +165,7 @@ type TabsTabPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TabsTab = React.forwardRef((props, forwardedRef) => {
-  const { value, disabled, ...tabProps } = props;
+  const { selector = getSelector(TAB_NAME), value, disabled, ...tabProps } = props;
   const context = useTabsContext(TAB_NAME);
   const tabId = makeTabId(context.tabsId, value);
   const tabPanelId = makeTabsPanelId(context.tabsId, value);
@@ -207,17 +208,17 @@ const TabsTab = React.forwardRef((props, forwardedRef) => {
   return (
     <Primitive
       role="tab"
-      selector={getSelector(TAB_NAME)}
       aria-selected={isSelected}
       aria-controls={tabPanelId}
       aria-disabled={disabled || undefined}
       {...tabProps}
       {...rovingFocusProps}
+      selector={selector}
+      ref={forwardedRef}
       data-state={isSelected ? 'active' : 'inactive'}
       data-disabled={disabled ? '' : undefined}
       data-orientation={context.orientation}
       id={tabId}
-      ref={forwardedRef}
       onKeyDown={handleKeyDown}
       onMouseDown={handleMouseDown}
       onFocus={handleFocus}
@@ -240,7 +241,7 @@ type TabsPanelPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TabsPanel = React.forwardRef((props, forwardedRef) => {
-  const { value, ...tabPanelProps } = props;
+  const { selector = getSelector(TAB_PANEL_NAME), value, ...tabPanelProps } = props;
   const context = useTabsContext(TAB_PANEL_NAME);
   const tabId = makeTabId(context.tabsId, value);
   const tabPanelId = makeTabsPanelId(context.tabsId, value);
@@ -248,7 +249,6 @@ const TabsPanel = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      selector={getSelector(TAB_PANEL_NAME)}
       data-state={isSelected ? 'active' : 'inactive'}
       data-orientation={context.orientation}
       id={tabPanelId}
@@ -257,6 +257,7 @@ const TabsPanel = React.forwardRef((props, forwardedRef) => {
       tabIndex={0}
       hidden={!isSelected}
       {...tabPanelProps}
+      selector={selector}
       ref={forwardedRef}
     />
   );

--- a/packages/react/toggle-button/src/ToggleButton.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.tsx
@@ -31,6 +31,8 @@ type ToggleButtonPrimitive = Polymorphic.ForwardRefComponent<
 
 const ToggleButton = React.forwardRef((props, forwardedRef) => {
   const {
+    as = DEFAULT_TAG,
+    selector = getSelector(NAME),
     toggled: toggledProp,
     defaultToggled = false,
     onClick,
@@ -47,13 +49,13 @@ const ToggleButton = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Primitive
-      as={DEFAULT_TAG}
-      selector={getSelector(NAME)}
       type="button"
       aria-pressed={toggled}
       data-state={toggled ? 'on' : 'off'}
       data-disabled={props.disabled ? '' : undefined}
       {...buttonProps}
+      as={as}
+      selector={selector}
       ref={forwardedRef}
       onClick={composeEventHandlers(onClick, () => {
         if (!props.disabled) {

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -144,16 +144,17 @@ type TooltipTriggerPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TooltipTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, selector = getSelector(TRIGGER_NAME), ...triggerProps } = props;
   const context = useTooltipContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 
   return (
     <Primitive
-      as={TRIGGER_DEFAULT_TAG}
-      selector={getSelector(TRIGGER_NAME)}
       type="button"
       aria-describedby={context.open ? context.id : undefined}
-      {...props}
+      {...triggerProps}
+      as={as}
+      selector={selector}
       ref={composedTriggerRef}
       onMouseEnter={composeEventHandlers(props.onMouseEnter, () =>
         stateMachine.transition('mouseEntered', { id: context.id })
@@ -232,7 +233,14 @@ type TooltipContentImplPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TooltipContentImpl = React.forwardRef((props, forwardedRef) => {
-  const { children, 'aria-label': ariaLabel, anchorRef, portalled = true, ...contentProps } = props;
+  const {
+    selector = getSelector(CONTENT_NAME),
+    children,
+    'aria-label': ariaLabel,
+    anchorRef,
+    portalled = true,
+    ...contentProps
+  } = props;
   const context = useTooltipContext(CONTENT_NAME);
   const PortalWrapper = portalled ? Portal : React.Fragment;
 
@@ -240,10 +248,10 @@ const TooltipContentImpl = React.forwardRef((props, forwardedRef) => {
     <PortalWrapper>
       <CheckTriggerMoved />
       <PopperPrimitive.Root
-        selector={getSelector(CONTENT_NAME)}
         {...contentProps}
-        data-state={context.stateAttribute}
+        selector={selector}
         ref={forwardedRef}
+        data-state={context.stateAttribute}
         anchorRef={anchorRef || context.triggerRef}
         style={{
           ...contentProps.style,

--- a/packages/react/utils/src/extendComponent.tsx
+++ b/packages/react/utils/src/extendComponent.tsx
@@ -14,8 +14,9 @@ function extendComponent<As extends Polymorphic.ForwardRefComponent<any, any>>(
     Polymorphic.OwnProps<typeof Comp>
   >;
   const Extended = React.forwardRef((props, forwardedRef) => {
+    const { selector = getSelector(displayName), ...asProps } = props;
     const As = Comp as any;
-    return <As selector={getSelector(displayName)} {...props} ref={forwardedRef} />;
+    return <As {...asProps} selector={selector} ref={forwardedRef} />;
   }) as ExtendedPrimitive;
   Extended.displayName = displayName;
   return Extended;

--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -13,28 +13,31 @@ type VisuallyHiddenPrimitive = Polymorphic.ForwardRefComponent<
   VisuallyHiddenOwnProps
 >;
 
-const VisuallyHidden = React.forwardRef((props, forwardedRef) => (
-  <Primitive
-    as={DEFAULT_TAG}
-    selector={getSelector(NAME)}
-    {...props}
-    ref={forwardedRef}
-    style={{
-      ...props.style,
-      // See: https://github.com/twbs/bootstrap/blob/master/scss/mixins/_screen-reader.scss
-      position: 'absolute',
-      border: 0,
-      width: 1,
-      height: 1,
-      padding: 0,
-      margin: -1,
-      overflow: 'hidden',
-      clip: 'rect(0, 0, 0, 0)',
-      whiteSpace: 'nowrap',
-      wordWrap: 'normal',
-    }}
-  />
-)) as VisuallyHiddenPrimitive;
+const VisuallyHidden = React.forwardRef((props, forwardedRef) => {
+  const { as = DEFAULT_TAG, selector = getSelector(NAME), ...visuallyHiddenProps } = props;
+  return (
+    <Primitive
+      {...visuallyHiddenProps}
+      as={as}
+      selector={selector}
+      ref={forwardedRef}
+      style={{
+        ...props.style,
+        // See: https://github.com/twbs/bootstrap/blob/master/scss/mixins/_screen-reader.scss
+        position: 'absolute',
+        border: 0,
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        wordWrap: 'normal',
+      }}
+    />
+  );
+}) as VisuallyHiddenPrimitive;
 
 VisuallyHidden.displayName = NAME;
 


### PR DESCRIPTION
We noticed that Stitches passes an explicit `as={undefined}` prop to our components which wipes them out. We've decided that this shouldn't be possible and to explicitly handle this case by always falling back to a default.

We're going to make sure all our other defaults are handled correctly in a separate PR to avoid similar situations like this in future.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
