### PR TITLE
[Presence] Fix unmount hanging

### DIFF
--- a/.yarn/versions/6574b316.yml
+++ b/.yarn/versions/6574b316.yml
@@ -1,0 +1,15 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

While trying to fix #330, I realised that our recent change to remove `requestAnimationFrame`s in `Presence` had unmasked an issue that appears to have always been lurking within `Presence` but surfaced when we removed the rafs.

It was breaking `ContextMenu` so I've fixed this first before focusing on #330.

`Presence` would sometimes think the animation name had changed when it hadn't, or it would communicate an animation start when changing to `none` which would suspend unmount but an `animationEnd` event would never occur.

Fixes:

- Only update `prevAnimationNameRef` on `animationEnd` event because we know an animation has occurred in this case.
- If the animation name changes to `none` there is no exit animation so we `send('UNMOUNT')` instantly. This occurs in the following scenario:
  ```jsx
  const dialogContentClass = css({
    '&[data-state="open"]': { animation: `${fadeIn} 300ms` },
  });
  ```

