### PR TITLE
[Accordion] Fix open/close flicker

### DIFF
--- a/.yarn/versions/5499fbcf.yml
+++ b/.yarn/versions/5499fbcf.yml
@@ -1,0 +1,15 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.test.tsx
+++ b/packages/react/checkbox/src/Checkbox.test.tsx
@@ -27,6 +27,7 @@ describe('given a default Checkbox', () => {
       fireEvent.click(checkbox);
       await waitFor(() => {
         indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
+        expect(indicator).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
Closes #416 .

I've had to bite the bullet here and delay mount to. Tbh, it actually makes sense that `Presence` would ensure mount and unmount happen in the same frame. 

I can't think of a reason why delaying the mount by a frame will cause any issues but let me know if you can.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
