### PR TITLE
Fix `onPointerDownOutside` event issues 🔥 

### DIFF
--- a/.yarn/versions/4120ce26.yml
+++ b/.yarn/versions/4120ce26.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -104,7 +104,7 @@ export const NoEscapeDismiss = () => (
   </Dialog>
 );
 
-export const NoInteractOutsideDismiss = () => (
+export const NoPointerDownOutsideDismiss = () => (
   <Dialog>
     <DialogTrigger>open</DialogTrigger>
     <DialogOverlay className={overlayClass} />

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -241,14 +241,14 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
               disableOutsidePointerEvents
               onEscapeKeyDown={onEscapeKeyDown}
               onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
-                // If the pointer down outside event was a right-click, we shouldn't close
-                // because it is effectively as if we right-clicked the `Overlay`.
-                const isRightClick =
-                  (event as MouseEvent).button === 2 ||
-                  ((event as MouseEvent).button === 0 && event.ctrlKey === true);
-                if (isRightClick) {
-                  event.preventDefault();
-                }
+                const originalEvent = event.detail.originalEvent as MouseEvent;
+                const wasRightButton =
+                  originalEvent.button === 2 ||
+                  (originalEvent.button === 0 && originalEvent.ctrlKey === true);
+
+                // If the event was a right-click, we shouldn't close because
+                // it is effectively as if we right-clicked the `Overlay`.
+                if (wasRightButton) event.preventDefault();
               })}
               // When focus is trapped, a focusout event may still happen.
               // We make sure we don't trigger our `onDismiss` in such case.
@@ -281,14 +281,9 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
                     dismissableLayerProps.onFocusCapture,
                     { checkForDefaultPrevented: false }
                   )}
-                  onMouseDownCapture={composeEventHandlers(
-                    contentProps.onMouseDownCapture,
-                    dismissableLayerProps.onMouseDownCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onTouchStartCapture={composeEventHandlers(
-                    contentProps.onTouchStartCapture,
-                    dismissableLayerProps.onTouchStartCapture,
+                  onPointerDownCapture={composeEventHandlers(
+                    contentProps.onPointerDownCapture,
+                    dismissableLayerProps.onPointerDownCapture,
                     { checkForDefaultPrevented: false }
                   )}
                 />

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -242,13 +242,13 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
               onEscapeKeyDown={onEscapeKeyDown}
               onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
                 const originalEvent = event.detail.originalEvent as MouseEvent;
-                const wasRightButton =
+                const wasRightClick =
                   originalEvent.button === 2 ||
                   (originalEvent.button === 0 && originalEvent.ctrlKey === true);
 
                 // If the event was a right-click, we shouldn't close because
                 // it is effectively as if we right-clicked the `Overlay`.
-                if (wasRightButton) event.preventDefault();
+                if (wasRightClick) event.preventDefault();
               })}
               // When focus is trapped, a focusout event may still happen.
               // We make sure we don't trigger our `onDismiss` in such case.

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -242,13 +242,13 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
               onEscapeKeyDown={onEscapeKeyDown}
               onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
                 const originalEvent = event.detail.originalEvent as MouseEvent;
-                const wasRightClick =
+                const isRightClick =
                   originalEvent.button === 2 ||
                   (originalEvent.button === 0 && originalEvent.ctrlKey === true);
 
-                // If the event was a right-click, we shouldn't close because
+                // If the event is a right-click, we shouldn't close because
                 // it is effectively as if we right-clicked the `Overlay`.
-                if (wasRightClick) event.preventDefault();
+                if (isRightClick) event.preventDefault();
               })}
               // When focus is trapped, a focusout event may still happen.
               // We make sure we don't trigger our `onDismiss` in such case.

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -618,10 +618,6 @@ function DummyPopover({
                   } else {
                     onPointerDownOutside?.(event);
                   }
-
-                  if (event.defaultPrevented) {
-                    setSkipUnmountAutoFocus(false);
-                  }
                 }}
                 onFocusOutside={onFocusOutside}
                 onInteractOutside={onInteractOutside}

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -207,7 +207,9 @@ function usePointerDownOutside(
           cancelable: true,
           detail: { originalEvent: event },
         });
-        target.addEventListener(POINTER_DOWN_OUTSIDE, onPointerDownOutside, { once: true });
+        target.addEventListener(POINTER_DOWN_OUTSIDE, onPointerDownOutside as EventListener, {
+          once: true,
+        });
         target.dispatchEvent(pointerDownOutsideEvent);
       }
       isEventInside.current = false;
@@ -317,7 +319,4 @@ export {
   DismissableLayer,
   //
   Root,
-  //
-  POINTER_DOWN_OUTSIDE,
 };
-export type { PointerDownOutsideEvent };

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -182,10 +182,7 @@ function DismissableLayerImpl(props: React.ComponentProps<typeof DismissableLaye
  * -----------------------------------------------------------------------------------------------*/
 
 const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside';
-type PointerDownOutsideEvent = CustomEvent<{
-  relatedTarget: EventTarget | null;
-  originalEvent: MouseEvent | TouchEvent;
-}>;
+type PointerDownOutsideEvent = CustomEvent<{ originalEvent: MouseEvent | TouchEvent }>;
 
 /**
  * Sets up `pointerdown` listener which listens for events outside a react subtree.

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -52,7 +52,7 @@ type DismissableLayerProps = {
    * Event handler called when the a pointer event happens outside of the `DismissableLayer`.
    * Can be prevented.
    */
-  onPointerDownOutside?: (event: MouseEvent | TouchEvent) => void;
+  onPointerDownOutside?: (event: PointerDownOutsideEvent) => void;
 
   /**
    * Event handler called when the focus moves outside of the `DismissableLayer`.
@@ -65,7 +65,7 @@ type DismissableLayerProps = {
    * Specifically, when a pointer event happens outside of the `DismissableLayer` or focus moves outside of it.
    * Can be prevented.
    */
-  onInteractOutside?: (event: MouseEvent | TouchEvent | React.FocusEvent) => void;
+  onInteractOutside?: (event: PointerDownOutsideEvent | React.FocusEvent) => void;
 
   /** Callback called when the `DismissableLayer` should be dismissed */
   onDismiss?: () => void;
@@ -181,36 +181,43 @@ function DismissableLayerImpl(props: React.ComponentProps<typeof DismissableLaye
  * Utility hooks
  * -----------------------------------------------------------------------------------------------*/
 
+const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside';
+type PointerDownOutsideEvent = CustomEvent<{
+  relatedTarget: EventTarget | null;
+  originalEvent: MouseEvent | TouchEvent;
+}>;
+
 /**
- * Sets up mousedown/touchstart listeners which listens for pointer down events outside a react subtree.
+ * Sets up `pointerdown` listener which listens for events outside a react subtree.
  *
- * We use `mousedown` rather than click` for 2 reasons:
- * - to mimic layer dismissing behaviour present in OS which usually happens on mousedown
- * - to enable to us call `event.preventDefault()` and prevent focus from happening.
+ * We use `pointerdown` rather than `pointerup` to mimic layer dismissing behaviour
+ * present in OS which usually happens on `pointerdown`.
  *
  * Returns props to pass to the node we want to check for outside events.
  */
 function usePointerDownOutside(
-  onPointerDownOutsideProp?: (event: MouseEvent | TouchEvent) => void
+  onPointerDownOutsideProp?: (event: PointerDownOutsideEvent) => void
 ) {
   const onPointerDownOutside = useCallbackRef(onPointerDownOutsideProp);
   const isEventInside = React.useRef(false);
 
   React.useEffect(() => {
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (!isEventInside.current) {
-        onPointerDownOutside(event);
+      const target = event.target as HTMLElement | null;
+      if (target && !isEventInside.current) {
+        const pointerDownOutsideEvent = new CustomEvent(POINTER_DOWN_OUTSIDE, {
+          bubbles: false,
+          cancelable: true,
+          detail: { originalEvent: event },
+        });
+        target.addEventListener(POINTER_DOWN_OUTSIDE, onPointerDownOutside, { once: true });
+        target.dispatchEvent(pointerDownOutsideEvent);
       }
       isEventInside.current = false;
     };
 
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('touchstart', handlePointerDown);
-
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('touchstart', handlePointerDown);
-    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [onPointerDownOutside]);
 
   const markEventAsInside = () => {
@@ -219,8 +226,7 @@ function usePointerDownOutside(
 
   return {
     // ensures we check React component tree (not just DOM tree)
-    onMouseDownCapture: markEventAsInside as React.MouseEventHandler,
-    onTouchStartCapture: markEventAsInside as React.TouchEventHandler,
+    onPointerDownCapture: markEventAsInside as React.PointerEventHandler,
   };
 }
 
@@ -314,4 +320,7 @@ export {
   DismissableLayer,
   //
   Root,
+  //
+  POINTER_DOWN_OUTSIDE,
 };
+export type { PointerDownOutsideEvent };

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -202,11 +202,10 @@ function usePointerDownOutside(
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
       const target = event.target as HTMLElement | null;
       if (target && !isEventInside.current) {
-        const pointerDownOutsideEvent = new CustomEvent(POINTER_DOWN_OUTSIDE, {
-          bubbles: false,
-          cancelable: true,
-          detail: { originalEvent: event },
-        });
+        const pointerDownOutsideEvent: PointerDownOutsideEvent = new CustomEvent(
+          POINTER_DOWN_OUTSIDE,
+          { bubbles: false, cancelable: true, detail: { originalEvent: event } }
+        );
         target.addEventListener(POINTER_DOWN_OUTSIDE, onPointerDownOutside as EventListener, {
           once: true,
         });

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -155,12 +155,10 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
       onPointerDownOutside={composeEventHandlers(
         props.onPointerDownOutside,
         (event) => {
-          const targetWasTrigger = context.triggerRef.current?.contains(
-            event.target as HTMLElement
-          );
+          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           // prevent dismissing when clicking the trigger
           // as it's already setup to close, otherwise it would close and immediately open.
-          if (targetWasTrigger) event.preventDefault();
+          if (targetIsTrigger) event.preventDefault();
         },
         { checkForDefaultPrevented: false }
       )}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -155,13 +155,12 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
       onPointerDownOutside={composeEventHandlers(
         props.onPointerDownOutside,
         (event) => {
-          const wasTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
-
+          const targetWasTrigger = context.triggerRef.current?.contains(
+            event.target as HTMLElement
+          );
           // prevent dismissing when clicking the trigger
           // as it's already setup to close, otherwise it would close and immediately open.
-          if (wasTrigger) {
-            event.preventDefault();
-          }
+          if (targetWasTrigger) event.preventDefault();
         },
         { checkForDefaultPrevented: false }
       )}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -262,9 +262,9 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                   onPointerDownOutside,
                   (event) => {
                     const originalEvent = event.detail.originalEvent as MouseEvent;
-                    const wasLeftClick =
+                    const isLeftClick =
                       originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                    setSkipCloseAutoFocus(!disableOutsidePointerEvents && wasLeftClick);
+                    setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
                   },
                   { checkForDefaultPrevented: false }
                 )}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -262,9 +262,9 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                   onPointerDownOutside,
                   (event) => {
                     const originalEvent = event.detail.originalEvent as MouseEvent;
-                    const isLeftClick =
+                    const wasLeftClick =
                       originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                    setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+                    setSkipCloseAutoFocus(!disableOutsidePointerEvents && wasLeftClick);
                   },
                   { checkForDefaultPrevented: false }
                 )}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -267,10 +267,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     ...contentProps
   } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const [
-    isPermittedPointerDownOutsideEvent,
-    setIsPermittedPointerDownOutsideEvent,
-  ] = React.useState(false);
+  const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -290,15 +287,12 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     <PortalWrapper>
       <ScrollLockWrapper>
         <FocusScope
-          // clicking outside may raise a focusout event, which may get trapped.
-          // in cases where outside pointer events are permitted, we stop trapping.
-          // we also make sure we're not trapping once it's been closed
+          // we make sure we're not trapping once it's been closed
           // (closed !== unmounted when animating out)
-          trapped={isPermittedPointerDownOutsideEvent ? false : trapFocus && context.open}
+          trapped={trapFocus && context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={(event) => {
-            // skip autofocus on close if clicking outside is permitted and it happened
-            if (isPermittedPointerDownOutsideEvent) {
+            if (skipCloseAutoFocus) {
               event.preventDefault();
             } else {
               onCloseAutoFocus?.(event);
@@ -308,28 +302,22 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
           {(focusScopeProps) => (
             <DismissableLayer
               disableOutsidePointerEvents={disableOutsidePointerEvents}
-              onEscapeKeyDown={onEscapeKeyDown}
+              onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
+                setSkipCloseAutoFocus(false);
+              })}
               onPointerDownOutside={composeEventHandlers(
                 onPointerDownOutside,
                 (event) => {
-                  const wasTrigger = context.triggerRef.current?.contains(
+                  const originalEvent = event.detail.originalEvent as MouseEvent;
+                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+
+                  const targetWasTrigger = context.triggerRef.current?.contains(
                     event.target as HTMLElement
                   );
-
-                  const isLeftClick = (event as MouseEvent).button === 0 && event.ctrlKey === false;
-                  const isPermitted = !disableOutsidePointerEvents && isLeftClick;
-                  setIsPermittedPointerDownOutsideEvent(isPermitted);
-
                   // prevent dismissing when clicking the trigger
                   // as it's already setup to close, otherwise it would close and immediately open.
-                  if (wasTrigger) {
-                    event.preventDefault();
-                  }
-
-                  if (event.defaultPrevented) {
-                    // reset this because the event was prevented
-                    setIsPermittedPointerDownOutsideEvent(false);
-                  }
+                  if (targetWasTrigger) event.preventDefault();
                 },
                 { checkForDefaultPrevented: false }
               )}
@@ -373,14 +361,9 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
                     dismissableLayerProps.onFocusCapture,
                     { checkForDefaultPrevented: false }
                   )}
-                  onMouseDownCapture={composeEventHandlers(
-                    contentProps.onMouseDownCapture,
-                    dismissableLayerProps.onMouseDownCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onTouchStartCapture={composeEventHandlers(
-                    contentProps.onTouchStartCapture,
-                    dismissableLayerProps.onTouchStartCapture,
+                  onPointerDownCapture={composeEventHandlers(
+                    contentProps.onPointerDownCapture,
+                    dismissableLayerProps.onPointerDownCapture,
                     { checkForDefaultPrevented: false }
                   )}
                 />

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -309,16 +309,15 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
                 onPointerDownOutside,
                 (event) => {
                   const originalEvent = event.detail.originalEvent as MouseEvent;
-                  const wasLeftClick =
-                    originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && wasLeftClick);
+                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
 
-                  const targetWasTrigger = context.triggerRef.current?.contains(
+                  const targetIsTrigger = context.triggerRef.current?.contains(
                     event.target as HTMLElement
                   );
                   // prevent dismissing when clicking the trigger
                   // as it's already setup to close, otherwise it would close and immediately open.
-                  if (targetWasTrigger) event.preventDefault();
+                  if (targetIsTrigger) event.preventDefault();
                 },
                 { checkForDefaultPrevented: false }
               )}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -309,8 +309,9 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
                 onPointerDownOutside,
                 (event) => {
                   const originalEvent = event.detail.originalEvent as MouseEvent;
-                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+                  const wasLeftClick =
+                    originalEvent.button === 0 && originalEvent.ctrlKey === false;
+                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && wasLeftClick);
 
                   const targetWasTrigger = context.triggerRef.current?.contains(
                     event.target as HTMLElement

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,3 @@
-import { POINTER_DOWN_OUTSIDE } from '../packages/react/dismissable-layer/src';
-import type { PointerDownOutsideEvent } from '../packages/react/dismissable-layer/src';
-
 export {};
 
 type RequestIdleCallbackHandle = any;
@@ -11,9 +8,3 @@ type RequestIdleCallbackDeadline = {
   readonly didTimeout: boolean;
   timeRemaining: () => number;
 };
-
-declare global {
-  interface HTMLElementEventMap {
-    [POINTER_DOWN_OUTSIDE]: PointerDownOutsideEvent;
-  }
-}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,3 +1,6 @@
+import { POINTER_DOWN_OUTSIDE } from '../packages/react/dismissable-layer/src';
+import type { PointerDownOutsideEvent } from '../packages/react/dismissable-layer/src';
+
 export {};
 
 type RequestIdleCallbackHandle = any;
@@ -8,3 +11,9 @@ type RequestIdleCallbackDeadline = {
   readonly didTimeout: boolean;
   timeRemaining: () => number;
 };
+
+declare global {
+  interface HTMLElementEventMap {
+    [POINTER_DOWN_OUTSIDE]: PointerDownOutsideEvent;
+  }
+}


### PR DESCRIPTION
Fix #646

This is a prequel to the modality changes as I bumped into that issue first hand when trying to make a dialog non-modal trying to focus something outside it by calling `event.preventDefault` in `onInteractOutside`.

> Note

:fire: This change affects the event signature of `onPointerDownOutside` and/or `onInteractOutside` for the given components and therefore will need docs updates:
- `AlertDialog`
- `ContextMenu`
- `Dialog`
- `DropdownMenu`
- `Popover`