### PR TITLE
[DismissableLayer] Cleanup `onFocusOutside` timer

### DIFF
--- a/.yarn/versions/825bad1a.yml
+++ b/.yarn/versions/825bad1a.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -231,6 +231,11 @@ function usePointerDownOutside(
 function useFocusOutside(onFocusOutside?: (event: React.FocusEvent) => void) {
   const timerRef = React.useRef<number>(0);
 
+  // Cleanup timer if an unmount occurs before onFocusCapture fires
+  React.useEffect(() => {
+    return () => window.clearTimeout(timerRef.current);
+  }, []);
+
   return {
     onBlurCapture: (event: React.FocusEvent) => {
       event.persist();


### PR DESCRIPTION
I ran across a case where layers unmount before `onFocusCapture` fires, causing the async state warning to throw.

This PR ensures the cleanup also happens in lifecycle.

https://user-images.githubusercontent.com/11708259/115879022-19f13600-a441-11eb-8777-01510dce1bde.mov

