### PR TITLE
Add `Slot` component

### DIFF
--- a/.yarn/versions/bc72dcf8.yml
+++ b/.yarn/versions/bc72dcf8.yml
@@ -1,0 +1,40 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -67,7 +67,7 @@ const [AccordionItemContext, useAccordionItemContext] = createContext<AccordionI
  * `AccordionItem` contains all of the parts of a collapsible section inside of an `Accordion`.
  */
 const AccordionItem = React.forwardRef((props, forwardedRef) => {
-  const { selector = getSelector(ITEM_NAME), value, children, ...accordionItemProps } = props;
+  const { selector = getSelector(ITEM_NAME), value, ...accordionItemProps } = props;
   const accordionContext = useAccordionContext(ITEM_NAME);
   const generatedButtonId = `accordion-button-${useId()}`;
   const buttonId = props.id || generatedButtonId;
@@ -80,18 +80,18 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
   ]);
 
   return (
-    <Collapsible
-      {...accordionItemProps}
-      selector={selector}
-      ref={forwardedRef}
-      data-state={open ? 'open' : 'closed'}
-      data-disabled={disabled || undefined}
-      disabled={disabled}
-      open={open}
-      onOpenChange={() => accordionContext.setValue(value)}
-    >
-      <AccordionItemContext.Provider value={itemContext}>{children}</AccordionItemContext.Provider>
-    </Collapsible>
+    <AccordionItemContext.Provider value={itemContext}>
+      <Collapsible
+        {...accordionItemProps}
+        selector={selector}
+        ref={forwardedRef}
+        data-state={open ? 'open' : 'closed'}
+        data-disabled={disabled || undefined}
+        disabled={disabled}
+        open={open}
+        onOpenChange={() => accordionContext.setValue(value)}
+      />
+    </AccordionItemContext.Provider>
   );
 }) as AccordionItemPrimitive;
 
@@ -246,7 +246,6 @@ const Accordion = React.forwardRef((props, forwardedRef) => {
     selector = getSelector(ACCORDION_NAME),
     value: valueProp,
     defaultValue,
-    children,
     disabled,
     onValueChange = () => {},
     ...accordionProps
@@ -313,14 +312,14 @@ const Accordion = React.forwardRef((props, forwardedRef) => {
   );
 
   return (
-    <Primitive
-      {...accordionProps}
-      selector={selector}
-      ref={composedRefs}
-      onKeyDown={disabled ? undefined : handleKeyDown}
-    >
-      <AccordionContext.Provider value={context}>{children}</AccordionContext.Provider>
-    </Primitive>
+    <AccordionContext.Provider value={context}>
+      <Primitive
+        {...accordionProps}
+        selector={selector}
+        ref={composedRefs}
+        onKeyDown={disabled ? undefined : handleKeyDown}
+      />
+    </AccordionContext.Provider>
   );
 }) as AccordionPrimitive;
 

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -96,10 +96,10 @@ const Announce = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(NAME),
     'aria-relevant': ariaRelevant,
-    children,
     type = 'polite',
     role = ROLES[type],
     regionIdentifier,
+    children,
     ...regionProps
   } = props;
 

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -96,10 +96,10 @@ const Announce = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(NAME),
     'aria-relevant': ariaRelevant,
+    children,
     type = 'polite',
     role = ROLES[type],
     regionIdentifier,
-    children,
     ...regionProps
   } = props;
 

--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -18,13 +18,7 @@ type AspectRatioPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AspectRatio = React.forwardRef((props, forwardedRef) => {
-  const {
-    selector = getSelector(NAME),
-    ratio = 1 / 1,
-    style,
-    children,
-    ...aspectRatioProps
-  } = props;
+  const { selector = getSelector(NAME), ratio = 1 / 1, style, ...aspectRatioProps } = props;
   return (
     <div
       style={{
@@ -48,9 +42,7 @@ const AspectRatio = React.forwardRef((props, forwardedRef) => {
           bottom: 0,
           left: 0,
         }}
-      >
-        {children}
-      </Primitive>
+      />
     </div>
   );
 }) as AspectRatioPrimitive;

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -27,17 +27,12 @@ const [AvatarContext, useAvatarContext] = createContext<AvatarContextValue>(
 );
 
 const Avatar = React.forwardRef((props, forwardedRef) => {
-  const {
-    as = AVATAR_DEFAULT_TAG,
-    selector = getSelector(AVATAR_NAME),
-    children,
-    ...avatarProps
-  } = props;
+  const { as = AVATAR_DEFAULT_TAG, selector = getSelector(AVATAR_NAME), ...avatarProps } = props;
   const context = React.useState<ImageLoadingStatus>('idle');
   return (
-    <Primitive {...avatarProps} as={as} selector={selector} ref={forwardedRef}>
-      <AvatarContext.Provider value={context}>{children}</AvatarContext.Provider>
-    </Primitive>
+    <AvatarContext.Provider value={context}>
+      <Primitive {...avatarProps} as={as} selector={selector} ref={forwardedRef} />
+    </AvatarContext.Provider>
   );
 }) as AvatarPrimitive;
 

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -48,7 +48,6 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
     as = CHECKBOX_DEFAULT_TAG,
     selector = getSelector(CHECKBOX_NAME),
     'aria-labelledby': ariaLabelledby,
-    children,
     name,
     checked: checkedProp,
     defaultChecked,
@@ -95,30 +94,30 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
           setChecked(event.target.checked);
         })}
       />
-      <Primitive
-        type="button"
-        {...checkboxProps}
-        as={as}
-        selector={selector}
-        ref={ref}
-        role="checkbox"
-        aria-checked={checked === 'indeterminate' ? 'mixed' : checked}
-        aria-labelledby={labelledBy}
-        aria-required={required}
-        data-state={getState(checked)}
-        data-readonly={readOnly}
-        disabled={disabled}
-        value={value}
-        /**
-         * The `input` is hidden, so when the button is clicked we trigger
-         * the input manually
-         */
-        onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
-          checkForDefaultPrevented: false,
-        })}
-      >
-        <CheckboxContext.Provider value={checked}>{children}</CheckboxContext.Provider>
-      </Primitive>
+      <CheckboxContext.Provider value={checked}>
+        <Primitive
+          type="button"
+          {...checkboxProps}
+          as={as}
+          selector={selector}
+          ref={ref}
+          role="checkbox"
+          aria-checked={checked === 'indeterminate' ? 'mixed' : checked}
+          aria-labelledby={labelledBy}
+          aria-required={required}
+          data-state={getState(checked)}
+          data-readonly={readOnly}
+          disabled={disabled}
+          value={value}
+          /**
+           * The `input` is hidden, so when the button is clicked we trigger
+           * the input manually
+           */
+          onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
+            checkForDefaultPrevented: false,
+          })}
+        />
+      </CheckboxContext.Provider>
     </>
   );
 }) as CheckboxPrimitive;

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -50,7 +50,6 @@ const Collapsible = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(COLLAPSIBLE_NAME),
     id: idProp,
-    children,
     open: openProp,
     defaultOpen,
     disabled,
@@ -76,14 +75,14 @@ const Collapsible = React.forwardRef((props, forwardedRef) => {
   );
 
   return (
-    <Primitive
-      {...collapsibleProps}
-      selector={selector}
-      data-state={getState(context.open)}
-      ref={forwardedRef}
-    >
-      <CollapsibleContext.Provider value={context}>{children}</CollapsibleContext.Provider>
-    </Primitive>
+    <CollapsibleContext.Provider value={context}>
+      <Primitive
+        {...collapsibleProps}
+        selector={selector}
+        data-state={getState(context.open)}
+        ref={forwardedRef}
+      />
+    </CollapsibleContext.Provider>
   );
 }) as CollapsiblePrimitive;
 

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -25,7 +25,6 @@ const Label = React.forwardRef((props, forwardedRef) => {
     selector = getSelector(NAME),
     htmlFor,
     id: idProp,
-    children,
     ...labelProps
   } = props;
   const labelRef = React.useRef<HTMLSpanElement>(null);
@@ -76,11 +75,9 @@ const Label = React.forwardRef((props, forwardedRef) => {
   }, [id, htmlFor]);
 
   return (
-    <Primitive {...labelProps} as={as} selector={selector} ref={ref} id={id} role="label">
-      <LabelContext.Provider value={React.useMemo(() => ({ id, ref: labelRef }), [id])}>
-        {children}
-      </LabelContext.Provider>
-    </Primitive>
+    <LabelContext.Provider value={React.useMemo(() => ({ id, ref: labelRef }), [id])}>
+      <Primitive {...labelProps} as={as} selector={selector} ref={ref} id={id} role="label" />
+    </LabelContext.Provider>
   );
 }) as LabelPrimitive;
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -65,13 +65,11 @@ type MenuPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const Menu = React.forwardRef((props, forwardedRef) => {
-  const { children, forceMount, open = false, ...menuProps } = props;
+  const { forceMount, open = false, ...menuProps } = props;
 
   return (
     <Presence present={forceMount || open}>
-      <MenuImpl ref={forwardedRef} {...menuProps} data-state={getOpenState(open)}>
-        {children}
-      </MenuImpl>
+      <MenuImpl ref={forwardedRef} {...menuProps} data-state={getOpenState(open)} />
     </Presence>
   );
 }) as MenuPrimitive;
@@ -157,7 +155,6 @@ type MenuImplPrimitive = Polymorphic.ForwardRefComponent<
 const MenuImpl = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(MENU_NAME),
-    children,
     onOpenChange,
     anchorRef,
     loop,
@@ -306,14 +303,14 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
                     }
                   })}
                 >
-                  <RovingFocusGroup
-                    reachable={itemsReachable}
-                    onReachableChange={setItemsReachable}
-                    orientation="vertical"
-                    loop={loop}
-                  >
-                    <MenuContext.Provider value={context}>{children}</MenuContext.Provider>
-                  </RovingFocusGroup>
+                  <MenuContext.Provider value={context}>
+                    <RovingFocusGroup
+                      reachable={itemsReachable}
+                      onReachableChange={setItemsReachable}
+                      orientation="vertical"
+                      loop={loop}
+                    />
+                  </MenuContext.Provider>
                 </PopperPrimitive.Root>
               )}
             </DismissableLayer>
@@ -512,25 +509,24 @@ const MenuCheckboxItem = React.forwardRef((props, forwardedRef) => {
     selector = getSelector(CHECKBOX_ITEM_NAME),
     checked = false,
     onCheckedChange,
-    children,
     ...checkboxItemProps
   } = props;
   return (
-    <MenuItem
-      role="menuitemcheckbox"
-      aria-checked={checked}
-      {...checkboxItemProps}
-      selector={selector}
-      ref={forwardedRef}
-      data-state={getCheckedState(checked)}
-      onSelect={composeEventHandlers(
-        checkboxItemProps.onSelect,
-        () => onCheckedChange?.(!checked),
-        { checkForDefaultPrevented: false }
-      )}
-    >
-      <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
-    </MenuItem>
+    <ItemIndicatorContext.Provider value={checked}>
+      <MenuItem
+        role="menuitemcheckbox"
+        aria-checked={checked}
+        {...checkboxItemProps}
+        selector={selector}
+        ref={forwardedRef}
+        data-state={getCheckedState(checked)}
+        onSelect={composeEventHandlers(
+          checkboxItemProps.onSelect,
+          () => onCheckedChange?.(!checked),
+          { checkForDefaultPrevented: false }
+        )}
+      />
+    </ItemIndicatorContext.Provider>
   );
 }) as MenyCheckboxItemPrimitive;
 
@@ -558,22 +554,16 @@ type MenuRadioGroupPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuRadioGroup = React.forwardRef((props, forwardedRef) => {
-  const {
-    selector = getSelector(RADIO_GROUP_NAME),
-    children,
-    value,
-    onValueChange,
-    ...groupProps
-  } = props;
+  const { selector = getSelector(RADIO_GROUP_NAME), value, onValueChange, ...groupProps } = props;
   const handleValueChange = useCallbackRef(onValueChange);
   const context = React.useMemo(() => ({ value, onValueChange: handleValueChange }), [
     value,
     handleValueChange,
   ]);
   return (
-    <MenuGroup {...groupProps} selector={selector} ref={forwardedRef}>
-      <RadioGroupContext.Provider value={context}>{children}</RadioGroupContext.Provider>
-    </MenuGroup>
+    <RadioGroupContext.Provider value={context}>
+      <MenuGroup {...groupProps} selector={selector} ref={forwardedRef} />
+    </RadioGroupContext.Provider>
   );
 }) as MenuRadioGroupPrimitive;
 
@@ -592,25 +582,25 @@ type MenuRadioItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const MenuRadioItem = React.forwardRef((props, forwardedRef) => {
-  const { selector = getSelector(RADIO_ITEM_NAME), value, children, ...radioItemProps } = props;
+  const { selector = getSelector(RADIO_ITEM_NAME), value, ...radioItemProps } = props;
   const context = React.useContext(RadioGroupContext);
   const checked = value === context.value;
   return (
-    <MenuItem
-      role="menuitemradio"
-      aria-checked={checked}
-      {...radioItemProps}
-      selector={selector}
-      ref={forwardedRef}
-      data-state={getCheckedState(checked)}
-      onSelect={composeEventHandlers(
-        radioItemProps.onSelect,
-        () => context.onValueChange?.(value),
-        { checkForDefaultPrevented: false }
-      )}
-    >
-      <ItemIndicatorContext.Provider value={checked}>{children}</ItemIndicatorContext.Provider>
-    </MenuItem>
+    <ItemIndicatorContext.Provider value={checked}>
+      <MenuItem
+        role="menuitemradio"
+        aria-checked={checked}
+        {...radioItemProps}
+        selector={selector}
+        ref={forwardedRef}
+        data-state={getCheckedState(checked)}
+        onSelect={composeEventHandlers(
+          radioItemProps.onSelect,
+          () => context.onValueChange?.(value),
+          { checkForDefaultPrevented: false }
+        )}
+      />
+    </ItemIndicatorContext.Provider>
   );
 }) as MenuRadioItemPrimitive;
 

--- a/packages/react/polymorphic/src/forwardRefWithAs.ts
+++ b/packages/react/polymorphic/src/forwardRefWithAs.ts
@@ -33,18 +33,6 @@ interface ForwardRefComponent<
     MergeProps<IntrinsicElementString, OwnProps & { as?: IntrinsicElementString }>
   > {
   /**
-   * When passing an `as` prop as a string, use this overload.
-   * Merges orignal own props (without DOM props) and the inferred props
-   * from `as` element with the own props taking precendence.
-   *
-   * We explicitly define a `JSX.IntrinsicElements` overload so that
-   * events are typed for consumers.
-   */
-  <As extends keyof JSX.IntrinsicElements>(
-    props: MergeProps<As, OwnProps & { as: As }>
-  ): React.ReactElement | null;
-
-  /**
    * When passing an `as` prop as a component, use this overload.
    * Merges orignal own props (without DOM props) and the inferred props
    * from `as` element with the own props taking precendence.
@@ -59,6 +47,18 @@ interface ForwardRefComponent<
     _AsWithProps = As extends React.ElementType<infer P> ? React.ElementType<P> : never
   >(
     props: MergeProps<_AsWithProps, OwnProps & { as: _AsWithProps }>
+  ): React.ReactElement | null;
+
+  /**
+   * When passing an `as` prop as a string, use this overload.
+   * Merges orignal own props (without DOM props) and the inferred props
+   * from `as` element with the own props taking precendence.
+   *
+   * We explicitly define a `JSX.IntrinsicElements` overload so that
+   * events are typed for consumers.
+   */
+  <As extends keyof JSX.IntrinsicElements>(
+    props: MergeProps<As, OwnProps & { as: As }>
   ): React.ReactElement | null;
 }
 

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Popover, PopoverTrigger, PopoverContent, PopoverClose, PopoverArrow } from './Popover';
 import { Arrow } from '@radix-ui/react-arrow';
 import { styled, css } from '../../../../stitches.config';
+import { Slot } from '@radix-ui/react-slot';
 
 export default { title: 'Components/Popover' };
 
@@ -180,6 +181,20 @@ export const NonModal = () => {
       </Popover>
       <input style={{ marginLeft: 10 }} />
     </>
+  );
+};
+
+export const WithSlottedTrigger = () => {
+  return (
+    <Popover>
+      <PopoverTrigger as={Slot}>
+        <StyledTrigger onClick={() => console.log('StyledTrigger click')}>open</StyledTrigger>
+      </PopoverTrigger>
+      <PopoverContent as={StyledContent} sideOffset={5}>
+        <PopoverClose as={StyledClose}>close</PopoverClose>
+        <PopoverArrow as={StyledArrow} width={20} height={10} offset={10} />
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -128,6 +128,7 @@ type PopoverContentPrimitive = Polymorphic.ForwardRefComponent<
 const PopoverContent = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...contentProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
+
   return (
     <Presence present={forceMount || context.open}>
       <PopoverContentImpl
@@ -217,7 +218,6 @@ type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
 const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(CONTENT_NAME),
-    children,
     anchorRef,
     trapFocus = true,
     onOpenAutoFocus,
@@ -348,9 +348,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
                     dismissableLayerProps.onTouchStartCapture,
                     { checkForDefaultPrevented: false }
                   )}
-                >
-                  {children}
-                </PopperPrimitive.Root>
+                />
               )}
             </DismissableLayer>
           )}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -50,7 +50,6 @@ type PopperPrimitive = Polymorphic.ForwardRefComponent<
 const Popper = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(POPPER_NAME),
-    children,
     anchorRef,
     side = 'bottom',
     sideOffset,
@@ -94,21 +93,21 @@ const Popper = React.forwardRef((props, forwardedRef) => {
 
   return (
     <div style={popperStyles} {...(selector ? getSelectorObj(selector + '-wrapper') : undefined)}>
-      <Primitive
-        selector={selector}
-        {...popperProps}
-        style={{
-          ...popperProps.style,
-          // if the Popper hasn't been placed yet (not all measurements done)
-          // we prevent animations so that users's animation don't kick in too early referring wrong sides
-          animation: !isPlaced ? 'none' : undefined,
-        }}
-        ref={composedPopperRef}
-        data-side={placedSide}
-        data-align={placedAlign}
-      >
-        <PopperContext.Provider value={context}>{children}</PopperContext.Provider>
-      </Primitive>
+      <PopperContext.Provider value={context}>
+        <Primitive
+          selector={selector}
+          {...popperProps}
+          style={{
+            ...popperProps.style,
+            // if the Popper hasn't been placed yet (not all measurements done)
+            // we prevent animations so that users's animation don't kick in too early referring wrong sides
+            animation: !isPlaced ? 'none' : undefined,
+          }}
+          ref={composedPopperRef}
+          data-side={placedSide}
+          data-align={placedAlign}
+        />
+      </PopperContext.Provider>
     </div>
   );
 }) as PopperPrimitive;

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -37,7 +37,6 @@ type ProgressPrimitive = Polymorphic.ForwardRefComponent<
 const Progress = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(PROGRESS_NAME),
-    children,
     value: valueProp,
     max: maxProp,
     getValueLabel = defaultGetValueLabel,
@@ -50,21 +49,21 @@ const Progress = React.forwardRef((props, forwardedRef) => {
   const valueLabel = isNumber(value) ? getValueLabel(value, max) : undefined;
 
   return (
-    <Primitive
-      aria-valuemax={max}
-      aria-valuemin={0}
-      aria-valuenow={isNumber(value) ? value : undefined}
-      aria-valuetext={valueLabel}
-      role="progressbar"
-      {...progressProps}
-      selector={selector}
-      ref={forwardedRef}
-      data-state={getProgressState(value, max)}
-      data-value={value ?? undefined}
-      data-max={max}
-    >
-      <ProgressContext.Provider value={ctx}>{children}</ProgressContext.Provider>
-    </Primitive>
+    <ProgressContext.Provider value={ctx}>
+      <Primitive
+        aria-valuemax={max}
+        aria-valuemin={0}
+        aria-valuenow={isNumber(value) ? value : undefined}
+        aria-valuetext={valueLabel}
+        role="progressbar"
+        {...progressProps}
+        selector={selector}
+        ref={forwardedRef}
+        data-state={getProgressState(value, max)}
+        data-value={value ?? undefined}
+        data-max={max}
+      />
+    </ProgressContext.Provider>
   );
 }) as ProgressPrimitive;
 

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -41,7 +41,6 @@ const Radio = React.forwardRef((props, forwardedRef) => {
     as = RADIO_DEFAULT_TAG,
     selector = getSelector(RADIO_NAME),
     'aria-labelledby': ariaLabelledby,
-    children,
     name,
     checked: checkedProp,
     defaultChecked,
@@ -83,29 +82,29 @@ const Radio = React.forwardRef((props, forwardedRef) => {
           setChecked(event.target.checked);
         })}
       />
-      <Primitive
-        type="button"
-        {...radioProps}
-        as={as}
-        selector={selector}
-        ref={ref}
-        role="radio"
-        aria-checked={checked}
-        aria-labelledby={labelledBy}
-        data-state={getState(checked)}
-        data-readonly={readOnly}
-        disabled={disabled}
-        value={value}
-        /**
-         * The `input` is hidden, so when the button is clicked we trigger
-         * the input manually
-         */
-        onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
-          checkForDefaultPrevented: false,
-        })}
-      >
-        <RadioContext.Provider value={checked}>{children}</RadioContext.Provider>
-      </Primitive>
+      <RadioContext.Provider value={checked}>
+        <Primitive
+          type="button"
+          {...radioProps}
+          as={as}
+          selector={selector}
+          ref={ref}
+          role="radio"
+          aria-checked={checked}
+          aria-labelledby={labelledBy}
+          data-state={getState(checked)}
+          data-readonly={readOnly}
+          disabled={disabled}
+          value={value}
+          /**
+           * The `input` is hidden, so when the button is clicked we trigger
+           * the input manually
+           */
+          onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
+            checkForDefaultPrevented: false,
+          })}
+        />
+      </RadioContext.Provider>
     </>
   );
 }) as RadioPrimitive;

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -52,7 +52,6 @@ const RadioGroup = React.forwardRef((props, forwardedRef) => {
     selector = getSelector(RADIO_GROUP_NAME),
     'aria-labelledby': ariaLabelledby,
     defaultValue,
-    children,
     value: valueProp,
     required,
     onValueChange,
@@ -78,17 +77,17 @@ const RadioGroup = React.forwardRef((props, forwardedRef) => {
   );
 
   return (
-    <Primitive
-      {...groupProps}
-      selector={selector}
-      ref={forwardedRef}
-      role="radiogroup"
-      aria-labelledby={labelledBy}
-    >
-      <RadioGroupContext.Provider value={context}>
-        <RovingFocusGroup loop>{children}</RovingFocusGroup>
-      </RadioGroupContext.Provider>
-    </Primitive>
+    <RadioGroupContext.Provider value={context}>
+      <RovingFocusGroup loop>
+        <Primitive
+          {...groupProps}
+          selector={selector}
+          ref={forwardedRef}
+          role="radiogroup"
+          aria-labelledby={labelledBy}
+        />
+      </RovingFocusGroup>
+    </RadioGroupContext.Provider>
   );
 }) as RadioGroupPrimitive;
 

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -208,7 +208,7 @@ type ScrollAreaPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollArea = React.forwardRef(function ScrollArea(props, forwardedRef) {
-  const { unstable_forceNative: forceNative = false, children, ...restProps } = {
+  const { unstable_forceNative: forceNative = false, ...restProps } = {
     ...ROOT_DEFAULT_PROPS,
     ...props,
   };
@@ -227,14 +227,14 @@ const ScrollArea = React.forwardRef(function ScrollArea(props, forwardedRef) {
   useExtendedScrollAreaRef(forwardedRef as any, scrollAreaRef, positionRef);
 
   return (
-    <ScrollAreaCustomOrNative
-      positionRef={positionRef}
-      scrollAreaRef={scrollAreaRef}
-      {...restProps}
-      ref={forwardedRef}
-    >
-      <NativeScrollContext.Provider value={usesNative}>{children}</NativeScrollContext.Provider>
-    </ScrollAreaCustomOrNative>
+    <NativeScrollContext.Provider value={usesNative}>
+      <ScrollAreaCustomOrNative
+        positionRef={positionRef}
+        scrollAreaRef={scrollAreaRef}
+        {...restProps}
+        ref={forwardedRef}
+      />
+    </NativeScrollContext.Provider>
   );
 }) as ScrollAreaPrimitive;
 
@@ -249,21 +249,21 @@ type ScrollAreaNoNativeFallbackPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaNoNativeFallback = React.forwardRef(function ScrollArea(props, forwardedRef) {
-  const { children, ...restProps } = {
+  const { ...restProps } = {
     ...ROOT_DEFAULT_PROPS,
     ...props,
   };
   const positionRef = React.useRef<HTMLDivElement>(null);
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   return (
-    <ScrollAreaImpl
-      positionRef={positionRef}
-      scrollAreaRef={scrollAreaRef}
-      {...restProps}
-      ref={forwardedRef}
-    >
-      <NativeScrollContext.Provider value={false}>{children}</NativeScrollContext.Provider>
-    </ScrollAreaImpl>
+    <NativeScrollContext.Provider value={false}>
+      <ScrollAreaImpl
+        positionRef={positionRef}
+        scrollAreaRef={scrollAreaRef}
+        {...restProps}
+        ref={forwardedRef}
+      />
+    </NativeScrollContext.Provider>
   );
 }) as ScrollAreaNoNativeFallbackPrimitive;
 
@@ -352,7 +352,6 @@ const initialState: ScrollAreaReducerState = {
 const ScrollAreaImpl = React.forwardRef(function ScrollAreaImpl(props, forwardedRef) {
   const {
     selector = getSelector(ROOT_NAME),
-    children,
     onScroll,
     overflowX,
     overflowY,
@@ -502,9 +501,7 @@ const ScrollAreaImpl = React.forwardRef(function ScrollAreaImpl(props, forwarded
               }}
               onPointerEnter={composeEventHandlers(props.onPointerEnter, onPointerEnter)}
               onPointerLeave={composeEventHandlers(props.onPointerLeave, onPointerLeave)}
-            >
-              {children}
-            </Primitive>
+            />
           </ScrollAreaStateContext.Provider>
         </ScrollAreaContext.Provider>
       </ScrollAreaRefsContext.Provider>
@@ -707,7 +704,7 @@ const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(props, f
 
 ScrollAreaViewport.displayName = VIEWPORT_NAME;
 
-/* -------------------------------------------------------------------------------------------------
+/* ---------------------------------------------------  ----------------------------------------------
  * ScrollAreaScrollbarX / ScrollAreaScrollbarY
  * -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -704,7 +704,7 @@ const ScrollAreaViewport = React.forwardRef(function ScrollAreaViewport(props, f
 
 ScrollAreaViewport.displayName = VIEWPORT_NAME;
 
-/* ---------------------------------------------------  ----------------------------------------------
+/* -------------------------------------------------------------------------------------------------
  * ScrollAreaScrollbarX / ScrollAreaScrollbarY
  * -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -249,7 +249,7 @@ type ScrollAreaNoNativeFallbackPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ScrollAreaNoNativeFallback = React.forwardRef(function ScrollArea(props, forwardedRef) {
-  const { ...restProps } = {
+  const restProps = {
     ...ROOT_DEFAULT_PROPS,
     ...props,
   };

--- a/packages/react/slider/src/Slider.stories.tsx
+++ b/packages/react/slider/src/Slider.stories.tsx
@@ -13,6 +13,15 @@ export const Styled = () => (
   </Slider>
 );
 
+export const RightToLeft = () => (
+  <Slider as={StyledRoot} dir="rtl">
+    <SliderTrack as={StyledTrack}>
+      <SliderRange as={StyledRange} />
+    </SliderTrack>
+    <SliderThumb as={StyledThumb} />
+  </Slider>
+);
+
 export const Horizontal = () => (
   <>
     <Slider

--- a/packages/react/slot/README.md
+++ b/packages/react/slot/README.md
@@ -1,0 +1,13 @@
+# `react-slot`
+
+## Installation
+
+```sh
+$ yarn add @radix-ui/react-slot
+# or
+$ npm install @radix-ui/react-slot
+```
+
+## Usage
+
+View docs [here](https://radix-ui.com/primitives/docs/utilities/slot).

--- a/packages/react/slot/package.json
+++ b/packages/react/slot/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@radix-ui/react-slot",
+  "version": "0.0.0",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prepublish": "yarn clean"
+  },
+  "dependencies": {
+    "@radix-ui/react-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0"
+  },
+  "homepage": "https://radix-ui.com/primitives",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/radix-ui/primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/radix-ui/primitives/issues"
+  }
+}

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Slot, Slottable } from './Slot';
+
+export default { title: 'Components/Slot' };
+
+export const WithoutSlottable = () => (
+  <AsCompWithoutSlottable as={Slot}>
+    <b data-slot-element>hello</b>
+  </AsCompWithoutSlottable>
+);
+
+export const WithSlottable = () => (
+  <AsCompWithSlottable as={Slot}>
+    <b data-slot-element>hello</b>
+  </AsCompWithSlottable>
+);
+
+type AsCompProps = React.ComponentProps<'div'> & { as: React.ElementType };
+
+const AsCompWithoutSlottable = ({ as: Comp = 'div', ...props }: AsCompProps) => <Comp {...props} />;
+const AsCompWithSlottable = ({ as: Comp = 'div', children, ...props }: AsCompProps) => (
+  <Comp {...props}>
+    <Slottable>{children}</Slottable>
+    <span>world</span>
+  </Comp>
+);

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -68,7 +68,9 @@ const Slottable = ({ children }: { children: React.ReactNode }) => {
 
 /* ---------------------------------------------------------------------------------------------- */
 
-function mergeProps<P extends { [key: string]: any }>(baseProps: P, otherProps: P) {
+type AnyProps = Record<string, any>;
+
+function mergeProps(baseProps: AnyProps, otherProps: AnyProps) {
   // all other props should override
   const overrideProps = { ...otherProps };
 
@@ -82,7 +84,7 @@ function mergeProps<P extends { [key: string]: any }>(baseProps: P, otherProps: 
       // make sure we only override handlers which are actually passed in as functions
       overrideProps[propName] =
         typeof basePropValue === 'function' && typeof otherPropValue === 'function'
-          ? (composeEventHandlers(otherPropValue, basePropValue) as any)
+          ? composeEventHandlers(otherPropValue, basePropValue)
           : basePropValue;
     }
   }

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -7,7 +7,7 @@ import { composeRefs } from '@radix-ui/react-utils';
 
 type SlotProps = { children: React.ReactNode };
 
-const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
+const Slot = React.forwardRef<never, SlotProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
   const childLength = React.Children.count(children);
 

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -22,15 +22,15 @@ const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
   return (
     <>
       {React.Children.map(children, (child) => {
-        if (!React.isValidElement(child) || child.type !== Slottable) {
-          return child;
+        if (React.isValidElement(child) && child.type === Slottable) {
+          return (
+            <SlotClone {...slotProps} ref={forwardedRef}>
+              {child.props.children}
+            </SlotClone>
+          );
         }
 
-        return (
-          <SlotClone {...slotProps} ref={forwardedRef}>
-            {child.props.children}
-          </SlotClone>
-        );
+        return child;
       })}
     </>
   );

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { composeRefs } from '@radix-ui/react-utils';
+
+/* -------------------------------------------------------------------------------------------------
+ * Slot
+ * -----------------------------------------------------------------------------------------------*/
+
+type SlotProps = { children: React.ReactNode };
+
+const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
+  const { children, ...slotProps } = props;
+  const childLength = React.Children.count(children);
+
+  if (childLength === 1) {
+    return (
+      <SlotClone {...slotProps} ref={forwardedRef}>
+        {children}
+      </SlotClone>
+    );
+  }
+
+  return (
+    <>
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child) || child.type !== Slottable) {
+          return child;
+        }
+
+        return (
+          <SlotClone {...slotProps} ref={forwardedRef}>
+            {child.props.children}
+          </SlotClone>
+        );
+      })}
+    </>
+  );
+});
+
+Slot.displayName = 'Slot';
+
+/* -------------------------------------------------------------------------------------------------
+ * SlotClone
+ * -----------------------------------------------------------------------------------------------*/
+
+type SlotCloneProps = { children: React.ReactNode };
+
+const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
+  const { children, ...cloneProps } = props;
+  const child = React.Children.only(children);
+
+  return React.isValidElement(child)
+    ? React.cloneElement(child, {
+        ...cloneProps,
+        ...child.props,
+        ref: composeRefs(forwardedRef, (child as any).ref),
+      })
+    : null;
+});
+
+SlotClone.displayName = 'SlotClone';
+
+/* -------------------------------------------------------------------------------------------------
+ * Slottable
+ * -----------------------------------------------------------------------------------------------*/
+
+const Slottable = ({ children }: { children: React.ReactNode }) => {
+  return children as React.ReactElement;
+};
+
+/* ---------------------------------------------------------------------------------------------- */
+
+export { Slot, Slottable };

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Slot';

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -43,7 +43,6 @@ const Switch = React.forwardRef((props, forwardedRef) => {
     as = SWITCH_DEFAULT_TAG,
     selector = getSelector(SWITCH_NAME),
     'aria-labelledby': ariaLabelledby,
-    children,
     name,
     checked: checkedProp,
     defaultChecked,
@@ -85,30 +84,30 @@ const Switch = React.forwardRef((props, forwardedRef) => {
           setChecked(event.target.checked);
         })}
       />
-      <Primitive
-        type="button"
-        {...switchProps}
-        as={as}
-        selector={selector}
-        ref={ref}
-        role="switch"
-        aria-checked={checked}
-        aria-labelledby={labelledBy}
-        aria-required={required}
-        data-state={getState(checked)}
-        data-readonly={readOnly}
-        disabled={disabled}
-        value={value}
-        /**
-         * The `input` is hidden, so when the button is clicked we trigger
-         * the input manually
-         */
-        onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
-          checkForDefaultPrevented: false,
-        })}
-      >
-        <SwitchContext.Provider value={checked}>{children}</SwitchContext.Provider>
-      </Primitive>
+      <SwitchContext.Provider value={checked}>
+        <Primitive
+          type="button"
+          {...switchProps}
+          as={as}
+          selector={selector}
+          ref={ref}
+          role="switch"
+          aria-checked={checked}
+          aria-labelledby={labelledBy}
+          aria-required={required}
+          data-state={getState(checked)}
+          data-readonly={readOnly}
+          disabled={disabled}
+          value={value}
+          /**
+           * The `input` is hidden, so when the button is clicked we trigger
+           * the input manually
+           */
+          onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
+            checkForDefaultPrevented: false,
+          })}
+        />
+      </SwitchContext.Provider>
     </>
   );
 }) as SwitchPrimitive;

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -60,7 +60,6 @@ type TabsPrimitive = Polymorphic.ForwardRefComponent<
 const Tabs = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(TABS_NAME),
-    children,
     id,
     value: valueProp,
     onValueChange,
@@ -92,9 +91,7 @@ const Tabs = React.forwardRef((props, forwardedRef) => {
         {...tabsProps}
         selector={selector}
         ref={forwardedRef}
-      >
-        {children}
-      </Primitive>
+      />
     </TabsContext.Provider>
   );
 }) as TabsPrimitive;
@@ -124,22 +121,20 @@ type TabsListPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const TabsList = React.forwardRef((props, forwardedRef) => {
-  const { selector = getSelector(TAB_LIST_NAME), loop = true, children, ...otherProps } = props;
+  const { selector = getSelector(TAB_LIST_NAME), loop = true, ...otherProps } = props;
   const { orientation } = useTabsContext(TAB_LIST_NAME);
 
   return (
-    <Primitive
-      data-orientation={orientation}
-      role="tablist"
-      aria-orientation={orientation}
-      {...otherProps}
-      selector={selector}
-      ref={forwardedRef}
-    >
-      <RovingFocusGroup orientation={orientation} loop={loop}>
-        {children}
-      </RovingFocusGroup>
-    </Primitive>
+    <RovingFocusGroup orientation={orientation} loop={loop}>
+      <Primitive
+        data-orientation={orientation}
+        role="tablist"
+        aria-orientation={orientation}
+        {...otherProps}
+        selector={selector}
+        ref={forwardedRef}
+      />
+    </RovingFocusGroup>
   );
 }) as TabsListPrimitive;
 

--- a/packages/react/toggle-button/src/ToggleButton.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.tsx
@@ -37,7 +37,6 @@ const ToggleButton = React.forwardRef((props, forwardedRef) => {
     defaultToggled = false,
     onClick,
     onToggledChange,
-    children,
     ...buttonProps
   } = props;
 
@@ -62,9 +61,7 @@ const ToggleButton = React.forwardRef((props, forwardedRef) => {
           setToggled(!toggled);
         }
       })}
-    >
-      {children}
-    </Primitive>
+    />
   );
 }) as ToggleButtonPrimitive;
 

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-popper": "workspace:*",
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-utils": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
     "@radix-ui/utils": "workspace:*"

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipArrow } from './Tooltip';
 import { Arrow } from '@radix-ui/react-arrow';
+import { Slot } from '@radix-ui/react-slot';
 import { styled, css } from '../../../../stitches.config';
 
 export default { title: 'Components/Tooltip' };
 
 export const Styled = () => (
   <Tooltip>
-    <TooltipTrigger as={StyledTrigger} style={{ margin: 100 }}>
-      Hover or Focus me
-    </TooltipTrigger>
-    <TooltipContent as={StyledContent} sideOffset={5} aria-label="Even better done this way!">
+    <TooltipTrigger as={StyledTrigger}>Hover or Focus me</TooltipTrigger>
+    <TooltipContent as={StyledContent} sideOffset={5}>
       Nicely done!
       <TooltipArrow as={StyledArrow} offset={10} />
     </TooltipContent>
@@ -340,6 +339,18 @@ export const Animated = () => {
     </div>
   );
 };
+
+export const SlottableContent = () => (
+  <Tooltip>
+    <TooltipTrigger as={StyledTrigger}>Hover or Focus me</TooltipTrigger>
+    <TooltipContent as={Slot} sideOffset={5}>
+      <StyledContent>
+        Nicely done!
+        <TooltipArrow as={StyledArrow} offset={10} />
+      </StyledContent>
+    </TooltipContent>
+  </Tooltip>
+);
 
 function SimpleTooltip({
   children,

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -14,6 +14,7 @@ import {
 import { Primitive } from '@radix-ui/react-primitive';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
+import { Slottable } from '@radix-ui/react-slot';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { createStateMachine, stateChart } from './machine';
 
@@ -259,7 +260,7 @@ const TooltipContentImpl = React.forwardRef((props, forwardedRef) => {
           ['--radix-tooltip-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
         }}
       >
-        {children}
+        <Slottable>{children}</Slottable>
         <VisuallyHidden id={context.id} role="tooltip">
           {ariaLabel || children}
         </VisuallyHidden>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "@radix-ui/react-scroll-area": ["./packages/react/react-scroll-area/src"],
       "@radix-ui/react-separator": ["./packages/react/separator/src"],
       "@radix-ui/react-slider": ["./packages/react/slider/src"],
+      "@radix-ui/react-slot": ["./packages/react/slot/src"],
       "@radix-ui/react-switch": ["./packages/react/switch/src"],
       "@radix-ui/react-tabs": ["./packages/react/tabs/src"],
       "@radix-ui/react-toggle-button": ["./packages/react/toggle-button/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,6 +3438,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@radix-ui/react-slot@workspace:*, @radix-ui/react-slot@workspace:packages/react/slot":
+  version: 0.0.0-use.local
+  resolution: "@radix-ui/react-slot@workspace:packages/react/slot"
+  dependencies:
+    "@radix-ui/react-utils": "workspace:*"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  languageName: unknown
+  linkType: soft
+
 "@radix-ui/react-switch@workspace:packages/react/switch":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-switch@workspace:packages/react/switch"
@@ -3487,6 +3497,7 @@ __metadata:
     "@radix-ui/react-popper": "workspace:*"
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
     "@radix-ui/utils": "workspace:*"


### PR DESCRIPTION
Allows consumers to turn any of our components into a "slot" when wrapping to create more closed APIs. For example:

```jsx
function Tooltip({ label, children }) {
	return (
		<TooltipPrimitive.Root>
			<TooltipPrimitive.Trigger as={Slot}>
				{children}
			</TooltipPrimitive.Trigger>
			<TooltipPrimitive.Content>
				{label}
			</TooltipPrimitive.Content>
		</TooltipPrimitive.Root>
	);
}

// Usage
<Tooltip label="Notifications" sideOffset={5}>
	<button onClick={handleNotificationsClick}>
		<svg><path /></svg>
	</button>
</Tooltip>
```

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [X] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [X] Other
