### PR TITLE
Add `HoverCard` primitive

### DIFF
--- a/.yarn/versions/51d71892.yml
+++ b/.yarn/versions/51d71892.yml
@@ -1,0 +1,4 @@
+declined:
+  - primitives
+  - ssr-testing
+  - "@radix-ui/react-hover-card"

--- a/.yarn/versions/51d71892.yml
+++ b/.yarn/versions/51d71892.yml
@@ -1,4 +1,6 @@
+releases:
+  "@radix-ui/react-hover-card": patch
+
 declined:
   - primitives
   - ssr-testing
-  - "@radix-ui/react-hover-card"

--- a/packages/react/hover-card/README.md
+++ b/packages/react/hover-card/README.md
@@ -1,0 +1,15 @@
+# `react-hover-card`
+
+## Installation
+
+```sh
+$ yarn add @radix-ui/react-hover-card
+# or
+$ npm install @radix-ui/react-hover-card
+```
+
+## Usage
+
+TODO
+
+View docs ...

--- a/packages/react/hover-card/README.md
+++ b/packages/react/hover-card/README.md
@@ -10,6 +10,4 @@ $ npm install @radix-ui/react-hover-card
 
 ## Usage
 
-TODO
-
-View docs ...
+View docs [here](https://radix-ui.com/primitives/docs/components/hover-card).

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radix-ui/react-hover-card",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -29,7 +29,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@radix-ui/react-hover-card",
+  "version": "0.0.1",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "clean": "rm -rf dist",
+    "prepublish": "yarn clean",
+    "version": "yarn version"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.13.10",
+    "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-compose-refs": "workspace:*",
+    "@radix-ui/react-context": "workspace:*",
+    "@radix-ui/react-id": "workspace:*",
+    "@radix-ui/react-polymorphic": "workspace:*",
+    "@radix-ui/react-popper": "workspace:*",
+    "@radix-ui/react-portal": "workspace:*",
+    "@radix-ui/react-presence": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-use-controllable-state": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0"
+  },
+  "homepage": "https://radix-ui.com/primitives",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/radix-ui/primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/radix-ui/primitives/issues"
+  }
+}

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -19,9 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
-    "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
-    "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-popper": "workspace:*",
     "@radix-ui/react-portal": "workspace:*",

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -25,7 +25,6 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -1,0 +1,597 @@
+import * as React from 'react';
+import { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardArrow } from './HoverCard';
+import { Slot } from '@radix-ui/react-slot';
+import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/popper';
+import { css } from '../../../../stitches.config';
+
+export default { title: 'Components/HoverCard' };
+
+export const HoverInteractionTest = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '150vh' }}
+    >
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardContent className={contentClass} sideOffset={5}>
+          <HoverCardArrow className={arrowClass} width={20} height={10} />
+          Lorem ipsum dolor sit amet
+          <br />
+          Lorem ipsum dolor sit amet
+          <br />
+          Lorem ipsum dolor sit amet
+          <br />
+          Lorem ipsum dolor sit amet
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const Styled = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardContent className={contentClass} sideOffset={5}>
+          <HoverCardArrow className={arrowClass} width={20} height={10} />
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const Controlled = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}
+    >
+      <HoverCard open={open} onOpenChange={setOpen}>
+        <HoverCardTrigger
+          className={triggerClass}
+          style={{ backgroundColor: 'red', padding: 50, display: 'block' }}
+        >
+          trigger
+        </HoverCardTrigger>
+        <HoverCardContent className={contentClass}>
+          <HoverCardArrow className={arrowClass} width={20} height={10} />
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const Animated = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardContent className={animatedContentClass} sideOffset={10}>
+          <HoverCardArrow className={arrowClass} width={20} height={10} />
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const ForcedMount = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardContent className={contentClass} sideOffset={10} forceMount>
+          <HoverCardArrow className={arrowClass} width={20} height={10} />
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const Nested = () => {
+  const anchorRef = React.useRef<HTMLAnchorElement>(null);
+
+  return (
+    <div
+      style={{
+        height: '300vh',
+        width: '300vw',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <a
+        href="/"
+        style={{ position: 'fixed', top: 10, left: 10 }}
+        onClick={() => anchorRef.current?.focus()}
+      >
+        Focus HoverCard button
+      </a>
+
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass} ref={anchorRef}>
+          Open HoverCard
+        </HoverCardTrigger>
+
+        <HoverCardContent
+          className={contentClass}
+          sideOffset={5}
+          style={{ backgroundColor: 'crimson' }}
+        >
+          <HoverCard>
+            <HoverCardTrigger className={triggerClass}>Open nested HoverCard</HoverCardTrigger>
+            <HoverCardContent
+              className={contentClass}
+              side="top"
+              align="center"
+              sideOffset={5}
+              style={{ backgroundColor: 'green' }}
+            >
+              <HoverCardArrow
+                className={arrowClass}
+                width={20}
+                height={10}
+                offset={20}
+                style={{ fill: 'green' }}
+              />
+            </HoverCardContent>
+          </HoverCard>
+          dfsdf
+          <HoverCardArrow
+            className={arrowClass}
+            width={20}
+            height={10}
+            offset={20}
+            style={{ fill: 'crimson' }}
+          />
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const CustomAnchor = () => {
+  const itemBoxRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <div
+      ref={itemBoxRef}
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: 250,
+        padding: 20,
+        margin: 100,
+        backgroundColor: '#eee',
+      }}
+    >
+      Item
+      <HoverCard>
+        <HoverCardTrigger className={triggerClass}>hover</HoverCardTrigger>
+        <HoverCardContent
+          className={contentClass}
+          anchorRef={itemBoxRef}
+          side="right"
+          sideOffset={1}
+          align="start"
+          style={{ borderRadius: 0, width: 200, height: 100 }}
+        ></HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};
+
+export const NonPortal = () => {
+  return (
+    <HoverCard>
+      <HoverCardTrigger className={triggerClass}>hover</HoverCardTrigger>
+      <HoverCardContent portalled={false} className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+export const WithSlottedTrigger = () => {
+  return (
+    <HoverCard>
+      <HoverCardTrigger as={Slot}>
+        <button className={triggerClass} onClick={() => console.log('StyledTrigger click')}>
+          hover
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+export const WithSlottedContent = () => (
+  <HoverCard>
+    <HoverCardTrigger className={triggerClass}>Hover or Focus me</HoverCardTrigger>
+    <HoverCardContent as={Slot} sideOffset={5}>
+      <div className={contentClass}>
+        Nicely done!
+        <HoverCardArrow className={arrowClass} offset={10} />
+      </div>
+    </HoverCardContent>
+  </HoverCard>
+);
+
+// change order slightly for more pleasing visual
+const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
+
+export const Chromatic = () => (
+  <div style={{ padding: 200 }}>
+    <h1>Uncontrolled</h1>
+    <h2>Closed</h2>
+    <HoverCard>
+      <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h2>Open</h2>
+    <HoverCard defaultOpen>
+      <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h1 style={{ marginTop: 100 }}>Controlled</h1>
+    <h2>Closed</h2>
+    <HoverCard open={false}>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h2>Open</h2>
+    <HoverCard open>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h1 style={{ marginTop: 100 }}>Force mounted content</h1>
+    <HoverCard>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5} forceMount>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h1 style={{ marginTop: 100 }}>Positioning</h1>
+    <h2>No collisions</h2>
+    <h3>Side & Align</h3>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              align={align}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+
+    <h3>Arrow offset</h3>
+    <h4>Positive</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              align={align}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} offset={5} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+    <h4>Negative</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              align={align}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} offset={-10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+
+    <h3>Side offset</h3>
+    <h4>Positive</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              sideOffset={5}
+              align={align}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+    <h4>Negative</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              sideOffset={-10}
+              align={align}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+
+    <h3>Align offset</h3>
+    <h4>Positive</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              align={align}
+              alignOffset={20}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+    <h4>Negative</h4>
+    <div className={gridClass}>
+      {SIDES.map((side) =>
+        ALIGN_OPTIONS.map((align) => (
+          <HoverCard key={`${side}-${align}`} open>
+            <HoverCardTrigger className={chromaticTriggerClass} />
+            <HoverCardContent
+              className={chromaticContentClass}
+              side={side}
+              align={align}
+              alignOffset={-10}
+              avoidCollisions={false}
+            >
+              <p style={{ textAlign: 'center' }}>
+                {side}
+                <br />
+                {align}
+              </p>
+              <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+            </HoverCardContent>
+          </HoverCard>
+        ))
+      )}
+    </div>
+
+    <h2>Collisions</h2>
+    <p>See instances on the periphery of the page.</p>
+    {SIDES.map((side) =>
+      ALIGN_OPTIONS.map((align) => (
+        <HoverCard key={`${side}-${align}`} open>
+          <HoverCardTrigger
+            className={chromaticTriggerClass}
+            style={{
+              position: 'absolute',
+              [side]: 10,
+              ...((side === 'right' || side === 'left') &&
+                (align === 'start'
+                  ? { bottom: 10 }
+                  : align === 'center'
+                  ? { top: 'calc(50% - 15px)' }
+                  : { top: 10 })),
+              ...((side === 'top' || side === 'bottom') &&
+                (align === 'start'
+                  ? { right: 10 }
+                  : align === 'center'
+                  ? { left: 'calc(50% - 15px)' }
+                  : { left: 10 })),
+            }}
+          />
+          <HoverCardContent className={chromaticContentClass} side={side} align={align}>
+            <p style={{ textAlign: 'center' }}>
+              {side}
+              <br />
+              {align}
+            </p>
+            <HoverCardArrow className={chromaticArrowClass} width={20} height={10} />
+          </HoverCardContent>
+        </HoverCard>
+      ))
+    )}
+
+    <h1 style={{ marginTop: 100 }}>With slotted trigger</h1>
+    <HoverCard open>
+      <HoverCardTrigger as={Slot}>
+        <button className={triggerClass}>open</button>
+      </HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h1 style={{ marginTop: 100 }}>State attributes</h1>
+    <h2>Closed</h2>
+    <HoverCard open={false}>
+      <HoverCardTrigger className={triggerAttrClass}>open</HoverCardTrigger>
+      <HoverCardContent className={contentAttrClass} sideOffset={5}>
+        <HoverCardArrow className={arrowAttrClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h2>Open</h2>
+    <HoverCard open>
+      <HoverCardTrigger className={triggerAttrClass}>open</HoverCardTrigger>
+      <HoverCardContent className={contentAttrClass} side="right" sideOffset={5}>
+        <HoverCardArrow className={arrowAttrClass} width={20} height={10} />
+      </HoverCardContent>
+    </HoverCard>
+  </div>
+);
+Chromatic.parameters = { chromatic: { disable: false } };
+
+const triggerClass = css({});
+
+const RECOMMENDED_CSS__HOVERCARD__CONTENT = {
+  transformOrigin: 'var(--radix-hovercard-content-transform-origin)',
+};
+
+const contentClass = css({
+  ...RECOMMENDED_CSS__HOVERCARD__CONTENT,
+  backgroundColor: '$gray300',
+  padding: 20,
+  borderRadius: 5,
+});
+
+const arrowClass = css({
+  fill: '$gray300',
+});
+
+const fadeIn = css.keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+});
+
+const fadeOut = css.keyframes({
+  from: { opacity: 1 },
+  to: { opacity: 0 },
+});
+
+const animatedContentClass = css(contentClass, {
+  '&[data-state="open"]': {
+    animation: `${fadeIn} 300ms ease-out`,
+  },
+  '&[data-state="closed"]': {
+    animation: `${fadeOut} 300ms ease-in`,
+  },
+});
+
+const gridClass = css({
+  display: 'inline-grid',
+  gridTemplateColumns: 'repeat(3, 50px)',
+  columnGap: 150,
+  rowGap: 100,
+  padding: 100,
+  border: '1px solid black',
+});
+
+const chromaticTriggerClass = css({
+  boxSizing: 'border-box',
+  width: 30,
+  height: 30,
+  backgroundColor: 'tomato',
+  border: '1px solid rgba(0, 0, 0, 0.3)',
+});
+
+const chromaticContentClass = css({
+  boxSizing: 'border-box',
+  display: 'grid',
+  placeContent: 'center',
+  width: 60,
+  height: 60,
+  backgroundColor: 'royalblue',
+  color: 'white',
+  fontSize: 10,
+  border: '1px solid rgba(0, 0, 0, 0.3)',
+});
+
+const chromaticArrowClass = css({
+  fill: 'black',
+});
+
+const styles = {
+  backgroundColor: 'rgba(0, 0, 255, 0.3)',
+  border: '2px solid blue',
+  padding: 10,
+
+  '&[data-state="closed"]': { borderColor: 'red' },
+  '&[data-state="open"]': { borderColor: 'green' },
+};
+const triggerAttrClass = css(styles);
+const contentAttrClass = css(chromaticContentClass, styles);
+const arrowAttrClass = css(styles);

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -595,7 +595,7 @@ function CardContentPlaceholder() {
 }
 
 const RECOMMENDED_CSS__HOVERCARD__CONTENT = {
-  transformOrigin: 'var(--radix-hovercard-content-transform-origin)',
+  transformOrigin: 'var(--radix-hover-card-content-transform-origin)',
 };
 
 const contentClass = css({
@@ -620,8 +620,6 @@ const fadeOut = css.keyframes({
 });
 
 const animatedContentClass = css(contentClass, {
-  transformOrigin: 'top center',
-
   '&[data-state="open"]': {
     animation: `${fadeIn} 300ms ease`,
   },

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -267,7 +267,7 @@ export const Chromatic = () => (
     <h1>Uncontrolled</h1>
     <h2>Closed</h2>
     <HoverCard>
-      <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
         Some content
@@ -276,11 +276,20 @@ export const Chromatic = () => (
 
     <h2>Open</h2>
     <HoverCard defaultOpen>
-      <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
         Some content
       </HoverCardContent>
+    </HoverCard>
+
+    <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
+    <HoverCard defaultOpen>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        Some content
+        <HoverCardArrow className={arrowClass} offset={10} />
+      </HoverCardContent>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
     </HoverCard>
 
     <h1 style={{ marginTop: 100 }}>Controlled</h1>
@@ -300,6 +309,15 @@ export const Chromatic = () => (
         <HoverCardArrow className={arrowClass} width={20} height={10} />
         Some content
       </HoverCardContent>
+    </HoverCard>
+
+    <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
+    <HoverCard open>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        Some content
+        <HoverCardArrow className={arrowClass} offset={10} />
+      </HoverCardContent>
+      <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
     </HoverCard>
 
     <h1 style={{ marginTop: 100 }}>Force mounted content</h1>

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  HoverCard,
-  HoverCardTrigger,
-  HoverCardContent,
-  HoverCardArrow,
-  HoverCardAnchor,
-} from './HoverCard';
+import { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardArrow } from './HoverCard';
 import { Slot } from '@radix-ui/react-slot';
 import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/popper';
 import { css } from '../../../../stitches.config';
@@ -216,38 +210,6 @@ export const Nested = () => {
           offset={20}
           style={{ fill: 'crimson' }}
         />
-      </HoverCardContent>
-    </HoverCard>
-  );
-};
-
-export const CustomAnchor = () => {
-  return (
-    <HoverCard>
-      <HoverCardAnchor
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          width: 250,
-          padding: 20,
-          margin: 100,
-          backgroundColor: '#eee',
-        }}
-      >
-        Item
-        <HoverCardTrigger href="/" className={triggerClass}>
-          trigger
-        </HoverCardTrigger>
-      </HoverCardAnchor>
-      <HoverCardContent
-        className={contentClass}
-        side="right"
-        sideOffset={1}
-        align="start"
-        style={{ borderRadius: 0, width: 200, height: 100 }}
-      >
-        content
       </HoverCardContent>
     </HoverCard>
   );

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -308,6 +308,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -316,6 +317,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerClass}>trigger</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -325,6 +327,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -333,6 +336,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -341,6 +345,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5} forceMount>
         <HoverCardArrow className={arrowClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -561,6 +566,7 @@ export const Chromatic = () => (
       </HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -570,6 +576,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerAttrClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentAttrClass} sideOffset={5}>
         <HoverCardArrow className={arrowAttrClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
 
@@ -578,6 +585,7 @@ export const Chromatic = () => (
       <HoverCardTrigger className={triggerAttrClass}>open</HoverCardTrigger>
       <HoverCardContent className={contentAttrClass} side="right" sideOffset={5}>
         <HoverCardArrow className={arrowAttrClass} width={20} height={10} />
+        Some content
       </HoverCardContent>
     </HoverCard>
   </div>

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -99,62 +99,63 @@ export const Nested = () => {
   const anchorRef = React.useRef<HTMLAnchorElement>(null);
 
   return (
-    <div
-      style={{
-        height: '300vh',
-        width: '300vw',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <a
-        href="/"
-        style={{ position: 'fixed', top: 10, left: 10 }}
-        onClick={() => anchorRef.current?.focus()}
+    <HoverCard>
+      <HoverCardTrigger className={triggerClass} ref={anchorRef}>
+        Open HoverCard
+      </HoverCardTrigger>
+
+      <HoverCardContent
+        className={contentClass}
+        sideOffset={5}
+        style={{ backgroundColor: 'crimson' }}
       >
-        Focus HoverCard button
-      </a>
+        <HoverCard>
+          <HoverCardTrigger className={triggerClass}>Open level 1 HoverCard</HoverCardTrigger>
+          <HoverCardContent
+            className={contentClass}
+            side="top"
+            align="center"
+            sideOffset={5}
+            style={{ backgroundColor: 'green' }}
+          >
+            <HoverCardArrow
+              className={arrowClass}
+              width={20}
+              height={10}
+              offset={20}
+              style={{ fill: 'green' }}
+            />
+            <HoverCard>
+              <HoverCardTrigger className={triggerClass}>Open level 2 HoverCard</HoverCardTrigger>
+              <HoverCardContent
+                className={contentClass}
+                side="bottom"
+                align="start"
+                sideOffset={5}
+                style={{ backgroundColor: 'purple' }}
+              >
+                <HoverCardArrow
+                  className={arrowClass}
+                  width={20}
+                  height={10}
+                  offset={20}
+                  style={{ fill: 'purple' }}
+                />
+                Level 2 content
+              </HoverCardContent>
+            </HoverCard>
+          </HoverCardContent>
+        </HoverCard>
 
-      <HoverCard>
-        <HoverCardTrigger className={triggerClass} ref={anchorRef}>
-          Open HoverCard
-        </HoverCardTrigger>
-
-        <HoverCardContent
-          className={contentClass}
-          sideOffset={5}
-          style={{ backgroundColor: 'crimson' }}
-        >
-          <HoverCard>
-            <HoverCardTrigger className={triggerClass}>Open nested HoverCard</HoverCardTrigger>
-            <HoverCardContent
-              className={contentClass}
-              side="top"
-              align="center"
-              sideOffset={5}
-              style={{ backgroundColor: 'green' }}
-            >
-              <HoverCardArrow
-                className={arrowClass}
-                width={20}
-                height={10}
-                offset={20}
-                style={{ fill: 'green' }}
-              />
-            </HoverCardContent>
-          </HoverCard>
-          dfsdf
-          <HoverCardArrow
-            className={arrowClass}
-            width={20}
-            height={10}
-            offset={20}
-            style={{ fill: 'crimson' }}
-          />
-        </HoverCardContent>
-      </HoverCard>
-    </div>
+        <HoverCardArrow
+          className={arrowClass}
+          width={20}
+          height={10}
+          offset={20}
+          style={{ fill: 'crimson' }}
+        />
+      </HoverCardContent>
+    </HoverCard>
   );
 };
 

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardArrow } from './HoverCard';
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+  HoverCardArrow,
+  HoverCardAnchor,
+} from './HoverCard';
 import { Slot } from '@radix-ui/react-slot';
 import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/popper';
 import { css } from '../../../../stitches.config';
@@ -63,7 +69,7 @@ export const AsyncUpdate = () => {
 };
 
 export const CustomDurations = () => (
-  <>
+  <div>
     <h1>Delay duration</h1>
     <h2>Default (700ms enter, 400ms exit)</h2>
 
@@ -92,12 +98,11 @@ export const CustomDurations = () => (
       <HoverCardTrigger href="/" className={triggerClass}>
         trigger
       </HoverCardTrigger>
-      <HoverCardContent className={contentClass} sideOffset={5}>
-        <HoverCardArrow className={arrowClass} width={20} height={10} />
+      <HoverCardContent className={contentClass}>
         <CardContentPlaceholder />
       </HoverCardContent>
     </HoverCard>
-  </>
+  </div>
 );
 
 export const Controlled = () => {
@@ -217,36 +222,34 @@ export const Nested = () => {
 };
 
 export const CustomAnchor = () => {
-  const itemBoxRef = React.useRef<HTMLDivElement>(null);
-
   return (
-    <div
-      ref={itemBoxRef}
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: 250,
-        padding: 20,
-        margin: 100,
-        backgroundColor: '#eee',
-      }}
-    >
-      Item
-      <HoverCard>
+    <HoverCard>
+      <HoverCardAnchor
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: 250,
+          padding: 20,
+          margin: 100,
+          backgroundColor: '#eee',
+        }}
+      >
+        Item
         <HoverCardTrigger href="/" className={triggerClass}>
           trigger
         </HoverCardTrigger>
-        <HoverCardContent
-          className={contentClass}
-          anchorRef={itemBoxRef}
-          side="right"
-          sideOffset={1}
-          align="start"
-          style={{ borderRadius: 0, width: 200, height: 100 }}
-        ></HoverCardContent>
-      </HoverCard>
-    </div>
+      </HoverCardAnchor>
+      <HoverCardContent
+        className={contentClass}
+        side="right"
+        sideOffset={1}
+        align="start"
+        style={{ borderRadius: 0, width: 200, height: 100 }}
+      >
+        content
+      </HoverCardContent>
+    </HoverCard>
   );
 };
 

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -65,7 +65,7 @@ export const AsyncUpdate = () => {
 export const CustomDurations = () => (
   <div>
     <h1>Delay duration</h1>
-    <h2>Default (700ms enter, 400ms exit)</h2>
+    <h2>Default (700ms open, 300ms close)</h2>
 
     <HoverCard>
       <HoverCardTrigger href="/" className={triggerClass}>
@@ -76,8 +76,8 @@ export const CustomDurations = () => (
       </HoverCardContent>
     </HoverCard>
 
-    <h2>Custom (instant open, 0ms enter, 0ms exit)</h2>
-    <HoverCard enterDelayDuration={0} exitDelayDuration={0}>
+    <h2>Custom (instant, 0ms open, 0ms close)</h2>
+    <HoverCard openDelay={0} closeDelay={0}>
       <HoverCardTrigger href="/" className={triggerClass}>
         trigger
       </HoverCardTrigger>
@@ -86,9 +86,9 @@ export const CustomDurations = () => (
       </HoverCardContent>
     </HoverCard>
 
-    <h2>Custom (2s enter, 1s exit)</h2>
+    <h2>Custom (300ms open, 100ms close)</h2>
 
-    <HoverCard enterDelayDuration={2000} exitDelayDuration={1000}>
+    <HoverCard openDelay={300} closeDelay={100}>
       <HoverCardTrigger href="/" className={triggerClass}>
         trigger
       </HoverCardTrigger>

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -6,59 +6,112 @@ import { css } from '../../../../stitches.config';
 
 export default { title: 'Components/HoverCard' };
 
-export const HoverInteractionTest = () => {
+export const Basic = () => {
   return (
-    <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '150vh' }}
-    >
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
       <HoverCard>
-        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardTrigger href="/" className={triggerClass}>
+          trigger
+        </HoverCardTrigger>
         <HoverCardContent className={contentClass} sideOffset={5}>
           <HoverCardArrow className={arrowClass} width={20} height={10} />
-          Lorem ipsum dolor sit amet
-          <br />
-          Lorem ipsum dolor sit amet
-          <br />
-          Lorem ipsum dolor sit amet
-          <br />
-          Lorem ipsum dolor sit amet
+          <CardContentPlaceholder />
         </HoverCardContent>
       </HoverCard>
     </div>
   );
 };
 
-export const Styled = () => {
+export const AsyncUpdate = () => {
+  const [open, setOpen] = React.useState(false);
+  const [contentLoaded, setContentLoaded] = React.useState(false);
+  const timerRef = React.useRef(0);
+
+  const handleOpenChange = React.useCallback((open) => {
+    clearTimeout(timerRef.current);
+
+    if (open) {
+      timerRef.current = window.setTimeout(() => {
+        setContentLoaded(true);
+      }, 500);
+    } else {
+      setContentLoaded(false);
+    }
+
+    setOpen(open);
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(timerRef.current);
+    };
+  }, []);
+
   return (
-    <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
-    >
-      <HoverCard>
-        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
+      <HoverCard open={open} onOpenChange={handleOpenChange}>
+        <HoverCardTrigger href="/" className={triggerClass}>
+          trigger
+        </HoverCardTrigger>
         <HoverCardContent className={contentClass} sideOffset={5}>
           <HoverCardArrow className={arrowClass} width={20} height={10} />
+          {contentLoaded ? <CardContentPlaceholder /> : 'Loading...'}
         </HoverCardContent>
       </HoverCard>
     </div>
   );
 };
+
+export const CustomDurations = () => (
+  <>
+    <h1>Delay duration</h1>
+    <h2>Default (700ms enter, 400ms exit)</h2>
+
+    <HoverCard>
+      <HoverCardTrigger href="/" className={triggerClass}>
+        trigger
+      </HoverCardTrigger>
+      <HoverCardContent className={contentClass}>
+        <CardContentPlaceholder />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h2>Custom (instant open, 0ms enter, 0ms exit)</h2>
+    <HoverCard enterDelayDuration={0} exitDelayDuration={0}>
+      <HoverCardTrigger href="/" className={triggerClass}>
+        trigger
+      </HoverCardTrigger>
+      <HoverCardContent className={contentClass}>
+        <CardContentPlaceholder />
+      </HoverCardContent>
+    </HoverCard>
+
+    <h2>Custom (2s enter, 1s exit)</h2>
+
+    <HoverCard enterDelayDuration={2000} exitDelayDuration={1000}>
+      <HoverCardTrigger href="/" className={triggerClass}>
+        trigger
+      </HoverCardTrigger>
+      <HoverCardContent className={contentClass} sideOffset={5}>
+        <HoverCardArrow className={arrowClass} width={20} height={10} />
+        <CardContentPlaceholder />
+      </HoverCardContent>
+    </HoverCard>
+  </>
+);
 
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}
-    >
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
       <HoverCard open={open} onOpenChange={setOpen}>
-        <HoverCardTrigger
-          className={triggerClass}
-          style={{ backgroundColor: 'red', padding: 50, display: 'block' }}
-        >
+        <HoverCardTrigger href="/" className={triggerClass}>
           trigger
         </HoverCardTrigger>
         <HoverCardContent className={contentClass}>
           <HoverCardArrow className={arrowClass} width={20} height={10} />
+          <CardContentPlaceholder />
         </HoverCardContent>
       </HoverCard>
     </div>
@@ -67,13 +120,14 @@ export const Controlled = () => {
 
 export const Animated = () => {
   return (
-    <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
-    >
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
       <HoverCard>
-        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardTrigger href="/" className={triggerClass}>
+          trigger
+        </HoverCardTrigger>
         <HoverCardContent className={animatedContentClass} sideOffset={10}>
           <HoverCardArrow className={arrowClass} width={20} height={10} />
+          <CardContentPlaceholder />
         </HoverCardContent>
       </HoverCard>
     </div>
@@ -82,13 +136,14 @@ export const Animated = () => {
 
 export const ForcedMount = () => {
   return (
-    <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
-    >
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
       <HoverCard>
-        <HoverCardTrigger className={triggerClass}>Trigger</HoverCardTrigger>
+        <HoverCardTrigger href="/" className={triggerClass}>
+          trigger
+        </HoverCardTrigger>
         <HoverCardContent className={contentClass} sideOffset={10} forceMount>
           <HoverCardArrow className={arrowClass} width={20} height={10} />
+          <CardContentPlaceholder />
         </HoverCardContent>
       </HoverCard>
     </div>
@@ -96,12 +151,10 @@ export const ForcedMount = () => {
 };
 
 export const Nested = () => {
-  const anchorRef = React.useRef<HTMLAnchorElement>(null);
-
   return (
     <HoverCard>
-      <HoverCardTrigger className={triggerClass} ref={anchorRef}>
-        Open HoverCard
+      <HoverCardTrigger href="/" className={triggerClass}>
+        trigger level 1
       </HoverCardTrigger>
 
       <HoverCardContent
@@ -110,7 +163,9 @@ export const Nested = () => {
         style={{ backgroundColor: 'crimson' }}
       >
         <HoverCard>
-          <HoverCardTrigger className={triggerClass}>Open level 1 HoverCard</HoverCardTrigger>
+          <HoverCardTrigger href="/" className={triggerClass}>
+            trigger level 2
+          </HoverCardTrigger>
           <HoverCardContent
             className={contentClass}
             side="top"
@@ -126,7 +181,9 @@ export const Nested = () => {
               style={{ fill: 'green' }}
             />
             <HoverCard>
-              <HoverCardTrigger className={triggerClass}>Open level 2 HoverCard</HoverCardTrigger>
+              <HoverCardTrigger href="/" className={triggerClass}>
+                trigger level 3
+              </HoverCardTrigger>
               <HoverCardContent
                 className={contentClass}
                 side="bottom"
@@ -141,7 +198,7 @@ export const Nested = () => {
                   offset={20}
                   style={{ fill: 'purple' }}
                 />
-                Level 2 content
+                level 3
               </HoverCardContent>
             </HoverCard>
           </HoverCardContent>
@@ -177,7 +234,9 @@ export const CustomAnchor = () => {
     >
       Item
       <HoverCard>
-        <HoverCardTrigger className={triggerClass}>hover</HoverCardTrigger>
+        <HoverCardTrigger href="/" className={triggerClass}>
+          trigger
+        </HoverCardTrigger>
         <HoverCardContent
           className={contentClass}
           anchorRef={itemBoxRef}
@@ -194,9 +253,12 @@ export const CustomAnchor = () => {
 export const NonPortal = () => {
   return (
     <HoverCard>
-      <HoverCardTrigger className={triggerClass}>hover</HoverCardTrigger>
+      <HoverCardTrigger href="/" className={triggerClass}>
+        trigger
+      </HoverCardTrigger>
       <HoverCardContent portalled={false} className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+        <CardContentPlaceholder />
       </HoverCardContent>
     </HoverCard>
   );
@@ -207,11 +269,12 @@ export const WithSlottedTrigger = () => {
     <HoverCard>
       <HoverCardTrigger as={Slot}>
         <button className={triggerClass} onClick={() => console.log('StyledTrigger click')}>
-          hover
+          trigger
         </button>
       </HoverCardTrigger>
       <HoverCardContent className={contentClass} sideOffset={5}>
         <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+        <CardContentPlaceholder />
       </HoverCardContent>
     </HoverCard>
   );
@@ -219,11 +282,13 @@ export const WithSlottedTrigger = () => {
 
 export const WithSlottedContent = () => (
   <HoverCard>
-    <HoverCardTrigger className={triggerClass}>Hover or Focus me</HoverCardTrigger>
+    <HoverCardTrigger href="/" className={triggerClass}>
+      trigger
+    </HoverCardTrigger>
     <HoverCardContent as={Slot} sideOffset={5}>
       <div className={contentClass}>
-        Nicely done!
-        <HoverCardArrow className={arrowClass} offset={10} />
+        <HoverCardArrow className={arrowClass} width={20} height={10} offset={10} />
+        <CardContentPlaceholder />
       </div>
     </HoverCardContent>
   </HoverCard>
@@ -518,6 +583,26 @@ Chromatic.parameters = { chromatic: { disable: false } };
 
 const triggerClass = css({});
 
+function CardContentPlaceholder() {
+  return (
+    <div style={{ maxWidth: 400, display: 'flex', alignItems: 'center' }}>
+      <div style={{ width: 60, height: 60, backgroundColor: 'white', borderRadius: 100 }} />
+      <div style={{ marginLeft: 14 }}>
+        <div style={{ width: 200, backgroundColor: 'white', height: 14, borderRadius: 100 }} />
+        <div
+          style={{
+            width: 150,
+            backgroundColor: 'white',
+            height: 14,
+            borderRadius: 100,
+            marginTop: 10,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
 const RECOMMENDED_CSS__HOVERCARD__CONTENT = {
   transformOrigin: 'var(--radix-hovercard-content-transform-origin)',
 };
@@ -534,21 +619,23 @@ const arrowClass = css({
 });
 
 const fadeIn = css.keyframes({
-  from: { opacity: 0 },
-  to: { opacity: 1 },
+  from: { transform: 'scale(0.9)', opacity: 0 },
+  to: { transform: 'scale(1)', opacity: 1 },
 });
 
 const fadeOut = css.keyframes({
-  from: { opacity: 1 },
-  to: { opacity: 0 },
+  from: { transform: 'scale(1)', opacity: 1 },
+  to: { transform: 'scale(0.9)', opacity: 0 },
 });
 
 const animatedContentClass = css(contentClass, {
+  transformOrigin: 'top center',
+
   '&[data-state="open"]': {
-    animation: `${fadeIn} 300ms ease-out`,
+    animation: `${fadeIn} 300ms ease`,
   },
   '&[data-state="closed"]': {
-    animation: `${fadeOut} 300ms ease-in`,
+    animation: `${fadeOut} 300ms ease`,
   },
 });
 

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -81,16 +81,14 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
   }, []);
 
   return (
-    <PopperPrimitive.Root>
-      <HoverCardProvider
-        open={open}
-        onOpenChange={setOpen}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handelMouseLeave}
-      >
-        {children}
-      </HoverCardProvider>
-    </PopperPrimitive.Root>
+    <HoverCardProvider
+      open={open}
+      onOpenChange={setOpen}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handelMouseLeave}
+    >
+      <PopperPrimitive.Root>{children}</PopperPrimitive.Root>
+    </HoverCardProvider>
   );
 };
 

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -42,7 +42,6 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
     openDelay = 700,
     closeDelay = 300,
   } = props;
-  const openInvokedRef = React.useRef(false);
   const openTimerRef = React.useRef(0);
   const closeTimerRef = React.useRef(0);
 
@@ -57,7 +56,6 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
 
     openTimerRef.current = window.setTimeout(() => {
       setOpen(true);
-      openInvokedRef.current = true;
     }, openDelay);
   }, [openDelay, setOpen]);
 
@@ -65,10 +63,7 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
     clearTimeout(openTimerRef.current);
 
     closeTimerRef.current = window.setTimeout(() => {
-      if (openInvokedRef.current) {
-        setOpen(false);
-        openInvokedRef.current = false;
-      }
+      setOpen(false);
     }, closeDelay);
   }, [closeDelay, setOpen]);
 

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { createContext } from '@radix-ui/react-context';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import * as PopperPrimitive from '@radix-ui/react-popper';
+import { Portal } from '@radix-ui/react-portal';
+import { Presence } from '@radix-ui/react-presence';
+import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
+import { useId } from '@radix-ui/react-id';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+
+/* -------------------------------------------------------------------------------------------------
+ * HoverCard
+ * -----------------------------------------------------------------------------------------------*/
+
+const HOVERCARD_NAME = 'HoverCard';
+
+type HoverCardContextValue = {
+  triggerRef: React.RefObject<HTMLAnchorElement>;
+  contentId: string;
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  onOpen(): void;
+  onClose(): void;
+};
+
+const [HoverCardProvider, useHoverCardContext] = createContext<HoverCardContextValue>(
+  HOVERCARD_NAME
+);
+
+type HoverCardOwnProps = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
+  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const triggerRef = React.useRef<HTMLAnchorElement>(null);
+  const [open = false, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+
+  return (
+    <HoverCardProvider
+      contentId={useId()}
+      triggerRef={triggerRef}
+      open={open}
+      onOpenChange={setOpen}
+      onOpen={React.useCallback(() => setOpen(true), [setOpen])}
+      onClose={React.useCallback(() => setOpen(false), [setOpen])}
+    >
+      {children}
+    </HoverCardProvider>
+  );
+};
+
+HoverCard.displayName = HOVERCARD_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * HoverCardTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_NAME = 'HoverCardTrigger';
+const TRIGGER_DEFAULT_TAG = 'a';
+
+type HoverCardTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
+type HoverCardTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof TRIGGER_DEFAULT_TAG,
+  HoverCardTriggerOwnProps
+>;
+
+const HoverCardTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
+  const context = useHoverCardContext(TRIGGER_NAME);
+  const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
+  return (
+    <Primitive
+      type="a"
+      data-state={context.open ? 'open' : 'closed'}
+      {...triggerProps}
+      as={as}
+      ref={composedTriggerRef}
+      onMouseEnter={composeEventHandlers(props.onMouseEnter, context.onOpen)}
+      onMouseLeave={composeEventHandlers(props.onMouseEnter, context.onClose)}
+    />
+  );
+}) as HoverCardTriggerPrimitive;
+
+HoverCardTrigger.displayName = TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * HoverCardContent
+ * -----------------------------------------------------------------------------------------------*/
+
+const CONTENT_NAME = 'HoverCardContent';
+
+type HoverCardContentOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof HoverCardContentImpl>,
+  {
+    /**
+     * Used to force mounting when more control is needed. Useful when
+     * controlling animation with React animation libraries.
+     */
+    forceMount?: true;
+  }
+>;
+
+type HoverCardContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof HoverCardContentImpl>,
+  HoverCardContentOwnProps
+>;
+
+const HoverCardContent = React.forwardRef((props, forwardedRef) => {
+  const { forceMount, ...contentProps } = props;
+  const context = useHoverCardContext(CONTENT_NAME);
+
+  return (
+    <Presence present={forceMount || context.open}>
+      <HoverCardContentImpl
+        data-state={context.open ? 'open' : 'closed'}
+        {...contentProps}
+        ref={forwardedRef}
+      />
+    </Presence>
+  );
+}) as HoverCardContentPrimitive;
+
+type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Root>;
+type HoverCardContentImplOwnProps = Polymorphic.Merge<
+  PopperPrimitiveOwnProps,
+  {
+    /**
+     * Whether the `HoverCard` should render in a `Portal`
+     * (default: `true`)
+     */
+    portalled?: boolean;
+    anchorRef?: PopperPrimitiveOwnProps['anchorRef'];
+  }
+>;
+
+type HoverCardContentImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Root>,
+  HoverCardContentImplOwnProps
+>;
+
+const HoverCardContentImpl = React.forwardRef((props, forwardedRef) => {
+  const { anchorRef, portalled = true, ...contentProps } = props;
+  const context = useHoverCardContext(CONTENT_NAME);
+
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+
+  return (
+    <PortalWrapper>
+      <PopperPrimitive.Root
+        id={context.contentId}
+        {...contentProps}
+        ref={forwardedRef}
+        anchorRef={anchorRef || context.triggerRef}
+        style={{
+          ...contentProps.style,
+          // re-namespace exposed content custom property
+          ['--radix-hovercard-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+        }}
+      />
+    </PortalWrapper>
+  );
+}) as HoverCardContentImplPrimitive;
+
+HoverCardContent.displayName = CONTENT_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+const HoverCardArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'HoverCardArrow' });
+
+/* -----------------------------------------------------------------------------------------------*/
+
+const Root = HoverCard;
+const Trigger = HoverCardTrigger;
+const Content = HoverCardContent;
+const Arrow = HoverCardArrow;
+
+export {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+  HoverCardArrow,
+  //
+  Root,
+  Trigger,
+  Content,
+  Arrow,
+};

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -29,8 +29,8 @@ type HoverCardOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
-  enterDelayDuration?: number;
-  exitDelayDuration?: number;
+  openDelay?: number;
+  closeDelay?: number;
 };
 
 const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
@@ -39,8 +39,8 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
     open: openProp,
     defaultOpen,
     onOpenChange,
-    enterDelayDuration = 700,
-    exitDelayDuration = 400,
+    openDelay = 700,
+    closeDelay = 300,
   } = props;
   const enterInvokedRef = React.useRef(false);
   const enterTimerRef = React.useRef(0);
@@ -58,8 +58,8 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
     enterTimerRef.current = window.setTimeout(() => {
       setOpen(true);
       enterInvokedRef.current = true;
-    }, enterDelayDuration);
-  }, [enterDelayDuration, setOpen]);
+    }, openDelay);
+  }, [openDelay, setOpen]);
 
   const handelMouseLeave = React.useCallback(() => {
     clearTimeout(enterTimerRef.current);
@@ -69,8 +69,8 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
         setOpen(false);
         enterInvokedRef.current = false;
       }
-    }, exitDelayDuration);
-  }, [exitDelayDuration, setOpen]);
+    }, closeDelay);
+  }, [closeDelay, setOpen]);
 
   // cleanup any queued state updates on unmount
   React.useEffect(() => {

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -54,17 +54,13 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
   const handleOpen = React.useCallback(() => {
     clearTimeout(closeTimerRef.current);
 
-    openTimerRef.current = window.setTimeout(() => {
-      setOpen(true);
-    }, openDelay);
+    openTimerRef.current = window.setTimeout(() => setOpen(true), openDelay);
   }, [openDelay, setOpen]);
 
   const handleClose = React.useCallback(() => {
     clearTimeout(openTimerRef.current);
 
-    closeTimerRef.current = window.setTimeout(() => {
-      setOpen(false);
-    }, closeDelay);
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), closeDelay);
   }, [closeDelay, setOpen]);
 
   // cleanup any queued state updates on unmount

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -112,8 +112,8 @@ const HoverCardTrigger = React.forwardRef((props, forwardedRef) => {
       {...triggerProps}
       as={as}
       ref={forwardedRef}
-      onMouseEnter={composeEventHandlers(props.onMouseEnter, context.onOpen)}
-      onMouseLeave={composeEventHandlers(props.onMouseLeave, context.onClose)}
+      onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
+      onPointerLeave={composeEventHandlers(props.onPointerLeave, excludeTouch(context.onClose))}
     />
   );
 }) as HoverCardTriggerPrimitive;
@@ -151,8 +151,8 @@ const HoverCardContent = React.forwardRef((props, forwardedRef) => {
       <HoverCardContentImpl
         data-state={context.open ? 'open' : 'closed'}
         {...contentProps}
-        onMouseEnter={composeEventHandlers(props.onMouseEnter, context.onOpen)}
-        onMouseLeave={composeEventHandlers(props.onMouseLeave, context.onClose)}
+        onPointerEnter={composeEventHandlers(props.onMouseEnter, excludeTouch(context.onOpen))}
+        onPointerLeave={composeEventHandlers(props.onMouseLeave, excludeTouch(context.onClose))}
         ref={forwardedRef}
       />
     </Presence>
@@ -203,6 +203,11 @@ HoverCardContent.displayName = CONTENT_NAME;
 const HoverCardArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'HoverCardArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
+
+function excludeTouch<E>(eventHandler: () => void) {
+  return (event: React.PointerEvent<E>) =>
+    event.pointerType === 'touch' ? undefined : eventHandler();
+}
 
 const Root = HoverCard;
 const Trigger = HoverCardTrigger;

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -53,13 +53,11 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
 
   const handleOpen = React.useCallback(() => {
     clearTimeout(closeTimerRef.current);
-
     openTimerRef.current = window.setTimeout(() => setOpen(true), openDelay);
   }, [openDelay, setOpen]);
 
   const handleClose = React.useCallback(() => {
     clearTimeout(openTimerRef.current);
-
     closeTimerRef.current = window.setTimeout(() => setOpen(false), closeDelay);
   }, [closeDelay, setOpen]);
 

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -6,7 +6,6 @@ import * as PopperPrimitive from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 /* -------------------------------------------------------------------------------------------------
@@ -20,9 +19,6 @@ type HoverCardContextValue = {
   onOpenChange(open: boolean): void;
   onMouseEnter(): void;
   onMouseLeave(): void;
-  hasCustomAnchor: boolean;
-  onCustomAnchorAdd(): void;
-  onCustomAnchorRemove(): void;
 };
 
 const [HoverCardProvider, useHoverCardContext] = createContext<HoverCardContextValue>(
@@ -46,7 +42,6 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
     enterDelayDuration = 700,
     exitDelayDuration = 400,
   } = props;
-  const [hasCustomAnchor, setHasCustomAnchor] = React.useState(false);
   const enterInvokedRef = React.useRef(false);
   const enterTimerRef = React.useRef(0);
   const leaveTimerRef = React.useRef(0);
@@ -92,9 +87,6 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
         onOpenChange={setOpen}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handelMouseLeave}
-        hasCustomAnchor={hasCustomAnchor}
-        onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
-        onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}
       >
         {children}
       </HoverCardProvider>
@@ -103,32 +95,6 @@ const HoverCard: React.FC<HoverCardOwnProps> = (props) => {
 };
 
 HoverCard.displayName = HOVERCARD_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * HoverCardAnchor
- * -----------------------------------------------------------------------------------------------*/
-
-const ANCHOR_NAME = 'HoverCardAnchor';
-
-type HoverCardAnchorOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Anchor>;
-type HoverCardAnchorPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof PopperPrimitive.Anchor>,
-  HoverCardAnchorOwnProps
->;
-
-const HoverCardAnchor = React.forwardRef((props, forwardedRef) => {
-  const context = useHoverCardContext(ANCHOR_NAME);
-  const { onCustomAnchorAdd, onCustomAnchorRemove } = context;
-
-  React.useEffect(() => {
-    onCustomAnchorAdd();
-    return () => onCustomAnchorRemove();
-  }, [onCustomAnchorAdd, onCustomAnchorRemove]);
-
-  return <PopperPrimitive.Anchor {...props} ref={forwardedRef} />;
-}) as HoverCardAnchorPrimitive;
-
-HoverCardAnchor.displayName = ANCHOR_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * HoverCardTrigger
@@ -147,8 +113,8 @@ const HoverCardTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useHoverCardContext(TRIGGER_NAME);
 
-  const trigger = (
-    <Primitive
+  return (
+    <PopperPrimitive.Anchor
       data-state={context.open ? 'open' : 'closed'}
       {...triggerProps}
       as={as}
@@ -156,12 +122,6 @@ const HoverCardTrigger = React.forwardRef((props, forwardedRef) => {
       onMouseEnter={composeEventHandlers(props.onMouseEnter, context.onMouseEnter)}
       onMouseLeave={composeEventHandlers(props.onMouseLeave, context.onMouseLeave)}
     />
-  );
-
-  return context.hasCustomAnchor ? (
-    trigger
-  ) : (
-    <PopperPrimitive.Anchor as={Slot}>{trigger}</PopperPrimitive.Anchor>
   );
 }) as HoverCardTriggerPrimitive;
 
@@ -255,17 +215,14 @@ const Root = HoverCard;
 const Trigger = HoverCardTrigger;
 const Content = HoverCardContent;
 const Arrow = HoverCardArrow;
-const Anchor = HoverCardAnchor;
 
 export {
   HoverCard,
-  HoverCardAnchor,
   HoverCardTrigger,
   HoverCardContent,
   HoverCardArrow,
   //
   Root,
-  Anchor,
   Trigger,
   Content,
   Arrow,

--- a/packages/react/hover-card/src/index.ts
+++ b/packages/react/hover-card/src/index.ts
@@ -1,0 +1,1 @@
+export * from './HoverCard';

--- a/ssr-testing/pages/hover-card.tsx
+++ b/ssr-testing/pages/hover-card.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+  HoverCardArrow,
+} from '@radix-ui/react-hover-card';
+
+export default function PopoverPage() {
+  return (
+    <HoverCard>
+      <HoverCardTrigger>Hover me</HoverCardTrigger>
+
+      <HoverCardContent>
+        <HoverCardArrow width={20} height={10} />
+        Nicely done!
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/ssr-testing/pages/hover-card.tsx
+++ b/ssr-testing/pages/hover-card.tsx
@@ -6,7 +6,7 @@ import {
   HoverCardArrow,
 } from '@radix-ui/react-hover-card';
 
-export default function PopoverPage() {
+export default function HoverCardPage() {
   return (
     <HoverCard>
       <HoverCardTrigger>Hover me</HoverCardTrigger>

--- a/ssr-testing/pages/index.tsx
+++ b/ssr-testing/pages/index.tsx
@@ -22,6 +22,9 @@ export default function HomePage() {
           <Link href="/dialog">Dialog</Link>
         </li>
         <li>
+          <Link href="/hover-card">HoverCard</Link>
+        </li>
+        <li>
           <Link href="/label">Label</Link>
         </li>
         <li>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "@radix-ui/react-dropdown-menu": ["packages/react/dropdown-menu/src"],
       "@radix-ui/react-focus-guards": ["packages/react/focus-guards/src"],
       "@radix-ui/react-focus-scope": ["./packages/react/focus-scope/src"],
+      "@radix-ui/react-hover-card": ["./packages/react/hover-card/src"],
       "@radix-ui/react-id": ["./packages/react/id/src"],
       "@radix-ui/react-label": ["./packages/react/label/src"],
       "@radix-ui/react-menu": ["./packages/react/menu/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3500,14 +3500,13 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
-    "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
-    "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-popper": "workspace:*"
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,7 +3506,6 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
-    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@radix-ui/react-hover-card@workspace:packages/react/hover-card":
+  version: 0.0.0-use.local
+  resolution: "@radix-ui/react-hover-card@workspace:packages/react/hover-card"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-compose-refs": "workspace:*"
+    "@radix-ui/react-context": "workspace:*"
+    "@radix-ui/react-id": "workspace:*"
+    "@radix-ui/react-polymorphic": "workspace:*"
+    "@radix-ui/react-popper": "workspace:*"
+    "@radix-ui/react-portal": "workspace:*"
+    "@radix-ui/react-presence": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-use-controllable-state": "workspace:*"
+  peerDependencies:
+    react: ^16.8 || ^17.0
+  languageName: unknown
+  linkType: soft
+
 "@radix-ui/react-id@workspace:*, @radix-ui/react-id@workspace:packages/react/id":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-id@workspace:packages/react/id"


### PR DESCRIPTION
Closes https://github.com/radix-ui/primitives/issues/387

### Description

This PR adds the `HoverCard` primitive, [see here for discussion](https://github.com/radix-ui/primitives/issues/387).

Simple, straightforward primitive heavily based on `Popover` and `Tooltip`, intended as a contextual enhancement for links via pointer interaction, no focus management.

https://user-images.githubusercontent.com/11708259/114609510-cb9ca400-9c96-11eb-8cfd-abb5bdda506c.mov

Basic usage:

```jsx
<HoverCard>
      <HoverCardTrigger href="/some-awesome-page">
        Link text
      </HoverCardTrigger>
      <HoverCardContent>
        <HoverCardArrow />
        Card content
      </HoverCardContent>
</HoverCard>
```
