### PR TITLE
[Primitive] Add `defaultProps` support to `extendPrimitive`

### DIFF
--- a/.yarn/versions/d06510b4.yml
+++ b/.yarn/versions/d06510b4.yml
@@ -1,0 +1,32 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-announce"
+  - "@radix-ui/react-arrow"
+  - "@radix-ui/react-aspect-ratio"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-label"
+  - "@radix-ui/react-popper"
+  - "@radix-ui/react-portal"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-scroll-area"
+  - "@radix-ui/react-separator"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toggle-button"
+  - "@radix-ui/react-toolbar"
+  - "@radix-ui/react-visually-hidden"

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -169,9 +169,15 @@ AlertDialogCancel.displayName = CANCEL_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const AlertDialogTrigger = extendPrimitive(DialogPrimitive.Trigger, 'AlertDialogTrigger');
-const AlertDialogOverlay = extendPrimitive(DialogPrimitive.Overlay, 'AlertDialogOverlay');
-const AlertDialogAction = extendPrimitive(DialogPrimitive.Close, 'AlertDialogAction');
+const AlertDialogTrigger = extendPrimitive(DialogPrimitive.Trigger, {
+  displayName: 'AlertDialogTrigger',
+});
+const AlertDialogOverlay = extendPrimitive(DialogPrimitive.Overlay, {
+  displayName: 'AlertDialogOverlay',
+});
+const AlertDialogAction = extendPrimitive(DialogPrimitive.Close, {
+  displayName: 'AlertDialogAction',
+});
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -135,20 +135,24 @@ ContextMenuContent.displayName = CONTENT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const ContextMenuGroup = extendPrimitive(MenuPrimitive.Group, 'ContextMenuGroup');
-const ContextMenuLabel = extendPrimitive(MenuPrimitive.Label, 'ContextMenuLabel');
-const ContextMenuItem = extendPrimitive(MenuPrimitive.Item, 'ContextMenuItem');
-const ContextMenuCheckboxItem = extendPrimitive(
-  MenuPrimitive.CheckboxItem,
-  'ContextMenuCheckboxItem'
-);
-const ContextMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, 'ContextMenuRadioGroup');
-const ContextMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, 'ContextMenuRadioItem');
-const ContextMenuItemIndicator = extendPrimitive(
-  MenuPrimitive.ItemIndicator,
-  'ContextMenuItemIndicator'
-);
-const ContextMenuSeparator = extendPrimitive(MenuPrimitive.Separator, 'ContextMenuSeparator');
+const ContextMenuGroup = extendPrimitive(MenuPrimitive.Group, { displayName: 'ContextMenuGroup' });
+const ContextMenuLabel = extendPrimitive(MenuPrimitive.Label, { displayName: 'ContextMenuLabel' });
+const ContextMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'ContextMenuItem' });
+const ContextMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
+  displayName: 'ContextMenuCheckboxItem',
+});
+const ContextMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, {
+  displayName: 'ContextMenuRadioGroup',
+});
+const ContextMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, {
+  displayName: 'ContextMenuRadioItem',
+});
+const ContextMenuItemIndicator = extendPrimitive(MenuPrimitive.ItemIndicator, {
+  displayName: 'ContextMenuItemIndicator',
+});
+const ContextMenuSeparator = extendPrimitive(MenuPrimitive.Separator, {
+  displayName: 'ContextMenuSeparator',
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -173,21 +173,31 @@ DropdownMenuContent.displayName = CONTENT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, 'DropdownMenuGroup');
-const DropdownMenuLabel = extendPrimitive(MenuPrimitive.Label, 'DropdownMenuLabel');
-const DropdownMenuItem = extendPrimitive(MenuPrimitive.Item, 'DropdownMenuItem');
-const DropdownMenuCheckboxItem = extendPrimitive(
-  MenuPrimitive.CheckboxItem,
-  'DropdownMenuCheckboxItem'
-);
-const DropdownMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, 'DropdownMenuRadioGroup');
-const DropdownMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, 'DropdownMenuRadioItem');
-const DropdownMenuItemIndicator = extendPrimitive(
-  MenuPrimitive.ItemIndicator,
-  'DropdownMenuItemIndicator'
-);
-const DropdownMenuSeparator = extendPrimitive(MenuPrimitive.Separator, 'DropdownMenuSeparator');
-const DropdownMenuArrow = extendPrimitive(MenuPrimitive.Arrow, 'DropdownMenuArrow');
+const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, {
+  displayName: 'DropdownMenuGroup',
+});
+const DropdownMenuLabel = extendPrimitive(MenuPrimitive.Label, {
+  displayName: 'DropdownMenuLabel',
+});
+const DropdownMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'DropdownMenuItem' });
+const DropdownMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
+  displayName: 'DropdownMenuCheckboxItem',
+});
+const DropdownMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, {
+  displayName: 'DropdownMenuRadioGroup',
+});
+const DropdownMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, {
+  displayName: 'DropdownMenuRadioItem',
+});
+const DropdownMenuItemIndicator = extendPrimitive(MenuPrimitive.ItemIndicator, {
+  displayName: 'DropdownMenuItemIndicator',
+});
+const DropdownMenuSeparator = extendPrimitive(MenuPrimitive.Separator, {
+  displayName: 'DropdownMenuSeparator',
+});
+const DropdownMenuArrow = extendPrimitive(MenuPrimitive.Arrow, {
+  displayName: 'DropdownMenuArrow',
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -322,24 +322,6 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
 Menu.displayName = MENU_NAME;
 
 /* -------------------------------------------------------------------------------------------------
- * MenuGroup
- * -----------------------------------------------------------------------------------------------*/
-
-const GROUP_NAME = 'MenuGroup';
-
-type MenuGroupOwnProps = Polymorphic.OwnProps<typeof Primitive>;
-type MenuGroupPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
-  MenuGroupOwnProps
->;
-
-const MenuGroup = React.forwardRef((props, forwardedRef) => {
-  return <Primitive role="group" {...props} ref={forwardedRef} />;
-}) as MenuGroupPrimitive;
-
-MenuGroup.displayName = GROUP_NAME;
-
-/* -------------------------------------------------------------------------------------------------
  * MenuItem
  * -----------------------------------------------------------------------------------------------*/
 
@@ -616,27 +598,17 @@ const MenuItemIndicator = React.forwardRef((props, forwardedRef) => {
 
 MenuItemIndicator.displayName = ITEM_INDICATOR_NAME;
 
-/* -------------------------------------------------------------------------------------------------
- * MenuSeparator
- * -----------------------------------------------------------------------------------------------*/
-
-const SEPARATOR_NAME = 'MenuSeparator';
-
-type MenuSeparatorOwnProps = Polymorphic.OwnProps<typeof Primitive>;
-type MenuSeparatorPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
-  MenuSeparatorOwnProps
->;
-
-const MenuSeparator = React.forwardRef((props, forwardedRef) => {
-  return <Primitive role="separator" aria-orientation="horizontal" {...props} ref={forwardedRef} />;
-}) as MenuSeparatorPrimitive;
-
-MenuSeparator.displayName = SEPARATOR_NAME;
-
 /* ---------------------------------------------------------------------------------------------- */
 
+const MenuGroup = extendPrimitive(Primitive, {
+  defaultProps: { role: 'group' },
+  displayName: 'MenuGroup',
+});
 const MenuLabel = extendPrimitive(Primitive, { displayName: 'MenuLabel' });
+const MenuSeparator = extendPrimitive(Primitive, {
+  defaultProps: { role: 'separator', 'aria-orientation': 'horizontal' },
+  displayName: 'MenuSeparator ',
+});
 const MenuArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'MenuArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -636,8 +636,8 @@ MenuSeparator.displayName = SEPARATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const MenuLabel = extendPrimitive(Primitive, 'MenuLabel');
-const MenuArrow = extendPrimitive(PopperPrimitive.Arrow, 'MenuArrow');
+const MenuLabel = extendPrimitive(Primitive, { displayName: 'MenuLabel' });
+const MenuArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'MenuArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -387,7 +387,7 @@ PopoverClose.displayName = CLOSE_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, 'PopoverArrow');
+const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'PopoverArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/primitive/src/extendPrimitive.test.tsx
+++ b/packages/react/primitive/src/extendPrimitive.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { extendPrimitive } from './extendPrimitive';
+import { Primitive } from './Primitive';
 
 import type { RenderResult } from '@testing-library/react';
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
@@ -18,10 +19,25 @@ const Button = React.forwardRef((props, forwardedRef) => {
 }) as ButtonPrimitive;
 
 /* -------------------------------------------------------------------------------------------------
+ * Extend `Primitive` as another element type
+ * -----------------------------------------------------------------------------------------------*/
+
+const PrimitiveAsButton = extendPrimitive(Primitive, { defaultProps: { as: 'button' } });
+
+/* -------------------------------------------------------------------------------------------------
  * Extended Polymorphic Button
  * -----------------------------------------------------------------------------------------------*/
 
 const ExtendedButton = extendPrimitive(Button, { displayName: 'ExtendedButton' });
+
+/* -------------------------------------------------------------------------------------------------
+ * Extended Polymorphic Button with default props
+ * -----------------------------------------------------------------------------------------------*/
+
+const ExtendedButtonDefaultProps = extendPrimitive(Button, {
+  defaultProps: { type: 'submit' },
+  displayName: 'ExtendedButton',
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Normal Link
@@ -79,6 +95,9 @@ export function Test() {
       {/* ExtendedButton as Link does not accept form prop */}
       {/* @ts-expect-error */}
       <ExtendedButton as={Link} form="form" />
+
+      {/* PrimitiveAsButton accepts type prop */}
+      <PrimitiveAsButton type="submit" />
     </>
   );
 }
@@ -90,7 +109,31 @@ describe('Given extended components via extendPrimitive', () => {
     rendered = render(<Test />);
   });
 
-  it('should render', async () => {
+  it('should render', () => {
     expect(rendered.container.firstChild).toBeInTheDocument();
+  });
+});
+
+describe('Given an extended component with default props', () => {
+  let rendered: RenderResult;
+
+  beforeEach(() => {
+    rendered = render(<ExtendedButtonDefaultProps />);
+  });
+
+  it('should have the default attributes', () => {
+    expect(rendered.container.firstChild).toHaveAttribute('type', 'submit');
+  });
+});
+
+describe('Given an extended component with default as prop', () => {
+  let rendered: RenderResult;
+
+  beforeEach(() => {
+    rendered = render(<PrimitiveAsButton />);
+  });
+
+  it('should be a button element', () => {
+    expect(rendered.container.firstChild).toBeInstanceOf(HTMLButtonElement);
   });
 });

--- a/packages/react/primitive/src/extendPrimitive.test.tsx
+++ b/packages/react/primitive/src/extendPrimitive.test.tsx
@@ -21,7 +21,7 @@ const Button = React.forwardRef((props, forwardedRef) => {
  * Extended Polymorphic Button
  * -----------------------------------------------------------------------------------------------*/
 
-const ExtendedButton = extendPrimitive(Button, 'ExtendedButton');
+const ExtendedButton = extendPrimitive(Button, { displayName: 'ExtendedButton' });
 
 /* -------------------------------------------------------------------------------------------------
  * Normal Link

--- a/packages/react/primitive/src/extendPrimitive.tsx
+++ b/packages/react/primitive/src/extendPrimitive.tsx
@@ -6,17 +6,14 @@ function extendPrimitive<As extends Polymorphic.ForwardRefComponent<any, any>>(
   Comp: As extends Polymorphic.ForwardRefComponent<infer I, infer P>
     ? Polymorphic.ForwardRefComponent<I, P>
     : As,
-  displayName: string
+  config: { displayName?: string; defaultProps?: Partial<React.ComponentProps<typeof Comp>> }
 ) {
-  type ExtendedPrimitive = Polymorphic.ForwardRefComponent<
-    Polymorphic.IntrinsicElement<typeof Comp>,
-    Polymorphic.OwnProps<typeof Comp>
-  >;
   const Extended = React.forwardRef((props, forwardedRef) => {
     const As = Comp as any;
-    return <As {...props} ref={forwardedRef} />;
-  }) as ExtendedPrimitive;
-  Extended.displayName = displayName;
+    const propsWithDefaults = { ...config.defaultProps, ...props };
+    return <As {...propsWithDefaults} ref={forwardedRef} />;
+  }) as As;
+  Extended.displayName = config.displayName || 'Extended' + Comp.displayName;
   return Extended;
 }
 

--- a/packages/react/primitive/src/extendPrimitive.tsx
+++ b/packages/react/primitive/src/extendPrimitive.tsx
@@ -2,19 +2,24 @@ import * as React from 'react';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-function extendPrimitive<As extends Polymorphic.ForwardRefComponent<any, any>>(
-  Comp: As extends Polymorphic.ForwardRefComponent<infer I, infer P>
-    ? Polymorphic.ForwardRefComponent<I, P>
-    : As,
-  config: { displayName?: string; defaultProps?: Partial<React.ComponentProps<typeof Comp>> }
-) {
+type ExtendedPrimitive<C, As> = Polymorphic.ForwardRefComponent<As, Polymorphic.OwnProps<C>>;
+type DefaultProps<C, As> = { as?: As } & Omit<
+  Partial<React.ComponentProps<ExtendedPrimitive<C, As>>>,
+  'as'
+>;
+
+function extendPrimitive<
+  C extends Polymorphic.ForwardRefComponent<any, any>,
+  DefaultAs extends React.ElementType = Polymorphic.IntrinsicElement<C>
+>(Comp: C, config: { displayName?: string; defaultProps?: DefaultProps<C, DefaultAs> }) {
   const Extended = React.forwardRef((props, forwardedRef) => {
     const As = Comp as any;
     const propsWithDefaults = { ...config.defaultProps, ...props };
     return <As {...propsWithDefaults} ref={forwardedRef} />;
-  }) as As;
+  });
+
   Extended.displayName = config.displayName || 'Extended' + Comp.displayName;
-  return Extended;
+  return Extended as ExtendedPrimitive<C, DefaultAs>;
 }
 
 export { extendPrimitive };

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -174,7 +174,7 @@ const RadioGroupItemImpl = React.forwardRef((props, forwardedRef) => {
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const RadioGroupIndicator = extendPrimitive(RadioIndicator, 'RadioGroupIndicator');
+const RadioGroupIndicator = extendPrimitive(RadioIndicator, { displayName: 'RadioGroupIndicator' });
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -255,7 +255,7 @@ TooltipContent.displayName = CONTENT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const TooltipArrow = extendPrimitive(PopperPrimitive.Arrow, 'TooltipArrow');
+const TooltipArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'TooltipArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Adds support for `defaultProps` to `extendPrimitive`. 

The plan is that with this change we could document this so that consumers can avoid the re-wrapping of types and `React.forwardRef` dance when all the need is to add a `className` or `data` attribute.
