### PR TITLE
[Dialog][Popover][Menu] Prevent delayed trapping

### DIFF
--- a/.yarn/versions/3cd46ef0.yml
+++ b/.yarn/versions/3cd46ef0.yml
@@ -1,0 +1,10 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -244,7 +244,8 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
     <Portal>
       <RemoveScroll>
         <FocusScope
-          // we make sure we're not trapping once it's been closed.
+          // we make sure we're not trapping once it's been closed
+          // (closed !== unmounted when animating out)
           trapped={context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={onCloseAutoFocus}

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -244,7 +244,8 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
     <Portal>
       <RemoveScroll>
         <FocusScope
-          trapped
+          // we make sure we're not trapping once it's been closed.
+          trapped={context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={onCloseAutoFocus}
         >

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -69,7 +69,7 @@ const Menu = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Presence present={forceMount || open}>
-      <MenuImpl ref={forwardedRef} {...menuProps} data-state={getOpenState(open)} />
+      <MenuImpl ref={forwardedRef} {...menuProps} open={open} data-state={getOpenState(open)} />
     </Presence>
   );
 }) as MenuPrimitive;
@@ -77,6 +77,7 @@ const Menu = React.forwardRef((props, forwardedRef) => {
 type MenuImplOwnProps = Merge<
   Polymorphic.OwnProps<typeof PopperPrimitive.Root>,
   {
+    open: boolean;
     onOpenChange?: (open: boolean) => void;
     loop?: boolean;
 
@@ -155,6 +156,7 @@ type MenuImplPrimitive = Polymorphic.ForwardRefComponent<
 const MenuImpl = React.forwardRef((props, forwardedRef) => {
   const {
     selector = getSelector(MENU_NAME),
+    open,
     onOpenChange,
     anchorRef,
     loop,
@@ -218,7 +220,8 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
             <FocusScope
               // clicking outside may raise a focusout event, which may get trapped.
               // in cases where outside pointer events are permitted, we stop trapping.
-              trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
+              // we also make sure we're not trapping once it's been closed.
+              trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && open}
               onMountAutoFocus={onOpenAutoFocus}
               onUnmountAutoFocus={(event) => {
                 // skip autofocus on unmount if clicking outside is permitted and it happened

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -220,7 +220,8 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
             <FocusScope
               // clicking outside may raise a focusout event, which may get trapped.
               // in cases where outside pointer events are permitted, we stop trapping.
-              // we also make sure we're not trapping once it's been closed.
+              // we also make sure we're not trapping once it's been closed
+              // (closed !== unmounted when animating out)
               trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && open}
               onMountAutoFocus={onOpenAutoFocus}
               onUnmountAutoFocus={(event) => {

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -257,7 +257,8 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
         <FocusScope
           // clicking outside may raise a focusout event, which may get trapped.
           // in cases where outside pointer events are permitted, we stop trapping.
-          // we also make sure we're not trapping once it's been closed.
+          // we also make sure we're not trapping once it's been closed
+          // (closed !== unmounted when animating out)
           trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={(event) => {

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -257,7 +257,8 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
         <FocusScope
           // clicking outside may raise a focusout event, which may get trapped.
           // in cases where outside pointer events are permitted, we stop trapping.
-          trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus}
+          // we also make sure we're not trapping once it's been closed.
+          trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={(event) => {
             // skip autofocus on close if clicking outside is permitted and it happened


### PR DESCRIPTION
Closes #419

Because of the fact some of our components use `Presence` to ensure animating on unmount can be done, unmounting is actually potentially delayed by a couple frames.

This could cause our `FocusScope` unmount focus event to be trapped even though we've actually already closed the component (Dialog, Popover, Menu, etc).

For some reason, it sent Chrome into a weird state in these conditions which meant nothing was really focused (even though it reports `document.activeElement === document.body`…).