### PR TITLE
Support proper focus when having invisible menu items

### DIFF
--- a/.yarn/versions/0ecaafde.yml
+++ b/.yarn/versions/0ecaafde.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -184,6 +184,24 @@ export const PreventClosing = () => (
   </div>
 );
 
+// Contains invisible (display: none) items
+export const InvisibleItems = () => (
+  <div style={{ textAlign: 'center', padding: 50 }}>
+    <DropdownMenu>
+      <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+      <DropdownMenuContent className={rootClass} sideOffset={5}>
+        <DropdownMenuItem className={itemClass}>Item 1 (Visible)</DropdownMenuItem>
+        <DropdownMenuItem className={itemClass}>Item 2 (Visible)</DropdownMenuItem>
+        <DropdownMenuItem className={itemClass} style={{ display: 'none' }}>
+          Item 3 (Invisible)
+        </DropdownMenuItem>
+        <DropdownMenuItem className={itemClass}>Item 4 (Visible)</DropdownMenuItem>
+        <DropdownMenuArrow />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -5,7 +5,7 @@ import { createContext } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
+import { RovingFocusGroup, useRovingFocus, filterVisibleItems } from '@radix-ui/react-roving-focus';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
@@ -299,7 +299,9 @@ const MenuImpl = React.forwardRef((props, forwardedRef) => {
                         if (event.target === menu) {
                           if (ALL_KEYS.includes(event.key)) {
                             event.preventDefault();
-                            const items = Array.from(menu.querySelectorAll(ENABLED_ITEM_SELECTOR));
+                            const items = filterVisibleItems(
+                              Array.from(menu.querySelectorAll(ENABLED_ITEM_SELECTOR))
+                            );
                             const item = FIRST_KEYS.includes(event.key)
                               ? items[0]
                               : items.reverse()[0];

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -114,7 +114,7 @@ function useRovingFocus({ disabled, active }: UseRovingFocusItemOptions) {
       if (focusIntent !== undefined) {
         event.preventDefault();
 
-        const items = getRovingFocusItems(context.groupId);
+        const items = filterVisibleItems(getRovingFocusItems(context.groupId));
         const count = items.length;
         const currentItem = document.activeElement as HTMLElement | null;
         const currentIndex = currentItem ? items.indexOf(currentItem) : -1;
@@ -165,6 +165,11 @@ function getRovingFocusItems(groupId: string): HTMLElement[] {
   return Array.from(document.querySelectorAll(`[${GROUP_ID_DATA_ATTR}="${groupId}"]`));
 }
 
+// items that are not visible (ie: display: none) should not be cycled through
+function filterVisibleItems(elements: HTMLElement[]) {
+  return elements.filter((item) => Boolean(item.offsetParent));
+}
+
 const Root = RovingFocusGroup;
 
 export {
@@ -173,4 +178,6 @@ export {
   Root,
   //
   useRovingFocus,
+  //
+  filterVisibleItems,
 };


### PR DESCRIPTION
Fixes: https://github.com/radix-ui/primitives/issues/581
Reproduceable Issue: https://codesandbox.io/s/relaxed-mestorf-ru0rd?file=/src/App.tsx

Packages changed:
- `@radix-ui/react-menu`
- `@radix-ui/react-roving-focus`

Packages affected:
- `@radix-ui/react-context-menu`
- `@radix-ui/react-dropdown-menu`
- `@radix-ui/react-radio-group`
- `@radix-ui/react-tabs`
- `@radix-ui/react-toggle-group`
- `@radix-ui/react-toolbar`

I'm not sure we need to publish all of them, but I think they might all be impacted by the change.

### Description

When navigating with the arrow keys through a DropdownMenu that has hidden items (ie: with display: none), the focus selection stops when reaching the hidden item, and as such doesn't focus all items.

This PR fixes this issue. It does so by filtering invisible items on the RovingFocus and Menu (when opening it up with the arrow keys, in case the first/last items are hidden).

I've added a Storybook example.


