### PR TITLE
[Polymorphic] Narrow with `React.ComponentType` instead

### DIFF
--- a/.yarn/versions/fe0cbc34.yml
+++ b/.yarn/versions/fe0cbc34.yml
@@ -1,0 +1,37 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/polymorphic/src/polymorphic.ts
+++ b/packages/react/polymorphic/src/polymorphic.ts
@@ -44,11 +44,11 @@ interface ForwardRefComponent<
   <
     As extends
       | keyof JSX.IntrinsicElements
-      | React.JSXElementConstructor<any> = NarrowIntrinsic<IntrinsicElementString>
+      | React.ComponentType<any> = NarrowIntrinsic<IntrinsicElementString>
   >(
     props: As extends keyof JSX.IntrinsicElements
       ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
-      : As extends React.JSXElementConstructor<infer P>
+      : As extends React.ComponentType<infer P>
       ? Merge<P, OwnProps & { as: As }>
       : never
   ): React.ReactElement | null;


### PR DESCRIPTION
Fixes #647

Replaces `React.JSXElementConstructor` with `React.ComponentType` to allow components typed by external libs in the `as` prop.

You can see the example from the issue working with this code here https://codesandbox.io/s/admiring-kalam-k2ltk?file=/src/App.tsx