### PR TITLE
[Popper] Fix potential issues with non-measured positioning

### DIFF
--- a/.yarn/versions/b4dfb97b.yml
+++ b/.yarn/versions/b4dfb97b.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/popper": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -359,7 +359,7 @@ const UNMEASURED_POPPER_STYLES: CSS.Properties = {
   top: 0,
   left: 0,
   opacity: 0,
-  pointerEvents: 'none',
+  transform: 'translate3d(0, -200%, 0)',
 };
 
 const UNMEASURED_ARROW_STYLES: CSS.Properties = {


### PR DESCRIPTION
Closes #540 

The issue is kinda intricate but I will try and give a summary here…

- For a popper to position itself it needs a few measurements (anchor react, popper size)
- Until these measurements are available, the popper needs to be measurable, but not visible, nor impact the flow/layout
- For this, we return some default styles where it is positioned fixed, out of the flow, and also had `pointer-events: none` to avoid catching any events
- That said, we can see here that some events were still caught (including hover)
- This is because `DropdownMenu` and others use `DismissableLayer` and sometimes set `disabledOutsidePointerEvents: true`
- This in turn puts `pointerEvents: 'none'` on `document.body` and `pointerEvents: 'auto'` on the content part, so in this case it puts it on what ends up being the primitive wrapped by the outer popper div
- So even though in the popper we say prevent pointer events, it gets re-enabled