### PR TITLE
[Popover][DropdownMenu][Tooltip] Replace or remove `anchorRef` 🔥

### DIFF
--- a/.yarn/versions/fd71a5b7.yml
+++ b/.yarn/versions/fd71a5b7.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-rect": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/AlertDialog.stories.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.stories.tsx
@@ -69,7 +69,7 @@ export const Chromatic = () => (
   <div
     style={{
       display: 'grid',
-      gridTemplateColumns: 'repeat(2, 1fr)',
+      gridTemplateColumns: 'repeat(4, 1fr)',
       gridTemplateRows: 'repeat(2, 1fr)',
       height: '100vh',
     }}
@@ -91,13 +91,46 @@ export const Chromatic = () => (
       <h2>Open</h2>
       <AlertDialog defaultOpen>
         <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
-        <AlertDialogOverlay className={overlayClass} style={{ right: '50%', bottom: '50%' }} />
-        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '25%' }}>
+        <AlertDialogOverlay
+          className={overlayClass}
+          style={{ left: 0, bottom: '50%', width: '25%' }}
+        />
+        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '12%' }}>
           <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
           <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
           <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
           <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
         </AlertDialogContent>
+      </AlertDialog>
+    </div>
+
+    <div>
+      <h1>Uncontrolled with reordered parts</h1>
+      <h2>Closed</h2>
+      <AlertDialog>
+        <AlertDialogOverlay className={overlayClass} />
+        <AlertDialogContent className={chromaticContentClass}>
+          <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
+          <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
+          <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
+          <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
+        </AlertDialogContent>
+        <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
+      </AlertDialog>
+
+      <h2>Open</h2>
+      <AlertDialog defaultOpen>
+        <AlertDialogOverlay
+          className={overlayClass}
+          style={{ left: '25%', bottom: '50%', width: '25%' }}
+        />
+        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '37%' }}>
+          <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
+          <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
+          <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
+          <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
+        </AlertDialogContent>
+        <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
       </AlertDialog>
     </div>
 
@@ -118,13 +151,46 @@ export const Chromatic = () => (
       <h2>Open</h2>
       <AlertDialog open>
         <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
-        <AlertDialogOverlay className={overlayClass} style={{ left: '50%', bottom: '50%' }} />
-        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '75%' }}>
+        <AlertDialogOverlay
+          className={overlayClass}
+          style={{ left: '50%', bottom: '50%', width: '25%' }}
+        />
+        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '62%' }}>
           <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
           <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
           <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
           <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
         </AlertDialogContent>
+      </AlertDialog>
+    </div>
+
+    <div>
+      <h1>Controlled with reordered parts</h1>
+      <h2>Closed</h2>
+      <AlertDialog open={false}>
+        <AlertDialogOverlay className={overlayClass} />
+        <AlertDialogContent className={chromaticContentClass}>
+          <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
+          <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
+          <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
+          <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
+        </AlertDialogContent>
+        <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
+      </AlertDialog>
+
+      <h2>Open</h2>
+      <AlertDialog open>
+        <AlertDialogOverlay
+          className={overlayClass}
+          style={{ left: '75%', bottom: '50%', width: '25%' }}
+        />
+        <AlertDialogContent className={chromaticContentClass} style={{ top: '25%', left: '88%' }}>
+          <AlertDialogTitle className={titleClass}>Title</AlertDialogTitle>
+          <AlertDialogDescription className={descriptionClass}>Description</AlertDialogDescription>
+          <AlertDialogAction className={actionClass}>Confirm</AlertDialogAction>
+          <AlertDialogCancel className={cancelClass}>Cancel</AlertDialogCancel>
+        </AlertDialogContent>
+        <AlertDialogTrigger className={triggerClass}>delete everything</AlertDialogTrigger>
       </AlertDialog>
     </div>
 

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -16,7 +16,7 @@ import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
 import { classes, TickIcon } from '../../menu/src/Menu.stories';
 
-const { rootClass, itemClass, labelClass, separatorClass } = classes;
+const { contentClass, itemClass, labelClass, separatorClass } = classes;
 
 export default { title: 'Components/ContextMenu' };
 
@@ -33,8 +33,7 @@ export const Styled = () => (
   >
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={rootClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass} sideOffset={-5}>
         <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
           Undo
         </ContextMenuItem>
@@ -60,7 +59,7 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={rootClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass} sideOffset={-5}>
         {foodGroups.map((foodGroup, index) => (
           <ContextMenuGroup key={index}>
             {foodGroup.label && (
@@ -98,7 +97,7 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={rootClass} sideOffset={-5}>
+        <ContextMenuContent className={contentClass} sideOffset={-5}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </ContextMenuItem>
@@ -137,7 +136,7 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={rootClass} sideOffset={-5}>
+        <ContextMenuContent className={contentClass} sideOffset={-5}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('minimize')}>
             Minimize window
           </ContextMenuItem>
@@ -169,7 +168,7 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={rootClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass} sideOffset={-5}>
         <ContextMenuItem className={itemClass} onSelect={() => window.alert('action 1')}>
           I will close
         </ContextMenuItem>
@@ -271,7 +270,7 @@ export const Nested = () => (
       >
         <ContextMenu>
           <ContextMenuTrigger className={triggerClass} style={{ backgroundColor: 'tomato' }} />{' '}
-          <ContextMenuContent className={rootClass} sideOffset={-5}>
+          <ContextMenuContent className={contentClass} sideOffset={-5}>
             <ContextMenuLabel className={labelClass}>Red box menu</ContextMenuLabel>
             <ContextMenuSeparator className={separatorClass} />
             <ContextMenuItem className={itemClass} onSelect={() => console.log('red action1')}>
@@ -283,7 +282,7 @@ export const Nested = () => (
           </ContextMenuContent>
         </ContextMenu>
       </ContextMenuTrigger>
-      <ContextMenuContent className={rootClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass} sideOffset={-5}>
         <ContextMenuLabel className={labelClass}>Blue box menu</ContextMenuLabel>
         <ContextMenuSeparator className={separatorClass} />
         <ContextMenuItem className={itemClass} onSelect={() => console.log('blue action1')}>
@@ -317,7 +316,7 @@ const scaleIn = css.keyframes({
   '100%': { transform: 'scale(1)' },
 });
 
-const animatedContentClass = css(rootClass, {
+const animatedContentClass = css(contentClass, {
   transformOrigin: 'var(--radix-context-menu-content-transform-origin)',
   '&[data-state="open"]': { animation: `${scaleIn} 0.6s cubic-bezier(0.16, 1, 0.3, 1)` },
 });

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -14,12 +14,7 @@ type Point = { x: number; y: number };
 
 const CONTEXT_MENU_NAME = 'ContextMenu';
 
-type ExtractRef<T> = T extends React.RefObject<infer B> ? B : never;
-type Anchor = ExtractRef<React.ComponentProps<typeof MenuPrimitive.Root>['anchorRef']>;
-
 type ContextMenuContextValue = {
-  anchorPointRef: React.MutableRefObject<Point>;
-  anchorRef: React.MutableRefObject<Anchor | null>;
   open: boolean;
   onOpenChange(open: boolean): void;
 };
@@ -31,21 +26,13 @@ const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuCo
 const ContextMenu: React.FC = (props) => {
   const { children } = props;
   const [open, setOpen] = React.useState(false);
-  const anchorPointRef = React.useRef<Point>({ x: 0, y: 0 });
-  const anchorRef = React.useRef({
-    getBoundingClientRect: () =>
-      DOMRect.fromRect({ width: 0, height: 0, ...anchorPointRef.current }),
-  });
 
   return (
-    <ContextMenuProvider
-      anchorPointRef={anchorPointRef}
-      anchorRef={anchorRef}
-      open={open}
-      onOpenChange={setOpen}
-    >
-      {children}
-    </ContextMenuProvider>
+    <MenuPrimitive.Root open={open} onOpenChange={setOpen}>
+      <ContextMenuProvider open={open} onOpenChange={setOpen}>
+        {children}
+      </ContextMenuProvider>
+    </MenuPrimitive.Root>
   );
 };
 
@@ -67,18 +54,24 @@ type ContextMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
 const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useContextMenuContext(TRIGGER_NAME);
+  const pointRef = React.useRef<Point>({ x: 0, y: 0 });
+  const virtualRef = React.useRef({
+    getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, ...pointRef.current }),
+  });
+
   return (
-    <Primitive
-      {...triggerProps}
-      as={as}
-      ref={forwardedRef}
-      onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
-        event.preventDefault();
-        const point = { x: event.clientX, y: event.clientY };
-        context.onOpenChange(true);
-        context.anchorPointRef.current = point;
-      })}
-    />
+    <MenuPrimitive.Anchor virtualRef={virtualRef}>
+      <Primitive
+        {...triggerProps}
+        as={as}
+        ref={forwardedRef}
+        onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
+          event.preventDefault();
+          pointRef.current = { x: event.clientX, y: event.clientY };
+          context.onOpenChange(true);
+        })}
+      />
+    </MenuPrimitive.Anchor>
   );
 }) as ContextMenuTriggerPrimitive;
 
@@ -91,12 +84,12 @@ ContextMenuTrigger.displayName = TRIGGER_NAME;
 const CONTENT_NAME = 'ContextMenuContent';
 
 type ContextMenuContentOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive.Root>,
-  'anchorRef' | 'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'onOpenAutoFocus' | 'onDismiss'
+  Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
+  'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'onOpenAutoFocus'
 >;
 
 type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Root>,
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Content>,
   ContextMenuContentOwnProps
 >;
 
@@ -109,24 +102,20 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = useContextMenuContext(CONTENT_NAME);
   return (
-    <MenuPrimitive.Root
+    <MenuPrimitive.Content
       {...contentProps}
       ref={forwardedRef}
       side={side}
       align={align}
       disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
-      open={context.open}
-      onOpenChange={context.onOpenChange}
       style={{
         ...props.style,
         // re-namespace exposed content custom property
         ['--radix-context-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
       }}
-      anchorRef={context.anchorRef}
       trapFocus
       disableOutsideScroll
       portalled
-      onDismiss={() => context.onOpenChange(false)}
     />
   );
 }) as ContextMenuContentPrimitive;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -60,7 +60,8 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
   });
 
   return (
-    <MenuPrimitive.Anchor virtualRef={virtualRef}>
+    <>
+      <MenuPrimitive.Anchor virtualRef={virtualRef} />
       <Primitive
         {...triggerProps}
         as={as}
@@ -71,7 +72,7 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
           context.onOpenChange(true);
         })}
       />
-    </MenuPrimitive.Anchor>
+    </>
   );
 }) as ContextMenuTriggerPrimitive;
 

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -141,7 +141,7 @@ export const Chromatic = () => (
   <div
     style={{
       display: 'grid',
-      gridTemplateColumns: 'repeat(2, 1fr)',
+      gridTemplateColumns: 'repeat(4, 1fr)',
       gridTemplateRows: 'repeat(2, 1fr)',
       height: '100vh',
     }}
@@ -160,10 +160,34 @@ export const Chromatic = () => (
       <h2>Open</h2>
       <Dialog defaultOpen>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogOverlay className={overlayClass} style={{ right: '50%', bottom: '50%' }} />
-        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '25%' }}>
+        <DialogOverlay className={overlayClass} style={{ left: 0, bottom: '50%', width: '25%' }} />
+        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '12%' }}>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
+      </Dialog>
+    </div>
+
+    <div>
+      <h1>Uncontrolled with reordered parts</h1>
+      <h2>Closed</h2>
+      <Dialog>
+        <DialogOverlay className={overlayClass} />
+        <DialogContent className={chromaticContentClass}>
+          <DialogClose className={closeClass}>close</DialogClose>
+        </DialogContent>
+        <DialogTrigger className={triggerClass}>open</DialogTrigger>
+      </Dialog>
+
+      <h2>Open</h2>
+      <Dialog defaultOpen>
+        <DialogOverlay
+          className={overlayClass}
+          style={{ left: '25%', bottom: '50%', width: '25%' }}
+        />
+        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '37%' }}>
+          <DialogClose className={closeClass}>close</DialogClose>
+        </DialogContent>
+        <DialogTrigger className={triggerClass}>open</DialogTrigger>
       </Dialog>
     </div>
 
@@ -181,10 +205,37 @@ export const Chromatic = () => (
       <h2>Open</h2>
       <Dialog open>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogOverlay className={overlayClass} style={{ left: '50%', bottom: '50%' }} />
-        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '75%' }}>
+        <DialogOverlay
+          className={overlayClass}
+          style={{ left: '50%', bottom: '50%', width: '25%' }}
+        />
+        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '62%' }}>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
+      </Dialog>
+    </div>
+
+    <div>
+      <h1>Controlled with reordered parts</h1>
+      <h2>Closed</h2>
+      <Dialog open={false}>
+        <DialogOverlay className={overlayClass} />
+        <DialogContent className={chromaticContentClass}>
+          <DialogClose className={closeClass}>close</DialogClose>
+        </DialogContent>
+        <DialogTrigger className={triggerClass}>open</DialogTrigger>
+      </Dialog>
+
+      <h2>Open</h2>
+      <Dialog open>
+        <DialogOverlay
+          className={overlayClass}
+          style={{ left: '75%', bottom: '50%', width: '25%' }}
+        />
+        <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '88%' }}>
+          <DialogClose className={closeClass}>close</DialogClose>
+        </DialogContent>
+        <DialogTrigger className={triggerClass}>open</DialogTrigger>
       </Dialog>
     </div>
 

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { FocusScope } from '@radix-ui/react-focus-scope';
-import { Popper, PopperArrow } from '@radix-ui/react-popper';
+import { Popper, PopperAnchor, PopperContent, PopperArrow } from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { FocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
@@ -595,10 +595,15 @@ function DummyPopover({
   const openButtonRef = React.useRef(null);
   const ScrollContainer = preventScroll ? RemoveScroll : React.Fragment;
   return (
-    <>
-      <button ref={openButtonRef} type="button" onClick={() => setOpen((prevOpen) => !prevOpen)}>
+    <Popper>
+      <PopperAnchor
+        as="button"
+        type="button"
+        ref={openButtonRef}
+        onClick={() => setOpen((prevOpen) => !prevOpen)}
+      >
         {openLabel}
-      </button>
+      </PopperAnchor>
       {open ? (
         <FocusGuards>
           <Portal>
@@ -633,10 +638,9 @@ function DummyPopover({
                     }}
                   >
                     {(focusScopeProps) => (
-                      <Popper
+                      <PopperContent
                         {...dismissableLayerProps}
                         {...focusScopeProps}
-                        anchorRef={openButtonRef}
                         style={{
                           filter: 'drop-shadow(0 2px 10px rgba(0, 0, 0, 0.12))',
                           display: 'flex',
@@ -659,7 +663,7 @@ function DummyPopover({
                         </button>
                         <input type="text" defaultValue="hello world" />
                         <PopperArrow width={10} height={4} style={{ fill: color }} offset={20} />
-                      </Popper>
+                      </PopperContent>
                     )}
                   </FocusScope>
                 )}
@@ -668,6 +672,6 @@ function DummyPopover({
           </Portal>
         </FocusGuards>
       ) : null}
-    </>
+    </Popper>
   );
 }

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -258,7 +258,7 @@ export const Chromatic = () => {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <h2 style={{ marginTop: 200 }}>Open with reordered parts</h2>
+      <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
       <DropdownMenu defaultOpen>
         <DropdownMenuContent
           className={contentClass}
@@ -346,7 +346,7 @@ export const Chromatic = () => {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <h2 style={{ marginTop: 200 }}>Open with reordered parts</h2>
+      <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
       <DropdownMenu open>
         <DropdownMenuContent
           className={contentClass}

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -258,6 +258,35 @@ export const Chromatic = () => {
         </DropdownMenuContent>
       </DropdownMenu>
 
+      <h2 style={{ marginTop: 200 }}>Open with reordered parts</h2>
+      <DropdownMenu defaultOpen>
+        <DropdownMenuContent
+          className={contentClass}
+          sideOffset={5}
+          avoidCollisions={false}
+          disableOutsideScroll={false}
+        >
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenuItem>
+          <DropdownMenuArrow />
+        </DropdownMenuContent>
+        <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+      </DropdownMenu>
+
       <h1 style={{ marginTop: 200 }}>Controlled</h1>
       <h2>Closed</h2>
       <DropdownMenu open={false}>
@@ -315,6 +344,35 @@ export const Chromatic = () => {
           </DropdownMenuItem>
           <DropdownMenuArrow />
         </DropdownMenuContent>
+      </DropdownMenu>
+
+      <h2 style={{ marginTop: 200 }}>Open with reordered parts</h2>
+      <DropdownMenu open>
+        <DropdownMenuContent
+          className={contentClass}
+          sideOffset={5}
+          avoidCollisions={false}
+          disableOutsideScroll={false}
+        >
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenuItem>
+          <DropdownMenuArrow />
+        </DropdownMenuContent>
+        <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
       </DropdownMenu>
 
       <h1 style={{ marginTop: 200 }}>Positioning</h1>

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -18,7 +18,7 @@ import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
 import { classes, TickIcon } from '../../menu/src/Menu.stories';
 
-const { rootClass, itemClass, labelClass, separatorClass } = classes;
+const { contentClass, itemClass, labelClass, separatorClass } = classes;
 
 export default { title: 'Components/DropdownMenu' };
 
@@ -26,7 +26,7 @@ export const Styled = () => (
   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}>
     <DropdownMenu>
       <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-      <DropdownMenuContent className={rootClass} sideOffset={5}>
+      <DropdownMenuContent className={contentClass} sideOffset={5}>
         <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
           Undo
         </DropdownMenuItem>
@@ -53,7 +53,7 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <DropdownMenu>
       <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-      <DropdownMenuContent className={rootClass} sideOffset={5}>
+      <DropdownMenuContent className={contentClass} sideOffset={5}>
         {foodGroups.map((foodGroup, index) => (
           <DropdownMenuGroup key={index}>
             {foodGroup.label && (
@@ -92,7 +92,7 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <DropdownMenu>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent className={rootClass} sideOffset={5}>
+        <DropdownMenuContent className={contentClass} sideOffset={5}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </DropdownMenuItem>
@@ -132,7 +132,7 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <DropdownMenu>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent className={rootClass} sideOffset={5}>
+        <DropdownMenuContent className={contentClass} sideOffset={5}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('minimize')}>
             Minimize window
           </DropdownMenuItem>
@@ -165,7 +165,7 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <DropdownMenu>
       <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-      <DropdownMenuContent className={rootClass} sideOffset={5}>
+      <DropdownMenuContent className={contentClass} sideOffset={5}>
         <DropdownMenuItem className={itemClass} onSelect={() => window.alert('action 1')}>
           I will close
         </DropdownMenuItem>
@@ -204,7 +204,7 @@ export const Chromatic = () => {
       <DropdownMenu>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}
@@ -233,7 +233,7 @@ export const Chromatic = () => {
       <DropdownMenu defaultOpen>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}
@@ -263,7 +263,7 @@ export const Chromatic = () => {
       <DropdownMenu open={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}
@@ -292,7 +292,7 @@ export const Chromatic = () => {
       <DropdownMenu open>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}
@@ -553,7 +553,7 @@ export const Chromatic = () => {
       <DropdownMenu open>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}
@@ -588,7 +588,7 @@ export const Chromatic = () => {
       <DropdownMenu open>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
-          className={rootClass}
+          className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
           disableOutsideScroll={false}

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   Menu as MenuPrimitive,
+  MenuAnchor,
+  MenuContent,
   MenuGroup,
   MenuLabel,
   MenuItem,
@@ -13,9 +15,10 @@ import {
 import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
 
-import type * as Polymorphic from '@radix-ui/react-polymorphic';
-
-export default { title: 'Components/Menu', excludeStories: ['TickIcon', 'styledComponents'] };
+export default {
+  title: 'Components/Menu',
+  excludeStories: ['TickIcon', 'styledComponents', 'classes'],
+};
 
 export const Styled = () => (
   <Menu>
@@ -249,9 +252,8 @@ export const Animated = () => {
 };
 
 type MenuOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive>,
+  React.ComponentProps<typeof MenuPrimitive> & React.ComponentProps<typeof MenuContent>,
   | 'onOpenChange'
-  | 'anchorRef'
   | 'portalled'
   | 'trapFocus'
   | 'onOpenAutoFocus'
@@ -260,23 +262,13 @@ type MenuOwnProps = Omit<
   | 'disableOutsideScroll'
 >;
 
-type MenuPrimitiveType = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuPrimitive>,
-  MenuOwnProps
->;
-
-const Menu = React.forwardRef((props, forwardedRef) => {
-  const { open = true } = props;
-  const ref = React.useRef<HTMLDivElement>(null);
+const Menu: React.FC<MenuOwnProps> = (props) => {
+  const { open = true, children, ...contentProps } = props;
   return (
-    <>
-      <div ref={ref} />
-      <MenuPrimitive
-        className={rootClass}
-        ref={forwardedRef}
-        open={open}
-        onOpenChange={() => {}}
-        anchorRef={ref}
+    <MenuPrimitive open={open} onOpenChange={() => {}}>
+      <MenuAnchor />
+      <MenuContent
+        className={contentClass}
         portalled
         trapFocus={false}
         onOpenAutoFocus={(event) => event.preventDefault()}
@@ -284,13 +276,15 @@ const Menu = React.forwardRef((props, forwardedRef) => {
         disableOutsidePointerEvents={false}
         disableOutsideScroll={false}
         align="start"
-        {...props}
-      />
-    </>
+        {...contentProps}
+      >
+        {children}
+      </MenuContent>
+    </MenuPrimitive>
   );
-}) as MenuPrimitiveType;
+};
 
-const rootClass = css({
+const contentClass = css({
   display: 'inline-block',
   boxSizing: 'border-box',
   minWidth: 130,
@@ -355,7 +349,7 @@ const fadeOut = css.keyframes({
   to: { opacity: 0 },
 });
 
-const animatedRootClass = css(rootClass, {
+const animatedRootClass = css(contentClass, {
   '&[data-state="open"]': {
     animation: `${fadeIn} 300ms ease-out`,
   },
@@ -390,7 +384,7 @@ export const TickIcon = () => (
 );
 
 export const classes = {
-  rootClass,
+  contentClass,
   labelClass,
   itemClass,
   separatorClass,

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -30,6 +30,8 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
+    "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -228,6 +228,15 @@ export const Chromatic = () => (
       </PopoverContent>
     </Popover>
 
+    <h2 style={{ marginTop: 100 }}>Open with reordered parts</h2>
+    <Popover defaultOpen>
+      <PopoverContent className={contentClass} sideOffset={5}>
+        <PopoverClose className={closeClass}>close</PopoverClose>
+        <PopoverArrow className={arrowClass} width={20} height={10} />
+      </PopoverContent>
+      <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+    </Popover>
+
     <h1 style={{ marginTop: 100 }}>Controlled</h1>
     <h2>Closed</h2>
     <Popover open={false}>
@@ -247,10 +256,42 @@ export const Chromatic = () => (
       </PopoverContent>
     </Popover>
 
+    <h2 style={{ marginTop: 100 }}>Open with reordered parts</h2>
+    <Popover open>
+      <PopoverContent className={contentClass} sideOffset={5}>
+        <PopoverClose className={closeClass}>close</PopoverClose>
+        <PopoverArrow className={arrowClass} width={20} height={10} />
+      </PopoverContent>
+      <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+    </Popover>
+
     <h1 style={{ marginTop: 100 }}>Force mounted content</h1>
     <Popover>
       <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
       <PopoverContent className={contentClass} sideOffset={5} forceMount>
+        <PopoverClose className={closeClass}>close</PopoverClose>
+        <PopoverArrow className={arrowClass} width={20} height={10} />
+      </PopoverContent>
+    </Popover>
+
+    <h1 style={{ marginTop: 100 }}>Anchor</h1>
+    <h2>Controlled</h2>
+    <Popover open>
+      <PopoverAnchor style={{ padding: 20, background: 'gainsboro' }}>
+        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+      </PopoverAnchor>
+      <PopoverContent className={contentClass}>
+        <PopoverClose className={closeClass}>close</PopoverClose>
+        <PopoverArrow className={arrowClass} width={20} height={10} />
+      </PopoverContent>
+    </Popover>
+
+    <h2>Uncontrolled</h2>
+    <Popover defaultOpen>
+      <PopoverAnchor style={{ padding: 20, background: 'gainsboro' }}>
+        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+      </PopoverAnchor>
+      <PopoverContent className={contentClass}>
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Popover, PopoverTrigger, PopoverContent, PopoverClose, PopoverArrow } from './Popover';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverClose,
+  PopoverArrow,
+} from './Popover';
 import { Slot } from '@radix-ui/react-slot';
 import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/popper';
 import { css } from '../../../../stitches.config';
@@ -139,12 +146,9 @@ export const Nested = () => {
   );
 };
 
-export const CustomAnchor = () => {
-  const itemBoxRef = React.useRef<HTMLDivElement>(null);
-
-  return (
-    <div
-      ref={itemBoxRef}
+export const CustomAnchor = () => (
+  <Popover>
+    <PopoverAnchor
       style={{
         display: 'flex',
         justifyContent: 'space-between',
@@ -155,23 +159,19 @@ export const CustomAnchor = () => {
         backgroundColor: '#eee',
       }}
     >
-      Item
-      <Popover>
-        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-        <PopoverContent
-          className={contentClass}
-          anchorRef={itemBoxRef}
-          side="right"
-          sideOffset={1}
-          align="start"
-          style={{ borderRadius: 0, width: 200, height: 100 }}
-        >
-          <PopoverClose>close</PopoverClose>
-        </PopoverContent>
-      </Popover>
-    </div>
-  );
-};
+      Item <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+    </PopoverAnchor>
+    <PopoverContent
+      className={contentClass}
+      side="right"
+      sideOffset={1}
+      align="start"
+      style={{ borderRadius: 0, width: 200, height: 100 }}
+    >
+      <PopoverClose>close</PopoverClose>
+    </PopoverContent>
+  </Popover>
+);
 
 export const NonModal = () => {
   return (

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
+import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -10,6 +11,7 @@ import { Portal } from '@radix-ui/react-portal';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
 import { useId } from '@radix-ui/react-id';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
@@ -31,6 +33,9 @@ type PopoverContextValue = {
   open: boolean;
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
+  hasCustomAnchor: boolean;
+  onCustomAnchorAdd(): void;
+  onCustomAnchorRemove(): void;
 };
 
 const [PopoverProvider, usePopoverContext] = createContext<PopoverContextValue>(POPOVER_NAME);
@@ -44,6 +49,7 @@ type PopoverOwnProps = {
 const Popover: React.FC<PopoverOwnProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [hasCustomAnchor, setHasCustomAnchor] = React.useState(false);
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -51,19 +57,51 @@ const Popover: React.FC<PopoverOwnProps> = (props) => {
   });
 
   return (
-    <PopoverProvider
-      contentId={useId()}
-      triggerRef={triggerRef}
-      open={open}
-      onOpenChange={setOpen}
-      onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
-    >
-      {children}
-    </PopoverProvider>
+    <PopperPrimitive.Root>
+      <PopoverProvider
+        contentId={useId()}
+        triggerRef={triggerRef}
+        open={open}
+        onOpenChange={setOpen}
+        onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+        hasCustomAnchor={hasCustomAnchor}
+        onCustomAnchorAdd={() => setHasCustomAnchor(true)}
+        onCustomAnchorRemove={() => setHasCustomAnchor(false)}
+      >
+        {children}
+      </PopoverProvider>
+    </PopperPrimitive.Root>
   );
 };
 
 Popover.displayName = POPOVER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * PopoverAnchor
+ * -----------------------------------------------------------------------------------------------*/
+
+const ANCHOR_NAME = 'PopoverAnchor';
+
+type PopoverAnchorOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Anchor>;
+type PopoverAnchorPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Anchor>,
+  PopoverAnchorOwnProps
+>;
+
+const PopoverAnchor = React.forwardRef((props, forwardedRef) => {
+  const context = usePopoverContext(ANCHOR_NAME);
+  const handleCustomAnchorAdd = useCallbackRef(context.onCustomAnchorAdd);
+  const handleCustomAnchorRemove = useCallbackRef(context.onCustomAnchorRemove);
+
+  React.useEffect(() => {
+    handleCustomAnchorAdd();
+    return () => handleCustomAnchorRemove();
+  }, [handleCustomAnchorAdd, handleCustomAnchorRemove]);
+
+  return <PopperPrimitive.Anchor {...props} ref={forwardedRef} />;
+}) as PopoverAnchorPrimitive;
+
+PopoverAnchor.displayName = ANCHOR_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * PopoverTrigger
@@ -82,7 +120,8 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = usePopoverContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
-  return (
+
+  const primitive = (
     <Primitive
       type="button"
       aria-haspopup="dialog"
@@ -94,6 +133,12 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
       ref={composedTriggerRef}
       onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
     />
+  );
+
+  return context.hasCustomAnchor ? (
+    primitive
+  ) : (
+    <PopperPrimitive.Anchor as={Slot}>{primitive}</PopperPrimitive.Anchor>
   );
 }) as PopoverTriggerPrimitive;
 
@@ -136,7 +181,7 @@ const PopoverContent = React.forwardRef((props, forwardedRef) => {
   );
 }) as PopoverContentPrimitive;
 
-type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Root>;
+type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Content>;
 type PopoverContentImplOwnProps = Polymorphic.Merge<
   PopperPrimitiveOwnProps,
   {
@@ -201,19 +246,16 @@ type PopoverContentImplOwnProps = Polymorphic.Merge<
      * (default: `true`)
      */
     portalled?: boolean;
-
-    anchorRef?: PopperPrimitiveOwnProps['anchorRef'];
   }
 >;
 
 type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Root>,
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Content>,
   PopoverContentImplOwnProps
 >;
 
 const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
-    anchorRef,
     trapFocus = true,
     onOpenAutoFocus,
     onCloseAutoFocus,
@@ -306,14 +348,13 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
               onDismiss={() => context.onOpenChange(false)}
             >
               {(dismissableLayerProps) => (
-                <PopperPrimitive.Root
+                <PopperPrimitive.Content
                   role="dialog"
                   aria-modal
                   id={context.contentId}
                   {...focusScopeProps}
                   {...contentProps}
                   ref={composeRefs(forwardedRef, contentRef, focusScopeProps.ref)}
-                  anchorRef={anchorRef || context.triggerRef}
                   onKeyDown={composeEventHandlers(
                     contentProps.onKeyDown,
                     focusScopeProps.onKeyDown
@@ -392,6 +433,7 @@ const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'Popo
 /* -----------------------------------------------------------------------------------------------*/
 
 const Root = Popover;
+const Anchor = PopoverAnchor;
 const Trigger = PopoverTrigger;
 const Content = PopoverContent;
 const Close = PopoverClose;
@@ -399,12 +441,14 @@ const Arrow = PopoverArrow;
 
 export {
   Popover,
+  PopoverAnchor,
   PopoverTrigger,
   PopoverContent,
   PopoverClose,
   PopoverArrow,
   //
   Root,
+  Anchor,
   Trigger,
   Content,
   Close,

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -65,8 +65,8 @@ const Popover: React.FC<PopoverOwnProps> = (props) => {
         onOpenChange={setOpen}
         onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
         hasCustomAnchor={hasCustomAnchor}
-        onCustomAnchorAdd={() => setHasCustomAnchor(true)}
-        onCustomAnchorRemove={() => setHasCustomAnchor(false)}
+        onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
+        onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}
       >
         {children}
       </PopoverProvider>
@@ -90,13 +90,12 @@ type PopoverAnchorPrimitive = Polymorphic.ForwardRefComponent<
 
 const PopoverAnchor = React.forwardRef((props, forwardedRef) => {
   const context = usePopoverContext(ANCHOR_NAME);
-  const handleCustomAnchorAdd = useCallbackRef(context.onCustomAnchorAdd);
-  const handleCustomAnchorRemove = useCallbackRef(context.onCustomAnchorRemove);
+  const { onCustomAnchorAdd, onCustomAnchorRemove } = context;
 
   React.useEffect(() => {
-    handleCustomAnchorAdd();
-    return () => handleCustomAnchorRemove();
-  }, [handleCustomAnchorAdd, handleCustomAnchorRemove]);
+    onCustomAnchorAdd();
+    return () => onCustomAnchorRemove();
+  }, [onCustomAnchorAdd, onCustomAnchorRemove]);
 
   return <PopperPrimitive.Anchor {...props} ref={forwardedRef} />;
 }) as PopoverAnchorPrimitive;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -121,7 +121,7 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
   const context = usePopoverContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 
-  const primitive = (
+  const trigger = (
     <Primitive
       type="button"
       aria-haspopup="dialog"
@@ -136,9 +136,9 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
   );
 
   return context.hasCustomAnchor ? (
-    primitive
+    trigger
   ) : (
-    <PopperPrimitive.Anchor as={Slot}>{primitive}</PopperPrimitive.Anchor>
+    <PopperPrimitive.Anchor as={Slot}>{trigger}</PopperPrimitive.Anchor>
   );
 }) as PopoverTriggerPrimitive;
 

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -1,87 +1,98 @@
 import * as React from 'react';
-import { Popper, PopperArrow } from './Popper';
+import { Popper, PopperAnchor, PopperContent, PopperArrow } from './Popper';
 import { Portal } from '@radix-ui/react-portal';
-import { Arrow } from '@radix-ui/react-arrow';
-import { styled, css } from '../../../../stitches.config';
+import { css } from '../../../../stitches.config';
 
 export default { title: 'Components/Popper' };
 
 export const Styled = () => {
   const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
   return (
     <Scrollable>
-      <Anchor ref={anchorRef} onClick={() => setOpen(true)} />
+      <Popper>
+        <PopperAnchor className={anchorClass} onClick={() => setOpen(true)}>
+          open
+        </PopperAnchor>
 
-      {open && (
-        <Popper as={StyledRoot} anchorRef={anchorRef} sideOffset={5}>
-          <button onClick={() => setOpen(false)}>close</button>
-          <PopperArrow as={StyledArrow} width={20} height={10} />
-        </Popper>
-      )}
+        {open && (
+          <PopperContent className={contentClass} sideOffset={5}>
+            <button onClick={() => setOpen(false)}>close</button>
+            <PopperArrow className={arrowClass} width={20} height={10} />
+          </PopperContent>
+        )}
+      </Popper>
     </Scrollable>
   );
 };
 
 export const WithCustomArrow = () => {
   const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
   return (
     <Scrollable>
-      <Anchor ref={anchorRef} onClick={() => setOpen(true)} />
+      <Popper>
+        <PopperAnchor className={anchorClass} onClick={() => setOpen(true)}>
+          open
+        </PopperAnchor>
 
-      {open && (
-        <Popper as={StyledRoot} anchorRef={anchorRef} side="right" sideOffset={5}>
-          <button onClick={() => setOpen(false)}>close</button>
-          <PopperArrow as={CustomArrow} width={20} height={10} offset={20} />
-        </Popper>
-      )}
+        {open && (
+          <PopperContent className={contentClass} side="right" sideOffset={5}>
+            <button onClick={() => setOpen(false)}>close</button>
+            <PopperArrow as={CustomArrow} width={20} height={10} offset={20} />
+          </PopperContent>
+        )}
+      </Popper>
     </Scrollable>
   );
 };
 
 export const Animated = () => {
   const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <Scrollable>
-      <Anchor ref={anchorRef} onClick={() => setOpen(true)} />
+      <Popper>
+        <PopperAnchor className={anchorClass} onClick={() => setOpen(true)}>
+          open
+        </PopperAnchor>
 
-      {open && (
-        <Portal>
-          <Popper as={AnimatedPopper} anchorRef={anchorRef} sideOffset={5}>
-            <button onClick={() => setOpen(false)}>close</button>
-            <PopperArrow as={StyledArrow} width={20} height={10} offset={25} />
-          </Popper>
-        </Portal>
-      )}
+        {open && (
+          <Portal>
+            <PopperContent className={animatedContentClass} sideOffset={5}>
+              <button onClick={() => setOpen(false)}>close</button>
+              <PopperArrow className={arrowClass} width={20} height={10} offset={25} />
+            </PopperContent>
+          </Portal>
+        )}
+      </Popper>
     </Scrollable>
   );
 };
 
 export const WithPortal = () => {
   const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
   return (
     <Scrollable>
-      <Anchor ref={anchorRef} onClick={() => setOpen(true)} />
+      <Popper>
+        <PopperAnchor className={anchorClass} onClick={() => setOpen(true)}>
+          open
+        </PopperAnchor>
 
-      {open && (
-        <Portal>
-          <Popper as={StyledRoot} anchorRef={anchorRef} sideOffset={5}>
-            <button onClick={() => setOpen(false)}>close</button>
-            <PopperArrow as={StyledArrow} width={20} height={10} />
-          </Popper>
-        </Portal>
-      )}
+        {open && (
+          <Portal>
+            <PopperContent className={contentClass} sideOffset={5}>
+              <button onClick={() => setOpen(false)}>close</button>
+              <PopperArrow className={arrowClass} width={20} height={10} />
+            </PopperContent>
+          </Portal>
+        )}
+      </Popper>
     </Scrollable>
   );
 };
 
 export const WithVirtualElement = () => {
   const mousePosRef = React.useRef({ x: 0, y: 0 });
-  const anchorRef = React.useRef({
+  const virtualRef = React.useRef({
     getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, ...mousePosRef.current }),
   });
 
@@ -93,7 +104,12 @@ export const WithVirtualElement = () => {
     return () => document.removeEventListener('mousemove', handleMouseMove);
   }, []);
 
-  return <Popper as={StyledRoot} anchorRef={anchorRef} align="start" />;
+  return (
+    <Popper>
+      <PopperAnchor virtualRef={virtualRef} />
+      <PopperContent className={contentClass} align="start" />
+    </Popper>
+  );
 };
 
 const Scrollable = (props: any) => (
@@ -103,34 +119,26 @@ const Scrollable = (props: any) => (
   />
 );
 
-const Anchor = React.forwardRef<HTMLDivElement, any>((props, forwardedRef) => (
-  <div ref={forwardedRef} style={{ backgroundColor: 'hotpink', width: 100, height: 100 }}>
-    <button {...props}>open</button>
-  </div>
-));
+const CustomArrow = (props: any) => (
+  <div
+    {...props}
+    style={{
+      ...props.style,
+      width: 20,
+      height: 10,
+      borderBottomLeftRadius: 10,
+      borderBottomRightRadius: 10,
+      backgroundColor: 'tomato',
+    }}
+  />
+);
 
-function CustomArrow(props: any) {
-  return (
-    <div
-      {...props}
-      style={{
-        ...props.style,
-        width: 20,
-        height: 10,
-        borderBottomLeftRadius: 10,
-        borderBottomRightRadius: 10,
-        backgroundColor: 'tomato',
-      }}
-    />
-  );
-}
-
-const RECOMMENDED_CSS__POPPER__ROOT = {
+const RECOMMENDED_CSS__POPPER__CONTENT = {
   transformOrigin: 'var(--radix-popper-transform-origin)',
 };
 
-const StyledRoot = styled('div', {
-  ...RECOMMENDED_CSS__POPPER__ROOT,
+const contentClass = css({
+  ...RECOMMENDED_CSS__POPPER__CONTENT,
   backgroundColor: '$gray100',
   width: 300,
   height: 150,
@@ -138,7 +146,13 @@ const StyledRoot = styled('div', {
   borderRadius: 10,
 });
 
-const StyledArrow = styled(Arrow, {
+const anchorClass = css({
+  backgroundColor: 'hotpink',
+  width: 100,
+  height: 100,
+});
+
+const arrowClass = css({
   fill: '$gray100',
 });
 
@@ -147,7 +161,7 @@ const rotateIn = css.keyframes({
   '100%': { transform: 'scale(1)' },
 });
 
-const AnimatedPopper = styled(StyledRoot, {
+const animatedContentClass = css(contentClass, {
   '&[data-side="top"]': { '--direction': '1' },
   '&[data-side="bottom"]': { '--direction': '-1' },
   animation: `${rotateIn} 0.6s cubic-bezier(0.16, 1, 0.3, 1)`,

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -55,14 +55,15 @@ const PopperAnchor = React.forwardRef((props, forwardedRef) => {
   );
 
   React.useEffect(() => {
+    // Consumer can anchor the popper to something that isn't
+    // a DOM node e.g. pointer position, so we override the
+    // `anchorRef` with their virtual ref in this case.
     if (virtualRef?.current) {
       context.anchorRef.current = virtualRef.current;
     }
   });
 
-  return virtualRef ? (
-    <>{children}</>
-  ) : (
+  return virtualRef ? null : (
     <Primitive {...anchorProps} ref={composedRefs}>
       {children}
     </Primitive>
@@ -148,7 +149,7 @@ const PopperContent = React.forwardRef((props, forwardedRef) => {
   const isPlaced = placedSide !== undefined;
 
   return (
-    <div style={popperStyles} data-radix-popper-wrapper="">
+    <div style={popperStyles} data-radix-popper-content-wrapper="">
       <PopperContentProvider
         arrowRef={arrowRef}
         arrowStyles={arrowStyles}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -48,10 +48,16 @@ const PopperAnchor = React.forwardRef((props, forwardedRef) => {
   const { virtualRef, children, ...anchorProps } = props;
   const context = usePopperContext(ANCHOR_NAME);
   const ref = React.useRef<React.ElementRef<typeof Primitive>>(null);
-  const composedRefs = useComposedRefs(forwardedRef, ref);
+  const composedRefs = useComposedRefs(
+    forwardedRef,
+    ref,
+    context.anchorRef as React.MutableRefObject<React.ElementRef<typeof Primitive>>
+  );
 
   React.useEffect(() => {
-    context.anchorRef.current = virtualRef?.current || ref.current;
+    if (virtualRef?.current) {
+      context.anchorRef.current = virtualRef.current;
+    }
   });
 
   return virtualRef ? (

--- a/packages/react/toolbar/src/Toolbar.stories.tsx
+++ b/packages/react/toolbar/src/Toolbar.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@radix-ui/react-dropdown-menu';
 
 import { classes } from '../../menu/src/Menu.stories';
-const { contentClass: dropdownMenuRootClass, itemClass: dropdownMenuItemClass } = classes;
+const { contentClass: dropdownMenuContentClass, itemClass: dropdownMenuItemClass } = classes;
 
 export default { title: 'Components/Toolbar' };
 
@@ -80,7 +80,7 @@ const ToolbarExample = ({ title, orientation }: any) => (
         <ToolbarButton className={toolbarItemClass} as={DropdownMenuTrigger}>
           Menu
         </ToolbarButton>
-        <DropdownMenuContent className={dropdownMenuRootClass} sideOffset={5}>
+        <DropdownMenuContent className={dropdownMenuContentClass} sideOffset={5}>
           <DropdownMenuItem className={dropdownMenuItemClass}>Undo</DropdownMenuItem>
           <DropdownMenuItem className={dropdownMenuItemClass}>Redo</DropdownMenuItem>
           <DropdownMenuArrow />

--- a/packages/react/toolbar/src/Toolbar.stories.tsx
+++ b/packages/react/toolbar/src/Toolbar.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@radix-ui/react-dropdown-menu';
 
 import { classes } from '../../menu/src/Menu.stories';
-const { rootClass: dropdownMenuRootClass, itemClass: dropdownMenuItemClass } = classes;
+const { contentClass: dropdownMenuRootClass, itemClass: dropdownMenuItemClass } = classes;
 
 export default { title: 'Components/Toolbar' };
 

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -544,6 +544,15 @@ export const Chromatic = () => (
       </TooltipContent>
     </Tooltip>
 
+    <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
+    <Tooltip defaultOpen>
+      <TooltipContent className={contentClass} sideOffset={5}>
+        Some content
+        <TooltipArrow className={arrowClass} offset={10} />
+      </TooltipContent>
+      <TooltipTrigger className={triggerClass}>open</TooltipTrigger>
+    </Tooltip>
+
     <h1 style={{ marginTop: 100 }}>Controlled</h1>
     <h2>Closed</h2>
     <Tooltip open={false}>
@@ -561,6 +570,15 @@ export const Chromatic = () => (
         Some content
         <TooltipArrow className={arrowClass} offset={10} />
       </TooltipContent>
+    </Tooltip>
+
+    <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
+    <Tooltip open>
+      <TooltipContent className={contentClass} sideOffset={5}>
+        Some content
+        <TooltipArrow className={arrowClass} offset={10} />
+      </TooltipContent>
+      <TooltipTrigger className={triggerClass}>open</TooltipTrigger>
     </Tooltip>
 
     <h1 style={{ marginTop: 100 }}>Positioning</h1>

--- a/packages/react/use-rect/package.json
+++ b/packages/react/use-rect/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/react-use-layout-effect": "workspace:*",
     "@radix-ui/rect": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/use-rect/src/useRect.tsx
+++ b/packages/react/use-rect/src/useRect.tsx
@@ -7,9 +7,9 @@ import type { Measurable } from '@radix-ui/rect';
  * Use this custom hook to get access to an element's rect (getBoundingClientRect)
  * and observe it along time.
  */
-function useRect(
+function useRect<T extends Measurable>(
   /** A reference to the element whose rect to observe */
-  refToObserve: React.RefObject<Measurable>
+  refToObserve: React.RefObject<T>
 ) {
   const [rect, setRect] = React.useState<ClientRect>();
 

--- a/packages/react/use-rect/src/useRect.tsx
+++ b/packages/react/use-rect/src/useRect.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { observeElementRect } from '@radix-ui/rect';
-import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
 import type { Measurable } from '@radix-ui/rect';
 
@@ -13,7 +12,8 @@ function useRect(
   refToObserve: React.RefObject<Measurable>
 ) {
   const [rect, setRect] = React.useState<ClientRect>();
-  useLayoutEffect(() => {
+
+  React.useEffect(() => {
     if (refToObserve.current) {
       const unobserve = observeElementRect(refToObserve.current, setRect);
       return () => {
@@ -23,6 +23,7 @@ function useRect(
     }
     return;
   }, [refToObserve]);
+
   return rect;
 }
 

--- a/packages/react/use-rect/src/useRect.tsx
+++ b/packages/react/use-rect/src/useRect.tsx
@@ -7,12 +7,11 @@ import type { Measurable } from '@radix-ui/rect';
  * Use this custom hook to get access to an element's rect (getBoundingClientRect)
  * and observe it along time.
  */
-function useRect<T extends Measurable>(
+function useRect(
   /** A reference to the element whose rect to observe */
-  refToObserve: React.RefObject<T>
+  refToObserve: React.RefObject<Measurable>
 ) {
   const [rect, setRect] = React.useState<ClientRect>();
-
   React.useEffect(() => {
     if (refToObserve.current) {
       const unobserve = observeElementRect(refToObserve.current, setRect);
@@ -23,7 +22,6 @@ function useRect<T extends Measurable>(
     }
     return;
   }, [refToObserve]);
-
   return rect;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,6 +3572,8 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0
@@ -3927,7 +3929,6 @@ __metadata:
   resolution: "@radix-ui/react-use-rect@workspace:packages/react/use-rect"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@radix-ui/react-use-layout-effect": "workspace:*"
     "@radix-ui/rect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

--------------

ℹ️ &nbsp;&nbsp;&nbsp;Easier to review with hidden whitespace changes.

--------------

We had refs as hook dependencies which meant the hook logic would never execute if refs weren't available on mount and wouldn't re-execute if refs were re-assigned.

~This adds a new `useNode` hook that will return an up to date `node` base on a given `ref` so that the `node` can be used as the hook dependency instead.~

This PR is the first part of a wider change. This part does the following: 

- Creates a new `Anchor` part in `Popper` that will allow us to attach a callback ref internally (next PR)
- Recomposes `Anchor` in the relevant components (`Tooltip`, `DropdownMenu`, `Popover` etc.)
- 🔥 Exposes the `Anchor` from `Popover` as an optional part
- 🔥 Removes `anchorRef` capability from `DropdownMenu` and `Tooltip` altogether as we believe it's not relevant there. We'll see what feedback we get here. 
- 🔥 `data-radix-popper-wrapper` => `data-radix-popper-content-wrapper`
- Adds new Chromatic stories to reflect fixes

These changes fix #447 including the part re-ordering issue mentioned there. Next PR will fix delayed mounting of things.



