### PR TITLE
[Accordion] Move disabled prop after spread

### DIFF
--- a/.yarn/versions/d3072ea0.yml
+++ b/.yarn/versions/d3072ea0.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-accordion": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.stories.tsx
+++ b/packages/react/accordion/src/Accordion.stories.tsx
@@ -522,13 +522,51 @@ export const Chromatic = () => {
       </Accordion>
 
       <h1>State attributes</h1>
-      <Accordion type="single" className={rootAttrClass} defaultValue="Two">
+      <h2>Accordion disabled</h2>
+      <Accordion type="single" className={rootAttrClass} defaultValue="Two" disabled>
+        {items.map((item) => (
+          <AccordionItem key={item} className={itemAttrClass} value={item}>
+            <AccordionHeader className={headerAttrClass}>
+              <AccordionButton className={buttonAttrClass}>{item}</AccordionButton>
+            </AccordionHeader>
+            <AccordionPanel className={panelAttrClass}>
+              {item}: Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate
+              viverra integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam
+              suscipit habitant sed.
+            </AccordionPanel>
+          </AccordionItem>
+        ))}
+      </Accordion>
+
+      <h2>Accordion enabled with item override</h2>
+      <Accordion type="single" className={rootAttrClass} defaultValue="Two" disabled={false}>
         {items.map((item) => (
           <AccordionItem
             key={item}
             className={itemAttrClass}
             value={item}
-            disabled={item === 'Four'}
+            disabled={['Two', 'Four'].includes(item)}
+          >
+            <AccordionHeader className={headerAttrClass}>
+              <AccordionButton className={buttonAttrClass}>{item}</AccordionButton>
+            </AccordionHeader>
+            <AccordionPanel className={panelAttrClass}>
+              {item}: Per erat orci nostra luctus sociosqu mus risus penatibus, duis elit vulputate
+              viverra integer ullamcorper congue curabitur sociis, nisi malesuada scelerisque quam
+              suscipit habitant sed.
+            </AccordionPanel>
+          </AccordionItem>
+        ))}
+      </Accordion>
+
+      <h2>Accordion disabled with item override</h2>
+      <Accordion type="single" className={rootAttrClass} defaultValue="Two" disabled={true}>
+        {items.map((item) => (
+          <AccordionItem
+            key={item}
+            className={itemAttrClass}
+            value={item}
+            disabled={['Two', 'Four'].includes(item) ? false : undefined}
           >
             <AccordionHeader className={headerAttrClass}>
               <AccordionButton className={buttonAttrClass}>{item}</AccordionButton>

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -301,9 +301,9 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
     <AccordionItemProvider open={open} disabled={disabled} buttonId={buttonId}>
       <CollapsiblePrimitive.Root
         data-state={open ? 'open' : 'closed'}
-        disabled={disabled}
         {...accordionItemProps}
         ref={forwardedRef}
+        disabled={disabled}
         open={open}
         onOpenChange={(open) => {
           if (open) {

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -295,7 +295,7 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
   const valueContext = useAccordionValueContext(ITEM_NAME);
   const buttonId = useId();
   const open = (value && valueContext.value.includes(value)) || false;
-  const disabled = accordionContext.disabled || props.disabled;
+  const disabled = accordionContext.disabled === true ? true : props.disabled;
 
   return (
     <AccordionItemProvider open={open} disabled={disabled} buttonId={buttonId}>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

We moved props above spread to give consumers control but the variable here was already handling the prop value fallback. By moving it above the spread, the spread was overriding it completely because we do not destructure `disabled` from props.

```jsx
const disabled = accordionContext.disabled || props.disabled;
```

We had it the way it was because the expectation is:

- Root disabled = All items disabled
- **Root disabled with an item enabled = All items disabled**
- Root enabled = All items enabled
- Root enabled with an item disabled = Item disabled

I've updated the Chromatic stories to catch this in future.
