### PR TITLE
Chromatic build for `main` pushes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,12 @@
 name: 'Chromatic'
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+  # "You must append a colon (:) to all events, including events without configuration."
+  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-multiple-events-with-activity-types-or-configuration
+  pull_request:
 
 jobs:
   chromatic-deployment:

--- a/.yarn/versions/b232b1ff.yml
+++ b/.yarn/versions/b232b1ff.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives


### PR DESCRIPTION
We need these apparently. This will consume our screenshot quota quite a bit more but I've started the OSS project process with Chromatic team as we can apparently have an increased quota this way 🤞 