### PR TITLE
Add flag to improve Chromatic action speed

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,3 +18,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
+          exitZeroOnChanges: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true

--- a/.yarn/versions/82b83501.yml
+++ b/.yarn/versions/82b83501.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.stories.tsx
+++ b/packages/react/accordion/src/Accordion.stories.tsx
@@ -138,7 +138,7 @@ export const Chromatic = () => {
   const items = ['One', 'Two', 'Three', 'Four'];
   return (
     <>
-      <h1>Uncontrolled Test</h1>
+      <h1>Uncontrolled</h1>
       <h2>Closed</h2>
       <Accordion className={rootClass}>
         {items.map((item) => (

--- a/packages/react/accordion/src/Accordion.stories.tsx
+++ b/packages/react/accordion/src/Accordion.stories.tsx
@@ -138,7 +138,7 @@ export const Chromatic = () => {
   const items = ['One', 'Two', 'Three', 'Four'];
   return (
     <>
-      <h1>Uncontrolled</h1>
+      <h1>Uncontrolled Test</h1>
       <h2>Closed</h2>
       <Accordion className={rootClass}>
         {items.map((item) => (


### PR DESCRIPTION
Adding `--exit-once-uploaded` and `--exit-zero-on-changes` flags to improve github action speed.