### PR TITLE
[Primitive][Slot] Fix slot event composition for custom handlers

### DIFF
--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,10 +1,10 @@
 function composeEventHandlers<E>(
-  originalEventHandler?: (event: E) => void,
+  originalEventHandler?: (...args: any[]) => void,
   ourEventHandler?: (event: E) => void,
   { checkForDefaultPrevented = true } = {}
 ) {
   return function handleEvent(event: E) {
-    originalEventHandler?.(event);
+    originalEventHandler?.(...arguments);
 
     if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
       return ourEventHandler?.(event);

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,10 +1,10 @@
 function composeEventHandlers<E>(
-  originalEventHandler?: (...args: any[]) => void,
+  originalEventHandler?: (event: E) => void,
   ourEventHandler?: (event: E) => void,
   { checkForDefaultPrevented = true } = {}
 ) {
   return function handleEvent(event: E) {
-    originalEventHandler?.(...arguments);
+    originalEventHandler?.(...((arguments as unknown) as [E]));
 
     if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
       return ourEventHandler?.(event);

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -4,20 +4,12 @@ function composeEventHandlers<E>(
   { checkForDefaultPrevented = true } = {}
 ) {
   return function handleEvent(event: E) {
-    originalEventHandler?.(...((arguments as unknown) as [E]));
+    originalEventHandler?.(event);
 
-    if (
-      !isObject(event) ||
-      checkForDefaultPrevented === false ||
-      !((event as unknown) as Event).defaultPrevented
-    ) {
-      return ourEventHandler?.(...((arguments as unknown) as [E]));
+    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
+      return ourEventHandler?.(event);
     }
   };
-}
-
-function isObject(value: unknown): boolean {
-  return value !== undefined && value !== null && typeof value === 'object';
 }
 
 export { composeEventHandlers };

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -6,10 +6,18 @@ function composeEventHandlers<E>(
   return function handleEvent(event: E) {
     originalEventHandler?.(...((arguments as unknown) as [E]));
 
-    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
+    if (
+      !isObject(event) ||
+      checkForDefaultPrevented === false ||
+      !((event as unknown) as Event).defaultPrevented
+    ) {
       return ourEventHandler?.(...((arguments as unknown) as [E]));
     }
   };
+}
+
+function isObject(value: unknown): boolean {
+  return value !== undefined && value !== null && typeof value === 'object';
 }
 
 export { composeEventHandlers };

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -7,7 +7,7 @@ function composeEventHandlers<E>(
     originalEventHandler?.(...((arguments as unknown) as [E]));
 
     if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
-      return ourEventHandler?.(event);
+      return ourEventHandler?.(...((arguments as unknown) as [E]));
     }
   };
 }

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
 import { composeRefs } from '@radix-ui/react-compose-refs';
 
 /* -------------------------------------------------------------------------------------------------
@@ -82,11 +81,31 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
     const isHandler = /^on[A-Z]/.test(propName);
 
     if (isHandler) {
-      overrideProps[propName] = composeEventHandlers(childPropValue, slotPropValue);
+      overrideProps[propName] = composeHandlers(childPropValue, slotPropValue);
     }
   }
 
   return { ...slotProps, ...overrideProps };
+}
+
+function composeHandlers(
+  originalEventHandler?: (...args: unknown[]) => unknown,
+  ourEventHandler?: (...args: unknown[]) => unknown,
+  { checkForDefaultPrevented = true } = {}
+) {
+  return function (...args: unknown[]) {
+    originalEventHandler?.(...args);
+
+    if (checkForDefaultPrevented && isEvent(args[0]) && args[0].defaultPrevented) {
+      return;
+    }
+
+    return ourEventHandler?.(...args);
+  };
+}
+
+function isEvent(value: unknown): value is Event {
+  return value != null && typeof value === 'object' && value instanceof Event;
 }
 
 const Root = Slot;

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -96,16 +96,12 @@ function composeHandlers(
   return function (...args: unknown[]) {
     originalEventHandler?.(...args);
 
-    if (checkForDefaultPrevented && isEvent(args[0]) && args[0].defaultPrevented) {
+    if (checkForDefaultPrevented && args[0] instanceof Event && args[0].defaultPrevented) {
       return;
     }
 
     return ourEventHandler?.(...args);
   };
-}
-
-function isEvent(value: unknown): value is Event {
-  return value != null && typeof value === 'object' && value instanceof Event;
 }
 
 const Root = Slot;


### PR DESCRIPTION
### Description

Right now `SlotClone` components replace child handlers (props starting with 'on') with a composed event with child handler and slot handler.
If the child handler is a custom handler that should receive more than 1 argument, it will receive only the first argument because the `composeEventHandlers` only pass the first argument to the handlers. 

With this change it will pass all received arguments to the handlers.
