### PR TITLE
[Polymorphic] Improve perf and fix `as={Comp}` props

### DIFF
--- a/.yarn/versions/0182f8a3.yml
+++ b/.yarn/versions/0182f8a3.yml
@@ -1,0 +1,36 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -85,7 +85,13 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
       })}
     >
       <AlertDialogContentProvider cancelRef={cancelRef}>
-        {process.env.NODE_ENV === 'development' && <AccessibilityDevWarnings {...props} />}
+        {process.env.NODE_ENV === 'development' && (
+          <AccessibilityDevWarnings
+            ariaLabel={ariaLabel}
+            ariaLabelledBy={ariaLabelledBy}
+            ariaDescribedBy={ariaDescribedBy}
+          />
+        )}
         {/**
          * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
          * around everything, otherwise the `AccessibilityDevWarnings` would be rendered straight away.
@@ -204,14 +210,12 @@ For more information, see https://LINK-TO-DOCS.com`;
 // underlying DialogContent mounts. We stick this inner component inside DialogContent to make
 // sure the effects fire as expected. This component is only useful in a dev environment, so we
 // won't bother rendering it in production.
-const AccessibilityDevWarnings: React.FC<React.ComponentProps<typeof AlertDialogContent>> = (
-  props
-) => {
-  const {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    'aria-describedby': ariaDescribedBy,
-  } = props;
+const AccessibilityDevWarnings: React.FC<{
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
+}> = (props) => {
+  const { ariaLabel, ariaLabelledBy, ariaDescribedBy } = props;
   const context = useAlertDialogContext('AlertDialogContent');
 
   React.useEffect(() => {

--- a/packages/react/polymorphic/src/polymorphic.test.tsx
+++ b/packages/react/polymorphic/src/polymorphic.test.tsx
@@ -99,8 +99,21 @@ const Anchor = React.forwardRef((props, forwardedRef) => {
 /* -----------------------------------------------------------------------------------------------*/
 
 export function Test() {
+  const buttonRef = React.useRef<React.ElementRef<typeof Button>>(null);
+  const buttonAsDivRef = React.useRef<HTMLDivElement>(null);
+  const buttonAsLinkRef = React.useRef<React.ElementRef<typeof Link>>(null);
+
   return (
     <>
+      {/* Button accepts ref */}
+      <Button ref={buttonRef} />
+
+      {/* Button as "div" accepts ref */}
+      <Button as="div" ref={buttonAsDivRef} />
+
+      {/* Button as Link accepts ref */}
+      <Button as={Link} ref={buttonAsLinkRef} />
+
       {/* Link accepts onToggle prop */}
       <Link onToggle={(open) => console.log(open)} />
 

--- a/packages/react/polymorphic/src/polymorphic.test.tsx
+++ b/packages/react/polymorphic/src/polymorphic.test.tsx
@@ -40,7 +40,7 @@ export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(
   props: React.ComponentProps<typeof Button>
 ) {
   /* Should not error with inline `as` component */
-  return <Button as={(props) => <button {...props} />} {...props} />;
+  return <Button as={(prop: any) => <button {...props} />} {...props} />;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/react/polymorphic/src/polymorphic.test.tsx
+++ b/packages/react/polymorphic/src/polymorphic.test.tsx
@@ -40,7 +40,7 @@ export function ExtendedButtonUsingReactUtilsWithInternalInlineAs(
   props: React.ComponentProps<typeof Button>
 ) {
   /* Should not error with inline `as` component */
-  return <Button as={(prop: any) => <button {...props} />} {...props} />;
+  return <Button as={(buttonProps: any) => <button {...buttonProps} />} {...props} />;
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/react/polymorphic/src/polymorphic.ts
+++ b/packages/react/polymorphic/src/polymorphic.ts
@@ -4,8 +4,6 @@ import * as React from 'react';
  * Utility types
  * -----------------------------------------------------------------------------------------------*/
 type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2;
-type MergeWithRefProps<E, P = {}> = P &
-  Merge<E extends React.ElementType ? React.ComponentPropsWithRef<E> : never, P>;
 
 /**
  * Infers the OwnProps if E is a ForwardRefExoticComponentWithAs
@@ -19,6 +17,10 @@ type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : nev
 
 type NarrowIntrinsic<E> = E extends keyof JSX.IntrinsicElements ? E : never;
 
+type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
+  Merge<E extends React.ElementType ? React.ComponentPropsWithRef<E> : never, OwnProps & { as?: E }>
+>;
+
 /* -------------------------------------------------------------------------------------------------
  * ForwardRefComponent
  * -----------------------------------------------------------------------------------------------*/
@@ -30,9 +32,7 @@ interface ForwardRefComponent<
    * Extends original type to ensure built in React types play nice
    * with polymorphic components still e.g. `React.ElementRef` etc.
    */
-> extends React.ForwardRefExoticComponent<
-    MergeWithRefProps<IntrinsicElementString, OwnProps & { as?: IntrinsicElementString }>
-  > {
+> extends ForwardRefExoticComponent<IntrinsicElementString, OwnProps> {
   /**
    * When `as` prop is passed, use this overload.
    * Merges original own props (without DOM props) and the inferred props


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Does what it says on the 🥫 

Pedro reported an issue today with this. When trying to pass a component to the `as` prop we would lose prop autocompletion for the custom props on the passed component.

I've fiddled about with this for a while and it seems I've managed to improve perf too as an unintended side effect 😅  bonus.

I've also added some new tests for the `ref` prop to make sure that still works!

https://user-images.githubusercontent.com/175330/115457283-37918600-a21c-11eb-9445-fd6862a7da14.mov


