### PR TITLE
Add version check to pre-push

### DIFF
--- a/.yarn/versions/199e942a.yml
+++ b/.yarn/versions/199e942a.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged && lint-staged",
-      "pre-push": "yarn types:check"
+      "pre-push": "yarn types:check && yarn bump:check"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
It has been bugging us that the version check always trips us up but we only find out it's an issue during CI. This will hopefully catch this issue sooner before we switch to different tasks!