### PR TITLE
[Popper][Label][Slider] Update hooks to receive node

### DIFF
--- a/.yarn/versions/54d8ec44.yml
+++ b/.yarn/versions/54d8ec44.yml
@@ -1,0 +1,17 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-rect": patch
+  "@radix-ui/react-use-size": patch
+
+declined:
+  - primitives

--- a/packages/core/popper/src/popper.stories.tsx
+++ b/packages/core/popper/src/popper.stories.tsx
@@ -42,14 +42,14 @@ function Demo({ disableCollisions = false }) {
   const side = SIDE_OPTIONS[sideIndex];
   const align = ALIGN_OPTIONS[alignIndex];
 
-  const anchorRef = React.useRef<HTMLDivElement>(null);
-  const anchorRect = useRect(anchorRef);
+  const [anchor, setAnchor] = React.useState<HTMLDivElement | null>(null);
+  const anchorRect = useRect(anchor);
 
-  const popperRef = React.useRef<HTMLDivElement>(null);
-  const popperSize = useSize(popperRef);
+  const [popper, setPopper] = React.useState<HTMLDivElement | null>(null);
+  const popperSize = useSize(popper);
 
-  const arrowRef = React.useRef<HTMLDivElement>(null);
-  const arrowSize = useSize(arrowRef);
+  const [arrow, setArrow] = React.useState<HTMLDivElement | null>(null);
+  const arrowSize = useSize(arrow);
 
   const { popperStyles, arrowStyles } = getPlacementData({
     popperSize,
@@ -73,7 +73,7 @@ function Demo({ disableCollisions = false }) {
   return (
     <>
       <div
-        ref={anchorRef}
+        ref={setAnchor}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -88,7 +88,7 @@ function Demo({ disableCollisions = false }) {
 
       <div style={popperStyles}>
         <div
-          ref={popperRef}
+          ref={setPopper}
           style={{
             display: 'flex',
             alignItems: 'center',
@@ -172,7 +172,7 @@ function Demo({ disableCollisions = false }) {
 
         <span style={arrowStyles}>
           <div
-            ref={arrowRef}
+            ref={setArrow}
             style={{
               width: 20,
               height: 10,

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -56,9 +56,9 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
     ...checkboxProps
   } = props;
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const ref = useComposedRefs(forwardedRef, buttonRef);
-  const labelId = useLabelContext(buttonRef);
+  const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
+  const labelId = useLabelContext(button);
   const labelledBy = ariaLabelledby || labelId;
   const [checked = false, setChecked] = useControllableState({
     prop: checkedProp,
@@ -105,7 +105,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
           value={value}
           {...checkboxProps}
           as={as}
-          ref={ref}
+          ref={composedRefs}
           /**
            * The `input` is hidden, so when the button is clicked we trigger
            * the input manually

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -80,7 +80,7 @@ Label.displayName = NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const useLabelContext = <E extends HTMLElement>(element?: E | null) => {
+const useLabelContext = (element?: HTMLElement | null) => {
   const context = React.useContext(LabelContext);
 
   React.useEffect(() => {

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -80,17 +80,16 @@ Label.displayName = NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const useLabelContext = <E extends HTMLElement>(ref?: React.RefObject<E>) => {
+const useLabelContext = <E extends HTMLElement>(element?: E | null) => {
   const context = React.useContext(LabelContext);
 
   React.useEffect(() => {
     const label = context?.ref.current;
-    const element = ref?.current;
 
     if (label && element) {
       return addLabelClickEventListener(label, element);
     }
-  }, [context, ref]);
+  }, [context, element]);
 
   return context?.id;
 };

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -53,15 +53,13 @@ const PopperAnchor = React.forwardRef((props, forwardedRef) => {
   const { virtualRef, children, ...anchorProps } = props;
   const context = usePopperContext(ANCHOR_NAME);
   const ref = React.useRef<React.ElementRef<typeof Primitive>>(null);
-  const composedRefs = useComposedRefs(forwardedRef, ref, (node) => context.onAnchorChange(node));
+  const composedRefs = useComposedRefs(forwardedRef, ref);
 
   React.useEffect(() => {
     // Consumer can anchor the popper to something that isn't
     // a DOM node e.g. pointer position, so we override the
     // `anchorRef` with their virtual ref in this case.
-    if (virtualRef?.current) {
-      context.onAnchorChange(virtualRef.current);
-    }
+    context.onAnchorChange(virtualRef?.current || ref.current);
   });
 
   return virtualRef ? null : (

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -18,13 +18,18 @@ import type { Measurable } from '@radix-ui/rect';
 const POPPER_NAME = 'Popper';
 
 type PopperContextValue = {
-  anchorRef: React.MutableRefObject<Measurable | null>;
+  anchor: Measurable | null;
+  onAnchorChange(anchor: Measurable | null): void;
 };
 const [PopperProvider, usePopperContext] = createContext<PopperContextValue>(POPPER_NAME);
 
 const Popper: React.FC = ({ children }) => {
-  const anchorRef = React.useRef<Measurable | null>(null);
-  return <PopperProvider anchorRef={anchorRef}>{children}</PopperProvider>;
+  const [anchor, setAnchor] = React.useState<Measurable | null>(null);
+  return (
+    <PopperProvider anchor={anchor} onAnchorChange={setAnchor}>
+      {children}
+    </PopperProvider>
+  );
 };
 
 Popper.displayName = POPPER_NAME;
@@ -48,18 +53,14 @@ const PopperAnchor = React.forwardRef((props, forwardedRef) => {
   const { virtualRef, children, ...anchorProps } = props;
   const context = usePopperContext(ANCHOR_NAME);
   const ref = React.useRef<React.ElementRef<typeof Primitive>>(null);
-  const composedRefs = useComposedRefs(
-    forwardedRef,
-    ref,
-    context.anchorRef as React.MutableRefObject<React.ElementRef<typeof Primitive>>
-  );
+  const composedRefs = useComposedRefs(forwardedRef, ref, (node) => context.onAnchorChange(node));
 
   React.useEffect(() => {
     // Consumer can anchor the popper to something that isn't
     // a DOM node e.g. pointer position, so we override the
     // `anchorRef` with their virtual ref in this case.
     if (virtualRef?.current) {
-      context.anchorRef.current = virtualRef.current;
+      context.onAnchorChange(virtualRef.current);
     }
   });
 
@@ -79,8 +80,8 @@ PopperAnchor.displayName = ANCHOR_NAME;
 const CONTENT_NAME = 'PopperContent';
 
 type PopperContentContextValue = {
-  arrowRef: React.RefObject<HTMLElement>;
   arrowStyles: React.CSSProperties;
+  onArrowChange(arrow: HTMLSpanElement | null): void;
   onArrowOffsetChange(offset?: number): void;
 };
 
@@ -118,13 +119,13 @@ const PopperContent = React.forwardRef((props, forwardedRef) => {
 
   const context = usePopperContext(CONTENT_NAME);
   const [arrowOffset, setArrowOffset] = React.useState<number>();
-  const anchorRect = useRect(context.anchorRef);
-  const contentRef = React.useRef<HTMLDivElement>(null);
-  const contentSize = useSize(contentRef);
-  const arrowRef = React.useRef<HTMLSpanElement>(null);
-  const arrowSize = useSize(arrowRef);
+  const anchorRect = useRect(context.anchor);
+  const [content, setContent] = React.useState<HTMLDivElement | null>(null);
+  const contentSize = useSize(content);
+  const [arrow, setArrow] = React.useState<HTMLSpanElement | null>(null);
+  const arrowSize = useSize(arrow);
 
-  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
 
   const windowSize = useWindowSize();
   const collisionBoundariesRect = windowSize
@@ -151,8 +152,8 @@ const PopperContent = React.forwardRef((props, forwardedRef) => {
   return (
     <div style={popperStyles} data-radix-popper-content-wrapper="">
       <PopperContentProvider
-        arrowRef={arrowRef}
         arrowStyles={arrowStyles}
+        onArrowChange={setArrow}
         onArrowOffsetChange={setArrowOffset}
       >
         <Primitive
@@ -204,7 +205,7 @@ const PopperArrow = React.forwardRef(function PopperArrow(props, forwardedRef) {
         // we have to use an extra wrapper because `ResizeObserver` (used by `useSize`)
         // doesn't report size as we'd expect on SVG elements.
         // it reports their bounding box which is effectively the largest path inside the SVG.
-        ref={context.arrowRef}
+        ref={context.onArrowChange}
         style={{
           display: 'inline-block',
           verticalAlign: 'top',

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -49,9 +49,9 @@ const Radio = React.forwardRef((props, forwardedRef) => {
     ...radioProps
   } = props;
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const ref = useComposedRefs(forwardedRef, buttonRef);
-  const labelId = useLabelContext(buttonRef);
+  const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
+  const labelId = useLabelContext(button);
   const labelledBy = ariaLabelledby || labelId;
   const [checked = false, setChecked] = useControllableState({
     prop: checkedProp,
@@ -92,7 +92,7 @@ const Radio = React.forwardRef((props, forwardedRef) => {
           value={value}
           {...radioProps}
           as={as}
-          ref={ref}
+          ref={composedRefs}
           /**
            * The `input` is hidden, so when the button is clicked we trigger
            * the input manually

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -683,11 +683,11 @@ const BubbleInput = (props: React.ComponentProps<'input'>) => {
   return <input hidden {...inputProps} ref={ref} />;
 };
 
-function useDirection<E extends HTMLElement>({
+function useDirection({
   element,
   directionProp,
 }: {
-  element: E | null;
+  element: HTMLElement | null;
   directionProp?: Direction;
 }) {
   const [direction, setDirection] = React.useState<Direction>('ltr');

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -234,14 +234,14 @@ type SliderHorizontalPrimitive = Polymorphic.ForwardRefComponent<
 
 const SliderHorizontal = React.forwardRef((props, forwardedRef) => {
   const { min, max, dir, onSlideStart, onSlideMove, onStepKeyDown, ...sliderProps } = props;
-  const sliderRef = React.useRef<React.ElementRef<typeof SliderPart>>(null);
-  const ref = useComposedRefs(forwardedRef, sliderRef);
+  const [slider, setSlider] = React.useState<React.ElementRef<typeof SliderPart> | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setSlider(node));
   const rectRef = React.useRef<ClientRect>();
-  const direction = useDirection({ ref: sliderRef, directionProp: dir });
+  const direction = useDirection({ element: slider, directionProp: dir });
   const isDirectionLTR = direction === 'ltr';
 
   function getValueFromPointer(pointerPosition: number) {
-    const rect = rectRef.current || sliderRef.current!.getBoundingClientRect();
+    const rect = rectRef.current || slider!.getBoundingClientRect();
     const input: [number, number] = [0, rect.width];
     const output: [number, number] = isDirectionLTR ? [min, max] : [max, min];
     const value = linearScale(input, output);
@@ -265,7 +265,7 @@ const SliderHorizontal = React.forwardRef((props, forwardedRef) => {
       <SliderPart
         data-orientation="horizontal"
         {...sliderProps}
-        ref={ref}
+        ref={composedRefs}
         style={{
           ...sliderProps.style,
           ['--radix-slider-thumb-transform' as any]: 'translateX(-50%)',
@@ -601,9 +601,9 @@ const SliderThumbImpl = React.forwardRef((props, forwardedRef) => {
   const { as = THUMB_DEFAULT_TAG, index, value, ...thumbProps } = props;
   const context = useSliderContext(THUMB_NAME);
   const orientation = React.useContext(SliderOrientationContext);
-  const thumbRef = React.useRef<HTMLSpanElement>(null);
-  const ref = useComposedRefs(forwardedRef, thumbRef);
-  const size = useSize(thumbRef);
+  const [thumb, setThumb] = React.useState<HTMLSpanElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setThumb(node));
+  const size = useSize(thumb);
   const percent = convertValueToPercentage(value, context.min, context.max);
   const label = getLabel(index, context.values.length);
   const orientationSize = size?.[orientation.size];
@@ -612,14 +612,13 @@ const SliderThumbImpl = React.forwardRef((props, forwardedRef) => {
     : 0;
 
   React.useEffect(() => {
-    const thumb = thumbRef.current;
     if (thumb) {
       context.thumbs.add(thumb);
       return () => {
         context.thumbs.delete(thumb);
       };
     }
-  }, [context.thumbs]);
+  }, [thumb, context.thumbs]);
 
   return (
     <span
@@ -642,7 +641,7 @@ const SliderThumbImpl = React.forwardRef((props, forwardedRef) => {
         tabIndex={0}
         {...thumbProps}
         as={as}
-        ref={ref}
+        ref={composedRefs}
         onFocus={composeEventHandlers(props.onFocus, () => {
           context.valueIndexToChangeRef.current = index;
         })}
@@ -684,11 +683,11 @@ const BubbleInput = (props: React.ComponentProps<'input'>) => {
   return <input hidden {...inputProps} ref={ref} />;
 };
 
-function useDirection({
-  ref,
+function useDirection<E extends HTMLElement>({
+  element,
   directionProp,
 }: {
-  ref: React.RefObject<any>;
+  element: E | null;
   directionProp?: Direction;
 }) {
   const [direction, setDirection] = React.useState<Direction>('ltr');
@@ -696,11 +695,11 @@ function useDirection({
   const rAFRef = React.useRef<number>(0);
 
   React.useEffect(() => {
-    if (directionProp === undefined) {
-      const computedStyle = getComputedStyle(ref.current);
+    if (element && directionProp === undefined) {
+      const computedStyle = getComputedStyle(element);
       setComputedStyle(computedStyle);
     }
-  }, [directionProp, ref]);
+  }, [element, directionProp]);
 
   React.useEffect(() => {
     function getDirection() {

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -48,9 +48,9 @@ const Switch = React.forwardRef((props, forwardedRef) => {
     ...switchProps
   } = props;
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const ref = useComposedRefs(forwardedRef, buttonRef);
-  const labelId = useLabelContext(buttonRef);
+  const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
+  const labelId = useLabelContext(button);
   const labelledBy = ariaLabelledby || labelId;
   const [checked = false, setChecked] = useControllableState({
     prop: checkedProp,
@@ -92,7 +92,7 @@ const Switch = React.forwardRef((props, forwardedRef) => {
           value={value}
           {...switchProps}
           as={as}
-          ref={ref}
+          ref={composedRefs}
           /**
            * The `input` is hidden, so when the button is clicked we trigger
            * the input manually

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -33,10 +33,11 @@ const stateMachine = createStateMachine(tooltipStateChart);
 const TOOLTIP_NAME = 'Tooltip';
 
 type TooltipContextValue = {
-  triggerRef: React.RefObject<HTMLButtonElement>;
   contentId: string;
   open: boolean;
   stateAttribute: StateAttribute;
+  trigger: HTMLButtonElement | null;
+  onTriggerChange(trigger: HTMLButtonElement | null): void;
   onFocus(): void;
   onOpen(): void;
   onClose(): void;
@@ -71,7 +72,7 @@ const Tooltip: React.FC<TooltipOwnProps> = (props) => {
     delayDuration = 700,
     skipDelayDuration = 300,
   } = props;
-  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [trigger, setTrigger] = React.useState<HTMLButtonElement | null>(null);
   const contentId = useId();
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
@@ -138,10 +139,11 @@ const Tooltip: React.FC<TooltipOwnProps> = (props) => {
   return (
     <PopperPrimitive.Root>
       <TooltipProvider
-        triggerRef={triggerRef}
         contentId={contentId}
         open={open}
         stateAttribute={stateAttribute}
+        trigger={trigger}
+        onTriggerChange={setTrigger}
         onFocus={handleFocus}
         onOpen={handleOpen}
         onClose={handleClose}
@@ -173,7 +175,7 @@ type TooltipTriggerPrimitive = Polymorphic.ForwardRefComponent<
 const TooltipTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useTooltipContext(TRIGGER_NAME);
-  const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+  const composedTriggerRef = useComposedRefs(forwardedRef, (node) => context.onTriggerChange(node));
 
   return (
     <PopperPrimitive.Anchor
@@ -292,7 +294,7 @@ const TooltipArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'Tool
 function CheckTriggerMoved() {
   const context = useTooltipContext('CheckTriggerMoved');
 
-  const triggerRect = useRect(context.triggerRef);
+  const triggerRect = useRect(context.trigger);
   const triggerLeft = triggerRect?.left;
   const previousTriggerLeft = usePrevious(triggerLeft);
   const triggerTop = triggerRect?.top;

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -36,8 +36,8 @@ type TooltipContextValue = {
   contentId: string;
   open: boolean;
   stateAttribute: StateAttribute;
-  trigger: HTMLButtonElement | null;
-  onTriggerChange(trigger: HTMLButtonElement | null): void;
+  trigger: React.ElementRef<typeof TooltipTrigger> | null;
+  onTriggerChange(trigger: React.ElementRef<typeof TooltipTrigger> | null): void;
   onFocus(): void;
   onOpen(): void;
   onClose(): void;

--- a/packages/react/use-rect/src/useRect.tsx
+++ b/packages/react/use-rect/src/useRect.tsx
@@ -7,21 +7,18 @@ import type { Measurable } from '@radix-ui/rect';
  * Use this custom hook to get access to an element's rect (getBoundingClientRect)
  * and observe it along time.
  */
-function useRect(
-  /** A reference to the element whose rect to observe */
-  refToObserve: React.RefObject<Measurable>
-) {
+function useRect(measurable: Measurable | null) {
   const [rect, setRect] = React.useState<ClientRect>();
   React.useEffect(() => {
-    if (refToObserve.current) {
-      const unobserve = observeElementRect(refToObserve.current, setRect);
+    if (measurable) {
+      const unobserve = observeElementRect(measurable, setRect);
       return () => {
         setRect(undefined);
         unobserve();
       };
     }
     return;
-  }, [refToObserve]);
+  }, [measurable]);
   return rect;
 }
 

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -2,15 +2,11 @@
 
 import * as React from 'react';
 
-function useSize(
-  /** A reference to the element whose size to observe */
-  refToObserve: React.RefObject<HTMLElement | SVGElement>
-) {
+function useSize<T extends HTMLElement | SVGElement>(elementToObserve: T | null) {
   const [size, setSize] = React.useState<{ width: number; height: number } | undefined>(undefined);
 
   React.useEffect(() => {
-    if (refToObserve.current) {
-      const elementToObserve = refToObserve.current;
+    if (elementToObserve) {
       const resizeObserver = new ResizeObserver((entries) => {
         if (!Array.isArray(entries)) {
           return;
@@ -51,7 +47,7 @@ function useSize(
       };
     }
     return;
-  }, [refToObserve]);
+  }, [elementToObserve]);
 
   return size;
 }

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -2,11 +2,11 @@
 
 import * as React from 'react';
 
-function useSize<T extends HTMLElement | SVGElement>(elementToObserve: T | null) {
+function useSize(element: HTMLElement | SVGElement | null) {
   const [size, setSize] = React.useState<{ width: number; height: number } | undefined>(undefined);
 
   React.useEffect(() => {
-    if (elementToObserve) {
+    if (element) {
       const resizeObserver = new ResizeObserver((entries) => {
         if (!Array.isArray(entries)) {
           return;
@@ -31,7 +31,7 @@ function useSize<T extends HTMLElement | SVGElement>(elementToObserve: T | null)
         } else {
           // for browsers that don't support `borderBoxSize`
           // we calculate a rect ourselves to get the correct border box.
-          const rect = elementToObserve.getBoundingClientRect();
+          const rect = element.getBoundingClientRect();
           width = rect.width;
           height = rect.height;
         }
@@ -39,15 +39,15 @@ function useSize<T extends HTMLElement | SVGElement>(elementToObserve: T | null)
         setSize({ width, height });
       });
 
-      resizeObserver.observe(elementToObserve, { box: 'border-box' });
+      resizeObserver.observe(element, { box: 'border-box' });
 
       return () => {
         setSize(undefined);
-        resizeObserver.unobserve(elementToObserve);
+        resizeObserver.unobserve(element);
       };
     }
     return;
-  }, [elementToObserve]);
+  }, [element]);
 
   return size;
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

--------------

- [x] Add versions when #580 is merged.

--------------

### Description

Part 2 of the `ref` work. This PR updates our `useSize`, `useRect`, `useDirection` and `useLabelContext` hooks to receive a DOM node rather than a ref. This allows effects to re-execute if the node changes or mount is delayed.
