### PR TITLE
[Toolbar] Replace `ToolbarRadioGroup` with `ToolbarToggleGroup`

### DIFF
--- a/.yarn/versions/616e0269.yml
+++ b/.yarn/versions/616e0269.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -20,10 +20,10 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-radio-group": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-separator": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*",
+    "@radix-ui/react-toggle-group": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/toolbar/src/Toolbar.stories.tsx
+++ b/packages/react/toolbar/src/Toolbar.stories.tsx
@@ -4,8 +4,8 @@ import {
   ToolbarSeparator,
   ToolbarButton,
   ToolbarLink,
-  ToolbarRadioGroup,
-  ToolbarRadioItem,
+  ToolbarToggleGroup,
+  ToolbarToggleItem,
 } from './Toolbar';
 import { css } from '../../../../stitches.config';
 import { ToggleButton } from '@radix-ui/react-toggle-button';
@@ -64,17 +64,17 @@ const ToolbarExample = ({ title, orientation }: any) => (
         Toggle
       </ToolbarButton>
       <ToolbarSeparator className={toolbarSeparatorClass}></ToolbarSeparator>
-      <ToolbarRadioGroup className={toolbarRadioGroupClass}>
-        <ToolbarRadioItem value="left" className={toolbarRadioItemClass}>
+      <ToolbarToggleGroup type="single" className={toolbarToggleGroupClass}>
+        <ToolbarToggleItem value="left" className={toolbarToggleItemClass}>
           Left
-        </ToolbarRadioItem>
-        <ToolbarRadioItem value="center" className={toolbarRadioItemClass}>
+        </ToolbarToggleItem>
+        <ToolbarToggleItem value="center" className={toolbarToggleItemClass}>
           Center
-        </ToolbarRadioItem>
-        <ToolbarRadioItem value="right" className={toolbarRadioItemClass}>
+        </ToolbarToggleItem>
+        <ToolbarToggleItem value="right" className={toolbarToggleItemClass}>
           Right
-        </ToolbarRadioItem>
-      </ToolbarRadioGroup>
+        </ToolbarToggleItem>
+      </ToolbarToggleGroup>
       <ToolbarSeparator className={toolbarSeparatorClass}></ToolbarSeparator>
       <DropdownMenu>
         <ToolbarButton className={toolbarItemClass} as={DropdownMenuTrigger}>
@@ -164,7 +164,7 @@ const toolbarToggleButtonClass = css(toolbarItemClass, {
   },
 });
 
-const toolbarRadioGroupClass = css({
+const toolbarToggleGroupClass = css({
   ...RECOMMENDED_CSS__TOOLBAR,
   gap: 5,
   '&[data-orientation="vertical"]': {
@@ -172,8 +172,8 @@ const toolbarRadioGroupClass = css({
   },
 });
 
-const toolbarRadioItemClass = css(toolbarItemClass, {
-  '&[data-state="checked"]': {
+const toolbarToggleItemClass = css(toolbarItemClass, {
+  '&[data-state="on"]': {
     background: 'black',
     color: 'white',
   },

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -5,7 +5,7 @@ import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
-import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
@@ -165,53 +165,53 @@ const ToolbarLink = React.forwardRef((props, forwardedRef) => {
 ToolbarLink.displayName = LINK_NAME;
 
 /* -------------------------------------------------------------------------------------------------
- * ToolbarRadioGroup
+ * ToolbarToggleGroup
  * -----------------------------------------------------------------------------------------------*/
 
-const RADIO_GROUP_NAME = 'ToolbarRadioGroup';
+const TOGGLE_GROUP_NAME = 'ToolbarToggleGroup';
 
-type ToolbarRadioGroupOwnProps = Polymorphic.OwnProps<typeof RadioGroupPrimitive.Root>;
-type ToolbarRadioGroupPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof RadioGroupPrimitive.Root>,
-  ToolbarRadioGroupOwnProps
+type ToolbarToggleGroupOwnProps = Polymorphic.OwnProps<typeof ToggleGroupPrimitive.Root>;
+type ToolbarToggleGroupPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof ToggleGroupPrimitive.Root>,
+  ToolbarToggleGroupOwnProps
 >;
 
-const ToolbarRadioGroup = React.forwardRef((props, forwardedRef) => {
-  const context = useToolbarContext(RADIO_GROUP_NAME);
+const ToolbarToggleGroup = React.forwardRef((props, forwardedRef) => {
+  const context = useToolbarContext(TOGGLE_GROUP_NAME);
   return (
-    <RadioGroupPrimitive.Root
+    <ToggleGroupPrimitive.Root
       data-orientation={context.orientation}
       {...props}
       ref={forwardedRef}
       rovingFocus={false}
     />
   );
-}) as ToolbarRadioGroupPrimitive;
+}) as ToolbarToggleGroupPrimitive;
 
-ToolbarRadioGroup.displayName = RADIO_GROUP_NAME;
+ToolbarToggleGroup.displayName = TOGGLE_GROUP_NAME;
 
 /* -------------------------------------------------------------------------------------------------
- * ToolbarRadioItem
+ * ToolbarToggleItem
  * -----------------------------------------------------------------------------------------------*/
 
-const RADIO_GROUP_ITEM_NAME = 'ToolbarRadioItem';
+const TOGGLE_ITEM_NAME = 'ToolbarToggleItem';
 
 type ToolbarRadioOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof ToolbarButton>,
-  Polymorphic.OwnProps<typeof RadioGroupPrimitive.Item>
+  Polymorphic.OwnProps<typeof ToggleGroupPrimitive.Item>
 >;
 type ToolbarRadioPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof RadioGroupPrimitive.Item>,
+  Polymorphic.IntrinsicElement<typeof ToggleGroupPrimitive.Item>,
   ToolbarRadioOwnProps
 >;
 
-const ToolbarRadioItem = React.forwardRef((props, forwardedRef) => (
+const ToolbarToggleItem = React.forwardRef((props, forwardedRef) => (
   <ToolbarButton as={Slot}>
-    <RadioGroupPrimitive.Item {...props} ref={forwardedRef} />
+    <ToggleGroupPrimitive.Item {...props} ref={forwardedRef} />
   </ToolbarButton>
 )) as ToolbarRadioPrimitive;
 
-ToolbarRadioItem.displayName = RADIO_GROUP_ITEM_NAME;
+ToolbarToggleItem.displayName = TOGGLE_ITEM_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -219,21 +219,21 @@ const Root = Toolbar;
 const Separator = ToolbarSeparator;
 const Button = ToolbarButton;
 const Link = ToolbarLink;
-const RadioGroup = ToolbarRadioGroup;
-const RadioItem = ToolbarRadioItem;
+const ToggleGroup = ToolbarToggleGroup;
+const ToggleItem = ToolbarToggleItem;
 
 export {
   Toolbar,
   ToolbarSeparator,
   ToolbarButton,
   ToolbarLink,
-  ToolbarRadioGroup,
-  ToolbarRadioItem,
+  ToolbarToggleGroup,
+  ToolbarToggleItem,
   //
   Root,
   Separator,
   Button,
   Link,
-  RadioGroup,
-  RadioItem,
+  ToggleGroup,
+  ToggleItem,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,7 +3409,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@radix-ui/react-radio-group@workspace:*, @radix-ui/react-radio-group@workspace:packages/react/radio-group":
+"@radix-ui/react-radio-group@workspace:packages/react/radio-group":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-radio-group@workspace:packages/react/radio-group"
   dependencies:
@@ -3547,12 +3547,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@radix-ui/react-toggle-group@workspace:packages/react/toggle-group":
+"@radix-ui/react-toggle-group@workspace:*, @radix-ui/react-toggle-group@workspace:packages/react/toggle-group":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-toggle-group@workspace:packages/react/toggle-group"
   dependencies:
+    "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-toggle-button": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3567,10 +3570,10 @@ __metadata:
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
-    "@radix-ui/react-radio-group": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-separator": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
+    "@radix-ui/react-toggle-group": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Now that we have merged `ToggleGroup`, this replaces `ToolbarRadioGroup` with `ToolbarToggleGroup` as we have agreed the former is more apt. in the context of a toolbar.
