### PR TITLE
Allow for global control of Tooltip mouse rest duration thresholds

### DIFF
--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -635,7 +635,6 @@ export const Chromatic = () => (
             className={chromaticTriggerClass}
             style={{
               position: 'absolute',
-              side: 10,
               ...((side === 'right' || side === 'left') &&
                 (align === 'start'
                   ? { bottom: 10 }

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -364,6 +364,51 @@ export const SlottableContent = () => (
   </Tooltip>
 );
 
+export const ControlledRestThresholdDuration = () => {
+  const [restThresholdDuration, setRestThresholdDuration] = React.useState(300);
+  const [skipRestThresholdDuration, setSkipRestThresholdDuration] = React.useState(300);
+
+  React.useEffect(() => {
+    window.RADIX_TOOLTIP_REST_THRESHOLD_DURATION = restThresholdDuration;
+    window.RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION = skipRestThresholdDuration;
+  }, [restThresholdDuration, skipRestThresholdDuration]);
+
+  const setRestThresholdsToZero = () => {
+    setRestThresholdDuration(0);
+    setSkipRestThresholdDuration(0);
+  };
+
+  const resetRestThresholds = () => {
+    setRestThresholdDuration(300);
+    setSkipRestThresholdDuration(300);
+  };
+
+  const increaseRestThresholds = () => {
+    setRestThresholdDuration(1500);
+    setSkipRestThresholdDuration(1500);
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', flexDirection: 'column', width: '20vw', margin: '1rem' }}>
+        <button onClick={setRestThresholdsToZero} style={{ margin: '0.5rem' }}>
+          Eliminate Rest Threshold Duration
+        </button>
+        <button onClick={resetRestThresholds} style={{ margin: '0.5rem' }}>
+          Reset Rest Threshold Duration (300ms)
+        </button>
+        <button onClick={increaseRestThresholds} style={{ margin: '0.5rem' }}>
+          Increase Rest Threshold Duration to 1.5 seconds
+        </button>
+      </div>
+
+      <SimpleTooltip label="Hello world!">
+        <TooltipTrigger>Hover over me or focus on me</TooltipTrigger>
+      </SimpleTooltip>
+    </div>
+  );
+};
+
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
 
@@ -590,7 +635,7 @@ export const Chromatic = () => (
             className={chromaticTriggerClass}
             style={{
               position: 'absolute',
-              [side]: 10,
+              side: 10,
               ...((side === 'right' || side === 'left') &&
                 (align === 'start'
                   ? { bottom: 10 }
@@ -768,6 +813,6 @@ const styles = {
   // '&[data-state="closed"]': { borderColor: 'red' },
   // '&[data-state="instant-open"]': { borderColor: 'green' },
 };
-const triggerAttrClass = css({ '&[data-radix-tooltip-trigger]': styles });
-const contentAttrClass = css({ '&[data-radix-tooltip-content]': styles });
-const arrowAttrClass = css({ '&[data-radix-tooltip-arrow]': styles });
+const triggerAttrClass = css({ '&[dataRadixTooltipTrigger]': styles });
+const contentAttrClass = css({ '&[dataRadixTooltipContent]': styles });
+const arrowAttrClass = css({ '&[dataRadixTooltipArrow]': styles });

--- a/packages/react/tooltip/src/Tooltip.test.tsx
+++ b/packages/react/tooltip/src/Tooltip.test.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './Tooltip';
 
 const TOOLTIP_CONTENT_TEST_ID = 'TOOLTIP_CONTENT_TEST_ID';
 
-describe.skip('when using Tooltip primitives', () => {
+describe('when using Tooltip primitives', () => {
   describe('when adjusting mouse rest threshold durations', () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/packages/react/tooltip/src/Tooltip.test.tsx
+++ b/packages/react/tooltip/src/Tooltip.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Tooltip, TooltipTrigger, TooltipContent } from './Tooltip';
+
+const TOOLTIP_CONTENT_TEST_ID = 'TOOLTIP_CONTENT_TEST_ID';
+
+describe.skip('when using Tooltip primitives', () => {
+  describe('when adjusting mouse rest threshold durations', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+
+      (window as any).ResizeObserver = class {
+        // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+        constructor(callback: ResizeObserverCallback) {}
+        disconnect() {}
+        observe(target: Element, options?: any) {}
+        unobserve(target: Element) {}
+      };
+
+      render(
+        <Tooltip>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+
+          <TooltipContent>
+            <div data-testid={TOOLTIP_CONTENT_TEST_ID}>Instantly rendered!</div>
+          </TooltipContent>
+        </Tooltip>
+      );
+    });
+
+    describe('with duration at 0', () => {
+      beforeEach(() => {
+        window.RADIX_TOOLTIP_REST_THRESHOLD_DURATION = 0;
+        window.RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION = 0;
+      });
+
+      it('renders the tooltip content instantly on hover', async () => {
+        expect(screen.queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeNull();
+        fireEvent.mouseEnter(screen.getByText('Trigger'));
+        jest.advanceTimersByTime(0);
+        expect(await screen.findByTestId(TOOLTIP_CONTENT_TEST_ID)).not.toBeNull();
+      });
+    });
+
+    describe.each([300, 1500])('to %i milliseconds', (duration) => {
+      beforeEach(() => {
+        window.RADIX_TOOLTIP_REST_THRESHOLD_DURATION = duration;
+        window.RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION = duration;
+      });
+
+      it(`renders the tooltip content after ${duration} milliseconds`, async () => {
+        expect(screen.queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeNull();
+        fireEvent.mouseEnter(screen.getByText('Trigger'));
+        jest.advanceTimersByTime(duration);
+        expect(await screen.findByTestId(TOOLTIP_CONTENT_TEST_ID)).not.toBeNull();
+      });
+    });
+  });
+});

--- a/packages/react/tooltip/src/machine.tsx
+++ b/packages/react/tooltip/src/machine.tsx
@@ -118,10 +118,17 @@ export function createStateMachine<State extends string, Event extends string, C
  * -----------------------------------------------------------------------------------------------*/
 
 // How long the mouse needs to stop moving for the tooltip to open
-const REST_THRESHOLD_DURATION = 300;
+const getRestThresholdDuration = () =>
+  typeof window !== 'undefined' && Number.isInteger(window?.RADIX_TOOLTIP_REST_THRESHOLD_DURATION)
+    ? window.RADIX_TOOLTIP_REST_THRESHOLD_DURATION
+    : 300;
 
 // How much time does the user has to move from one tooltip to another without incurring the rest wait
-const SKIP_REST_THRESHOLD_DURATION = 300;
+const getSkipRestThresholdDuration = () =>
+  typeof window !== 'undefined' &&
+  Number.isInteger(window?.RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION)
+    ? window.RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION
+    : 300;
 
 type TooltipState =
   // tooltip is closed
@@ -217,7 +224,7 @@ let restTimerId: number;
 
 function startRestTimer(transition: TooltipTransitionFn) {
   clearTimeout(restTimerId);
-  restTimerId = window.setTimeout(() => transition('restTimerElapsed'), REST_THRESHOLD_DURATION);
+  restTimerId = window.setTimeout(() => transition('restTimerElapsed'), getRestThresholdDuration());
 }
 
 function clearRestTimer() {
@@ -233,7 +240,7 @@ function startSkipRestTimer(transition: TooltipTransitionFn) {
   clearTimeout(skipRestTimerId);
   skipRestTimerId = window.setTimeout(
     () => transition('skipRestTimerElapsed'),
-    SKIP_REST_THRESHOLD_DURATION
+    getSkipRestThresholdDuration()
   );
 }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -8,3 +8,10 @@ type RequestIdleCallbackDeadline = {
   readonly didTimeout: boolean;
   timeRemaining: () => number;
 };
+
+declare global {
+  interface Window {
+    RADIX_TOOLTIP_REST_THRESHOLD_DURATION?: number;
+    RADIX_TOOLTIP_SKIP_REST_THRESHOLD_DURATION?: number;
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Add or edit tests to reflect the change (run `yarn test`).
- [X] Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Fixes a bug in an existing package
- [X] Adds additional features/functionality to an existing package
- [X] Updates documentation or example code
- [ ] Other

# Summary

The ongoing [w3c discussion on tooltips](https://github.com/w3c/aria-practices/issues/128) suggests that a small delay isn't a requirement. A delay in hover-based tooltip rendering also has no negative affect on accessibility for the tooltip itself.

There is support for this feature via the unerring measurement of comment emoji count on my comment on #26

I believe there should _also_ be an ability to control both timeouts via a prop on the Trigger primitive; however, a window-based solution seems ideal for those who want a global change to the thresholds for the sake of continuing to emulate an Operating System-like environment within their app.

I would've implemented the prop-based one myself, but I am unfamiliar with state machines. I am unaware of whether or not prop-driven state machine initializations are viable (let alone possible).

## Failing Test

jest seems unaware of `DOMRect` and I found no solutions online for properly mocking it. I didn't want to try auto-mocking, since it seems like a required implementation detail to get the tooltip content actually rendering.

Perhaps something like Cypress is a better solution for tests like this 👀 . Willing to implement it for ya.