### PR TITLE
[Polymorphic] Fix type autocompletion for polymorphic components

### DIFF
--- a/.yarn/versions/4cd277fa.yml
+++ b/.yarn/versions/4cd277fa.yml
@@ -1,0 +1,40 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
+++ b/packages/react/polymorphic/src/forwardRefWithAs.test.tsx
@@ -39,17 +39,8 @@ const ExtendedButtonUsingReactUtils = React.forwardRef<
 export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(
   props: React.ComponentProps<typeof Button>
 ) {
-  /* Should complain about implicit `any` for inline props */
-  /* @ts-expect-error */
-  const implicitAnyProps = <Button as={(props) => <button {...props} />} {...props} />;
   /* Should not error with inline `as` component */
-  const explicitAnyProps = <Button as={(props: any) => <button {...props} />} {...props} />;
-  return (
-    <>
-      {implicitAnyProps}
-      {explicitAnyProps}
-    </>
-  );
+  return <Button as={(props) => <button {...props} />} {...props} />;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/react/polymorphic/src/forwardRefWithAs.ts
+++ b/packages/react/polymorphic/src/forwardRefWithAs.ts
@@ -18,6 +18,8 @@ type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : {};
  */
 type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : never;
 
+type NarrowIntrinsic<E> = E extends keyof JSX.IntrinsicElements ? E : never;
+
 /* -------------------------------------------------------------------------------------------------
  * ForwardRefComponent
  * -----------------------------------------------------------------------------------------------*/
@@ -33,31 +35,26 @@ interface ForwardRefComponent<
     MergeProps<IntrinsicElementString, OwnProps & { as?: IntrinsicElementString }>
   > {
   /**
-   * When passing an `as` prop as a component, use this overload.
-   * Merges orignal own props (without DOM props) and the inferred props
-   * from `as` element with the own props taking precendence.
-   *
-   * We don't use `React.ComponentType` here as we get type errors
-   * when consumers try to do inline `as` components.
-   */
-  <
-    As extends React.ElementType<any>,
-    // Inferring with props so inline `as` components get implicit `any` errors
-    // e.g. `as={(props) => {}}` <-- `props` errors
-    _AsWithProps = As extends React.ElementType<infer P> ? React.ElementType<P> : never
-  >(
-    props: MergeProps<_AsWithProps, OwnProps & { as: _AsWithProps }>
-  ): React.ReactElement | null;
-
-  /**
    * When passing an `as` prop as a string, use this overload.
-   * Merges orignal own props (without DOM props) and the inferred props
+   * Merges original own props (without DOM props) and the inferred props
    * from `as` element with the own props taking precendence.
    *
    * We explicitly define a `JSX.IntrinsicElements` overload so that
    * events are typed for consumers.
    */
-  <As extends keyof JSX.IntrinsicElements>(
+  <As extends keyof JSX.IntrinsicElements = NarrowIntrinsic<IntrinsicElementString>>(
+    props: MergeProps<As, OwnProps & { as: As }>
+  ): React.ReactElement | null;
+
+  /**
+   * When passing an `as` prop as a component, use this overload.
+   * Merges original own props (without DOM props) and the inferred props
+   * from `as` element with the own props taking precendence.
+   *
+   * We don't use `React.ComponentType` here as we get type errors
+   * when consumers try to do inline `as` components.
+   */
+  <As extends React.ElementType>(
     props: MergeProps<As, OwnProps & { as: As }>
   ): React.ReactElement | null;
 }


### PR DESCRIPTION
Although all of our polymorphic type tests are passing, we don't know of a way to test the autocompletion element of TS and Pedro spotted that it wasn't working.

This PR fixes autocomplete:

https://user-images.githubusercontent.com/175330/106663246-58422c00-659b-11eb-86db-9dca344ca261.mov

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
