### PR TITLE
[Slider] Fix step rounding issue

### DIFF
--- a/.yarn/versions/0014e767.yml
+++ b/.yarn/versions/0014e767.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-slider": patch
+
+declined:
+  - primitives

--- a/packages/react/slider/src/Slider.stories.tsx
+++ b/packages/react/slider/src/Slider.stories.tsx
@@ -114,6 +114,28 @@ export const WithMultipleRanges = () => {
   );
 };
 
+export const SmallSteps = () => {
+  const [value, setValue] = React.useState([0.1]);
+  return (
+    <>
+      <Slider
+        className={rootClass}
+        value={value}
+        onValueChange={setValue}
+        min={0.1}
+        max={0.2}
+        step={0.003}
+      >
+        <SliderTrack className={trackClass}>
+          <SliderRange className={rangeClass} />
+        </SliderTrack>
+        <SliderThumb className={thumbClass} />
+      </Slider>
+      <div>{value}</div>
+    </>
+  );
+};
+
 export const Chromatic = () => (
   <>
     <h1>Uncontrolled</h1>

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -75,7 +75,7 @@ const Slider = React.forwardRef((props, forwardedRef) => {
     name,
     min = 0,
     max = 100,
-    step: stepProp = 1,
+    step = 1,
     orientation = 'horizontal',
     disabled = false,
     minStepsBetweenThumbs = 0,
@@ -84,8 +84,6 @@ const Slider = React.forwardRef((props, forwardedRef) => {
     onValueChange = () => {},
     ...sliderProps
   } = props;
-
-  const step = Math.max(stepProp, 1);
   const sliderRef = React.useRef<HTMLSpanElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, sliderRef);
   const thumbRefs = React.useRef<SliderContextValue['thumbs']>(new Set());
@@ -121,7 +119,8 @@ const Slider = React.forwardRef((props, forwardedRef) => {
   }
 
   function updateValues(value: number, atIndex: number): Promise<number> {
-    const snapToStep = Math.round((value - min) / step) * step + min;
+    const decimalCount = getDecimalCount(step);
+    const snapToStep = roundValue(Math.round((value - min) / step) * step + min, decimalCount);
     const nextValue = clamp(snapToStep, [min, max]);
 
     return new Promise((resolve) => {
@@ -836,6 +835,15 @@ function linearScale(domain: [number, number], range: [number, number]) {
     const ratio = (range[1] - range[0]) / (domain[1] - domain[0]);
     return range[0] + ratio * (value - domain[0]);
   };
+}
+
+function getDecimalCount(value: number) {
+  return (String(value).split('.')[1] || '').length;
+}
+
+function roundValue(value: number, decimalCount: number) {
+  const rounder = Math.pow(10, decimalCount);
+  return Math.round(value * rounder) / rounder;
 }
 
 const Root = Slider;


### PR DESCRIPTION
Closes #462

@jjenzz this is what you get if you pass `step={0}` and try and move it:
- it won't move
- the value becomes `NaN`
![image](https://user-images.githubusercontent.com/1539897/108375818-3df28a00-71fa-11eb-97d7-688a780b5cee.png)

I think that's fine personally. It's pretty obvious it shouldn't work if you say that it goes by increments of `0`.