### PR TITLE
[React utils refactor] move composeEventHandlers to new @radix-ui/primitive package

### DIFF
--- a/.yarn/versions/04b35335.yml
+++ b/.yarn/versions/04b35335.yml
@@ -1,0 +1,36 @@
+releases:
+  "@radix-ui/primitive": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-button": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-utils": patch
+
+declined:
+  - primitives
+  - ssr-testing
+  - "@radix-ui/react-announce"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-collection"
+  - "@radix-ui/react-dismissable-layer"
+  - "@radix-ui/react-focus-scope"
+  - "@radix-ui/react-label"
+  - "@radix-ui/react-popper"
+  - "@radix-ui/react-portal"
+  - "@radix-ui/react-presence"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-roving-focus"

--- a/packages/core/primitive/README.md
+++ b/packages/core/primitive/README.md
@@ -1,0 +1,13 @@
+# `primitive`
+
+## Installation
+
+```sh
+$ yarn add @radix-ui/primitive
+# or
+$ npm install @radix-ui/primitive
+```
+
+## Usage
+
+This is an internal utility, not intended for public usage.

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@radix-ui/react-toolbar",
-  "version": "0.0.1",
+  "name": "@radix-ui/primitive",
+  "version": "0.0.0",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -14,17 +14,6 @@
   "scripts": {
     "clean": "rm -rf dist",
     "prepublish": "yarn clean"
-  },
-  "dependencies": {
-    "@radix-ui/primitive": "workspace:*",
-    "@radix-ui/react-polymorphic": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-roving-focus": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*",
-    "@radix-ui/react-utils": "workspace:*"
-  },
-  "peerDependencies": {
-    "react": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/core/primitive/src/index.ts
+++ b/packages/core/primitive/src/index.ts
@@ -1,0 +1,1 @@
+export * from './primitive';

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,4 +1,4 @@
-export function composeEventHandlers<E extends React.SyntheticEvent | Event>(
+function composeEventHandlers<E>(
   originalEventHandler?: (event: E) => void,
   ourEventHandler?: (event: E) => void,
   { checkForDefaultPrevented = true } = {}
@@ -6,8 +6,10 @@ export function composeEventHandlers<E extends React.SyntheticEvent | Event>(
   return function handleEvent(event: E) {
     originalEventHandler?.(event);
 
-    if (checkForDefaultPrevented === false || !event.defaultPrevented) {
+    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
       return ourEventHandler?.(event);
     }
   };
 }
+
+export { composeEventHandlers };

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-collapsible": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import {
-  composeEventHandlers,
-  createContextObj,
-  useComposedRefs,
-  useControlledState,
-} from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useComposedRefs, useControlledState } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Collapsible, CollapsibleButton, CollapsibleContent } from '@radix-ui/react-collapsible';
 import { useId } from '@radix-ui/react-id';

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-dialog": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
   createContextObj,
   useComposedRefs,
   useDocumentRef,
-  composeEventHandlers,
   extendComponent,
 } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-label": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {
-  createContextObj,
-  composeEventHandlers,
-  useControlledState,
-  useComposedRefs,
-} from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useControlledState, useComposedRefs } from '@radix-ui/react-utils';
 import { useLabelContext } from '@radix-ui/react-label';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { createContextObj, composeEventHandlers, useControlledState } from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useControlledState } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Presence } from '@radix-ui/react-presence';
 import { useId } from '@radix-ui/react-id';

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { composeEventHandlers, createContextObj, extendComponent } from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, extendComponent } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",
     "@radix-ui/react-focus-guards": "workspace:*",
     "@radix-ui/react-focus-scope": "workspace:*",

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
   createContextObj,
   useComposedRefs,
-  composeEventHandlers,
   useControlledState,
   composeRefs,
 } from '@radix-ui/react-utils';

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
-  composeEventHandlers,
   createContextObj,
   extendComponent,
   useComposedRefs,

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",
     "@radix-ui/react-focus-guards": "workspace:*",
     "@radix-ui/react-focus-scope": "workspace:*",

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
-  composeEventHandlers,
   composeRefs,
   createContextObj,
   extendComponent,

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",
     "@radix-ui/react-focus-guards": "workspace:*",
     "@radix-ui/react-focus-scope": "workspace:*",

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
   createContextObj,
   useComposedRefs,
-  composeEventHandlers,
   useControlledState,
   composeRefs,
   extendComponent,

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-label": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {
-  createContextObj,
-  composeEventHandlers,
-  useControlledState,
-  useComposedRefs,
-} from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useControlledState, useComposedRefs } from '@radix-ui/react-utils';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLabelContext } from '@radix-ui/react-label';

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
-  composeEventHandlers,
   createContextObj,
   useCallbackRef,
   useControlledState,

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { RovingFocusGroup, useRovingFocus } from './RovingFocusGroup';
-import { composeEventHandlers } from '@radix-ui/react-utils';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
 

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/number": "workspace:*",
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-utils": "workspace:*"

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -8,8 +8,10 @@
 //  - PointerEvents
 //  - CSS scrollbar-width OR -webkit-scrollbar
 
+import * as React from 'react';
+import { clamp } from '@radix-ui/number';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
-  composeEventHandlers,
   createContextObj,
   getOwnerGlobals,
   useCallbackRef,
@@ -19,8 +21,6 @@ import {
   usePrefersReducedMotion,
 } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
-import { clamp } from '@radix-ui/number';
-import * as React from 'react';
 import { bezier } from './bezier-easing';
 import { Queue } from './queue';
 import { useHover } from './useHover';

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/number": "workspace:*",
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-collection": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clamp } from '@radix-ui/number';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
-  composeEventHandlers,
   createContextObj,
   useComposedRefs,
   useControlledState,

--- a/packages/react/slot/package.json
+++ b/packages/react/slot/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { composeRefs, composeEventHandlers } from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeRefs } from '@radix-ui/react-utils';
 
 /* -------------------------------------------------------------------------------------------------
  * Slot

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-label": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {
-  createContextObj,
-  composeEventHandlers,
-  useControlledState,
-  useComposedRefs,
-} from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useControlledState, useComposedRefs } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLabelContext } from '@radix-ui/react-label';
 

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
-import {
-  composeEventHandlers,
-  createContextObj,
-  useControlledState,
-  useCallbackRef,
-} from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { createContextObj, useControlledState, useCallbackRef } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 import { useId } from '@radix-ui/react-id';

--- a/packages/react/toggle-button/package.json
+++ b/packages/react/toggle-button/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-utils": "workspace:*"

--- a/packages/react/toggle-button/src/ToggleButton.tsx
+++ b/packages/react/toggle-button/src/ToggleButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { useControlledState, composeEventHandlers } from '@radix-ui/react-utils';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { useControlledState } from '@radix-ui/react-utils';
 import { Primitive } from '@radix-ui/react-primitive';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
-import { createContextObj, composeEventHandlers } from '@radix-ui/react-utils';
+import { createContextObj } from '@radix-ui/react-utils';
 import { Separator as SeparatorPrimitive } from '@radix-ui/react-separator';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -16,6 +16,7 @@
     "prepublish": "yarn clean"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-popper": "workspace:*",

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import {
   createContextObj,
   useComposedRefs,
-  composeEventHandlers,
   useRect,
   usePrevious,
   useControlledState,

--- a/packages/react/utils/src/index.ts
+++ b/packages/react/utils/src/index.ts
@@ -1,4 +1,3 @@
-export * from './composeEventHandlers';
 export * from './createContext';
 export * from './extendComponent';
 export * from './useCallbackRef';

--- a/ssr-testing/pages/roving-focus-group.tsx
+++ b/ssr-testing/pages/roving-focus-group.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
-import { composeEventHandlers } from '@radix-ui/react-utils';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
       "*": ["node_modules/*"],
       "@radix-ui/number": ["./packages/core/number/src"],
       "@radix-ui/popper": ["./packages/core/popper/src"],
+      "@radix-ui/primitive": ["./packages/core/primitive/src"],
       "@radix-ui/rect": ["./packages/core/rect/src"],
       "@radix-ui/react-accessible-icon": ["./packages/react/accessible-icon/src"],
       "@radix-ui/react-accordion": ["./packages/react/accordion/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,6 +3020,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@radix-ui/primitive@workspace:*, @radix-ui/primitive@workspace:packages/core/primitive":
+  version: 0.0.0-use.local
+  resolution: "@radix-ui/primitive@workspace:packages/core/primitive"
+  languageName: unknown
+  linkType: soft
+
 "@radix-ui/react-accessible-icon@workspace:packages/react/accessible-icon":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-accessible-icon@workspace:packages/react/accessible-icon"
@@ -3034,6 +3040,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-accordion@workspace:packages/react/accordion"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-collapsible": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
@@ -3048,6 +3055,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-alert-dialog@workspace:packages/react/alert-dialog"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-dialog": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
@@ -3109,6 +3117,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-checkbox@workspace:packages/react/checkbox"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-label": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
@@ -3123,6 +3132,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-collapsible@workspace:packages/react/collapsible"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
@@ -3147,6 +3157,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-context-menu@workspace:packages/react/context-menu"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-menu": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
@@ -3160,6 +3171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-dialog@workspace:packages/react/dialog"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"
     "@radix-ui/react-focus-guards": "workspace:*"
     "@radix-ui/react-focus-scope": "workspace:*"
@@ -3191,6 +3203,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-dropdown-menu@workspace:packages/react/dropdown-menu"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-menu": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
@@ -3244,6 +3257,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-menu@workspace:packages/react/menu"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"
     "@radix-ui/react-focus-guards": "workspace:*"
     "@radix-ui/react-focus-scope": "workspace:*"
@@ -3275,6 +3289,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-popover@workspace:packages/react/popover"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"
     "@radix-ui/react-focus-guards": "workspace:*"
     "@radix-ui/react-focus-scope": "workspace:*"
@@ -3356,6 +3371,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-radio-group@workspace:packages/react/radio-group"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-label": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
@@ -3384,6 +3400,7 @@ __metadata:
   resolution: "@radix-ui/react-scroll-area@workspace:packages/react/scroll-area"
   dependencies:
     "@radix-ui/number": "workspace:*"
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
@@ -3409,6 +3426,7 @@ __metadata:
   resolution: "@radix-ui/react-slider@workspace:packages/react/slider"
   dependencies:
     "@radix-ui/number": "workspace:*"
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-collection": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
@@ -3422,6 +3440,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-slot@workspace:packages/react/slot"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3432,6 +3451,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-switch@workspace:packages/react/switch"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-label": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
@@ -3445,6 +3465,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-tabs@workspace:packages/react/tabs"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
@@ -3459,6 +3480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-toggle-button@workspace:packages/react/toggle-button"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-utils": "workspace:*"
@@ -3471,6 +3493,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-toolbar@workspace:packages/react/toolbar"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
@@ -3485,6 +3508,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-tooltip@workspace:packages/react/tooltip"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-popper": "workspace:*"


### PR DESCRIPTION
----------

- [x] Change base branch to `main` once #517 is merged. 

----------

I'll add versions file after the above is merged ☝️ 
