### PR TITLE
[ContextMenu] Fix issue when no padding on Content 🔥 

### DIFF
--- a/.yarn/versions/dadf863a.yml
+++ b/.yarn/versions/dadf863a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -38,7 +38,7 @@ export const Styled = () => {
           className={triggerClass}
           style={{ background: open ? 'lightblue' : undefined }}
         />
-        <ContextMenuContent className={contentClass} sideOffset={-5}>
+        <ContextMenuContent className={contentClass}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </ContextMenuItem>
@@ -65,7 +65,7 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={contentClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass}>
         {foodGroups.map((foodGroup, index) => (
           <ContextMenuGroup key={index}>
             {foodGroup.label && (
@@ -103,7 +103,7 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={contentClass} sideOffset={-5}>
+        <ContextMenuContent className={contentClass}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </ContextMenuItem>
@@ -142,7 +142,7 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={contentClass} sideOffset={-5}>
+        <ContextMenuContent className={contentClass}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('minimize')}>
             Minimize window
           </ContextMenuItem>
@@ -174,7 +174,7 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={contentClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass}>
         <ContextMenuItem className={itemClass} onSelect={() => window.alert('action 1')}>
           I will close
         </ContextMenuItem>
@@ -276,7 +276,7 @@ export const Nested = () => (
       >
         <ContextMenu>
           <ContextMenuTrigger className={triggerClass} style={{ backgroundColor: 'tomato' }} />{' '}
-          <ContextMenuContent className={contentClass} sideOffset={-5}>
+          <ContextMenuContent className={contentClass}>
             <ContextMenuLabel className={labelClass}>Red box menu</ContextMenuLabel>
             <ContextMenuSeparator className={separatorClass} />
             <ContextMenuItem className={itemClass} onSelect={() => console.log('red action1')}>
@@ -288,7 +288,7 @@ export const Nested = () => (
           </ContextMenuContent>
         </ContextMenu>
       </ContextMenuTrigger>
-      <ContextMenuContent className={contentClass} sideOffset={-5}>
+      <ContextMenuContent className={contentClass}>
         <ContextMenuLabel className={labelClass}>Blue box menu</ContextMenuLabel>
         <ContextMenuSeparator className={separatorClass} />
         <ContextMenuItem className={itemClass} onSelect={() => console.log('blue action1')}>

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -38,7 +38,7 @@ export const Styled = () => {
           className={triggerClass}
           style={{ background: open ? 'lightblue' : undefined }}
         />
-        <ContextMenuContent className={contentClass}>
+        <ContextMenuContent className={contentClass} offset={-5}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </ContextMenuItem>
@@ -65,7 +65,7 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={contentClass}>
+      <ContextMenuContent className={contentClass} offset={-5}>
         {foodGroups.map((foodGroup, index) => (
           <ContextMenuGroup key={index}>
             {foodGroup.label && (
@@ -103,7 +103,7 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={contentClass}>
+        <ContextMenuContent className={contentClass} offset={-5}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </ContextMenuItem>
@@ -142,7 +142,7 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu>
         <ContextMenuTrigger className={triggerClass} />
-        <ContextMenuContent className={contentClass}>
+        <ContextMenuContent className={contentClass} offset={-5}>
           <ContextMenuItem className={itemClass} onSelect={() => console.log('minimize')}>
             Minimize window
           </ContextMenuItem>
@@ -174,7 +174,7 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu>
       <ContextMenuTrigger className={triggerClass} />
-      <ContextMenuContent className={contentClass}>
+      <ContextMenuContent className={contentClass} offset={-5}>
         <ContextMenuItem className={itemClass} onSelect={() => window.alert('action 1')}>
           I will close
         </ContextMenuItem>
@@ -204,7 +204,7 @@ export const Multiple = () => {
         const customColor = customColors[i];
         return (
           <ContextMenu key={i}>
-            <ContextMenuContent className={animatedContentClass}>
+            <ContextMenuContent className={animatedContentClass} offset={-5}>
               <ContextMenuLabel className={labelClass}>Color</ContextMenuLabel>
               <ContextMenuRadioGroup
                 value={customColor}
@@ -276,7 +276,7 @@ export const Nested = () => (
       >
         <ContextMenu>
           <ContextMenuTrigger className={triggerClass} style={{ backgroundColor: 'tomato' }} />{' '}
-          <ContextMenuContent className={contentClass}>
+          <ContextMenuContent className={contentClass} offset={-5}>
             <ContextMenuLabel className={labelClass}>Red box menu</ContextMenuLabel>
             <ContextMenuSeparator className={separatorClass} />
             <ContextMenuItem className={itemClass} onSelect={() => console.log('red action1')}>
@@ -288,7 +288,7 @@ export const Nested = () => (
           </ContextMenuContent>
         </ContextMenu>
       </ContextMenuTrigger>
-      <ContextMenuContent className={contentClass}>
+      <ContextMenuContent className={contentClass} offset={-5}>
         <ContextMenuLabel className={labelClass}>Blue box menu</ContextMenuLabel>
         <ContextMenuSeparator className={separatorClass} />
         <ContextMenuItem className={itemClass} onSelect={() => console.log('blue action1')}>

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -94,16 +94,19 @@ ContextMenuTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'ContextMenuContent';
 
-type ContextMenuContentOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-  | 'trapFocus'
-  | 'disableOutsideScroll'
-  | 'portalled'
-  | 'onOpenAutoFocus'
-  | 'side'
-  | 'sideOffset'
-  | 'align'
-  | 'alignOffset'
+type ContextMenuContentOwnProps = Polymorphic.Merge<
+  Omit<
+    Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
+    | 'trapFocus'
+    | 'disableOutsideScroll'
+    | 'portalled'
+    | 'onOpenAutoFocus'
+    | 'side'
+    | 'sideOffset'
+    | 'align'
+    | 'alignOffset'
+  >,
+  { offset?: number }
 >;
 
 type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
@@ -112,7 +115,7 @@ type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
-  const { disableOutsidePointerEvents = true, ...contentProps } = props;
+  const { disableOutsidePointerEvents = true, offset, ...contentProps } = props;
   const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Content
@@ -128,7 +131,7 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
       disableOutsideScroll
       portalled
       side="bottom"
-      sideOffset={0}
+      sideOffset={offset}
       align="start"
       alignOffset={2}
     />

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -96,7 +96,14 @@ const CONTENT_NAME = 'ContextMenuContent';
 
 type ContextMenuContentOwnProps = Omit<
   Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-  'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'onOpenAutoFocus'
+  | 'trapFocus'
+  | 'disableOutsideScroll'
+  | 'portalled'
+  | 'onOpenAutoFocus'
+  | 'side'
+  | 'sideOffset'
+  | 'align'
+  | 'alignOffset'
 >;
 
 type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
@@ -105,19 +112,12 @@ type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
-  const {
-    side = 'bottom',
-    align = 'start',
-    disableOutsidePointerEvents = true,
-    ...contentProps
-  } = props;
+  const { disableOutsidePointerEvents = true, ...contentProps } = props;
   const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Content
       {...contentProps}
       ref={forwardedRef}
-      side={side}
-      align={align}
       disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
       style={{
         ...props.style,
@@ -127,6 +127,10 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
       trapFocus
       disableOutsideScroll
       portalled
+      side="bottom"
+      sideOffset={0}
+      align="start"
+      alignOffset={2}
     />
   );
 }) as ContextMenuContentPrimitive;


### PR DESCRIPTION
Fixes #656

This PR introduces a quick fix for #656 before we implement things properly in the future (#657) by simply shifting the menu over a little.

As part of this I've also removed all the props that don't make sense on `ContextMenu`.
Only `sideOffset` remained, which I've renamed to `offset` as `side` now doesn't mean much here.
Let me know how you feel about this.

> Note for docs updates:

- 🔥 Remove `ContextMenu.Content` `side` prop
- 🔥 Remove `ContextMenu.Content` `align` prop
- 🔥 Remove `ContextMenu.Content` `alignOffset` prop
- 🔥 Rename `ContextMenu.Content` `sideOffset` prop to `offset`