### PR TITLE
[Popper] Fix collapsing layout issues

### DIFF
--- a/.yarn/versions/c0ee0213.yml
+++ b/.yarn/versions/c0ee0213.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -301,6 +301,7 @@ function getPlacementStylesForPoint(point: Point): CSS.Properties {
     position: 'absolute',
     top: 0,
     left: 0,
+    minWidth: 'max-content',
     willChange: 'transform',
     transform: `translate3d(${x}px, ${y}px, 0)`,
   };


### PR DESCRIPTION
We noticed an issue with Popover flashing (sliding) when positioning.
This was due to the changes we made to `Portal` adding styles to position above things.
The main issue is that now we have 2 parents with `position: absolute` and so intrinsic-sized elements would collapse. 

> Update: we've now made a more surgical fix in popper itself.