### PR TITLE
[RovingFocusGroup] Refactor internals to take into account hidden items

### DIFF
--- a/.yarn/versions/42082bf2.yml
+++ b/.yarn/versions/42082bf2.yml
@@ -1,0 +1,17 @@
+releases:
+  "@radix-ui/number": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives
+  - ssr-testing

--- a/.yarn/versions/42082bf2.yml
+++ b/.yarn/versions/42082bf2.yml
@@ -1,16 +1,21 @@
 releases:
   "@radix-ui/number": patch
   "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-collection": patch
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dropdown-menu": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
   "@radix-ui/react-radio-group": patch
   "@radix-ui/react-roving-focus": patch
   "@radix-ui/react-scroll-area": patch
   "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
   "@radix-ui/react-tabs": patch
   "@radix-ui/react-toggle-group": patch
   "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
 
 declined:
   - primitives

--- a/packages/core/number/src/number.ts
+++ b/packages/core/number/src/number.ts
@@ -2,8 +2,4 @@ function clamp(value: number, [min, max]: [number, number]): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function wrap(index: number, max: number) {
-  return (max + index) % max;
-}
-
-export { clamp, wrap };
+export { clamp };

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -295,7 +295,7 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
   const valueContext = useAccordionValueContext(ITEM_NAME);
   const buttonId = useId();
   const open = (value && valueContext.value.includes(value)) || false;
-  const disabled = accordionContext.disabled === true ? true : props.disabled;
+  const disabled = accordionContext.disabled || props.disabled;
 
   return (
     <AccordionItemProvider open={open} disabled={disabled} buttonId={buttonId}>

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/react-compose-refs": "workspace:*",
-    "@radix-ui/react-polymorphic": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/collection/src/Collection.stories.tsx
+++ b/packages/react/collection/src/Collection.stories.tsx
@@ -125,7 +125,10 @@ export const Nested = () => (
 
 type ItemData = { disabled: boolean };
 
-const [ListSlot, ListItemSlot, useItems] = createCollection<HTMLLIElement, ItemData>();
+const [ListSlot, ListItemSlot, useItems] = createCollection<
+  React.ElementRef<typeof Item>,
+  ItemData
+>();
 
 const List: React.FC = (props) => {
   return (

--- a/packages/react/collection/src/Collection.stories.tsx
+++ b/packages/react/collection/src/Collection.stories.tsx
@@ -5,9 +5,9 @@ export default { title: 'Components/Collection' };
 
 export const Basic = () => (
   <List>
-    <ListItem>Red</ListItem>
-    <ListItem disabled>Green</ListItem>
-    <ListItem>Blue</ListItem>
+    <Item>Red</Item>
+    <Item disabled>Green</Item>
+    <Item>Blue</Item>
     <LogItems />
   </List>
 );
@@ -15,23 +15,23 @@ export const Basic = () => (
 export const WithElementInBetween = () => (
   <List>
     <div style={{ fontVariant: 'small-caps' }}>Colors</div>
-    <ListItem>Red</ListItem>
-    <ListItem disabled>Green</ListItem>
-    <ListItem>Blue</ListItem>
+    <Item>Red</Item>
+    <Item disabled>Green</Item>
+    <Item>Blue</Item>
     <div style={{ fontVariant: 'small-caps' }}>Words</div>
-    <ListItem>Hello</ListItem>
-    <ListItem>World</ListItem>
+    <Item>Hello</Item>
+    <Item>World</Item>
     <LogItems />
   </List>
 );
 
-const Tomato = () => <ListItem style={{ color: 'tomato' }}>Tomato</ListItem>;
+const Tomato = () => <Item style={{ color: 'tomato' }}>Tomato</Item>;
 
 export const WithWrappedItem = () => (
   <List>
-    <ListItem>Red</ListItem>
-    <ListItem disabled>Green</ListItem>
-    <ListItem>Blue</ListItem>
+    <Item>Red</Item>
+    <Item disabled>Green</Item>
+    <Item>Blue</Item>
     <Tomato />
     <LogItems />
   </List>
@@ -40,9 +40,9 @@ export const WithWrappedItem = () => (
 export const WithFragment = () => {
   const countries = (
     <>
-      <ListItem>France</ListItem>
-      <ListItem disabled>UK</ListItem>
-      <ListItem>Spain</ListItem>
+      <Item>France</Item>
+      <Item disabled>UK</Item>
+      <Item>Spain</Item>
     </>
   );
   return (
@@ -93,9 +93,9 @@ export const WithChangingItem = () => {
       </button>
 
       <List>
-        <ListItem>Red</ListItem>
-        <ListItem disabled={isDisabled}>Green</ListItem>
-        <ListItem>Blue</ListItem>
+        <Item>Red</Item>
+        <Item disabled={isDisabled}>Green</Item>
+        <Item>Blue</Item>
         <LogItems />
       </List>
     </>
@@ -104,17 +104,17 @@ export const WithChangingItem = () => {
 
 export const Nested = () => (
   <List>
-    <ListItem>1</ListItem>
-    <ListItem>
+    <Item>1</Item>
+    <Item>
       2
       <List>
-        <ListItem>2.1</ListItem>
-        <ListItem>2.2</ListItem>
-        <ListItem>2.3</ListItem>
+        <Item>2.1</Item>
+        <Item>2.2</Item>
+        <Item>2.3</Item>
         <LogItems name="items inside 2" />
       </List>
-    </ListItem>
-    <ListItem>3</ListItem>
+    </Item>
+    <Item>3</Item>
     <LogItems name="top-level items" />
   </List>
 );
@@ -123,14 +123,33 @@ export const Nested = () => (
  * List implementation
  * -----------------------------------------------------------------------------------------------*/
 
-type ListItemOwnProps = { disabled?: boolean };
+type ItemData = { disabled: boolean };
 
-const [List, ListItem, useItems] = createCollection<ListItemOwnProps>();
-List.displayName = 'List';
-ListItem.displayName = 'ListItem';
+const [ListSlot, ListItemSlot, useItems] = createCollection<HTMLLIElement, ItemData>();
+
+const List: React.FC = (props) => {
+  return (
+    <ListSlot>
+      <ul style={{ width: 200 }} {...props} />
+    </ListSlot>
+  );
+};
+
+type ItemProps = React.ComponentPropsWithRef<'li'> & {
+  children: React.ReactNode;
+  disabled?: boolean;
+};
+
+function Item({ disabled = false, ...props }: ItemProps) {
+  return (
+    <ListItemSlot disabled={disabled}>
+      <li {...props} style={{ ...props.style, opacity: disabled ? 0.3 : undefined }} />
+    </ListItemSlot>
+  );
+}
 
 // Ensure that our implementation doesn't break if the item list/item is memoized
-const MemoItem = React.memo(ListItem);
+const MemoItem = React.memo(Item);
 const MemoItems = React.memo(WrappedItems);
 
 function LogItems({ name = 'items' }: { name?: string }) {

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-collection": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -414,9 +414,8 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
   };
 
   const handleLeave = () => {
-    // on leave, we reset the content (we focus it)
+    // on leave, we reset (the content gets focused, and the current item tab stop gets reset)
     contentContext.onReset();
-    if (ref.current) ref.current.tabIndex = -1;
   };
 
   React.useEffect(() => {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -67,7 +67,7 @@ const CONTENT_NAME = 'MenuContent';
 
 type ItemData = { disabled: boolean };
 const [CollectionSlot, CollectionItemSlot, useCollection] = createCollection<
-  HTMLSpanElement,
+  React.ElementRef<typeof MenuItem>,
   ItemData
 >();
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
+import { RemoveScroll } from 'react-remove-scroll';
+import { hideOthers } from 'aria-hidden';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
-import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
-import { Presence } from '@radix-ui/react-presence';
-import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
-import * as PopperPrimitive from '@radix-ui/react-popper';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
+import { Presence } from '@radix-ui/react-presence';
+import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
+import * as PopperPrimitive from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
+import { Slot } from '@radix-ui/react-slot';
+import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
-import { RemoveScroll } from 'react-remove-scroll';
-import { hideOthers } from 'aria-hidden';
 import { useMenuTypeahead, useMenuTypeaheadItem } from './useMenuTypeahead';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
@@ -62,10 +63,7 @@ Menu.displayName = MENU_NAME;
 
 const CONTENT_NAME = 'MenuContent';
 
-type MenuContentContextValue = {
-  contentRef: React.RefObject<HTMLDivElement>;
-  onItemsReachableChange(open: boolean): void;
-};
+type MenuContentContextValue = { onReset(): void };
 const [MenuContentProvider, useMenuContentContext] = createContext<MenuContentContextValue>(
   CONTENT_NAME
 );
@@ -101,10 +99,18 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
 }) as MenuContentPrimitive;
 
 type MenuContentImplOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof PopperPrimitive.Content>,
+  Polymorphic.Merge<
+    Omit<
+      Polymorphic.OwnProps<typeof RovingFocusGroup>,
+      | 'orientation'
+      | 'currentTabStopId'
+      | 'defaultCurrentTabStopId'
+      | 'onCurrentTabStopIdChange'
+      | 'onEntryFocus'
+    >,
+    Polymorphic.OwnProps<typeof PopperPrimitive.Content>
+  >,
   {
-    loop?: boolean;
-
     /**
      * Whether focus should be trapped within the `MenuContent`
      * (default: false)
@@ -176,7 +182,8 @@ type MenuContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
-    loop,
+    dir = 'ltr',
+    loop = false,
     trapFocus,
     onOpenAutoFocus,
     onCloseAutoFocus,
@@ -191,14 +198,9 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = useMenuContext(CONTENT_NAME);
   const contentRef = React.useRef<HTMLDivElement>(null);
-  const [contentTabIndex, setContentTabIndex] = React.useState(0);
-  const [itemsReachable, setItemsReachable] = React.useState(false);
   const typeaheadProps = useMenuTypeahead();
 
-  React.useEffect(() => {
-    setContentTabIndex(itemsReachable ? -1 : 0);
-  }, [itemsReachable]);
-
+  const [currentItemId, setCurrentItemId] = React.useState<string | null>(null);
   const [
     isPermittedPointerDownOutsideEvent,
     setIsPermittedPointerDownOutsideEvent,
@@ -220,67 +222,75 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   return (
     <PortalWrapper>
       <ScrollLockWrapper>
-        <MenuContentProvider contentRef={contentRef} onItemsReachableChange={setItemsReachable}>
-          <RovingFocusGroup
-            reachable={itemsReachable}
-            onReachableChange={setItemsReachable}
-            orientation="vertical"
-            loop={loop}
+        <MenuContentProvider
+          onReset={React.useCallback(() => {
+            contentRef.current?.focus();
+            setCurrentItemId(null);
+          }, [])}
+        >
+          <FocusScope
+            // clicking outside may raise a focusout event, which may get trapped.
+            // in cases where outside pointer events are permitted, we stop trapping.
+            // we also make sure we're not trapping once it's been closed
+            // (closed !== unmounted when animating out)
+            trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && context.open}
+            onMountAutoFocus={onOpenAutoFocus}
+            onUnmountAutoFocus={(event) => {
+              // skip autofocus on unmount if clicking outside is permitted and it happened
+              if (isPermittedPointerDownOutsideEvent) {
+                event.preventDefault();
+              } else {
+                onCloseAutoFocus?.(event);
+              }
+            }}
           >
-            <FocusScope
-              // clicking outside may raise a focusout event, which may get trapped.
-              // in cases where outside pointer events are permitted, we stop trapping.
-              // we also make sure we're not trapping once it's been closed
-              // (closed !== unmounted when animating out)
-              trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && context.open}
-              onMountAutoFocus={onOpenAutoFocus}
-              onUnmountAutoFocus={(event) => {
-                // skip autofocus on unmount if clicking outside is permitted and it happened
-                if (isPermittedPointerDownOutsideEvent) {
-                  event.preventDefault();
-                } else {
-                  onCloseAutoFocus?.(event);
-                }
-              }}
-            >
-              {(focusScopeProps) => (
-                <DismissableLayer
-                  disableOutsidePointerEvents={disableOutsidePointerEvents}
-                  onEscapeKeyDown={onEscapeKeyDown}
-                  onPointerDownOutside={composeEventHandlers(
-                    onPointerDownOutside,
-                    (event) => {
-                      const isLeftClick =
-                        (event as MouseEvent).button === 0 && event.ctrlKey === false;
-                      const isPermitted = !disableOutsidePointerEvents && isLeftClick;
-                      setIsPermittedPointerDownOutsideEvent(isPermitted);
+            {(focusScopeProps) => (
+              <DismissableLayer
+                disableOutsidePointerEvents={disableOutsidePointerEvents}
+                onEscapeKeyDown={onEscapeKeyDown}
+                onPointerDownOutside={composeEventHandlers(
+                  onPointerDownOutside,
+                  (event) => {
+                    const isLeftClick =
+                      (event as MouseEvent).button === 0 && event.ctrlKey === false;
+                    const isPermitted = !disableOutsidePointerEvents && isLeftClick;
+                    setIsPermittedPointerDownOutsideEvent(isPermitted);
 
-                      if (event.defaultPrevented) {
-                        // reset this because the event was prevented
-                        setIsPermittedPointerDownOutsideEvent(false);
-                      }
-                    },
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onFocusOutside={composeEventHandlers(
-                    onFocusOutside,
-                    (event) => {
-                      // When focus is trapped, a focusout event may still happen.
-                      // We make sure we don't trigger our `onDismiss` in such case.
-                      if (trapFocus) event.preventDefault();
-                    },
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onInteractOutside={onInteractOutside}
-                  onDismiss={() => context.onOpenChange(false)}
-                >
-                  {(dismissableLayerProps) => (
+                    if (event.defaultPrevented) {
+                      // reset this because the event was prevented
+                      setIsPermittedPointerDownOutsideEvent(false);
+                    }
+                  },
+                  { checkForDefaultPrevented: false }
+                )}
+                onFocusOutside={composeEventHandlers(
+                  onFocusOutside,
+                  (event) => {
+                    // When focus is trapped, a focusout event may still happen.
+                    // We make sure we don't trigger our `onDismiss` in such case.
+                    if (trapFocus) event.preventDefault();
+                  },
+                  { checkForDefaultPrevented: false }
+                )}
+                onInteractOutside={onInteractOutside}
+                onDismiss={() => context.onOpenChange(false)}
+              >
+                {(dismissableLayerProps) => (
+                  <RovingFocusGroup
+                    as={Slot}
+                    dir={dir}
+                    orientation="vertical"
+                    loop={loop}
+                    currentTabStopId={currentItemId}
+                    onCurrentTabStopIdChange={setCurrentItemId}
+                    // we override the default behaviour which automatically focuses the first item
+                    onEntryFocus={(event) => event.preventDefault()}
+                  >
                     <PopperPrimitive.Content
                       role="menu"
                       {...focusScopeProps}
                       {...contentProps}
                       ref={composeRefs(forwardedRef, contentRef, focusScopeProps.ref)}
-                      tabIndex={contentTabIndex}
                       style={{
                         ...dismissableLayerProps.style,
                         outline: 'none',
@@ -330,11 +340,11 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                         })
                       )}
                     />
-                  )}
-                </DismissableLayer>
-              )}
-            </FocusScope>
-          </RovingFocusGroup>
+                  </RovingFocusGroup>
+                )}
+              </DismissableLayer>
+            )}
+          </FocusScope>
         </MenuContentProvider>
       </ScrollLockWrapper>
     </PortalWrapper>
@@ -348,12 +358,14 @@ MenuContent.displayName = CONTENT_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const ITEM_NAME = 'MenuItem';
+const ITEM_DEFAULT_TAG = 'div';
+
 const ITEM_ATTR = 'data-radix-menu-item';
 const ENABLED_ITEM_SELECTOR = `[${ITEM_ATTR}]:not([data-disabled])`;
 const ITEM_SELECT = 'menu.itemSelect';
 
 type MenuItemOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
+  Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
   {
     disabled?: boolean;
     textValue?: string;
@@ -361,23 +373,19 @@ type MenuItemOwnProps = Polymorphic.Merge<
   }
 >;
 
-type MenuItemPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
-  MenuItemOwnProps
->;
+type MenuItemPrimitive = Polymorphic.ForwardRefComponent<typeof ITEM_DEFAULT_TAG, MenuItemOwnProps>;
 
 const MenuItem = React.forwardRef((props, forwardedRef) => {
-  const { disabled, textValue, onSelect, ...itemProps } = props;
-  const menuItemRef = React.useRef<HTMLDivElement>(null);
-  const composedRef = useComposedRefs(forwardedRef, menuItemRef);
+  const { as = ITEM_DEFAULT_TAG, disabled, textValue, onSelect, ...itemProps } = props;
+  const ref = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
   const context = useMenuContext(ITEM_NAME);
   const contentContext = useMenuContentContext(ITEM_NAME);
-  const rovingFocusProps = useRovingFocus({ disabled });
 
   // get the item's `.textContent` as default strategy for typeahead `textValue`
   const [textContent, setTextContent] = React.useState('');
   React.useEffect(() => {
-    const menuItem = menuItemRef.current;
+    const menuItem = ref.current;
     if (menuItem) {
       setTextContent((menuItem.textContent ?? '').trim());
     }
@@ -389,7 +397,7 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
   });
 
   const handleSelect = () => {
-    const menuItem = menuItemRef.current;
+    const menuItem = ref.current;
     if (!disabled && menuItem) {
       const itemSelectEvent = new Event(ITEM_SELECT, { bubbles: true, cancelable: true });
       menuItem.dispatchEvent(itemSelectEvent);
@@ -398,8 +406,14 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
     }
   };
 
+  const handleLeave = () => {
+    // on leave, we reset the content (we focus it)
+    contentContext.onReset();
+    if (ref.current) ref.current.tabIndex = -1;
+  };
+
   React.useEffect(() => {
-    const menuItem = menuItemRef.current;
+    const menuItem = ref.current;
     if (menuItem) {
       const handleItemSelect = (event: Event) => onSelect?.(event);
       menuItem.addEventListener(ITEM_SELECT, handleItemSelect);
@@ -408,29 +422,25 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
   }, [onSelect]);
 
   return (
-    <Primitive
+    <RovingFocusItem
       role="menuitem"
       aria-disabled={disabled || undefined}
+      focusable={!disabled}
       {...itemProps}
-      {...rovingFocusProps}
       {...menuTypeaheadItemProps}
       {...{ [ITEM_ATTR]: '' }}
-      ref={composedRef}
+      as={as}
+      ref={composedRefs}
       data-disabled={disabled ? '' : undefined}
-      onFocus={composeEventHandlers(itemProps.onFocus, rovingFocusProps.onFocus)}
-      onKeyDown={composeEventHandlers(
-        itemProps.onKeyDown,
-        composeEventHandlers(rovingFocusProps.onKeyDown, (event) => {
-          if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
-            // prevent page scroll if using the space key to select an item
-            if (event.key === ' ') event.preventDefault();
-            handleSelect();
-          }
-        })
-      )}
-      onMouseDown={composeEventHandlers(itemProps.onMouseDown, rovingFocusProps.onMouseDown)}
+      onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
+          // prevent page scroll if using the space key to select an item
+          if (event.key === ' ') event.preventDefault();
+          handleSelect();
+        }
+      })}
       // we handle selection on `mouseUp` rather than `click` to match native menus implementation
-      onMouseUp={composeEventHandlers(itemProps.onMouseUp, handleSelect)}
+      onMouseUp={composeEventHandlers(props.onMouseUp, handleSelect)}
       /**
        * We focus items on `mouseMove` to achieve the following:
        *
@@ -442,20 +452,15 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
        * If we used `mouseOver`/`mouseEnter` it would not re-focus when the mouse
        * wiggles. This is to match native menu implementation.
        */
-      onMouseMove={composeEventHandlers(itemProps.onMouseMove, (event) => {
+      onMouseMove={composeEventHandlers(props.onMouseMove, (event) => {
         if (!disabled) {
           const item = event.currentTarget;
           item.focus();
+        } else {
+          handleLeave();
         }
       })}
-      // make items unreachable when an item is blurred
-      onBlur={composeEventHandlers(itemProps.onBlur, (event) => {
-        contentContext.onItemsReachableChange(false);
-      })}
-      // focus the menu if the mouse leaves an item
-      onMouseLeave={composeEventHandlers(itemProps.onMouseLeave, (event) => {
-        contentContext.contentRef.current?.focus();
-      })}
+      onMouseLeave={composeEventHandlers(props.onMouseLeave, handleLeave)}
     />
   );
 }) as MenuItemPrimitive;

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -103,7 +103,10 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 const ITEM_NAME = 'RadioGroupItem';
 
 type RadioGroupItemOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Radio>,
+  Polymorphic.Merge<
+    Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
+    Polymorphic.OwnProps<typeof Radio>
+  >,
   { value: string; name?: never }
 >;
 type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
+import { useLabelContext } from '@radix-ui/react-label';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
+import { extendPrimitive } from '@radix-ui/react-primitive';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
+import { Slot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
 import { Radio, RadioIndicator } from './Radio';
-import { useLabelContext } from '@radix-ui/react-label';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
@@ -15,21 +16,24 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
  * RadioGroup
  * -----------------------------------------------------------------------------------------------*/
 const RADIO_GROUP_NAME = 'RadioGroup';
+const RADIO_GROUP_DEFAULT_TAG = 'div';
 
 type RadioGroupOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
+  Omit<
+    Polymorphic.OwnProps<typeof RovingFocusGroup>,
+    'reachable' | 'defaultReachable' | 'onReachableChange'
+  >,
   {
     name?: string;
     value?: string;
     defaultValue?: string;
     required?: React.ComponentProps<typeof Radio>['required'];
-    rovingFocus?: boolean;
     onValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   }
 >;
 
 type RadioGroupPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
+  typeof RADIO_GROUP_DEFAULT_TAG,
   RadioGroupOwnProps
 >;
 
@@ -37,7 +41,6 @@ type RadioGroupContextValue = {
   name: RadioGroupOwnProps['name'];
   value: RadioGroupOwnProps['value'];
   required: RadioGroupOwnProps['required'];
-  rovingFocus: RadioGroupOwnProps['rovingFocus'];
   onValueChange: Required<RadioGroupOwnProps>['onValueChange'];
 };
 
@@ -47,12 +50,15 @@ const [RadioGroupProvider, useRadioGroupContext] = createContext<RadioGroupConte
 
 const RadioGroup = React.forwardRef((props, forwardedRef) => {
   const {
+    as = RADIO_GROUP_DEFAULT_TAG,
     name,
     'aria-labelledby': ariaLabelledby,
     defaultValue,
     value: valueProp,
     required,
-    rovingFocus = true,
+    orientation,
+    dir = 'ltr',
+    loop = true,
     onValueChange,
     ...groupProps
   } = props;
@@ -64,22 +70,26 @@ const RadioGroup = React.forwardRef((props, forwardedRef) => {
     defaultProp: defaultValue,
   });
 
-  const primitive = (
-    <Primitive {...groupProps} ref={forwardedRef} role="radiogroup" aria-labelledby={labelledBy} />
-  );
-
   return (
     <RadioGroupProvider
       name={name}
       value={value}
       required={required}
-      rovingFocus={rovingFocus}
       onValueChange={React.useCallback(
         composeEventHandlers(handleValueChange, (event) => setValue(event.target.value)),
         [handleValueChange]
       )}
     >
-      {rovingFocus ? <RovingFocusGroup loop>{primitive}</RovingFocusGroup> : primitive}
+      <RovingFocusGroup
+        role="radiogroup"
+        aria-labelledby={labelledBy}
+        orientation={orientation}
+        dir={dir}
+        loop={loop}
+        {...groupProps}
+        as={as}
+        ref={forwardedRef}
+      />
     </RadioGroupProvider>
   );
 }) as RadioGroupPrimitive;
@@ -92,47 +102,34 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 
 const ITEM_NAME = 'RadioGroupItem';
 
-type RadioGroupItemOwnProps = Polymorphic.OwnProps<typeof RadioGroupItemImpl>;
+type RadioGroupItemOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof Radio>,
+  { value: string; name?: never }
+>;
 type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof RadioGroupItemImpl>,
+  Polymorphic.IntrinsicElement<typeof Radio>,
   RadioGroupItemOwnProps
 >;
 
 const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
-  const context = useRadioGroupContext(ITEM_NAME);
-  return context.rovingFocus ? (
-    <RadioGroupRovingFocusItem {...props} ref={forwardedRef} />
-  ) : (
-    <RadioGroupItemImpl {...props} ref={forwardedRef} />
-  );
-}) as RadioGroupItemPrimitive;
-
-RadioGroupItem.displayName = ITEM_NAME;
-
-type RadioGroupRovingFocusItemOwnProps = Polymorphic.OwnProps<typeof RadioGroupItemImpl>;
-type RadioGroupRovingFocusItemPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof RadioGroupItemImpl>,
-  RadioGroupRovingFocusItemOwnProps
->;
-
-const RadioGroupRovingFocusItem = React.forwardRef((props, forwardedRef) => {
   const { disabled, ...itemProps } = props;
   const context = useRadioGroupContext(ITEM_NAME);
-  const ref = React.useRef<React.ElementRef<typeof RadioGroupItemImpl>>(null);
+  const ref = React.useRef<React.ElementRef<typeof Radio>>(null);
   const composedRefs = useComposedRefs(forwardedRef, ref);
-  const isChecked = context.value === itemProps.value;
-  const rovingFocusProps = useRovingFocus({ disabled, active: isChecked });
+  const checked = context.value === itemProps.value;
+
   return (
-    <RadioGroupItemImpl
-      disabled={disabled}
-      {...itemProps}
-      {...rovingFocusProps}
-      ref={composedRefs}
-      onKeyDown={composeEventHandlers(itemProps.onKeyDown, rovingFocusProps.onKeyDown)}
-      onMouseDown={composeEventHandlers(itemProps.onMouseDown, rovingFocusProps.onMouseDown)}
-      onFocus={composeEventHandlers(
-        itemProps.onFocus,
-        composeEventHandlers(rovingFocusProps.onFocus, () => {
+    <RovingFocusItem as={Slot} focusable={!disabled} active={checked}>
+      <Radio
+        disabled={disabled}
+        required={context.required}
+        checked={checked}
+        {...itemProps}
+        // add `name` after spreading the props because users cannot pass a `name`
+        name={context.name}
+        ref={composedRefs}
+        onCheckedChange={composeEventHandlers(props.onCheckedChange, context.onValueChange)}
+        onFocus={composeEventHandlers(itemProps.onFocus, () => {
           /**
            * Roving index will focus the radio and we need to check it when this happens.
            * We do this imperatively instead of updating `context.value` because changing via
@@ -141,36 +138,13 @@ const RadioGroupRovingFocusItem = React.forwardRef((props, forwardedRef) => {
           if (context.value !== undefined) {
             ref.current?.click();
           }
-        })
-      )}
-    />
+        })}
+      />
+    </RovingFocusItem>
   );
-}) as RadioGroupRovingFocusItemPrimitive;
+}) as RadioGroupItemPrimitive;
 
-type RadioGroupItemImplOwnProps = Polymorphic.Merge<
-  Omit<Polymorphic.OwnProps<typeof Radio>, 'name'>,
-  { value: string }
->;
-type RadioGroupItemImplPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Radio>,
-  RadioGroupItemImplOwnProps
->;
-
-const RadioGroupItemImpl = React.forwardRef((props, forwardedRef) => {
-  const context = useRadioGroupContext(ITEM_NAME);
-  const isChecked = context.value === props.value;
-
-  return (
-    <Radio
-      required={context.required}
-      checked={isChecked}
-      name={context.name}
-      {...props}
-      ref={forwardedRef}
-      onCheckedChange={composeEventHandlers(props.onCheckedChange, context.onValueChange)}
-    />
-  );
-}) as RadioGroupItemImplPrimitive;
+RadioGroupItem.displayName = ITEM_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -103,10 +103,7 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 const ITEM_NAME = 'RadioGroupItem';
 
 type RadioGroupItemOwnProps = Polymorphic.Merge<
-  Polymorphic.Merge<
-    Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
-    Polymorphic.OwnProps<typeof Radio>
-  >,
+  Polymorphic.OwnProps<typeof Radio>,
   { value: string; name?: never }
 >;
 type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<
@@ -128,7 +125,6 @@ const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
         required={context.required}
         checked={checked}
         {...itemProps}
-        // add `name` after spreading the props because users cannot pass a `name`
         name={context.name}
         ref={composedRefs}
         onCheckedChange={composeEventHandlers(props.onCheckedChange, context.onValueChange)}

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -21,7 +21,7 @@ const RADIO_GROUP_DEFAULT_TAG = 'div';
 type RadioGroupOwnProps = Polymorphic.Merge<
   Omit<
     Polymorphic.OwnProps<typeof RovingFocusGroup>,
-    'reachable' | 'defaultReachable' | 'onReachableChange'
+    'currentTabStopId' | 'defaultCurrentTabStopId' | 'onCurrentTabStopIdChange' | 'onEntryFocus'
   >,
   {
     name?: string;

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -18,9 +18,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/number": "workspace:*",
+    "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
+    "@radix-ui/react-polymorphic": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-collection": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-id": "workspace:*",

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { RovingFocusGroup, useRovingFocus } from './RovingFocusGroup';
+import { RovingFocusGroup, RovingFocusItem } from './RovingFocusGroup';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
 
@@ -30,6 +30,9 @@ export const Basic = () => {
 
       <h2>no orientation (both) + looping</h2>
       <ButtonGroup dir={dir} loop>
+        <Button value="hidden" style={{ display: 'none' }}>
+          Hidden
+        </Button>
         <Button value="one">One</Button>
         <Button value="two">Two</Button>
         <Button disabled value="three">
@@ -137,6 +140,36 @@ export const Reachable = () => {
   );
 };
 
+export const EdgeCases = () => {
+  const [extra, setExtra] = React.useState(false);
+  const [disabled, setDisabled] = React.useState(false);
+  const [hidden, setHidden] = React.useState(false);
+
+  return (
+    <>
+      <button onClick={() => setExtra((x) => !x)}>Add/remove extra</button>
+      <button onClick={() => setDisabled((x) => !x)}>Disable/Enable "One"</button>
+      <button onClick={() => setHidden((x) => !x)}>Hide/show "One"</button>
+      <hr />
+
+      <ButtonGroup>
+        {extra ? <Button value="extra">Extra</Button> : null}
+        <Button value="one" disabled={disabled} style={{ display: hidden ? 'none' : undefined }}>
+          One
+        </Button>
+        <Button value="two" disabled>
+          Two
+        </Button>
+        <Button value="three">Three</Button>
+        <Button value="four" style={{ display: 'none' }}>
+          Four
+        </Button>
+        <Button value="five">Five</Button>
+      </ButtonGroup>
+    </>
+  );
+};
+
 const ButtonGroupContext = React.createContext<{
   value?: string;
   setValue: React.Dispatch<React.SetStateAction<string | undefined>>;
@@ -145,44 +178,35 @@ const ButtonGroupContext = React.createContext<{
 type ButtonGroupProps = Omit<React.ComponentPropsWithRef<'div'>, 'defaultValue'> &
   RovingFocusGroupProps & { defaultValue?: string };
 
-const ButtonGroup = ({
-  reachable,
-  orientation,
-  dir,
-  loop,
-  defaultValue,
-  ...props
-}: ButtonGroupProps) => {
+const ButtonGroup = ({ defaultValue, ...props }: ButtonGroupProps) => {
   const [value, setValue] = React.useState(defaultValue);
   return (
     <ButtonGroupContext.Provider value={{ value, setValue }}>
-      <RovingFocusGroup reachable={reachable} orientation={orientation} dir={dir} loop={loop}>
-        <div
-          {...props}
-          style={{
-            ...props.style,
-            display: 'inline-flex',
-            flexDirection: orientation === 'vertical' ? 'column' : 'row',
-            gap: 10,
-          }}
-        />
-      </RovingFocusGroup>
+      <RovingFocusGroup
+        {...props}
+        style={{
+          ...props.style,
+          display: 'inline-flex',
+          flexDirection: props.orientation === 'vertical' ? 'column' : 'row',
+          gap: 10,
+        }}
+      />
     </ButtonGroupContext.Provider>
   );
 };
 
 type ButtonProps = Omit<React.ComponentPropsWithRef<'button'>, 'value'> & { value?: string };
 
-const Button = ({ disabled, tabIndex, value, ...props }: ButtonProps) => {
+const Button = (props: ButtonProps) => {
   const { value: contextValue, setValue } = React.useContext(ButtonGroupContext);
-  const isSelected = contextValue !== undefined && value !== undefined && contextValue === value;
-  const rovingFocusProps = useRovingFocus({ disabled, active: isSelected });
+  const isSelected =
+    contextValue !== undefined && props.value !== undefined && contextValue === props.value;
 
   return (
-    <button
-      disabled={disabled}
+    <RovingFocusItem
       {...props}
-      {...rovingFocusProps}
+      as="button"
+      active={isSelected}
       style={{
         ...props.style,
         border: '1px solid',
@@ -197,8 +221,8 @@ const Button = ({ disabled, tabIndex, value, ...props }: ButtonProps) => {
             }
           : {}),
       }}
-      onClick={disabled ? undefined : () => setValue(value)}
-      onFocus={composeEventHandlers(rovingFocusProps.onFocus, (event) => {
+      onClick={props.disabled ? undefined : () => setValue(props.value)}
+      onFocus={composeEventHandlers(props.onFocus, (event) => {
         if (contextValue !== undefined) {
           event.target.click();
         }

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -110,36 +110,6 @@ export const Nested = () => (
   </ButtonGroup>
 );
 
-export const Reachable = () => {
-  const [reachable, setReachable] = React.useState(true);
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 20 }}>
-      <label>
-        <input
-          type="checkbox"
-          checked={reachable}
-          onChange={(event) => setReachable(event.target.checked)}
-        />{' '}
-        Reachable?
-      </label>
-
-      <div>
-        <ButtonGroup reachable={reachable}>
-          <Button value="one">One</Button>
-          <Button value="two">Two</Button>
-          <Button disabled value="three">
-            Three
-          </Button>
-          <Button value="four">Four</Button>
-        </ButtonGroup>
-      </div>
-
-      <input />
-    </div>
-  );
-};
-
 export const EdgeCases = () => {
   const [extra, setExtra] = React.useState(false);
   const [disabled, setDisabled] = React.useState(false);

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -170,8 +170,6 @@ const RovingFocusItem = React.forwardRef((props, forwardedRef) => {
   const composedRefs = useComposedRefs(forwardedRef, ref);
   const context = useRovingFocusContext(ITEM_NAME);
   const isCurrentTabStop = context.currentTabStopId === id;
-  const isCurrentTabStopRef = React.useRef(isCurrentTabStop);
-  React.useEffect(() => void (isCurrentTabStopRef.current = isCurrentTabStop));
 
   // We keep an up to date map of every item. We do this on every render
   // to make sure the map insertion order reflects the DOM order.
@@ -201,9 +199,6 @@ const RovingFocusItem = React.forwardRef((props, forwardedRef) => {
         }
 
         if (event.target !== event.currentTarget) return;
-
-        // stop key events from propagating to parent in case we're in a nested roving focus group
-        if (KEYS.includes(event.key)) event.stopPropagation();
 
         const focusIntent = getFocusIntent(event, context.orientation, context.dir);
 
@@ -242,7 +237,6 @@ const MAP_KEY_TO_FOCUS_INTENT: Record<string, FocusIntent> = {
   PageUp: 'first', Home: 'first',
   PageDown: 'last', End: 'last',
 };
-const KEYS = Object.keys(MAP_KEY_TO_FOCUS_INTENT);
 
 function getDirectionAwareKey(key: string, dir?: Direction) {
   if (dir !== 'rtl') return key;

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -213,11 +213,8 @@ const RovingFocusItem = React.forwardRef((props, forwardedRef) => {
           const items = Array.from(context.itemMap.values()).filter((item) => item.focusable);
           let candidateNodes = items.map((item) => item.ref.current!);
 
-          if (focusIntent === 'first' || focusIntent === 'last') {
-            if (focusIntent === 'last') candidateNodes.reverse();
-          }
-
-          if (focusIntent === 'prev' || focusIntent === 'next') {
+          if (focusIntent === 'last') candidateNodes.reverse();
+          else if (focusIntent === 'prev' || focusIntent === 'next') {
             if (focusIntent === 'prev') candidateNodes.reverse();
             const currentIndex = candidateNodes.indexOf(event.currentTarget);
             candidateNodes = context.loop

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -29,7 +29,7 @@ type RovingFocusGroupOptions = {
    */
   orientation?: Orientation;
   /**
-   * The direction of navigation between toolbar items.
+   * The direction of navigation between items.
    * @defaultValue ltr
    */
   dir?: Direction;

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -8,7 +8,7 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
 
 type SlotProps = { children: React.ReactNode };
 
-const Slot = React.forwardRef<never, SlotProps>((props, forwardedRef) => {
+const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
   const childLength = React.Children.count(children);
 

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -23,7 +23,6 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -18,12 +18,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -42,7 +42,7 @@ type TabsOwnProps = Polymorphic.Merge<
      * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
      * @defaultValue horizontal
      */
-    orientation?: React.AriaAttributes['aria-orientation'];
+    orientation?: RovingFocusGroupProps['orientation'];
     /**
      * The direction of navigation between toolbar items.
      * @defaultValue ltr

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -4,7 +4,7 @@ import { createContext } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive } from '@radix-ui/react-primitive';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
 import { useId } from '@radix-ui/react-id';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
@@ -40,12 +40,11 @@ type TabsOwnProps = Polymorphic.Merge<
     /**
      * The orientation the tabs are layed out.
      * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
-     * (default: horizontal)
+     * @defaultValue horizontal
      */
     orientation?: React.AriaAttributes['aria-orientation'];
     /**
      * The direction of navigation between toolbar items.
-     *
      * @defaultValue ltr
      */
     dir?: RovingFocusGroupProps['dir'];
@@ -70,8 +69,6 @@ const Tabs = React.forwardRef((props, forwardedRef) => {
     ...tabsProps
   } = props;
 
-  const baseId = useId();
-
   const [value, setValue] = useControllableState({
     prop: valueProp,
     onChange: onValueChange,
@@ -80,7 +77,7 @@ const Tabs = React.forwardRef((props, forwardedRef) => {
 
   return (
     <TabsProvider
-      baseId={baseId}
+      baseId={useId()}
       value={value}
       onValueChange={setValue}
       orientation={orientation}
@@ -99,37 +96,32 @@ Tabs.displayName = TABS_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TAB_LIST_NAME = 'TabsList';
+const TAB_LIST_DEFAULT_TAG = 'div';
 
-type TabsListOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
-  {
-    /**
-     * Whether keyboard navigation should loop focus
-     * @defaultValue true
-     */
-    loop?: boolean;
-  }
+type TabsListOwnProps = Omit<
+  Polymorphic.OwnProps<typeof RovingFocusGroup>,
+  'orientation' | 'reachable' | 'defaultReachable' | 'onReachableChange'
 >;
 
 type TabsListPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
+  typeof TAB_LIST_DEFAULT_TAG,
   TabsListOwnProps
 >;
 
 const TabsList = React.forwardRef((props, forwardedRef) => {
-  const { loop = true, ...otherProps } = props;
+  const { as = TAB_LIST_DEFAULT_TAG, loop = true, ...otherProps } = props;
   const context = useTabsContext(TAB_LIST_NAME);
 
   return (
-    <RovingFocusGroup orientation={context.orientation} loop={loop} dir={context.dir}>
-      <Primitive
-        role="tablist"
-        aria-orientation={context.orientation}
-        data-orientation={context.orientation}
-        {...otherProps}
-        ref={forwardedRef}
-      />
-    </RovingFocusGroup>
+    <RovingFocusGroup
+      role="tablist"
+      orientation={context.orientation}
+      dir={context.dir}
+      loop={loop}
+      {...otherProps}
+      as={as}
+      ref={forwardedRef}
+    />
   );
 }) as TabsListPrimitive;
 
@@ -140,77 +132,60 @@ TabsList.displayName = TAB_LIST_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TAB_NAME = 'TabsTab';
+const TAB_DEFAULT_TAG = 'div';
 
 type TabsTabOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
+  Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
   {
     value: string;
     disabled?: boolean;
   }
 >;
 
-type TabsTabPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
-  TabsTabOwnProps
->;
+type TabsTabPrimitive = Polymorphic.ForwardRefComponent<typeof TAB_DEFAULT_TAG, TabsTabOwnProps>;
 
 const TabsTab = React.forwardRef((props, forwardedRef) => {
-  const { value, disabled, ...tabProps } = props;
+  const { as = TAB_DEFAULT_TAG, value, disabled = false, ...tabProps } = props;
   const context = useTabsContext(TAB_NAME);
   const tabId = makeTabId(context.baseId, value);
   const tabPanelId = makeTabsPanelId(context.baseId, value);
   const isSelected = value === context.value;
-  const rovingFocusProps = useRovingFocus({ disabled, active: isSelected });
   const handleTabChange = useCallbackRef(() => context.onValueChange(value));
 
-  const handleKeyDown = composeEventHandlers(
-    tabProps.onKeyDown,
-    composeEventHandlers(rovingFocusProps.onKeyDown, (event) => {
-      if (!disabled && (event.key === ' ' || event.key === 'Enter')) {
-        handleTabChange();
-      }
-    })
-  );
-
-  const handleMouseDown = composeEventHandlers(
-    tabProps.onMouseDown,
-    composeEventHandlers(rovingFocusProps.onMouseDown, (event) => {
-      // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
-      // but not when the control key is pressed (avoiding MacOS right click)
-      if (!disabled && event.button === 0 && event.ctrlKey === false) {
-        handleTabChange();
-      }
-    })
-  );
-
-  const handleFocus = composeEventHandlers(
-    tabProps.onFocus,
-    composeEventHandlers(rovingFocusProps.onFocus, () => {
-      // handle "automatic" activation if necessary
-      // ie. activate tab following focus
-      const isAutomaticActivation = context.activationMode !== 'manual';
-      if (!isSelected && !disabled && isAutomaticActivation) {
-        handleTabChange();
-      }
-    })
-  );
-
   return (
-    <Primitive
+    <RovingFocusItem
       role="tab"
       aria-selected={isSelected}
       aria-controls={tabPanelId}
       aria-disabled={disabled || undefined}
       data-state={isSelected ? 'active' : 'inactive'}
       data-disabled={disabled ? '' : undefined}
-      data-orientation={context.orientation}
       id={tabId}
+      focusable={!disabled}
+      active={isSelected}
       {...tabProps}
-      {...rovingFocusProps}
+      as={as}
       ref={forwardedRef}
-      onKeyDown={handleKeyDown}
-      onMouseDown={handleMouseDown}
-      onFocus={handleFocus}
+      onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        if (!disabled && (event.key === ' ' || event.key === 'Enter')) {
+          handleTabChange();
+        }
+      })}
+      onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
+        // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
+        // but not when the control key is pressed (avoiding MacOS right click)
+        if (!disabled && event.button === 0 && event.ctrlKey === false) {
+          handleTabChange();
+        }
+      })}
+      onFocus={composeEventHandlers(props.onFocus, () => {
+        // handle "automatic" activation if necessary
+        // ie. activate tab following focus
+        const isAutomaticActivation = context.activationMode !== 'manual';
+        if (!isSelected && !disabled && isAutomaticActivation) {
+          handleTabChange();
+        }
+      })}
     />
   );
 }) as TabsTabPrimitive;

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -100,9 +100,12 @@ const TAB_LIST_DEFAULT_TAG = 'div';
 
 type TabsListOwnProps = Omit<
   Polymorphic.OwnProps<typeof RovingFocusGroup>,
-  'orientation' | 'reachable' | 'defaultReachable' | 'onReachableChange'
+  | 'orientation'
+  | 'currentTabStopId'
+  | 'defaultCurrentTabStopId'
+  | 'onCurrentTabStopIdChange'
+  | 'onEntryFocus'
 >;
-
 type TabsListPrimitive = Polymorphic.ForwardRefComponent<
   typeof TAB_LIST_DEFAULT_TAG,
   TabsListOwnProps

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -164,9 +164,9 @@ const TabsTab = React.forwardRef((props, forwardedRef) => {
       data-state={isSelected ? 'active' : 'inactive'}
       data-disabled={disabled ? '' : undefined}
       id={tabId}
+      {...tabProps}
       focusable={!disabled}
       active={isSelected}
-      {...tabProps}
       as={as}
       ref={forwardedRef}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {

--- a/packages/react/toggle-group/package.json
+++ b/packages/react/toggle-group/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-toggle": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -181,7 +181,7 @@ const [ToggleGroupContext, useToggleGroupContext] = createContext<ToggleGroupCon
 type ToggleGroupImplOwnProps = Polymorphic.Merge<
   Omit<
     Polymorphic.OwnProps<typeof RovingFocusGroup>,
-    'reachable' | 'defaultReachable' | 'onReachableChange'
+    'currentTabStopId' | 'defaultCurrentTabStopId' | 'onCurrentTabStopIdChange' | 'onEntryFocus'
   >,
   {
     /**

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { createContext } from '@radix-ui/react-context';
-import { composeEventHandlers } from '@radix-ui/primitive';
-import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
 import { Primitive } from '@radix-ui/react-primitive';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
+import { Slot } from '@radix-ui/react-slot';
 import { Toggle } from '@radix-ui/react-toggle';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
@@ -13,6 +13,7 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
  * -----------------------------------------------------------------------------------------------*/
 
 const TOGGLE_GROUP_NAME = 'ToggleGroup';
+const TOGGLE_GROUP_DEFAULT_TAG = 'div';
 
 type ToggleGroupOwnProps =
   | Polymorphic.OwnProps<typeof ToggleGroupSingle>
@@ -178,17 +179,18 @@ const [ToggleGroupContext, useToggleGroupContext] = createContext<ToggleGroupCon
 );
 
 type ToggleGroupImplOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
+  Omit<
+    Polymorphic.OwnProps<typeof RovingFocusGroup>,
+    'reachable' | 'defaultReachable' | 'onReachableChange'
+  >,
   {
     /**
      * Whether the group is disabled from user interaction.
-     *
      * @defaultValue false
      */
     disabled?: boolean;
     /**
      * Whether the group should maintain roving focus of its buttons.
-     *
      * @defaultValue true
      */
     rovingFocus?: boolean;
@@ -196,16 +198,33 @@ type ToggleGroupImplOwnProps = Polymorphic.Merge<
 >;
 
 type ToggleGroupImplPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
+  typeof TOGGLE_GROUP_DEFAULT_TAG,
   ToggleGroupImplOwnProps
 >;
 
 const ToggleGroupImpl = React.forwardRef((props, forwardedRef) => {
-  const { disabled = false, rovingFocus = true, ...toggleGroupProps } = props;
-  const primitive = <Primitive role="group" {...toggleGroupProps} ref={forwardedRef} />;
+  const {
+    as = TOGGLE_GROUP_DEFAULT_TAG,
+    disabled = false,
+    orientation,
+    loop = true,
+    rovingFocus = true,
+    ...toggleGroupProps
+  } = props;
   return (
     <ToggleGroupContext rovingFocus={rovingFocus} disabled={disabled}>
-      {rovingFocus ? <RovingFocusGroup loop>{primitive}</RovingFocusGroup> : primitive}
+      {rovingFocus ? (
+        <RovingFocusGroup
+          role="group"
+          orientation={orientation}
+          loop={loop}
+          {...toggleGroupProps}
+          as={as}
+          ref={forwardedRef}
+        />
+      ) : (
+        <Primitive role="group" {...toggleGroupProps} as={as} ref={forwardedRef} />
+      )}
     </ToggleGroupContext>
   );
 }) as ToggleGroupImplPrimitive;
@@ -216,9 +235,11 @@ const ToggleGroupImpl = React.forwardRef((props, forwardedRef) => {
 
 const ITEM_NAME = 'ToggleGroupItem';
 
-type ToggleGroupItemOwnProps =
+type ToggleGroupItemOwnProps = Omit<
   | Polymorphic.OwnProps<typeof ToggleGroupRovingFocusItem>
-  | Polymorphic.OwnProps<typeof ToggleGroupItemImpl>;
+  | Polymorphic.OwnProps<typeof ToggleGroupItemImpl>,
+  'pressed'
+>;
 
 type ToggleGroupItemPrimitive = Polymorphic.ForwardRefComponent<
   | Polymorphic.IntrinsicElement<typeof ToggleGroupRovingFocusItem>
@@ -227,19 +248,23 @@ type ToggleGroupItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ToggleGroupItem = React.forwardRef((props, forwardedRef) => {
+  const valueContext = useToggleGroupValueContext(ITEM_NAME);
   const context = useToggleGroupContext(ITEM_NAME);
-  return context.rovingFocus ? (
-    <ToggleGroupRovingFocusItem {...props} ref={forwardedRef} />
-  ) : (
-    <ToggleGroupItemImpl {...props} ref={forwardedRef} />
-  );
+  const pressed = valueContext.value.includes(props.value);
+  const disabled = context.disabled || props.disabled;
+  const Comp = context.rovingFocus ? ToggleGroupRovingFocusItem : ToggleGroupItemImpl;
+
+  return <Comp pressed={pressed} disabled={disabled} {...props} ref={forwardedRef} />;
 }) as ToggleGroupItemPrimitive;
 
 ToggleGroupItem.displayName = ITEM_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type ToggleGroupRovingFocusItemOwnProps = Polymorphic.OwnProps<typeof ToggleGroupItemImpl>;
+type ToggleGroupRovingFocusItemOwnProps = Polymorphic.Merge<
+  Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
+  Polymorphic.OwnProps<typeof ToggleGroupItemImpl>
+>;
 
 type ToggleGroupRovingFocusItemPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof ToggleGroupItemImpl>,
@@ -247,28 +272,17 @@ type ToggleGroupRovingFocusItemPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ToggleGroupRovingFocusItem = React.forwardRef((props, forwardedRef) => {
-  const valueContext = useToggleGroupValueContext(ITEM_NAME);
-  const context = useToggleGroupContext(ITEM_NAME);
-  const rovingFocusProps = useRovingFocus({
-    disabled: context.disabled || props.disabled,
-    active: valueContext.value.includes(props.value),
-  });
   return (
-    <ToggleGroupItemImpl
-      {...props}
-      {...rovingFocusProps}
-      ref={forwardedRef}
-      onFocus={composeEventHandlers(props.onFocus, rovingFocusProps.onFocus)}
-      onKeyDown={composeEventHandlers(props.onKeyDown, rovingFocusProps.onKeyDown)}
-      onMouseDown={composeEventHandlers(props.onMouseDown, rovingFocusProps.onMouseDown)}
-    />
+    <RovingFocusItem as={Slot} focusable={!props.disabled} active={props.pressed}>
+      <ToggleGroupItemImpl {...props} ref={forwardedRef} />
+    </RovingFocusItem>
   );
 }) as ToggleGroupRovingFocusItemPrimitive;
 
 /* -----------------------------------------------------------------------------------------------*/
 
 type ToggleGroupItemImplOwnProps = Polymorphic.Merge<
-  Omit<Polymorphic.OwnProps<typeof Toggle>, 'onPressedChange' | 'pressed' | 'defaultToggled'>,
+  Omit<Polymorphic.OwnProps<typeof Toggle>, 'defaultPressed' | 'onPressedChange'>,
   {
     /**
      * A string value for the toggle group item. All items within a toggle group should use a unique value.
@@ -284,17 +298,12 @@ type ToggleGroupItemImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const ToggleGroupItemImpl = React.forwardRef((props, forwardedRef) => {
   const { value, ...itemProps } = props;
-  const context = useToggleGroupContext(ITEM_NAME);
   const valueContext = useToggleGroupValueContext(ITEM_NAME);
-  const pressed = valueContext.value.includes(props.value);
-  const disabled = context.disabled ? true : props.disabled;
 
   return (
     <Toggle
       {...itemProps}
       ref={forwardedRef}
-      disabled={disabled}
-      pressed={pressed}
       onPressedChange={(pressed) => {
         if (pressed) {
           valueContext.onItemActivate(value);

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -254,19 +254,24 @@ const ToggleGroupItem = React.forwardRef((props, forwardedRef) => {
   const context = useToggleGroupContext(ITEM_NAME);
   const pressed = valueContext.value.includes(props.value);
   const disabled = context.disabled || props.disabled;
-  const Comp = context.rovingFocus ? ToggleGroupRovingFocusItem : ToggleGroupItemImpl;
 
-  return <Comp {...props} ref={forwardedRef} pressed={pressed} disabled={disabled} />;
+  return context.rovingFocus ? (
+    <ToggleGroupRovingFocusItem
+      {...props}
+      ref={forwardedRef}
+      pressed={pressed}
+      disabled={disabled}
+    />
+  ) : (
+    <ToggleGroupItemImpl {...props} ref={forwardedRef} pressed={pressed} disabled={disabled} />
+  );
 }) as ToggleGroupItemPrimitive;
 
 ToggleGroupItem.displayName = ITEM_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type ToggleGroupRovingFocusItemOwnProps = Polymorphic.Merge<
-  Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
-  Polymorphic.OwnProps<typeof ToggleGroupItemImpl>
->;
+type ToggleGroupRovingFocusItemOwnProps = Polymorphic.OwnProps<typeof ToggleGroupItemImpl>;
 
 type ToggleGroupRovingFocusItemPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof ToggleGroupItemImpl>,

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -206,9 +206,10 @@ const ToggleGroupImpl = React.forwardRef((props, forwardedRef) => {
   const {
     as = TOGGLE_GROUP_DEFAULT_TAG,
     disabled = false,
-    orientation,
-    loop = true,
     rovingFocus = true,
+    orientation,
+    dir = 'ltr',
+    loop = true,
     ...toggleGroupProps
   } = props;
   return (
@@ -217,6 +218,7 @@ const ToggleGroupImpl = React.forwardRef((props, forwardedRef) => {
         <RovingFocusGroup
           role="group"
           orientation={orientation}
+          dir={dir}
           loop={loop}
           {...toggleGroupProps}
           as={as}

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -256,7 +256,7 @@ const ToggleGroupItem = React.forwardRef((props, forwardedRef) => {
   const disabled = context.disabled || props.disabled;
   const Comp = context.rovingFocus ? ToggleGroupRovingFocusItem : ToggleGroupItemImpl;
 
-  return <Comp pressed={pressed} disabled={disabled} {...props} ref={forwardedRef} />;
+  return <Comp {...props} pressed={pressed} disabled={disabled} ref={forwardedRef} />;
 }) as ToggleGroupItemPrimitive;
 
 ToggleGroupItem.displayName = ITEM_NAME;

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -256,7 +256,7 @@ const ToggleGroupItem = React.forwardRef((props, forwardedRef) => {
   const disabled = context.disabled || props.disabled;
   const Comp = context.rovingFocus ? ToggleGroupRovingFocusItem : ToggleGroupItemImpl;
 
-  return <Comp {...props} pressed={pressed} disabled={disabled} ref={forwardedRef} />;
+  return <Comp {...props} ref={forwardedRef} pressed={pressed} disabled={disabled} />;
 }) as ToggleGroupItemPrimitive;
 
 ToggleGroupItem.displayName = ITEM_NAME;

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -21,7 +21,6 @@
     "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-separator": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -18,9 +18,8 @@ const TOOLBAR_DEFAULT_TAG = 'div';
 
 type ToolbarOwnProps = Omit<
   Polymorphic.OwnProps<typeof RovingFocusGroup>,
-  'reachable' | 'defaultReachable' | 'onReachableChange'
+  'currentTabStopId' | 'defaultCurrentTabStopId' | 'onCurrentTabStopIdChange' | 'onEntryFocus'
 >;
-
 type ToolbarPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof Primitive>,
   ToolbarOwnProps

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContext } from '@radix-ui/react-context';
 import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
-import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
@@ -21,7 +20,7 @@ type ToolbarOwnProps = Omit<
   'currentTabStopId' | 'defaultCurrentTabStopId' | 'onCurrentTabStopIdChange' | 'onEntryFocus'
 >;
 type ToolbarPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
+  typeof TOOLBAR_DEFAULT_TAG,
   ToolbarOwnProps
 >;
 

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContext } from '@radix-ui/react-context';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
@@ -14,33 +14,11 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
  * -----------------------------------------------------------------------------------------------*/
 
 const TOOLBAR_NAME = 'Toolbar';
+const TOOLBAR_DEFAULT_TAG = 'div';
 
-type Orientation = React.AriaAttributes['aria-orientation'];
-type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
-
-type ToolbarOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
-  {
-    /**
-     * The orientation of the toolbar.
-     * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
-     *
-     * @defaultValue horizontal
-     */
-    orientation?: RovingFocusGroupProps['orientation'];
-    /**
-     * The direction of navigation between toolbar items.
-     *
-     * @defaultValue ltr
-     */
-    dir?: RovingFocusGroupProps['dir'];
-    /**
-     * Whether keyboard navigation should loop focus
-     *
-     * @defaultValue true
-     */
-    loop?: RovingFocusGroupProps['loop'];
-  }
+type ToolbarOwnProps = Omit<
+  Polymorphic.OwnProps<typeof RovingFocusGroup>,
+  'reachable' | 'defaultReachable' | 'onReachableChange'
 >;
 
 type ToolbarPrimitive = Polymorphic.ForwardRefComponent<
@@ -48,23 +26,29 @@ type ToolbarPrimitive = Polymorphic.ForwardRefComponent<
   ToolbarOwnProps
 >;
 
-type ToolbarContextValue = { orientation: Orientation };
+type ToolbarContextValue = { orientation: ToolbarOwnProps['orientation'] };
 const [ToolbarProvider, useToolbarContext] = createContext<ToolbarContextValue>(TOOLBAR_NAME);
 
 const Toolbar = React.forwardRef((props, forwardedRef) => {
-  const { orientation = 'horizontal', dir = 'ltr', loop = true, ...toolbarProps } = props;
+  const {
+    as = TOOLBAR_DEFAULT_TAG,
+    orientation = 'horizontal',
+    dir = 'ltr',
+    loop = true,
+    ...toolbarProps
+  } = props;
 
   return (
     <ToolbarProvider orientation={orientation}>
-      <RovingFocusGroup orientation={orientation} dir={dir} loop={loop}>
-        <Primitive
-          role="toolbar"
-          aria-orientation={orientation}
-          data-orientation={orientation}
-          {...toolbarProps}
-          ref={forwardedRef}
-        />
-      </RovingFocusGroup>
+      <RovingFocusGroup
+        role="toolbar"
+        orientation={orientation}
+        dir={dir}
+        loop={loop}
+        {...toolbarProps}
+        as={as}
+        ref={forwardedRef}
+      />
     </ToolbarProvider>
   );
 }) as ToolbarPrimitive;
@@ -102,31 +86,25 @@ ToolbarSeparator.displayName = SEPARATOR_NAME;
 const BUTTON_NAME = 'ToolbarButton';
 const BUTTON_DEFAULT_TAG = 'button';
 
-type ToolbarButtonOwnProps = Polymorphic.Merge<Polymorphic.OwnProps<typeof Primitive>>;
+type ToolbarButtonOwnProps = Omit<
+  Polymorphic.OwnProps<typeof RovingFocusItem>,
+  'focusable' | 'active'
+>;
+
 type ToolbarButtonPrimitive = Polymorphic.ForwardRefComponent<
   typeof BUTTON_DEFAULT_TAG,
   ToolbarButtonOwnProps
 >;
 
 const ToolbarButton = React.forwardRef((props, forwardedRef) => {
-  const { as = BUTTON_DEFAULT_TAG, disabled, ...buttonProps } = props;
-
-  const rovingFocusProps = useRovingFocus({
-    disabled,
-    active: false,
-  });
-
+  const { as = BUTTON_DEFAULT_TAG, ...buttonProps } = props;
   return (
-    <Primitive
+    <RovingFocusItem
       role="toolbaritem"
-      disabled={disabled}
+      focusable={!props.disabled}
       {...buttonProps}
       as={as}
       ref={forwardedRef}
-      {...rovingFocusProps}
-      onFocus={composeEventHandlers(buttonProps.onFocus, rovingFocusProps.onFocus)}
-      onKeyDown={composeEventHandlers(buttonProps.onKeyDown, rovingFocusProps.onKeyDown)}
-      onMouseDown={composeEventHandlers(buttonProps.onMouseDown, rovingFocusProps.onMouseDown)}
     />
   );
 }) as ToolbarButtonPrimitive;

--- a/ssr-testing/pages/roving-focus-group.tsx
+++ b/ssr-testing/pages/roving-focus-group.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { RovingFocusGroup, useRovingFocus } from '@radix-ui/react-roving-focus';
+import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
 
@@ -115,44 +115,35 @@ const ButtonGroupContext = React.createContext<{
 type ButtonGroupProps = Omit<React.ComponentPropsWithRef<'div'>, 'defaultValue'> &
   RovingFocusGroupProps & { defaultValue?: string };
 
-const ButtonGroup = ({
-  reachable,
-  orientation,
-  dir,
-  loop,
-  defaultValue,
-  ...props
-}: ButtonGroupProps) => {
+const ButtonGroup = ({ defaultValue, ...props }: ButtonGroupProps) => {
   const [value, setValue] = React.useState(defaultValue);
   return (
     <ButtonGroupContext.Provider value={{ value, setValue }}>
-      <RovingFocusGroup reachable={reachable} orientation={orientation} dir={dir} loop={loop}>
-        <div
-          {...props}
-          style={{
-            ...props.style,
-            display: 'inline-flex',
-            flexDirection: orientation === 'vertical' ? 'column' : 'row',
-            gap: 10,
-          }}
-        />
-      </RovingFocusGroup>
+      <RovingFocusGroup
+        {...props}
+        style={{
+          ...props.style,
+          display: 'inline-flex',
+          flexDirection: props.orientation === 'vertical' ? 'column' : 'row',
+          gap: 10,
+        }}
+      />
     </ButtonGroupContext.Provider>
   );
 };
 
 type ButtonProps = Omit<React.ComponentPropsWithRef<'button'>, 'value'> & { value?: string };
 
-const Button = ({ disabled, tabIndex, value, ...props }: ButtonProps) => {
+const Button = (props: ButtonProps) => {
   const { value: contextValue, setValue } = React.useContext(ButtonGroupContext);
-  const isSelected = contextValue !== undefined && value !== undefined && contextValue === value;
-  const rovingFocusProps = useRovingFocus({ disabled, active: isSelected });
+  const isSelected =
+    contextValue !== undefined && props.value !== undefined && contextValue === props.value;
 
   return (
-    <button
-      disabled={disabled}
+    <RovingFocusItem
       {...props}
-      {...rovingFocusProps}
+      as="button"
+      active={isSelected}
       style={{
         ...props.style,
         border: '1px solid',
@@ -167,8 +158,8 @@ const Button = ({ disabled, tabIndex, value, ...props }: ButtonProps) => {
             }
           : {}),
       }}
-      onClick={disabled ? undefined : () => setValue(value)}
-      onFocus={composeEventHandlers(rovingFocusProps.onFocus, (event) => {
+      onClick={props.disabled ? undefined : () => setValue(props.value)}
+      onFocus={composeEventHandlers(props.onFocus, (event) => {
         if (contextValue !== undefined) {
           event.target.click();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,6 +3556,7 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0
@@ -3685,6 +3686,7 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
@@ -3697,9 +3699,13 @@ __metadata:
   resolution: "@radix-ui/react-roving-focus@workspace:packages/react/roving-focus"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@radix-ui/number": "workspace:*"
+    "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
+    "@radix-ui/react-polymorphic": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3792,12 +3798,12 @@ __metadata:
   resolution: "@radix-ui/react-tabs@workspace:packages/react/tabs"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3798,6 +3798,7 @@ __metadata:
   resolution: "@radix-ui/react-tabs@workspace:packages/react/tabs"
   dependencies:
     "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3803,7 +3803,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
-    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
@@ -3821,6 +3820,7 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-toggle": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,14 +3367,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@radix-ui/react-collection@workspace:packages/react/collection":
+"@radix-ui/react-collection@workspace:*, @radix-ui/react-collection@workspace:packages/react/collection":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-collection@workspace:packages/react/collection"
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/react-compose-refs": "workspace:*"
-    "@radix-ui/react-polymorphic": "workspace:*"
-    "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -3545,6 +3544,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-collection": "workspace:*"
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"
@@ -3700,6 +3700,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-collection": "workspace:*"
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-id": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3851,7 +3851,6 @@ __metadata:
     "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
-    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-separator": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"


### PR DESCRIPTION
Closes #581 

---
> Note: Better view with whitespace turned off
---

This PR primarily refactors the internals of `RovingFocusGroup` so we can take into account the fact that hidden items don't get focused by the browser.

The crux of the implementation here is that we've introduced a wrapper as part of that API which will act as a proxy to send focus programatically to the correct place. We have a reference to all items in the group and so, we can programatically and progressively attempt to focus the "first" item, and eventually land on the correct one (the first visible one) without having to resort to calculating computed styles to know if an item is indeed hidden.

Once that was done, all of the dependent packages needed updated accordingly.

This has made the overall implementation(s) more declarative, and more the React way.

> Note: There are now technically new changes to document for some packages because they now get the underlying props from `RovingFocusGroup`
- ✨ `RadioGroup` now gets new `orientation`, `dir` and `loop` props
- ✨ `ToggleGroup` now gets new `orientation`, `dir` and `loop` props 

cc @andy-hook, may be good for you to take a quick look through this to see if there's any impact on what you've been working on.