### PR TITLE
[Checkbox][RadioGroup][Switch] Remove `readOnly` prop 🔥 

### DIFF
--- a/.yarn/versions/baac8732.yml
+++ b/.yarn/versions/baac8732.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-switch": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -24,7 +24,6 @@ type CheckboxOwnProps = Polymorphic.Merge<
     checked?: CheckedState;
     defaultChecked?: CheckedState;
     required?: InputDOMProps['required'];
-    readOnly?: InputDOMProps['readOnly'];
     onCheckedChange?: InputDOMProps['onChange'];
   }
 >;
@@ -50,7 +49,6 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
     defaultChecked,
     required,
     disabled,
-    readOnly,
     value = 'on',
     onCheckedChange,
     ...checkboxProps
@@ -84,7 +82,6 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
         checked={checked === 'indeterminate' ? false : checked}
         required={required}
         disabled={disabled}
-        readOnly={readOnly}
         value={value}
         hidden
         onChange={composeEventHandlers(onCheckedChange, (event) => {
@@ -100,7 +97,6 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
           aria-required={required}
           data-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
-          data-readonly={readOnly}
           disabled={disabled}
           value={value}
           {...checkboxProps}

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -23,7 +23,6 @@ type RadioOwnProps = Polymorphic.Merge<
     checked?: boolean;
     defaultChecked?: boolean;
     required?: InputDOMProps['required'];
-    readOnly?: InputDOMProps['readOnly'];
     onCheckedChange?: InputDOMProps['onChange'];
   }
 >;
@@ -43,7 +42,6 @@ const Radio = React.forwardRef((props, forwardedRef) => {
     defaultChecked,
     required,
     disabled,
-    readOnly,
     value = 'on',
     onCheckedChange,
     ...radioProps
@@ -72,7 +70,6 @@ const Radio = React.forwardRef((props, forwardedRef) => {
         checked={checked}
         required={required}
         disabled={disabled}
-        readOnly={readOnly}
         value={value}
         hidden
         onChange={composeEventHandlers(onCheckedChange, (event) => {
@@ -86,7 +83,6 @@ const Radio = React.forwardRef((props, forwardedRef) => {
           aria-checked={checked}
           aria-labelledby={labelledBy}
           data-state={getState(checked)}
-          data-readonly={readOnly}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           value={value}

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -22,7 +22,6 @@ type SwitchOwnProps = Polymorphic.Merge<
     checked?: boolean;
     defaultChecked?: boolean;
     required?: InputDOMProps['required'];
-    readOnly?: InputDOMProps['readOnly'];
     onCheckedChange?: InputDOMProps['onChange'];
   }
 >;
@@ -42,7 +41,6 @@ const Switch = React.forwardRef((props, forwardedRef) => {
     defaultChecked,
     required,
     disabled,
-    readOnly,
     value = 'on',
     onCheckedChange,
     ...switchProps
@@ -71,7 +69,6 @@ const Switch = React.forwardRef((props, forwardedRef) => {
         checked={checked}
         required={required}
         disabled={disabled}
-        readOnly={readOnly}
         value={value}
         hidden
         onChange={composeEventHandlers(onCheckedChange, (event) => {
@@ -87,7 +84,6 @@ const Switch = React.forwardRef((props, forwardedRef) => {
           aria-required={required}
           data-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
-          data-readonly={readOnly}
           disabled={disabled}
           value={value}
           {...switchProps}


### PR DESCRIPTION
Fix #596

> Note: Only text controls can be made read-only, since for other controls (such as checkboxes and buttons) there is no useful distinction between being read-only and being disabled, so the readonly attribute does not apply.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly