### PR TITLE
[ContextMenu] Fix conflict between opening & disabling pointer events

### DIFF
--- a/.yarn/versions/69274a3d.yml
+++ b/.yarn/versions/69274a3d.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -319,5 +319,5 @@ const scaleIn = css.keyframes({
 
 const animatedContentClass = css(rootClass, {
   transformOrigin: 'var(--radix-context-menu-content-transform-origin)',
-  animation: `${scaleIn} 0.6s cubic-bezier(0.16, 1, 0.3, 1)`,
+  '&[data-state="open"]': { animation: `${scaleIn} 0.6s cubic-bezier(0.16, 1, 0.3, 1)` },
 });

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -114,7 +114,7 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
       ref={forwardedRef}
       side={side}
       align={align}
-      disableOutsidePointerEvents={disableOutsidePointerEvents}
+      disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
       open={context.open}
       onOpenChange={context.onOpenChange}
       style={{

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -240,7 +240,16 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
             <DismissableLayer
               disableOutsidePointerEvents
               onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={onPointerDownOutside}
+              onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
+                // If the pointer down outside event was a right-click, we shouldn't close
+                // because it is effectively as if we right-clicked the `Overlay`.
+                const isRightClick =
+                  (event as MouseEvent).button === 2 ||
+                  ((event as MouseEvent).button === 0 && event.ctrlKey === true);
+                if (isRightClick) {
+                  event.preventDefault();
+                }
+              })}
               // When focus is trapped, a focusout event may still happen.
               // We make sure we don't trigger our `onDismiss` in such case.
               onFocusOutside={(event) => event.preventDefault()}


### PR DESCRIPTION
Closes #330

**Notes for future self**:
- The reason this solution works is because we are essentially re-enabling pointer-events quicker (as soon as `open` changes to `false`) but also very importantly because of the order of events. This is because the `open` will change from `true` to `false` when a pointer down outside event happens in our `DismissableLayer` which happens when the `mousedown` event has bubbled up all the way to the `document`. Then the `contextmenu` event on `ContextMenu.Trigger` gets handled correctly because in DOM events, `contextmenu` happens AFTER `mousedown`.
- We are assuming that `Dialog.Overlay` isn't an optional part for now. That's why we always prevent closing on right click. If this becomes an issue down the line, we can track whether the overlay part is present in the tree and do this conditionally so that a `Dialog` with no overlay would act the same as a `Popover` with regards to being able to open a `ContextMenu` behind it (as there's no visible overlay).