### PR TITLE
Forward missing peer dependency: `react-dom`

### DIFF
--- a/.yarn/versions/917c19ff.yml
+++ b/.yarn/versions/917c19ff.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -28,7 +28,8 @@
     "@radix-ui/react-slot": "workspace:*"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -25,7 +25,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -34,7 +34,8 @@
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -28,7 +28,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -35,7 +35,8 @@
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -35,7 +35,8 @@
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -36,7 +36,8 @@
     "@radix-ui/react-visually-hidden": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,6 +3272,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ">=16.8"
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3400,6 +3401,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3434,6 +3436,7 @@ __metadata:
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3466,6 +3469,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3536,6 +3540,7 @@ __metadata:
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3572,6 +3577,7 @@ __metadata:
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 
@@ -3849,6 +3855,7 @@ __metadata:
     "@radix-ui/react-visually-hidden": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
See: https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0
Also related: https://github.com/pastelsky/bundlephobia/issues/494