### PR TITLE
[Menu] Add submenu primitives

### DIFF
--- a/.yarn/versions/c3fe9718.yml
+++ b/.yarn/versions/c3fe9718.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-use-direction": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-dismissable-layer": "workspace:*",
     "@radix-ui/react-focus-guards": "workspace:*",
     "@radix-ui/react-focus-scope": "workspace:*",
+    "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-popper": "workspace:*",
     "@radix-ui/react-portal": "workspace:*",
@@ -33,6 +34,7 @@
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-direction": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"
   },

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import {
-  Menu as MenuPrimitive,
+  Menu,
+  MenuSub,
   MenuAnchor,
+  MenuSubTrigger,
   MenuContent,
   MenuGroup,
   MenuLabel,
@@ -11,6 +13,7 @@ import {
   MenuRadioItem,
   MenuItemIndicator,
   MenuSeparator,
+  MenuArrow,
 } from './Menu';
 import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
@@ -21,7 +24,7 @@ export default {
 };
 
 export const Styled = () => (
-  <Menu>
+  <MenuWithAnchor>
     <MenuItem className={itemClass} onSelect={() => window.alert('undo')}>
       Undo
     </MenuItem>
@@ -38,11 +41,113 @@ export const Styled = () => (
     <MenuItem className={itemClass} onSelect={() => window.alert('paste')}>
       Paste
     </MenuItem>
-  </Menu>
+  </MenuWithAnchor>
 );
 
+export const Submenus = () => {
+  const [open1, setOpen1] = React.useState(false);
+  const [open2, setOpen2] = React.useState(false);
+  const [open3, setOpen3] = React.useState(false);
+  const [open4, setOpen4] = React.useState(false);
+  const [rtl, setRtl] = React.useState(false);
+  const [animated, setAnimated] = React.useState(false);
+
+  React.useEffect(() => {
+    if (rtl) {
+      document.documentElement.setAttribute('dir', 'rtl');
+      return () => document.documentElement.removeAttribute('dir');
+    }
+  }, [rtl]);
+
+  return (
+    <>
+      <div style={{ marginBottom: 8, display: 'grid', gridAutoFlow: 'row', gridGap: 4 }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={rtl}
+            onChange={(event) => setRtl(event.currentTarget.checked)}
+          />
+          rtl
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={animated}
+            onChange={(event) => setAnimated(event.currentTarget.checked)}
+          />
+          Animated
+        </label>
+      </div>
+      <MenuWithAnchor>
+        <MenuItem className={itemClass} onSelect={() => window.alert('undo')}>
+          Undo
+        </MenuItem>
+        <Submenu open={open1} onOpenChange={setOpen1} animated={animated}>
+          <MenuItem className={itemClass} disabled>
+            Disabled
+          </MenuItem>
+          <MenuItem className={itemClass} onSelect={() => window.alert('one')}>
+            One
+          </MenuItem>
+          <Submenu open={open2} onOpenChange={setOpen2} animated={animated}>
+            <MenuItem className={itemClass} onSelect={() => window.alert('one')}>
+              One
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('two')}>
+              Two
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('three')}>
+              Three
+            </MenuItem>
+          </Submenu>
+          <Submenu open={open3} onOpenChange={setOpen3} animated={animated}>
+            <MenuItem className={itemClass} onSelect={() => window.alert('one')}>
+              One
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('two')}>
+              Two
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('three')}>
+              Three
+            </MenuItem>
+          </Submenu>
+          <MenuItem className={itemClass} onSelect={() => window.alert('two')}>
+            Two
+          </MenuItem>
+          <Submenu open={open4} onOpenChange={setOpen4} animated={animated} disabled>
+            <MenuItem className={itemClass} onSelect={() => window.alert('one')}>
+              One
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('two')}>
+              Two
+            </MenuItem>
+            <MenuItem className={itemClass} onSelect={() => window.alert('three')}>
+              Three
+            </MenuItem>
+          </Submenu>
+          <MenuItem className={itemClass} onSelect={() => window.alert('three')}>
+            Three
+          </MenuItem>
+        </Submenu>
+
+        <MenuSeparator className={separatorClass} />
+        <MenuItem className={itemClass} disabled onSelect={() => window.alert('cut')}>
+          Cut
+        </MenuItem>
+        <MenuItem className={itemClass} onSelect={() => window.alert('copy')}>
+          Copy
+        </MenuItem>
+        <MenuItem className={itemClass} onSelect={() => window.alert('paste')}>
+          Paste
+        </MenuItem>
+      </MenuWithAnchor>
+    </>
+  );
+};
+
 export const WithLabels = () => (
-  <Menu>
+  <MenuWithAnchor>
     {foodGroups.map((foodGroup, index) => (
       <MenuGroup key={index}>
         {foodGroup.label && (
@@ -63,7 +168,7 @@ export const WithLabels = () => (
         {index < foodGroups.length - 1 && <MenuSeparator className={separatorClass} />}
       </MenuGroup>
     ))}
-  </Menu>
+  </MenuWithAnchor>
 );
 
 const suits = [
@@ -104,7 +209,7 @@ export const Typeahead = () => (
       <div>
         <h2>Complex children</h2>
         <p>(relying on `.textContent` — default)</p>
-        <Menu>
+        <MenuWithAnchor>
           {suits.map((suit) => (
             <MenuItem key={suit.emoji} className={itemClass}>
               {suit.label}
@@ -113,13 +218,13 @@ export const Typeahead = () => (
               </span>
             </MenuItem>
           ))}
-        </Menu>
+        </MenuWithAnchor>
       </div>
 
       <div>
         <h2>Complex children</h2>
         <p>(with explicit `textValue` prop)</p>
-        <Menu>
+        <MenuWithAnchor>
           {suits.map((suit) => (
             <MenuItem key={suit.emoji} className={itemClass} textValue={suit.label}>
               <span role="img" aria-label={suit.label}>
@@ -128,7 +233,7 @@ export const Typeahead = () => (
               {suit.label}
             </MenuItem>
           ))}
-        </Menu>
+        </MenuWithAnchor>
       </div>
     </div>
   </>
@@ -143,7 +248,7 @@ export const CheckboxItems = () => {
   ];
 
   return (
-    <Menu>
+    <MenuWithAnchor>
       <MenuItem className={itemClass} onSelect={() => window.alert('show')}>
         Show fonts
       </MenuItem>
@@ -168,7 +273,7 @@ export const CheckboxItems = () => {
           </MenuItemIndicator>
         </MenuCheckboxItem>
       ))}
-    </Menu>
+    </MenuWithAnchor>
   );
 };
 
@@ -177,7 +282,7 @@ export const RadioItems = () => {
   const [file, setFile] = React.useState(files[1]);
 
   return (
-    <Menu>
+    <MenuWithAnchor>
       <MenuItem className={itemClass} onSelect={() => window.alert('minimize')}>
         Minimize window
       </MenuItem>
@@ -198,7 +303,7 @@ export const RadioItems = () => {
           </MenuRadioItem>
         ))}
       </MenuRadioGroup>
-    </Menu>
+    </MenuWithAnchor>
   );
 };
 
@@ -221,7 +326,7 @@ export const Animated = () => {
       </label>
       <br />
       <br />
-      <Menu className={animatedRootClass} open={open}>
+      <MenuWithAnchor className={animatedContentClass} open={open}>
         {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
           <MenuCheckboxItem
             key={label}
@@ -246,14 +351,13 @@ export const Animated = () => {
             </MenuRadioItem>
           ))}
         </MenuRadioGroup>
-      </Menu>
+      </MenuWithAnchor>
     </>
   );
 };
 
 type MenuOwnProps = Omit<
-  React.ComponentProps<typeof MenuPrimitive> & React.ComponentProps<typeof MenuContent>,
-  | 'onOpenChange'
+  React.ComponentProps<typeof Menu> & React.ComponentProps<typeof MenuContent>,
   | 'portalled'
   | 'trapFocus'
   | 'onOpenAutoFocus'
@@ -262,11 +366,12 @@ type MenuOwnProps = Omit<
   | 'disableOutsideScroll'
 >;
 
-const Menu: React.FC<MenuOwnProps> = (props) => {
+const MenuWithAnchor: React.FC<MenuOwnProps> = (props) => {
   const { open = true, children, ...contentProps } = props;
   return (
-    <MenuPrimitive open={open} onOpenChange={() => {}}>
-      <MenuAnchor />
+    <Menu open={open} onOpenChange={() => {}}>
+      {/* inline-block allows anchor to move when rtl changes on document */}
+      <MenuAnchor style={{ display: 'inline-block' }} />
       <MenuContent
         className={contentClass}
         portalled
@@ -280,7 +385,26 @@ const Menu: React.FC<MenuOwnProps> = (props) => {
       >
         {children}
       </MenuContent>
-    </MenuPrimitive>
+    </Menu>
+  );
+};
+
+const Submenu: React.FC<MenuOwnProps & { animated: boolean; disabled?: boolean }> = (props) => {
+  const { open = true, onOpenChange, children, animated, disabled, ...contentProps } = props;
+  return (
+    <MenuSub open={open} onOpenChange={onOpenChange}>
+      <MenuSubTrigger className={subTriggerClass} disabled={disabled}>
+        Submenu →
+      </MenuSubTrigger>
+      <MenuContent
+        className={animated ? animatedContentClass : contentClass}
+        sideOffset={12}
+        {...contentProps}
+      >
+        {children}
+        <MenuArrow offset={8} />
+      </MenuContent>
+    </MenuSub>
   );
 };
 
@@ -333,37 +457,44 @@ const itemClass = css({
   },
 });
 
+const subTriggerClass = css(itemClass, {
+  '&[data-state="open"]': {
+    backgroundColor: '$gray100',
+    color: '$black',
+  },
+});
+
 const separatorClass = css({
   height: 1,
   margin: '5px 10px',
   backgroundColor: '$gray100',
 });
 
-const fadeIn = css.keyframes({
-  from: { opacity: 0 },
-  to: { opacity: 1 },
+const animateIn = css.keyframes({
+  from: { transform: 'scale(0.95)', opacity: 0 },
+  to: { transform: 'scale(1)', opacity: 1 },
 });
 
-const fadeOut = css.keyframes({
-  from: { opacity: 1 },
-  to: { opacity: 0 },
+const animateOut = css.keyframes({
+  from: { transform: 'scale(1)', opacity: 1 },
+  to: { transform: 'scale(0.95)', opacity: 0 },
 });
 
-const animatedRootClass = css(contentClass, {
+const animatedContentClass = css(contentClass, {
   '&[data-state="open"]': {
-    animation: `${fadeIn} 300ms ease-out`,
+    animation: `${animateIn} 300ms ease`,
   },
   '&[data-state="closed"]': {
-    animation: `${fadeOut} 300ms ease-in`,
+    animation: `${animateOut} 300ms ease`,
   },
 });
 
 const animatedItemIndicatorClass = css({
   '&[data-state="checked"]': {
-    animation: `${fadeIn} 300ms ease-out`,
+    animation: `${animateIn} 300ms ease`,
   },
   '&[data-state="unchecked"]': {
-    animation: `${fadeOut} 300ms ease-in`,
+    animation: `${animateOut} 300ms ease`,
   },
 });
 

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -68,7 +68,7 @@ export const Submenus = () => {
             checked={rtl}
             onChange={(event) => setRtl(event.currentTarget.checked)}
           />
-          rtl
+          Right-to-left
         </label>
         <label>
           <input

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -132,9 +132,7 @@ const MenuSub: React.FC<MenuOwnProps> = (props) => {
   React.useEffect(() => {
     const parentMenuContent = context.content;
     const handleParentMenuItemEnter = (event: Event) => {
-      const isItemSubMenuTrigger = event.target === trigger;
-      if (!isItemSubMenuTrigger) handleOpenChange(false);
-      event.stopPropagation();
+      if (event.target !== trigger) handleOpenChange(false);
     };
     if (parentMenuContent) {
       parentMenuContent.addEventListener(ITEM_ENTER, handleParentMenuItemEnter);
@@ -347,13 +345,22 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
       // don't want it to refocus the trigger in that case so we handle trigger focus ourselves.
       onCloseAutoFocus={(event) => event.preventDefault()}
       onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => context.trigger?.focus())}
-      onFocusLeave={composeEventHandlers(props.onFocusLeave, () => context.onOpenChange(false))}
+      onFocusLeave={composeEventHandlers(props.onFocusLeave, (event) => {
+        // We prevent closing when the trigger is focused to avoid triggering a re-open animation
+        // on pointer interaction.
+        if (event.relatedTarget !== context.trigger) context.onOpenChange(false);
+      })}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
         const element = event.target as HTMLElement;
         // Submenu key events bubble through portals. We only care about keys in this menu.
         const isKeyDownInside = event.currentTarget.contains(element);
         const isCloseKey = SUB_CLOSE_KEYS[context.dir].includes(event.key);
-        if (isKeyDownInside && isCloseKey) context.trigger?.focus();
+        if (isKeyDownInside && isCloseKey) {
+          // We need to explicitly close when keyboard focuses trigger because we prevented this
+          // in onFocusLeave for pointers.
+          context.onOpenChange(false);
+          context.trigger?.focus();
+        }
       })}
     />
   ) : null;

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -349,11 +349,15 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
       disableOutsidePointerEvents={false}
       disableOutsideScroll={false}
       trapFocus={false}
+      onEntryFocus={context.onEntryFocus}
       onOpenAutoFocus={(event) => event.preventDefault()}
       // The menu might close because of focusing another menu item in the parent menu. We
       // don't want it to refocus the trigger in that case so we handle trigger focus ourselves.
       onCloseAutoFocus={(event) => event.preventDefault()}
-      onEntryFocus={context.onEntryFocus}
+      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+        context.onOpenChange(false);
+        context.trigger?.focus();
+      })}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
         const element = event.target as HTMLElement;
         // Submenu key events bubble through portals. We only care about keys in this menu.
@@ -364,9 +368,8 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
           context.trigger?.focus();
         }
       })}
-      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+      onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, () => {
         context.onOpenChange(false);
-        context.trigger?.focus();
       })}
     />
   ) : null;
@@ -537,13 +540,13 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                   style={{ outline: 'none', ...contentProps.style }}
                   onKeyDownCapture={composeEventHandlers(
                     contentProps.onKeyDownCapture,
-                    composeEventHandlers(typeaheadProps.onKeyDownCapture, (event) => {
-                      if (event.key === 'Tab') event.preventDefault();
-                    })
+                    typeaheadProps.onKeyDownCapture
                   )}
                   // focus first/last item based on key pressed
                   onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
                     const content = contentRef.current;
+                    // menus should not be navigated using tab key so we prevent it
+                    if (event.key === 'Tab') event.preventDefault();
                     if (event.target !== content) return;
                     if (!FIRST_LAST_KEYS.includes(event.key)) return;
                     event.preventDefault();

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -3,7 +3,7 @@ import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
-import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
@@ -13,15 +13,30 @@ import * as PopperPrimitive from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { RovingFocusGroup, RovingFocusItem } from '@radix-ui/react-roving-focus';
 import { Slot } from '@radix-ui/react-slot';
+import { useDirection } from '@radix-ui/react-use-direction';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
+import { useId } from '@radix-ui/react-id';
 import { useMenuTypeahead, useMenuTypeaheadItem } from './useMenuTypeahead';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
+type MenuContentElement = React.ElementRef<typeof MenuContent>;
+type MenuSubTriggerElement = React.ElementRef<typeof MenuSubTrigger>;
+type Direction = 'ltr' | 'rtl';
+
+const SELECTION_KEYS = ['Enter', ' '];
 const FIRST_KEYS = ['ArrowDown', 'PageUp', 'Home'];
 const LAST_KEYS = ['ArrowUp', 'PageDown', 'End'];
-const ALL_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
+const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
+const SUB_OPEN_KEYS: Record<Direction, string[]> = {
+  ltr: [...SELECTION_KEYS, 'ArrowRight'],
+  rtl: [...SELECTION_KEYS, 'ArrowLeft'],
+};
+const SUB_CLOSE_KEYS: Record<Direction, string[]> = {
+  ltr: ['ArrowLeft'],
+  rtl: ['ArrowRight'],
+};
 
 /* -------------------------------------------------------------------------------------------------
  * Menu
@@ -30,23 +45,58 @@ const ALL_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
 const MENU_NAME = 'Menu';
 
 type MenuContextValue = {
+  isSubmenu: false;
+  dir: Direction;
   open: boolean;
   onOpenChange(open: boolean): void;
+  content: MenuContentElement | null;
+  onContentChange(content: MenuContentElement | null): void;
+  onRootClose(): void;
 };
 
-const [MenuProvider, useMenuContext] = createContext<MenuContextValue>(MENU_NAME);
+type MenuSubContextValue = {
+  isSubmenu: true;
+  dir: Direction;
+  contentId: string;
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  content: MenuContentElement | null;
+  onContentChange(content: MenuContentElement | null): void;
+  onRootClose(): void;
+  trigger: MenuSubTriggerElement | null;
+  onTriggerChange(trigger: MenuSubTriggerElement | null): void;
+  onKeyOpen(): void;
+  onPointerOpen(): void;
+  onEntryFocus: RovingFocusGroupOwnProps['onEntryFocus'];
+};
+
+const [MenuProvider, useMenuContext] = createContext<MenuContextValue | MenuSubContextValue>(
+  MENU_NAME
+);
 
 type MenuOwnProps = {
   open?: boolean;
   onOpenChange?(open: boolean): void;
+  dir?: Direction;
 };
 
 const Menu: React.FC<MenuOwnProps> = (props) => {
   const { open = false, children, onOpenChange } = props;
+  const [content, setContent] = React.useState<MenuContentElement | null>(null);
   const handleOpenChange = useCallbackRef(onOpenChange);
+  const computedDirection = useDirection(content, props.dir);
+
   return (
     <PopperPrimitive.Root>
-      <MenuProvider open={open} onOpenChange={handleOpenChange}>
+      <MenuProvider
+        isSubmenu={false}
+        dir={computedDirection}
+        open={open}
+        onOpenChange={handleOpenChange}
+        content={content}
+        onContentChange={setContent}
+        onRootClose={React.useCallback(() => handleOpenChange(false), [handleOpenChange])}
+      >
         {children}
       </MenuProvider>
     </PopperPrimitive.Root>
@@ -54,6 +104,119 @@ const Menu: React.FC<MenuOwnProps> = (props) => {
 };
 
 Menu.displayName = MENU_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+const SUB_NAME = 'MenuSub';
+
+const MenuSub: React.FC<MenuOwnProps> = (props) => {
+  const { children, open = false, onOpenChange } = props;
+  const [focusFirst, setFocusFirst] = React.useState(false);
+  const [trigger, setTrigger] = React.useState<MenuSubTriggerElement | null>(null);
+  const [content, setContent] = React.useState<MenuContentElement | null>(null);
+  const contentId = useId();
+  const handleOpenChange = useCallbackRef(onOpenChange);
+  const context = useMenuContext(SUB_NAME);
+
+  // If a parent menu unmounts, we ensure its submenus reset their open state.
+  // This prevents the parent menu from reopening with open submenus.
+  React.useEffect(() => {
+    if (context.open === false) handleOpenChange(false);
+    return () => handleOpenChange(false);
+  }, [context.open, handleOpenChange]);
+
+  React.useEffect(() => {
+    const parentMenuContent = context.content;
+    const handleParentMenuItemEnter = (event: Event) => {
+      const isItemSubMenuTrigger = event.target === trigger;
+      if (!isItemSubMenuTrigger) handleOpenChange(false);
+      event.stopPropagation();
+    };
+    if (parentMenuContent) {
+      parentMenuContent.addEventListener(ITEM_ENTER, handleParentMenuItemEnter);
+      return () => parentMenuContent.removeEventListener(ITEM_ENTER, handleParentMenuItemEnter);
+    }
+  }, [trigger, context.content, handleOpenChange]);
+
+  React.useEffect(() => {
+    if (focusFirst) content?.focus();
+  }, [content, focusFirst]);
+
+  return (
+    <PopperPrimitive.Root>
+      <MenuProvider
+        isSubmenu={true}
+        dir={context.dir}
+        open={open}
+        onOpenChange={handleOpenChange}
+        trigger={trigger}
+        onTriggerChange={setTrigger}
+        content={content}
+        contentId={contentId}
+        onContentChange={setContent}
+        onRootClose={context.onRootClose}
+        onEntryFocus={React.useCallback(
+          (event) => {
+            if (!focusFirst) event.preventDefault();
+            setFocusFirst(false);
+          },
+          [focusFirst]
+        )}
+        onKeyOpen={React.useCallback(() => {
+          handleOpenChange(true);
+          setFocusFirst(true);
+        }, [handleOpenChange])}
+        onPointerOpen={React.useCallback(() => handleOpenChange(true), [handleOpenChange])}
+      >
+        {children}
+      </MenuProvider>
+    </PopperPrimitive.Root>
+  );
+};
+
+MenuSub.displayName = SUB_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * MenuSubTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const SUB_TRIGGER_NAME = 'MenuSubTrigger';
+
+type MenuSubTriggerOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof MenuItemImpl>,
+  { disabled?: boolean }
+>;
+type MenuSubTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuItemImpl>,
+  MenuSubTriggerOwnProps
+>;
+
+const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
+  const context = useMenuContext(SUB_TRIGGER_NAME);
+  return context.isSubmenu ? (
+    <MenuAnchor as={Slot}>
+      <MenuItemImpl
+        aria-haspopup="menu"
+        aria-expanded={context.open || undefined}
+        aria-controls={context.contentId}
+        data-state={getOpenState(context.open)}
+        {...props}
+        ref={composeRefs(forwardedRef, context.onTriggerChange)}
+        onMouseMove={composeEventHandlers(props.onMouseMove, () => {
+          if (!props.disabled) context.onPointerOpen();
+        })}
+        onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          if (!props.disabled) {
+            if (SUB_OPEN_KEYS[context.dir].includes(event.key)) context.onKeyOpen();
+            if (FIRST_LAST_KEYS.includes(event.key)) context.onOpenChange(false);
+          }
+        })}
+      />
+    </MenuAnchor>
+  ) : null;
+}) as MenuSubTriggerPrimitive;
+
+MenuSubTrigger.displayName = SUB_TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * MenuContent
@@ -73,7 +236,7 @@ const [MenuContentProvider, useMenuContentContext] = createContext<MenuContentCo
 );
 
 type MenuContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof MenuContentImpl>,
+  Polymorphic.OwnProps<typeof MenuRootContent>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -84,7 +247,7 @@ type MenuContentOwnProps = Polymorphic.Merge<
 >;
 
 type MenuContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuContentImpl>,
+  Polymorphic.IntrinsicElement<typeof MenuRootContent>,
   MenuContentOwnProps
 >;
 
@@ -94,65 +257,178 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
   return (
     <Presence present={forceMount || context.open}>
       <CollectionSlot>
-        <MenuContentImpl
-          data-state={getOpenState(context.open)}
-          {...contentProps}
-          ref={forwardedRef}
-        />
+        {context.isSubmenu ? (
+          <MenuSubContent {...contentProps} ref={forwardedRef} />
+        ) : (
+          <MenuRootContent {...contentProps} ref={forwardedRef} />
+        )}
       </CollectionSlot>
     </Presence>
   );
 }) as MenuContentPrimitive;
 
+/* ---------------------------------------------------------------------------------------------- */
+
+type MenuRootContentOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuContentImpl>,
+  keyof MenuContentImplPrivateProps
+>;
+type MenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuContentImpl>,
+  MenuRootContentOwnProps
+>;
+
+const MenuRootContent = React.forwardRef((props, forwardedRef) => {
+  const context = useMenuContext(CONTENT_NAME);
+  const ref = React.useRef<React.ElementRef<typeof MenuContentImpl>>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  // Hide everything from ARIA except the `MenuContent`
+  React.useEffect(() => {
+    const content = ref.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <MenuContentImpl
+      {...props}
+      ref={composedRefs}
+      onDismiss={() => context.onOpenChange(false)}
+      onEntryFocus={(event) => event.preventDefault()}
+      onOpenAutoFocus={composeEventHandlers(props.onOpenAutoFocus, (event) => {
+        // explicitly focus the content area only when opening
+        event.preventDefault();
+        ref.current?.focus();
+      })}
+    />
+  );
+}) as MenuRootContentPrimitive;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type MenuSubContentPrivateProps =
+  | keyof MenuContentImplPrivateProps
+  | 'side'
+  | 'portalled'
+  | 'disabledOutsidePointerEvents'
+  | 'disableOutsideScroll'
+  | 'trapFocus'
+  | 'onOpenAutoFocus'
+  | 'onCloseAutoFocus';
+
+type MenuSubContentOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuContentImpl>,
+  MenuSubContentPrivateProps
+>;
+
+type MenuSubContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuContentImpl>,
+  MenuSubContentOwnProps
+>;
+
+const MenuSubContent = React.forwardRef((props, forwardedRef) => {
+  const context = useMenuContext(CONTENT_NAME);
+  const [ready, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    // Wait till next tick before rendering to ensure parent menu has been "placed" by popper.
+    // Without this, each submenu will flicker in the wrong position as its trigger hasn't
+    // been placed yet.
+    const timer = window.setTimeout(() => setReady(true));
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return context.isSubmenu && ready ? (
+    <MenuContentImpl
+      align="start"
+      id={context.contentId}
+      {...props}
+      ref={forwardedRef}
+      side={context.dir === 'rtl' ? 'left' : 'right'}
+      portalled
+      disableOutsidePointerEvents={false}
+      disableOutsideScroll={false}
+      trapFocus={false}
+      onOpenAutoFocus={(event) => event.preventDefault()}
+      // The menu might close because of focusing another menu item in the parent menu. We
+      // don't want it to refocus the trigger in that case so we handle trigger focus ourselves.
+      onCloseAutoFocus={(event) => event.preventDefault()}
+      onEntryFocus={context.onEntryFocus}
+      onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        const element = event.target as HTMLElement;
+        // Submenu key events bubble through portals. We only care about keys in this menu.
+        const isKeyDownInside = event.currentTarget.contains(element);
+        const isCloseKey = SUB_CLOSE_KEYS[context.dir].includes(event.key);
+        if (isKeyDownInside && isCloseKey) {
+          context.onOpenChange(false);
+          context.trigger?.focus();
+        }
+      })}
+      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+        context.onOpenChange(false);
+        context.trigger?.focus();
+      })}
+    />
+  ) : null;
+}) as MenuSubContentPrimitive;
+
+/* ---------------------------------------------------------------------------------------------- */
+
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 type DismissableLayerOwnProps = Polymorphic.OwnProps<typeof DismissableLayer>;
 type RovingFocusGroupOwnProps = Polymorphic.OwnProps<typeof RovingFocusGroup>;
 
+type MenuContentImplPrivateProps = {
+  onEntryFocus: RovingFocusGroupOwnProps['onEntryFocus'];
+  onDismiss?: DismissableLayerOwnProps['onDismiss'];
+};
+
 type MenuContentImplOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof PopperPrimitive.Content>,
-  Omit<DismissableLayerOwnProps, 'onDismiss'> & {
-    /**
-     * Whether focus should be trapped within the `MenuContent`
-     * (default: false)
-     */
-    trapFocus?: FocusScopeOwnProps['trapped'];
+  Omit<DismissableLayerOwnProps, 'onDismiss'> &
+    MenuContentImplPrivateProps & {
+      /**
+       * Whether focus should be trapped within the `MenuContent`
+       * (default: false)
+       */
+      trapFocus?: FocusScopeOwnProps['trapped'];
 
-    /**
-     * Event handler called when auto-focusing on open.
-     * Can be prevented.
-     */
-    onOpenAutoFocus?: FocusScopeOwnProps['onMountAutoFocus'];
+      /**
+       * Event handler called when auto-focusing on open.
+       * Can be prevented.
+       */
+      onOpenAutoFocus?: FocusScopeOwnProps['onMountAutoFocus'];
 
-    /**
-     * Event handler called when auto-focusing on close.
-     * Can be prevented.
-     */
-    onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
+      /**
+       * Event handler called when auto-focusing on close.
+       * Can be prevented.
+       */
+      onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
 
-    /**
-     * Whether scrolling outside the `MenuContent` should be prevented
-     * (default: `false`)
-     */
-    disableOutsideScroll?: boolean;
+      /**
+       * Whether scrolling outside the `MenuContent` should be prevented
+       * (default: `false`)
+       */
+      disableOutsideScroll?: boolean;
 
-    /**
-     * The direction of navigation between menu items.
-     * @defaultValue ltr
-     */
-    dir?: RovingFocusGroupOwnProps['dir'];
+      /**
+       * The direction of navigation between menu items.
+       * @defaultValue ltr
+       */
+      dir?: RovingFocusGroupOwnProps['dir'];
 
-    /**
-     * Whether keyboard navigation should loop around
-     * @defaultValue false
-     */
-    loop?: RovingFocusGroupOwnProps['loop'];
+      /**
+       * Whether keyboard navigation should loop around
+       * @defaultValue false
+       */
+      loop?: RovingFocusGroupOwnProps['loop'];
 
-    /**
-     * Whether the `MenuContent` should render in a `Portal`
-     * (default: `true`)
-     */
-    portalled?: boolean;
-  }
+      /**
+       * Whether the `MenuContent` should render in a `Portal`
+       * (default: `true`)
+       */
+      portalled?: boolean;
+    }
 >;
 
 type MenuContentImplPrimitive = Polymorphic.ForwardRefComponent<
@@ -162,7 +438,6 @@ type MenuContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
-    dir = 'ltr',
     loop = false,
     trapFocus,
     onOpenAutoFocus,
@@ -172,6 +447,8 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
     onPointerDownOutside,
     onFocusOutside,
     onInteractOutside,
+    onEntryFocus,
+    onDismiss,
     disableOutsideScroll,
     portalled,
     ...contentProps
@@ -180,9 +457,9 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   const typeaheadProps = useMenuTypeahead();
   const { getItems } = useCollection();
   const [currentItemId, setCurrentItemId] = React.useState<string | null>(null);
-  const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
   const contentRef = React.useRef<HTMLDivElement>(null);
-  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef, context.onContentChange);
+  const isPointerDownOutsideRef = React.useRef(false);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -190,12 +467,6 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   // Make sure the whole tree has focus guards as our `MenuContent` may be
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
-
-  // Hide everything from ARIA except the `MenuContent`
-  React.useEffect(() => {
-    const content = contentRef.current;
-    if (content) return hideOthers(content);
-  }, []);
 
   return (
     <PortalWrapper>
@@ -214,7 +485,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
             onMountAutoFocus={onOpenAutoFocus}
             onUnmountAutoFocus={(event) => {
               // skip autofocus on unmount if clicking outside is permitted and it happened
-              if (skipCloseAutoFocus) {
+              if (!disableOutsidePointerEvents && isPointerDownOutsideRef.current) {
                 event.preventDefault();
               } else {
                 onCloseAutoFocus?.(event);
@@ -225,14 +496,14 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
               as={Slot}
               disableOutsidePointerEvents={disableOutsidePointerEvents}
               onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                setSkipCloseAutoFocus(false);
+                isPointerDownOutsideRef.current = false;
               })}
               onPointerDownOutside={composeEventHandlers(
                 onPointerDownOutside,
                 (event) => {
                   const originalEvent = event.detail.originalEvent as MouseEvent;
                   const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+                  isPointerDownOutsideRef.current = isLeftClick;
                 },
                 { checkForDefaultPrevented: false }
               )}
@@ -246,32 +517,35 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                 { checkForDefaultPrevented: false }
               )}
               onInteractOutside={onInteractOutside}
-              onDismiss={() => context.onOpenChange(false)}
+              onDismiss={onDismiss}
             >
               <RovingFocusGroup
                 as={Slot}
-                dir={dir}
+                dir={context.dir}
                 orientation="vertical"
                 loop={loop}
                 currentTabStopId={currentItemId}
                 onCurrentTabStopIdChange={setCurrentItemId}
-                // we override the default behaviour which automatically focuses the first item
-                onEntryFocus={(event) => event.preventDefault()}
+                onEntryFocus={onEntryFocus}
               >
                 <PopperPrimitive.Content
                   role="menu"
+                  dir={context.dir}
+                  data-state={getOpenState(context.open)}
                   {...contentProps}
                   ref={composedRefs}
                   style={{ outline: 'none', ...contentProps.style }}
                   onKeyDownCapture={composeEventHandlers(
                     contentProps.onKeyDownCapture,
-                    typeaheadProps.onKeyDownCapture
+                    composeEventHandlers(typeaheadProps.onKeyDownCapture, (event) => {
+                      if (event.key === 'Tab') event.preventDefault();
+                    })
                   )}
                   // focus first/last item based on key pressed
                   onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
                     const content = contentRef.current;
                     if (event.target !== content) return;
-                    if (!ALL_KEYS.includes(event.key)) return;
+                    if (!FIRST_LAST_KEYS.includes(event.key)) return;
                     event.preventDefault();
                     const items = getItems().filter((item) => !item.disabled);
                     const candidateNodes = items.map((item) => item.ref.current!);
@@ -297,23 +571,84 @@ MenuContent.displayName = CONTENT_NAME;
 const ITEM_NAME = 'MenuItem';
 const ITEM_DEFAULT_TAG = 'div';
 const ITEM_SELECT = 'menu.itemSelect';
+const ITEM_ENTER = 'menu.itemEnter';
 
 type MenuItemOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof MenuItemImpl>,
+  { onSelect?: (event: Event) => void }
+>;
+
+type MenuItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuItemImpl>,
+  MenuItemOwnProps
+>;
+
+const MenuItem = React.forwardRef((props, forwardedRef) => {
+  const { disabled = false, onSelect, ...itemProps } = props;
+  const ref = React.useRef<HTMLDivElement>(null);
+  const context = useMenuContext(ITEM_NAME);
+  const contentContext = useMenuContentContext(ITEM_NAME);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+  const handleSelectProp = useCallbackRef(onSelect);
+
+  const handleSelect = () => {
+    const menuItem = ref.current;
+    if (!disabled && menuItem) {
+      const itemSelectEvent = new Event(ITEM_SELECT, { bubbles: true, cancelable: true });
+      menuItem.dispatchEvent(itemSelectEvent);
+      if (itemSelectEvent.defaultPrevented) return;
+      context.onRootClose();
+    }
+  };
+
+  React.useEffect(() => {
+    const menuItem = ref.current;
+    if (menuItem) {
+      menuItem.addEventListener(ITEM_SELECT, handleSelectProp);
+      return () => menuItem.removeEventListener(ITEM_SELECT, handleSelectProp);
+    }
+  }, [handleSelectProp]);
+
+  return (
+    <MenuItemImpl
+      {...itemProps}
+      ref={composedRefs}
+      disabled={disabled}
+      // we handle selection on `mouseUp` rather than `click` to match native menus implementation
+      onMouseUp={composeEventHandlers(props.onMouseUp, handleSelect)}
+      onMouseLeave={composeEventHandlers(props.onMouseLeave, () => contentContext.onItemLeave())}
+      onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        if (!disabled && SELECTION_KEYS.includes(event.key)) {
+          // prevent page scroll if using the space key to select an item
+          if (event.key === ' ') event.preventDefault();
+          handleSelect();
+        }
+      })}
+    />
+  );
+}) as MenuItemPrimitive;
+
+MenuItem.displayName = ITEM_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type MenuItemImplOwnProps = Polymorphic.Merge<
   Omit<Polymorphic.OwnProps<typeof RovingFocusItem>, 'focusable' | 'active'>,
   {
     disabled?: boolean;
     textValue?: string;
-    onSelect?: (event: Event) => void;
   }
 >;
 
-type MenuItemPrimitive = Polymorphic.ForwardRefComponent<typeof ITEM_DEFAULT_TAG, MenuItemOwnProps>;
+type MenuItemImplPrimitive = Polymorphic.ForwardRefComponent<
+  typeof ITEM_DEFAULT_TAG,
+  MenuItemImplOwnProps
+>;
 
-const MenuItem = React.forwardRef((props, forwardedRef) => {
+const MenuItemImpl = React.forwardRef((props, forwardedRef) => {
   const { as = ITEM_DEFAULT_TAG, disabled = false, textValue, onSelect, ...itemProps } = props;
   const ref = React.useRef<HTMLDivElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, ref);
-  const context = useMenuContext(ITEM_NAME);
   const contentContext = useMenuContentContext(ITEM_NAME);
 
   // get the item's `.textContent` as default strategy for typeahead `textValue`
@@ -330,45 +665,25 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
     disabled,
   });
 
-  const handleSelect = () => {
-    const menuItem = ref.current;
-    if (!disabled && menuItem) {
-      const itemSelectEvent = new Event(ITEM_SELECT, { bubbles: true, cancelable: true });
-      menuItem.dispatchEvent(itemSelectEvent);
-      if (itemSelectEvent.defaultPrevented) return;
-      context.onOpenChange?.(false);
-    }
+  const handleItemEnter = (event: React.MouseEvent | React.FocusEvent) => {
+    const itemEnterEvent = new Event(ITEM_ENTER, { bubbles: true, cancelable: true });
+    event.currentTarget.dispatchEvent(itemEnterEvent);
   };
-
-  React.useEffect(() => {
-    const menuItem = ref.current;
-    if (menuItem) {
-      const handleItemSelect = (event: Event) => onSelect?.(event);
-      menuItem.addEventListener(ITEM_SELECT, handleItemSelect);
-      return () => menuItem.removeEventListener(ITEM_SELECT, handleItemSelect);
-    }
-  }, [onSelect]);
 
   return (
     <CollectionItemSlot disabled={disabled}>
       <RovingFocusItem
         role="menuitem"
         aria-disabled={disabled || undefined}
+        data-disabled={disabled ? '' : undefined}
         focusable={!disabled}
         {...itemProps}
         {...menuTypeaheadItemProps}
         as={as}
         ref={composedRefs}
-        data-disabled={disabled ? '' : undefined}
-        onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-          if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
-            // prevent page scroll if using the space key to select an item
-            if (event.key === ' ') event.preventDefault();
-            handleSelect();
-          }
-        })}
-        // we handle selection on `mouseUp` rather than `click` to match native menus implementation
-        onMouseUp={composeEventHandlers(props.onMouseUp, handleSelect)}
+        onFocus={composeEventHandlers(props.onFocus, handleItemEnter)}
+        // Trigger ITEM_ENTER on mouse enter as well to ensure event fires for disabled items
+        onMouseEnter={composeEventHandlers(props.onMouseEnter, handleItemEnter)}
         /**
          * We focus items on `mouseMove` to achieve the following:
          *
@@ -388,13 +703,10 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
             contentContext.onItemLeave();
           }
         })}
-        onMouseLeave={composeEventHandlers(props.onMouseLeave, () => contentContext.onItemLeave())}
       />
     </CollectionItemSlot>
   );
-}) as MenuItemPrimitive;
-
-MenuItem.displayName = ITEM_NAME;
+}) as MenuItemImplPrimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * MenuCheckboxItem
@@ -590,7 +902,9 @@ function focusFirst(candidates: HTMLElement[]) {
 }
 
 const Root = Menu;
+const Sub = MenuSub;
 const Anchor = MenuAnchor;
+const SubTrigger = MenuSubTrigger;
 const Content = MenuContent;
 const Group = MenuGroup;
 const Label = MenuLabel;
@@ -604,7 +918,9 @@ const Arrow = MenuArrow;
 
 export {
   Menu,
+  MenuSub,
   MenuAnchor,
+  MenuSubTrigger,
   MenuContent,
   MenuGroup,
   MenuLabel,
@@ -617,7 +933,9 @@ export {
   MenuArrow,
   //
   Root,
+  Sub,
   Anchor,
+  SubTrigger,
   Content,
   Group,
   Label,
@@ -630,6 +948,7 @@ export {
   Arrow,
 };
 export type {
+  MenuSubTriggerPrimitive,
   MenuContentPrimitive,
   MenuItemPrimitive,
   MenuCheckboxItemPrimitive,

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -344,11 +344,16 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
       // The menu might close because of focusing another menu item in the parent menu. We
       // don't want it to refocus the trigger in that case so we handle trigger focus ourselves.
       onCloseAutoFocus={(event) => event.preventDefault()}
-      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => context.trigger?.focus())}
       onFocusLeave={composeEventHandlers(props.onFocusLeave, (event) => {
         // We prevent closing when the trigger is focused to avoid triggering a re-open animation
         // on pointer interaction.
         if (event.relatedTarget !== context.trigger) context.onOpenChange(false);
+      })}
+      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+        // We need to explicitly close when escape key focuses trigger because we prevented this
+        // in onFocusLeave for pointers.
+        context.onOpenChange(false);
+        context.trigger?.focus();
       })}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
         const element = event.target as HTMLElement;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -235,7 +235,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     ...contentProps
   } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
+  const isPointerDownOutsideRef = React.useRef(false);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, contentRef);
 
@@ -262,7 +262,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
           trapped={trapFocus && context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={(event) => {
-            if (skipCloseAutoFocus) {
+            if (!disableOutsidePointerEvents && isPointerDownOutsideRef.current) {
               event.preventDefault();
             } else {
               onCloseAutoFocus?.(event);
@@ -273,14 +273,14 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
             as={Slot}
             disableOutsidePointerEvents={disableOutsidePointerEvents}
             onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-              setSkipCloseAutoFocus(false);
+              isPointerDownOutsideRef.current = false;
             })}
             onPointerDownOutside={composeEventHandlers(
               onPointerDownOutside,
               (event) => {
                 const originalEvent = event.detail.originalEvent as MouseEvent;
                 const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+                isPointerDownOutsideRef.current = isLeftClick;
 
                 const targetIsTrigger = context.triggerRef.current?.contains(
                   event.target as HTMLElement

--- a/packages/react/use-direction/src/useDirection.tsx
+++ b/packages/react/use-direction/src/useDirection.tsx
@@ -8,6 +8,9 @@ export function useDirection(element: HTMLElement | null, directionProp?: Direct
   const rAFRef = React.useRef<number>(0);
 
   React.useEffect(() => {
+    // We check inherited direction of parent instead of `element` so that computed styles are
+    // not overridden by dir attribute on element if inherited direction changes. The `dir`
+    // attribute should always sync with direction prop OR its inherited direction.
     if (directionProp === undefined && element?.parentElement) {
       const computedStyle = getComputedStyle(element.parentElement);
       setComputedStyle(computedStyle);

--- a/packages/react/use-direction/src/useDirection.tsx
+++ b/packages/react/use-direction/src/useDirection.tsx
@@ -8,8 +8,8 @@ export function useDirection(element: HTMLElement | null, directionProp?: Direct
   const rAFRef = React.useRef<number>(0);
 
   React.useEffect(() => {
-    if (element && directionProp === undefined) {
-      const computedStyle = getComputedStyle(element);
+    if (directionProp === undefined && element?.parentElement) {
+      const computedStyle = getComputedStyle(element.parentElement);
       setComputedStyle(computedStyle);
     }
   }, [element, directionProp]);

--- a/packages/react/use-direction/src/useDirection.tsx
+++ b/packages/react/use-direction/src/useDirection.tsx
@@ -8,9 +8,10 @@ export function useDirection(element: HTMLElement | null, directionProp?: Direct
   const rAFRef = React.useRef<number>(0);
 
   React.useEffect(() => {
-    // We check inherited direction of parent instead of `element` so that computed styles are
-    // not overridden by dir attribute on element if inherited direction changes. The `dir`
-    // attribute should always sync with direction prop OR its inherited direction.
+    // We check inherited direction of the parent instead of the `element` itself.
+    // This is because we internally set the computed `dir` on the element so wouldn't be
+    // able to react to changes to the inherited direction. The `dir` attribute we set should
+    // always sync with the direction prop OR its inherited direction.
     if (directionProp === undefined && element?.parentElement) {
       const computedStyle = getComputedStyle(element.parentElement);
       setComputedStyle(computedStyle);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,6 +3558,7 @@ __metadata:
     "@radix-ui/react-dismissable-layer": "workspace:*"
     "@radix-ui/react-focus-guards": "workspace:*"
     "@radix-ui/react-focus-scope": "workspace:*"
+    "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-popper": "workspace:*"
     "@radix-ui/react-portal": "workspace:*"
@@ -3566,6 +3567,7 @@ __metadata:
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-direction": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0
   peerDependencies:


### PR DESCRIPTION
Closes https://github.com/radix-ui/primitives/issues/383

### Description

This PR adds submenu functionality to our base `Menu`

#### Approach

Additional primitives have been added to `Menu` to provide consistent submenu support across several consuming components.

Here is an example of how we can use the pieces to provide submenu support inside our components

```jsx
<Menu.Root>
  <Menu.Anchor>Open</Menu.Anchor>
  <Menu.Content>
    <Menu.Item>Item 1</Menu.Item>
    <Menu.Item>Item 2</Menu.Item>
    
    <Menu.Sub>
      <Menu.SubTrigger>
         Open Sub Menu
      </Menu.SubTrigger>

      <Menu.Content>
        <Menu.Item>Sub Item 1</Menu.Item>
        <Menu.Item>Sub Item 2</Menu.Item>
      </Menu.Content>
    </Menu.Sub>
  </Menu.Content>
</Menu.Root>
```

#### TODO
- [x] Adjust on top of https://github.com/radix-ui/primitives/pull/618 once merged
- [x] Add `rtl` support
- [x] Update versions
- [ ] Expose via nesting api in `ContextMenu` and `DropdownMenu` (see https://github.com/radix-ui/primitives/pull/629)
- [ ] Adjust typeahead to support nesting (see https://github.com/radix-ui/primitives/pull/662)
- [ ] Apply pointer grace on transit to sub menu (will raise a separate improvement)
