### PR TITLE
[Presence] Improve `Presence` perf

### DIFF
--- a/.yarn/versions/99ff61ba.yml
+++ b/.yarn/versions/99ff61ba.yml
@@ -1,0 +1,15 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -16,8 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
-    "@radix-ui/react-utils": "workspace:*",
-    "@xstate/fsm": "^1.5.1"
+    "@radix-ui/react-utils": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/react/presence/src/useStateMachine.tsx
+++ b/packages/react/presence/src/useStateMachine.tsx
@@ -1,27 +1,17 @@
 import * as React from 'react';
-import { createMachine, interpret } from '@xstate/fsm';
-import type { StateMachine, EventObject, Typestate } from '@xstate/fsm';
 
-export function useStateMachine<
-  C extends object,
-  E extends EventObject = EventObject,
-  S extends Typestate<C> = { value: any; context: C }
->(fsmConfig: StateMachine.Config<C, E, S>) {
-  const [machine] = React.useState(() => interpret(createMachine<C, E, S>(fsmConfig)));
-  const [state, setState] = React.useState<S['value']>(fsmConfig.initial);
-  const [context, setContext] = React.useState<C | undefined>(fsmConfig.context);
+type Machine = { [k: string]: { [k: string]: string } };
+type MachineState<T> = keyof T;
+type MachineEvent<T> = keyof UnionToIntersection<T[keyof T]>;
 
-  React.useEffect(() => {
-    const subscription = machine.subscribe((state) => {
-      setState(state.value);
-      setContext(state.context);
-    });
-    machine.start();
-    return () => {
-      subscription.unsubscribe();
-      machine.stop();
-    };
-  }, [machine]);
+// 🤯 https://fettblog.eu/typescript-union-to-intersection/
+type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any
+  ? R
+  : never;
 
-  return React.useMemo(() => ({ state, context, send: machine.send }), [state, context, machine]);
+export function useStateMachine<M extends Machine>(initialState: MachineState<M>, machine: M) {
+  return React.useReducer((state: MachineState<M>, event: MachineEvent<M>): MachineState<M> => {
+    const nextState = (machine[state] as any)[event];
+    return nextState ?? state;
+  }, initialState);
 }

--- a/packages/react/presence/src/useStateMachine.tsx
+++ b/packages/react/presence/src/useStateMachine.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type Machine = { [k: string]: { [k: string]: string } };
+type Machine<S> = { [k: string]: { [k: string]: S } };
 type MachineState<T> = keyof T;
 type MachineEvent<T> = keyof UnionToIntersection<T[keyof T]>;
 
@@ -9,7 +9,10 @@ type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x
   ? R
   : never;
 
-export function useStateMachine<M extends Machine>(initialState: MachineState<M>, machine: M) {
+export function useStateMachine<M>(
+  initialState: MachineState<M>,
+  machine: M & Machine<MachineState<M>>
+) {
   return React.useReducer((state: MachineState<M>, event: MachineEvent<M>): MachineState<M> => {
     const nextState = (machine[state] as any)[event];
     return nextState ?? state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,7 +3321,6 @@ __metadata:
   resolution: "@radix-ui/react-presence@workspace:packages/react/presence"
   dependencies:
     "@radix-ui/react-utils": "workspace:*"
-    "@xstate/fsm": ^1.5.1
   peerDependencies:
     react: ">=16.8"
   languageName: unknown
@@ -5046,13 +5045,6 @@ __metadata:
     "@webassemblyjs/wast-parser": 1.9.0
     "@xtuc/long": 4.2.2
   checksum: 9f013b27e28b60cb215011079a15c94d1a7b0784eb3b59ec4936f8c0635ecdb58875c6809485cff814e01df170f02c18676cf782826795dc08553b98e69c1049
-  languageName: node
-  linkType: hard
-
-"@xstate/fsm@npm:^1.5.1":
-  version: 1.6.0
-  resolution: "@xstate/fsm@npm:1.6.0"
-  checksum: 513401d52fda3e33a0cd72e6abff50a79b6227cc164bf7d0a0c448afae9ef6f4587f2d33d1e82a697f5ffa77cc5dadb2f4b8b97454a031cb11b6bc8b30e3b1a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
---------------

ℹ️&nbsp;&nbsp;Easier to review with hidden whitespace changes.

---------------

We had report of some perf issues with nested `Collapsible`s and I realised `Presence` was causing some problems there. 

I've prevented some `useEffect` logic from running unnecessarily on mount and removed `@xstate/fsm`. 

I had noticed that `@xstate/fsm` really eagerly re-renders components during my Carousel work so we can probably do without that and the additional bundle size it adds for such a simple machine here.

These changes managed to **double** the speed in my tests.