### PR TITLE
[ContextMenu][DropdownMenu] Integrate new submenu parts

### DIFF
--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -11,12 +11,13 @@ import {
   ContextMenuRadioItem,
   ContextMenuItemIndicator,
   ContextMenuSeparator,
+  ContextMenuArrow,
 } from './ContextMenu';
 import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
 import { classes, TickIcon } from '../../menu/src/Menu.stories';
 
-const { contentClass, itemClass, labelClass, separatorClass } = classes;
+const { contentClass, itemClass, labelClass, separatorClass, subTriggerClass } = classes;
 
 export default { title: 'Components/ContextMenu' };
 
@@ -57,6 +58,92 @@ export const Styled = () => {
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+    </div>
+  );
+};
+
+export const Submenus = () => {
+  const [open, setOpen] = React.useState(false);
+  const [rtl, setRtl] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '200vw',
+        height: '200vh',
+        gap: 20,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <label style={{ marginBottom: 10 }}>
+          <input
+            type="checkbox"
+            checked={rtl}
+            onChange={(event) => setRtl(event.currentTarget.checked)}
+          />
+          Right-to-left
+        </label>
+        <ContextMenu onOpenChange={setOpen} dir={rtl ? 'rtl' : 'ltr'}>
+          <ContextMenuTrigger
+            className={triggerClass}
+            style={{ background: open ? 'lightblue' : undefined }}
+          />
+          <ContextMenuContent className={contentClass} offset={-5}>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </ContextMenuItem>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenu>
+              <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+              <ContextMenuContent className={contentClass} offset={12}>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </ContextMenuItem>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </ContextMenuItem>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenu>
+                  <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+                  <ContextMenuContent className={contentClass} offset={12}>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                      One
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                      Two
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                      Three
+                    </ContextMenuItem>
+                    <ContextMenuArrow offset={8} />
+                  </ContextMenuContent>
+                </ContextMenu>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </ContextMenuItem>
+                <ContextMenuArrow offset={8} />
+              </ContextMenuContent>
+            </ContextMenu>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
     </div>
   );
 };
@@ -285,6 +372,25 @@ export const Nested = () => (
             <ContextMenuItem className={itemClass} onSelect={() => console.log('red action2')}>
               Red action 2
             </ContextMenuItem>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenu>
+              <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+              <ContextMenuContent className={contentClass} offset={12}>
+                <ContextMenuItem
+                  className={itemClass}
+                  onSelect={() => console.log('red sub action 1')}
+                >
+                  Red sub action 1
+                </ContextMenuItem>
+                <ContextMenuItem
+                  className={itemClass}
+                  onSelect={() => console.log('red sub action 2')}
+                >
+                  Red sub action 2
+                </ContextMenuItem>
+                <ContextMenuArrow offset={8} />
+              </ContextMenuContent>
+            </ContextMenu>
           </ContextMenuContent>
         </ContextMenu>
       </ContextMenuTrigger>
@@ -297,6 +403,25 @@ export const Nested = () => (
         <ContextMenuItem className={itemClass} onSelect={() => console.log('blue action2')}>
           Blue action 2
         </ContextMenuItem>
+        <ContextMenuSeparator className={separatorClass} />
+        <ContextMenu>
+          <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+          <ContextMenuContent className={contentClass} offset={12}>
+            <ContextMenuItem
+              className={itemClass}
+              onSelect={() => console.log('blue sub action 1')}
+            >
+              Blue sub action 1
+            </ContextMenuItem>
+            <ContextMenuItem
+              className={itemClass}
+              onSelect={() => console.log('blue sub action 2')}
+            >
+              Blue sub action 2
+            </ContextMenuItem>
+            <ContextMenuArrow offset={8} />
+          </ContextMenuContent>
+        </ContextMenu>
       </ContextMenuContent>
     </ContextMenu>
   </div>

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -28,7 +28,7 @@ const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuCo
   CONTEXT_MENU_NAME
 );
 
-type ContextMenuOwnProps = ContextMenuRootOwnProps & ContextMenuSubOwnProps;
+type ContextMenuOwnProps = React.ComponentProps<typeof ContextMenuImpl>;
 
 const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
   const parentSubmenuContext = React.useContext(SubmenuContext);
@@ -42,11 +42,11 @@ const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
   );
 };
 
-const ContextMenuImpl: React.FC<ContextMenuOwnProps> = (props) => {
-  const isSubmenu = React.useContext(SubmenuContext);
-  const ContextMenu = isSubmenu ? ContextMenuSub : ContextMenuRoot;
+type ContextMenuImplOwnProps = ContextMenuRootOwnProps & ContextMenuSubOwnProps;
 
-  return <ContextMenu {...props} />;
+const ContextMenuImpl: React.FC<ContextMenuImplOwnProps> = (props) => {
+  const isSubmenu = React.useContext(SubmenuContext);
+  return isSubmenu ? <ContextMenuSub {...props} /> : <ContextMenuRoot {...props} />;
 };
 
 /* -----------------------------------------------------------------------------------------------*/
@@ -87,14 +87,18 @@ type ContextMenuSubOwnProps = {
 };
 
 const ContextMenuSub: React.FC<ContextMenuSubOwnProps> = (props) => {
-  const { open: openProp, defaultOpen, onOpenChange } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange } = props;
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
     onChange: onOpenChange,
   });
 
-  return <MenuPrimitive.Sub open={open} onOpenChange={setOpen} />;
+  return (
+    <MenuPrimitive.Sub open={open} onOpenChange={setOpen}>
+      {children}
+    </MenuPrimitive.Sub>
+  );
 };
 
 ContextMenu.displayName = CONTEXT_MENU_NAME;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -200,27 +200,33 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
   const isSubmenu = React.useContext(SubmenuContext);
   const context = useContextMenuContext(CONTENT_NAME);
 
+  const commonProps = {
+    ...contentProps,
+    sideOffset: offset,
+    style: {
+      ...props.style,
+      // re-namespace exposed content custom property
+      ['--radix-context-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+    },
+  };
+
   return (
     <InsideContentContext.Provider value={true}>
-      <MenuPrimitive.Content
-        {...contentProps}
-        {...(!isSubmenu && {
-          disableOutsidePointerEvents: context.open ? disableOutsidePointerEvents : false,
-          trapFocus: true,
-          disableOutsideScroll: true,
-          portalled: true,
-          side: 'bottom' as const,
-          align: 'start' as const,
-          alignOffset: 2,
-        })}
-        sideOffset={offset}
-        ref={forwardedRef}
-        style={{
-          ...props.style,
-          // re-namespace exposed content custom property
-          ['--radix-context-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-        }}
-      />
+      {isSubmenu ? (
+        <MenuPrimitive.Content {...commonProps} ref={forwardedRef} />
+      ) : (
+        <MenuPrimitive.Content
+          {...commonProps}
+          ref={forwardedRef}
+          disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
+          trapFocus
+          disableOutsideScroll
+          portalled
+          side="bottom"
+          align="start"
+          alignOffset={2}
+        />
+      )}
     </InsideContentContext.Provider>
   );
 }) as ContextMenuContentPrimitive;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -122,14 +122,18 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
   const { as, ...triggerProps } = props;
   const isSubmenu = React.useContext(SubmenuContext);
 
-  return isSubmenu ? (
-    <MenuPrimitive.SubTrigger
-      {...triggerProps}
-      as={as as Polymorphic.IntrinsicElement<typeof ContextMenuRootTrigger>}
-      ref={forwardedRef}
-    />
-  ) : (
-    <ContextMenuRootTrigger {...triggerProps} as={as} ref={forwardedRef} />
+  return (
+    <InsideContentContext.Provider value={false}>
+      {isSubmenu ? (
+        <MenuPrimitive.SubTrigger
+          {...triggerProps}
+          as={as as Polymorphic.IntrinsicElement<typeof ContextMenuRootTrigger>}
+          ref={forwardedRef}
+        />
+      ) : (
+        <ContextMenuRootTrigger {...triggerProps} as={as} ref={forwardedRef} />
+      )}
+    </InsideContentContext.Provider>
   );
 }) as ContextMenuTriggerPrimitive;
 

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -23,7 +23,7 @@ type ContextMenuContextValue = {
 };
 
 const SubmenuContext = React.createContext<boolean | undefined>(undefined);
-const InsideContentContext = React.createContext<boolean>(false);
+const InsideContentContext = React.createContext(false);
 const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuContextValue>(
   CONTEXT_MENU_NAME
 );
@@ -84,18 +84,17 @@ type ContextMenuSubOwnProps = {
   open?: boolean;
   onOpenChange?(open: boolean): void;
   defaultOpen?: boolean;
-  dir?: Direction;
 };
 
 const ContextMenuSub: React.FC<ContextMenuSubOwnProps> = (props) => {
-  const { open: openProp, defaultOpen, onOpenChange, ...menuSubProps } = props;
+  const { open: openProp, defaultOpen, onOpenChange } = props;
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
     onChange: onOpenChange,
   });
 
-  return <MenuPrimitive.Sub {...menuSubProps} open={open} onOpenChange={setOpen} />;
+  return <MenuPrimitive.Sub open={open} onOpenChange={setOpen} />;
 };
 
 ContextMenu.displayName = CONTEXT_MENU_NAME;
@@ -105,7 +104,6 @@ ContextMenu.displayName = CONTEXT_MENU_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TRIGGER_NAME = 'ContextMenuTrigger';
-const ROOT_TRIGGER_DEFAULT_TAG = 'span';
 
 type ContextMenuTriggerOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof ContextMenuRootTrigger>,
@@ -135,14 +133,16 @@ ContextMenuTrigger.displayName = TRIGGER_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
+const TRIGGER_DEFAULT_TAG = 'span';
+
 type ContextMenuRootTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
 type ContextMenuRootTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  typeof ROOT_TRIGGER_DEFAULT_TAG,
+  typeof TRIGGER_DEFAULT_TAG,
   ContextMenuRootTriggerOwnProps
 >;
 
 const ContextMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
-  const { as = ROOT_TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
+  const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useContextMenuContext(TRIGGER_NAME);
   const pointRef = React.useRef<Point>({ x: 0, y: 0 });
   const virtualRef = React.useRef({
@@ -175,7 +175,13 @@ const CONTENT_NAME = 'ContextMenuContent';
 type ContextMenuContentOwnProps = Polymorphic.Merge<
   Omit<
     Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-    'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'onOpenAutoFocus' | 'side' | 'sideOffset'
+    | 'trapFocus'
+    | 'disableOutsideScroll'
+    | 'portalled'
+    | 'onOpenAutoFocus'
+    | 'side'
+    | 'sideOffset'
+    | 'align'
   >,
   { offset?: number }
 >;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -22,7 +22,7 @@ type ContextMenuContextValue = {
   onOpenChange(open: boolean): void;
 };
 
-const SubmenuContext = React.createContext<boolean | undefined>(undefined);
+const SubmenuContext = React.createContext(false);
 const InsideContentContext = React.createContext(false);
 const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuContextValue>(
   CONTEXT_MENU_NAME
@@ -31,18 +31,16 @@ const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuCo
 type ContextMenuOwnProps = React.ComponentProps<typeof ContextMenuImpl>;
 
 const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
-  const parentSubmenuContext = React.useContext(SubmenuContext);
   const isInsideContent = React.useContext(InsideContentContext);
-  const isRootMenu = parentSubmenuContext === undefined;
-
   return (
-    <SubmenuContext.Provider value={!isRootMenu && isInsideContent}>
+    // if we're inside content then we can assume this is a submenu
+    <SubmenuContext.Provider value={isInsideContent}>
       <ContextMenuImpl {...props} />
     </SubmenuContext.Provider>
   );
 };
 
-type ContextMenuImplOwnProps = ContextMenuRootOwnProps & ContextMenuSubOwnProps;
+type ContextMenuImplOwnProps = ContextMenuRootOwnProps | ContextMenuSubOwnProps;
 
 const ContextMenuImpl: React.FC<ContextMenuImplOwnProps> = (props) => {
   const isSubmenu = React.useContext(SubmenuContext);

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -18,7 +18,7 @@ import { css } from '../../../../stitches.config';
 import { foodGroups } from '../../../../test-data/foods';
 import { classes, TickIcon } from '../../menu/src/Menu.stories';
 
-const { contentClass, itemClass, labelClass, separatorClass } = classes;
+const { contentClass, itemClass, labelClass, separatorClass, subTriggerClass } = classes;
 
 export default { title: 'Components/DropdownMenu' };
 
@@ -48,6 +48,82 @@ export const Styled = () => (
     </DropdownMenu>
   </div>
 );
+
+export const Submenus = () => {
+  const [rtl, setRtl] = React.useState(false);
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+        <label style={{ marginBottom: 10 }}>
+          <input
+            type="checkbox"
+            checked={rtl}
+            onChange={(event) => setRtl(event.currentTarget.checked)}
+          />
+          Right-to-left
+        </label>
+        <DropdownMenu dir={rtl ? 'rtl' : 'ltr'}>
+          <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+          <DropdownMenuContent className={contentClass} sideOffset={5}>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenu>
+              <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+              <DropdownMenuContent className={contentClass} sideOffset={12}>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </DropdownMenuItem>
+
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </DropdownMenuItem>
+                <DropdownMenuSeparator className={separatorClass} />
+                <DropdownMenu>
+                  <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                  <DropdownMenuContent className={contentClass} sideOffset={12}>
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                      One
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                      Two
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                      Three
+                    </DropdownMenuItem>
+                    <DropdownMenuArrow offset={8} />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <DropdownMenuSeparator className={separatorClass} />
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </DropdownMenuItem>
+                <DropdownMenuArrow offset={8} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenuItem>
+            <DropdownMenuArrow />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};
 
 export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
@@ -375,7 +451,218 @@ export const Chromatic = () => {
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
       </DropdownMenu>
 
-      <h1 style={{ marginTop: 200 }}>Positioning</h1>
+      <h1 style={{ marginTop: 200 }}>Submenus</h1>
+      <h2>Open</h2>
+      <DropdownMenu open>
+        <DropdownMenuContent
+          className={contentClass}
+          sideOffset={5}
+          avoidCollisions={false}
+          disableOutsideScroll={false}
+        >
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenu open>
+            <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+            <DropdownMenuContent className={contentClass} sideOffset={12} avoidCollisions={false}>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                One
+              </DropdownMenuItem>
+
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                Two
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenu open>
+                <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                <DropdownMenuContent
+                  className={contentClass}
+                  sideOffset={12}
+                  avoidCollisions={false}
+                >
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenuItem>
+                  <DropdownMenuArrow offset={8} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                Three
+              </DropdownMenuItem>
+              <DropdownMenuArrow offset={8} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenuItem>
+          <DropdownMenuArrow />
+        </DropdownMenuContent>
+        <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+      </DropdownMenu>
+
+      <h2 style={{ marginTop: 275 }}>With custom alignment</h2>
+      <DropdownMenu open>
+        <DropdownMenuContent
+          className={contentClass}
+          sideOffset={5}
+          avoidCollisions={false}
+          disableOutsideScroll={false}
+        >
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenu open>
+            <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+            <DropdownMenuContent
+              className={contentClass}
+              sideOffset={12}
+              avoidCollisions={false}
+              align="center"
+            >
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                One
+              </DropdownMenuItem>
+
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                Two
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenu open>
+                <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                <DropdownMenuContent
+                  className={contentClass}
+                  sideOffset={12}
+                  avoidCollisions={false}
+                  align="end"
+                  alignOffset={-16}
+                >
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenuItem>
+                  <DropdownMenuArrow offset={24} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                Three
+              </DropdownMenuItem>
+              <DropdownMenuArrow offset={8} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DropdownMenuSeparator className={separatorClass} />
+          <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenuItem>
+          <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenuItem>
+          <DropdownMenuArrow />
+        </DropdownMenuContent>
+        <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+      </DropdownMenu>
+
+      <h2 style={{ marginTop: 275 }}>RTL</h2>
+      <div dir="rtl">
+        <DropdownMenu open dir="rtl">
+          <DropdownMenuContent
+            className={contentClass}
+            sideOffset={5}
+            avoidCollisions={false}
+            disableOutsideScroll={false}
+          >
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenu open>
+              <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+              <DropdownMenuContent className={contentClass} sideOffset={12} avoidCollisions={false}>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </DropdownMenuItem>
+
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </DropdownMenuItem>
+                <DropdownMenuSeparator className={separatorClass} />
+                <DropdownMenu open>
+                  <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className={contentClass}
+                    sideOffset={12}
+                    avoidCollisions={false}
+                  >
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                      One
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                      Two
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                      Three
+                    </DropdownMenuItem>
+                    <DropdownMenuArrow offset={8} />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <DropdownMenuSeparator className={separatorClass} />
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </DropdownMenuItem>
+                <DropdownMenuArrow offset={8} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenuItem>
+            <DropdownMenuArrow />
+          </DropdownMenuContent>
+          <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+        </DropdownMenu>
+      </div>
+
+      <h1 style={{ marginTop: 275 }}>Positioning</h1>
       <h2>No collisions</h2>
       <h3>Side & Align</h3>
       <div className={gridClass}>

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -9,6 +9,8 @@ import { useId } from '@radix-ui/react-id';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
+type Direction = 'ltr' | 'rtl';
+
 /* -------------------------------------------------------------------------------------------------
  * DropdownMenu
  * -----------------------------------------------------------------------------------------------*/
@@ -23,27 +25,43 @@ type DropdownMenuContextValue = {
   onOpenToggle(): void;
 };
 
+const SubmenuContext = React.createContext<boolean | undefined>(undefined);
+const InsideContentContext = React.createContext<boolean>(false);
 const [DropdownMenuProvider, useDropdownMenuContext] = createContext<DropdownMenuContextValue>(
   DROPDOWN_MENU_NAME
 );
 
 type DropdownMenuOwnProps = {
   open?: boolean;
-  defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
+  defaultOpen?: boolean;
+  dir?: Direction;
 };
 
 const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const parentSubmenuContext = React.useContext(SubmenuContext);
+  const isInsideContent = React.useContext(InsideContentContext);
+  const isRootMenu = parentSubmenuContext === undefined;
+
+  return (
+    <SubmenuContext.Provider value={!isRootMenu && isInsideContent}>
+      <DropdownMenuImpl {...props} />
+    </SubmenuContext.Provider>
+  );
+};
+
+const DropdownMenuImpl: React.FC<DropdownMenuOwnProps> = (props) => {
+  const { children, open: openProp, defaultOpen, onOpenChange, dir } = props;
+  const isSubmenu = React.useContext(SubmenuContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
     onChange: onOpenChange,
   });
-
+  const DropdownMenu = isSubmenu ? MenuPrimitive.Sub : MenuPrimitive.Root;
   return (
-    <MenuPrimitive.Root open={open} onOpenChange={setOpen}>
+    <DropdownMenu open={open} onOpenChange={setOpen} dir={dir}>
       <DropdownMenuProvider
         triggerRef={triggerRef}
         contentId={useId()}
@@ -53,7 +71,7 @@ const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
       >
         {children}
       </DropdownMenuProvider>
-    </MenuPrimitive.Root>
+    </DropdownMenu>
   );
 };
 
@@ -64,19 +82,48 @@ DropdownMenu.displayName = DROPDOWN_MENU_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TRIGGER_NAME = 'DropdownMenuTrigger';
-const TRIGGER_DEFAULT_TAG = 'button';
 
-type DropdownMenuTriggerOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive.Anchor>,
-  'virtualRef'
+type DropdownMenuTriggerOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof DropdownMenuRootTrigger>,
+  Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>
 >;
 type DropdownMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  typeof TRIGGER_DEFAULT_TAG,
+  Polymorphic.IntrinsicElement<typeof DropdownMenuRootTrigger>,
   DropdownMenuTriggerOwnProps
 >;
 
 const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
-  const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
+  const { as, ...triggerProps } = props;
+  const isSubmenu = React.useContext(SubmenuContext);
+
+  return isSubmenu ? (
+    <MenuPrimitive.SubTrigger
+      {...triggerProps}
+      as={as as Polymorphic.IntrinsicElement<typeof DropdownMenuRootTrigger>}
+      ref={forwardedRef}
+    />
+  ) : (
+    <DropdownMenuRootTrigger {...triggerProps} as={as} ref={forwardedRef} />
+  );
+}) as DropdownMenuTriggerPrimitive;
+
+DropdownMenuTrigger.displayName = TRIGGER_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+const ROOT_TRIGGER_DEFAULT_TAG = 'button';
+
+type DropdownMenuRootTriggerOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuPrimitive.Anchor>,
+  'virtualRef'
+>;
+type DropdownMenuRootTriggerPrimitive = Polymorphic.ForwardRefComponent<
+  typeof ROOT_TRIGGER_DEFAULT_TAG,
+  DropdownMenuRootTriggerOwnProps
+>;
+
+const DropdownMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
+  const { as = ROOT_TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useDropdownMenuContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 
@@ -105,9 +152,7 @@ const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
       })}
     />
   );
-}) as DropdownMenuTriggerPrimitive;
-
-DropdownMenuTrigger.displayName = TRIGGER_NAME;
+}) as DropdownMenuRootTriggerPrimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * DropdownMenuContent
@@ -135,34 +180,38 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
   return (
-    <MenuPrimitive.Content
-      id={context.contentId}
-      {...contentProps}
-      ref={forwardedRef}
-      disableOutsidePointerEvents={disableOutsidePointerEvents}
-      disableOutsideScroll={disableOutsideScroll}
-      portalled={portalled}
-      style={{
-        ...props.style,
-        // re-namespace exposed content custom property
-        ['--radix-dropdown-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-      }}
-      trapFocus
-      onCloseAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
-        event.preventDefault();
-        context.triggerRef.current?.focus();
-      })}
-      onPointerDownOutside={composeEventHandlers(
-        props.onPointerDownOutside,
-        (event) => {
-          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
-          if (targetIsTrigger) event.preventDefault();
-        },
-        { checkForDefaultPrevented: false }
-      )}
-    />
+    <InsideContentContext.Provider value={true}>
+      <MenuPrimitive.Content
+        id={context.contentId}
+        {...contentProps}
+        ref={forwardedRef}
+        disableOutsidePointerEvents={disableOutsidePointerEvents}
+        disableOutsideScroll={disableOutsideScroll}
+        portalled={portalled}
+        style={{
+          ...props.style,
+          // re-namespace exposed content custom property
+          ['--radix-dropdown-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+        }}
+        trapFocus
+        onCloseAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
+          event.preventDefault();
+          context.triggerRef.current?.focus();
+        })}
+        onPointerDownOutside={composeEventHandlers(
+          props.onPointerDownOutside,
+          (event) => {
+            const targetIsTrigger = context.triggerRef.current?.contains(
+              event.target as HTMLElement
+            );
+            // prevent dismissing when clicking the trigger
+            // as it's already setup to close, otherwise it would close and immediately open.
+            if (targetIsTrigger) event.preventDefault();
+          },
+          { checkForDefaultPrevented: false }
+        )}
+      />
+    </InsideContentContext.Provider>
   );
 }) as DropdownMenuContentPrimitive;
 

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -57,19 +57,25 @@ const DropdownMenuImpl: React.FC<DropdownMenuOwnImplProps> = (props) => {
     defaultProp: defaultOpen,
     onChange: onOpenChange,
   });
-  const DropdownMenu = isSubmenu ? MenuPrimitive.Sub : MenuPrimitive.Root;
+
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen} dir={dir}>
-      <DropdownMenuProvider
-        triggerRef={triggerRef}
-        contentId={useId()}
-        open={open}
-        onOpenChange={setOpen}
-        onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
-      >
-        {children}
-      </DropdownMenuProvider>
-    </DropdownMenu>
+    <DropdownMenuProvider
+      triggerRef={triggerRef}
+      contentId={useId()}
+      open={open}
+      onOpenChange={setOpen}
+      onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+    >
+      {isSubmenu ? (
+        <MenuPrimitive.Sub open={open} onOpenChange={setOpen}>
+          {children}
+        </MenuPrimitive.Sub>
+      ) : (
+        <MenuPrimitive.Root open={open} onOpenChange={setOpen} dir={dir}>
+          {children}
+        </MenuPrimitive.Root>
+      )}
+    </DropdownMenuProvider>
   );
 };
 

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -33,9 +33,9 @@ const [DropdownMenuProvider, useDropdownMenuContext] = createContext<DropdownMen
 type DropdownMenuOwnProps = React.ComponentProps<typeof DropdownMenuImpl>;
 
 const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
-  const parentSubmenuContext = React.useContext(SubmenuContext);
+  const parentMenuContext = React.useContext(SubmenuContext);
   return (
-    <SubmenuContext.Provider value={parentSubmenuContext === undefined ? false : true}>
+    <SubmenuContext.Provider value={parentMenuContext === undefined ? false : true}>
       <DropdownMenuImpl {...props} />
     </SubmenuContext.Provider>
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -30,12 +30,7 @@ const [DropdownMenuProvider, useDropdownMenuContext] = createContext<DropdownMen
   DROPDOWN_MENU_NAME
 );
 
-type DropdownMenuOwnProps = {
-  open?: boolean;
-  onOpenChange?(open: boolean): void;
-  defaultOpen?: boolean;
-  dir?: Direction;
-};
+type DropdownMenuOwnProps = React.ComponentProps<typeof DropdownMenuImpl>;
 
 const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
   const parentSubmenuContext = React.useContext(SubmenuContext);
@@ -46,7 +41,14 @@ const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
   );
 };
 
-const DropdownMenuImpl: React.FC<DropdownMenuOwnProps> = (props) => {
+type DropdownMenuOwnImplProps = {
+  open?: boolean;
+  onOpenChange?(open: boolean): void;
+  defaultOpen?: boolean;
+  dir?: Direction;
+};
+
+const DropdownMenuImpl: React.FC<DropdownMenuOwnImplProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange, dir } = props;
   const isSubmenu = React.useContext(SubmenuContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -107,19 +109,19 @@ DropdownMenuTrigger.displayName = TRIGGER_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const ROOT_TRIGGER_DEFAULT_TAG = 'button';
+const TRIGGER_DEFAULT_TAG = 'button';
 
 type DropdownMenuRootTriggerOwnProps = Omit<
   Polymorphic.OwnProps<typeof MenuPrimitive.Anchor>,
   'virtualRef'
 >;
 type DropdownMenuRootTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  typeof ROOT_TRIGGER_DEFAULT_TAG,
+  typeof TRIGGER_DEFAULT_TAG,
   DropdownMenuRootTriggerOwnProps
 >;
 
 const DropdownMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
-  const { as = ROOT_TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
+  const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useDropdownMenuContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
 

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -25,30 +25,19 @@ type DropdownMenuContextValue = {
   onOpenToggle(): void;
 };
 
-const SubmenuContext = React.createContext<boolean | undefined>(undefined);
+const SubmenuContext = React.createContext(false);
 const [DropdownMenuProvider, useDropdownMenuContext] = createContext<DropdownMenuContextValue>(
   DROPDOWN_MENU_NAME
 );
 
-type DropdownMenuOwnProps = React.ComponentProps<typeof DropdownMenuImpl>;
-
-const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
-  const parentMenuContext = React.useContext(SubmenuContext);
-  return (
-    <SubmenuContext.Provider value={parentMenuContext === undefined ? false : true}>
-      <DropdownMenuImpl {...props} />
-    </SubmenuContext.Provider>
-  );
-};
-
-type DropdownMenuOwnImplProps = {
+type DropdownMenuOwnProps = {
   open?: boolean;
   onOpenChange?(open: boolean): void;
   defaultOpen?: boolean;
   dir?: Direction;
 };
 
-const DropdownMenuImpl: React.FC<DropdownMenuOwnImplProps> = (props) => {
+const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange, dir } = props;
   const isSubmenu = React.useContext(SubmenuContext);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -184,35 +173,37 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
   return (
-    <MenuPrimitive.Content
-      id={context.contentId}
-      {...contentProps}
-      ref={forwardedRef}
-      disableOutsidePointerEvents={disableOutsidePointerEvents}
-      disableOutsideScroll={disableOutsideScroll}
-      portalled={portalled}
-      style={{
-        ...props.style,
-        // re-namespace exposed content custom property
-        ['--radix-dropdown-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-      }}
-      trapFocus
-      onCloseAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
-        event.preventDefault();
-        context.triggerRef.current?.focus();
-      })}
-      onPointerDownOutside={composeEventHandlers(
-        props.onPointerDownOutside,
-        (event) => {
-          const target = event.target as HTMLElement;
-          const targetIsTrigger = context.triggerRef.current?.contains(target);
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
-          if (targetIsTrigger) event.preventDefault();
-        },
-        { checkForDefaultPrevented: false }
-      )}
-    />
+    <SubmenuContext.Provider value={true}>
+      <MenuPrimitive.Content
+        id={context.contentId}
+        {...contentProps}
+        ref={forwardedRef}
+        disableOutsidePointerEvents={disableOutsidePointerEvents}
+        disableOutsideScroll={disableOutsideScroll}
+        portalled={portalled}
+        style={{
+          ...props.style,
+          // re-namespace exposed content custom property
+          ['--radix-dropdown-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+        }}
+        trapFocus
+        onCloseAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
+          event.preventDefault();
+          context.triggerRef.current?.focus();
+        })}
+        onPointerDownOutside={composeEventHandlers(
+          props.onPointerDownOutside,
+          (event) => {
+            const target = event.target as HTMLElement;
+            const targetIsTrigger = context.triggerRef.current?.contains(target);
+            // prevent dismissing when clicking the trigger
+            // as it's already setup to close, otherwise it would close and immediately open.
+            if (targetIsTrigger) event.preventDefault();
+          },
+          { checkForDefaultPrevented: false }
+        )}
+      />
+    </SubmenuContext.Provider>
   );
 }) as DropdownMenuContentPrimitive;
 

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -519,4 +519,5 @@ export const classes = {
   labelClass,
   itemClass,
   separatorClass,
+  subTriggerClass,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,6 +3401,7 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0
@@ -3580,7 +3581,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-polymorphic@workspace:packages/react/polymorphic"
   dependencies:
-    "@babel/runtime": ^7.13.10
     "@testing-library/react": ^10.4.8
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
Builds on https://github.com/radix-ui/primitives/pull/627

[See discussion](https://github.com/radix-ui/primitives/issues/383)

### Description

This PR uses the new submenu primitives from `Menu` to provide submenu support in `ContextMenu` and `DropdownMenu`

#### Approach

Menus can be nested to create sub menus.

#### Basic example

```jsx
<ContextMenu>
  <ContextMenuTrigger/>
  <ContextMenuContent>
    <ContextMenuItem>Item 1</ContextMenuItem>
    <ContextMenuItem>Item 2</ContextMenuItem>
    
    <ContextMenu>
      <ContextMenuTrigger>
         Open Sub Menu
      </ContextMenuTrigger>

      <ContextMenuContent>
        <ContextMenuItem>Sub Item 1</ContextMenuItem>
        <ContextMenuItem>Sub Item 2</ContextMenuItem>
      </ContextMenuContent>
    </ContextMenu>
  </ContextMenuContent>
</ContextMenu>
```

https://user-images.githubusercontent.com/11708259/116690178-ed916880-a9b0-11eb-969d-644e4237beb9.mov
