### PR TITLE
Update `createContext` to expose a Provider that accepts props

### DIFF
--- a/.yarn/versions/e9bd31b7.yml
+++ b/.yarn/versions/e9bd31b7.yml
@@ -1,0 +1,34 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-utils": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-announce"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-collection"
+  - "@radix-ui/react-context-menu"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-dismissable-layer"
+  - "@radix-ui/react-dropdown-menu"
+  - "@radix-ui/react-focus-scope"
+  - "@radix-ui/react-label"
+  - "@radix-ui/react-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-popper"
+  - "@radix-ui/react-portal"
+  - "@radix-ui/react-presence"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-scroll-area"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-slot"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toggle-button"
+  - "@radix-ui/react-toolbar"
+  - "@radix-ui/react-tooltip"

--- a/packages/react/utils/src/createContext.tsx
+++ b/packages/react/utils/src/createContext.tsx
@@ -12,3 +12,24 @@ export function createContext<ContextValueType>(displayName: string, rootCompone
   }
   return [Context, useContext] as const;
 }
+
+export function createContextObj<ContextValueType extends object>(rootComponentName: string) {
+  const Context = React.createContext<ContextValueType>(null as any);
+
+  function Provider(props: ContextValueType & { children: React.ReactNode }) {
+    const { children, ...providerProps } = props;
+    const value = React.useMemo(() => providerProps, [providerProps]) as ContextValueType;
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+  }
+
+  function useContext(componentName: string) {
+    const context = React.useContext(Context);
+    if (context === null) {
+      throw new Error(`\`${componentName}\` must be used within \`${rootComponentName}\``);
+    }
+    return context;
+  }
+
+  Provider.displayName = rootComponentName + 'Provider';
+  return [Provider, useContext] as const;
+}

--- a/packages/react/utils/src/createContext.tsx
+++ b/packages/react/utils/src/createContext.tsx
@@ -18,7 +18,12 @@ export function createContextObj<ContextValueType extends object>(rootComponentN
 
   function Provider(props: ContextValueType & { children: React.ReactNode }) {
     const { children, ...providerProps } = props;
-    const value = React.useMemo(() => providerProps, [providerProps]) as ContextValueType;
+    // Only re-memoize when prop values change
+    const value = React.useMemo(
+      () => providerProps,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      Object.values(providerProps)
+    ) as ContextValueType;
     return <Context.Provider value={value}>{children}</Context.Provider>;
   }
 


### PR DESCRIPTION
Before our `Carousel` call earlier, I started applying this across our codebase. I'll PR each component in separate PRs.