### PR TITLE
[Portal] Fix potential out of the box layering issues

### DIFF
--- a/.yarn/versions/8ca9debf.yml
+++ b/.yarn/versions/8ca9debf.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -16,7 +16,10 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
-    "@radix-ui/react-utils": "workspace:*"
+    "@radix-ui/react-polymorphic": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-utils": "workspace:*",
+    "@radix-ui/utils": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/portal/src/Portal.stories.tsx
+++ b/packages/react/portal/src/Portal.stories.tsx
@@ -19,7 +19,7 @@ export const Base = () => (
       necessitatibus eius pariatur.
     </p>
 
-    <Portal>
+    <Portal style={{ position: 'relative' }}>
       <h1>This content is rendered in a portal (another DOM tree)</h1>
       <p>
         Because of the portal, it can appear in a different DOM tree from the main one (by default a

--- a/packages/react/portal/src/Portal.test.tsx
+++ b/packages/react/portal/src/Portal.test.tsx
@@ -8,9 +8,12 @@ describe('Portal', () => {
     expect(baseElement).toMatchInlineSnapshot(`
       <body>
         <div />
-        <radix-portal>
+        <div
+          data-radix-portal=""
+          style="position: absolute; top: 0px; left: 0px; z-index: 2147483647;"
+        >
           portal
-        </radix-portal>
+        </div>
       </body>
     `);
   });
@@ -25,12 +28,18 @@ describe('Portal', () => {
     expect(baseElement).toMatchInlineSnapshot(`
       <body>
         <div />
-        <radix-portal>
+        <div
+          data-radix-portal=""
+          style="position: absolute; top: 0px; left: 0px; z-index: 2147483647;"
+        >
           portal 1
-        </radix-portal>
-        <radix-portal>
+        </div>
+        <div
+          data-radix-portal=""
+          style="position: absolute; top: 0px; left: 0px; z-index: 2147483647;"
+        >
           portal 2
-        </radix-portal>
+        </div>
       </body>
     `);
   });
@@ -52,9 +61,11 @@ describe('Portal', () => {
           <section
             id="portal-container"
           >
-            <radix-portal>
+            <div
+              data-radix-portal=""
+            >
               portal inside custom container
-            </radix-portal>
+            </div>
           </section>
         </div>
       </body>

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -1,13 +1,34 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { useLayoutEffect } from '@radix-ui/react-utils';
+import { getSelector } from '@radix-ui/utils';
+import { Primitive } from '@radix-ui/react-primitive';
 
-type PortalProps = {
-  children: React.ReactNode;
-  containerRef?: React.RefObject<HTMLElement>;
-};
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+import type { Merge } from '@radix-ui/utils';
 
-const Portal: React.FC<PortalProps> = ({ children, containerRef }) => {
+const MAX_Z_INDEX = 2147483647;
+
+/* -------------------------------------------------------------------------------------------------
+ * Portal
+ * -----------------------------------------------------------------------------------------------*/
+
+const PORTAL_NAME = 'Portal';
+
+type PortalOwnProps = Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    containerRef?: React.RefObject<HTMLElement>;
+  }
+>;
+
+type PortalPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  PortalOwnProps
+>;
+
+const Portal = React.forwardRef((props, forwardedRef) => {
+  const { selector = getSelector(PORTAL_NAME), containerRef, style, ...portalProps } = props;
   const hostElement =
     containerRef?.current ?? (typeof document !== 'undefined' ? document.body : undefined);
   const [, forceUpdate] = React.useState({});
@@ -21,13 +42,36 @@ const Portal: React.FC<PortalProps> = ({ children, containerRef }) => {
   }, []);
 
   if (hostElement) {
-    const RadixPortal = 'radix-portal' as any;
-    return ReactDOM.createPortal(<RadixPortal>{children}</RadixPortal>, hostElement);
+    return ReactDOM.createPortal(
+      <Primitive
+        selector={selector}
+        {...portalProps}
+        ref={forwardedRef}
+        style={
+          /**
+           * If the Portal is injected in `body`, we assume we want whatever is portalled
+           * to appear on top of everything. Ideally this would be handled by making sure the
+           * app root creates a new stacking context, however this is quite hard to automate.
+           * For this reason, we have opted for setting the max z-index on the portal itself.
+           */
+          hostElement === document.body
+            ? {
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                zIndex: MAX_Z_INDEX,
+                ...style,
+              }
+            : undefined
+        }
+      />,
+      hostElement
+    );
   }
 
   // bail out of ssr
   return null;
-};
+}) as PortalPrimitive;
 
 const Root = Portal;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,7 +3326,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-portal@workspace:packages/react/portal"
   dependencies:
+    "@radix-ui/react-polymorphic": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
+    "@radix-ui/utils": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0


### PR DESCRIPTION
If the `Portal` is injected in `body` (default behaviour), we will now assume we want whatever is portalled to appear on top of everything.

Ideally this would be handled by making sure the app root creates a new stacking context, however this is quite hard to automate and we have had many users getting tripped up by this already (see #368, https://github.com/modulz/composer/pull/97 for example).

For this reason, we have opted for setting the max z-index on the portal itself in such cases.

Also, standardizes the portal element to follow the usual convention of other primitives, with regards to as, types and selector.

> 🔥 NOTE: This is a potential breaking change as the element rendered used to be `<radix-portal>` and will now be `<div data-radix-portal>`