### PR TITLE
[FocusScope][DismissableLayer] Use `Primitive` and `Slot`

### DIFF
--- a/.yarn/versions/eedeb2d4.yml
+++ b/.yarn/versions/eedeb2d4.yml
@@ -1,0 +1,20 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -206,12 +206,14 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = useDialogContext(CONTENT_NAME);
 
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
   // Make sure the whole tree has focus guards as our `Dialog` will be
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
 
   // Hide everything from ARIA except the content
-  const contentRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const content = contentRef.current;
     if (content) return hideOthers(content);
@@ -233,7 +235,7 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
             aria-modal
             id={context.contentId}
             {...contentProps}
-            ref={composeRefs(forwardedRef, contentRef)}
+            ref={composedRefs}
             disableOutsidePointerEvents
             onEscapeKeyDown={onEscapeKeyDown}
             onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -2,21 +2,19 @@ import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
+import { useId } from '@radix-ui/react-id';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { Portal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
-import { useId } from '@radix-ui/react-id';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
-
-type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
-type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
 
 /* -------------------------------------------------------------------------------------------------
  * Dialog
@@ -171,37 +169,30 @@ const DialogContent = React.forwardRef((props, forwardedRef) => {
   );
 }) as DialogContentPrimitive;
 
+type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
+
 type DialogContentImplOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Primitive>,
+  Omit<
+    Polymorphic.OwnProps<typeof DismissableLayer>,
+    'disableOutsidePointerEvents' | 'onFocusOutside' | 'onInteractOutside' | 'onDismiss'
+  >,
   {
     /**
      * Event handler called when auto-focusing on open.
      * Can be prevented.
      */
-    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+    onOpenAutoFocus?: FocusScopeOwnProps['onMountAutoFocus'];
 
     /**
      * Event handler called when auto-focusing on close.
      * Can be prevented.
      */
-    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-
-    /**
-     * Event handler called when the escape key is down.
-     * Can be prevented.
-     */
-    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
-
-    /**
-     * Event handler called when the a pointer event happens outside of the `Dialog`.
-     * Can be prevented.
-     */
-    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
+    onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
   }
 >;
 
 type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof Primitive>,
+  Polymorphic.IntrinsicElement<typeof DismissableLayer>,
   DialogContentImplOwnProps
 >;
 
@@ -230,66 +221,36 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
     <Portal>
       <RemoveScroll>
         <FocusScope
+          as={Slot}
           // we make sure we're not trapping once it's been closed
           // (closed !== unmounted when animating out)
           trapped={context.open}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={onCloseAutoFocus}
         >
-          {(focusScopeProps) => (
-            <DismissableLayer
-              disableOutsidePointerEvents
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
-                const originalEvent = event.detail.originalEvent as MouseEvent;
-                const isRightClick =
-                  originalEvent.button === 2 ||
-                  (originalEvent.button === 0 && originalEvent.ctrlKey === true);
+          <DismissableLayer
+            role="dialog"
+            aria-modal
+            id={context.contentId}
+            {...contentProps}
+            ref={composeRefs(forwardedRef, contentRef)}
+            disableOutsidePointerEvents
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
+              const originalEvent = event.detail.originalEvent as MouseEvent;
+              const isRightClick =
+                originalEvent.button === 2 ||
+                (originalEvent.button === 0 && originalEvent.ctrlKey === true);
 
-                // If the event is a right-click, we shouldn't close because
-                // it is effectively as if we right-clicked the `Overlay`.
-                if (isRightClick) event.preventDefault();
-              })}
-              // When focus is trapped, a focusout event may still happen.
-              // We make sure we don't trigger our `onDismiss` in such case.
-              onFocusOutside={(event) => event.preventDefault()}
-              onDismiss={() => context.onOpenChange(false)}
-            >
-              {(dismissableLayerProps) => (
-                <Primitive
-                  role="dialog"
-                  aria-modal
-                  id={context.contentId}
-                  {...focusScopeProps}
-                  {...contentProps}
-                  ref={composeRefs(forwardedRef, contentRef, focusScopeProps.ref)}
-                  onKeyDown={composeEventHandlers(
-                    contentProps.onKeyDown,
-                    focusScopeProps.onKeyDown
-                  )}
-                  style={{
-                    ...dismissableLayerProps.style,
-                    ...contentProps.style,
-                  }}
-                  onBlurCapture={composeEventHandlers(
-                    contentProps.onBlurCapture,
-                    dismissableLayerProps.onBlurCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onFocusCapture={composeEventHandlers(
-                    contentProps.onFocusCapture,
-                    dismissableLayerProps.onFocusCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onPointerDownCapture={composeEventHandlers(
-                    contentProps.onPointerDownCapture,
-                    dismissableLayerProps.onPointerDownCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                />
-              )}
-            </DismissableLayer>
-          )}
+              // If the event is a right-click, we shouldn't close because
+              // it is effectively as if we right-clicked the `Overlay`.
+              if (isRightClick) event.preventDefault();
+            })}
+            // When focus is trapped, a focusout event may still happen.
+            // We make sure we don't trigger our `onDismiss` in such case.
+            onFocusOutside={(event) => event.preventDefault()}
+            onDismiss={() => context.onOpenChange(false)}
+          />
         </FocusScope>
       </RemoveScroll>
     </Portal>

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -18,6 +18,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-polymorphic": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-body-pointer-events": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-escape-keydown": "workspace:*"

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -5,6 +5,7 @@ import { FocusScope } from '@radix-ui/react-focus-scope';
 import { Popper, PopperAnchor, PopperContent, PopperArrow } from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { FocusGuards } from '@radix-ui/react-focus-guards';
+import { Slot } from '@radix-ui/react-slot';
 import { RemoveScroll } from 'react-remove-scroll';
 import { DismissableLayer } from './DismissableLayer';
 
@@ -94,26 +95,19 @@ export const Basic = () => {
           }}
           disableOutsidePointerEvents={disabledOutsidePointerEvents}
           onDismiss={() => setOpen(false)}
+          style={{
+            display: 'inline-flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            verticalAlign: 'middle',
+            width: 400,
+            height: 300,
+            backgroundColor: 'black',
+            borderRadius: 10,
+            marginBottom: 20,
+          }}
         >
-          {(props) => (
-            <div
-              {...props}
-              style={{
-                display: 'inline-flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                verticalAlign: 'middle',
-                width: 400,
-                height: 300,
-                backgroundColor: 'black',
-                borderRadius: 10,
-                marginBottom: 20,
-                ...props.style,
-              }}
-            >
-              <input type="text" />
-            </div>
-          )}
+          <input type="text" />
         </DismissableLayer>
       ) : null}
 
@@ -151,6 +145,7 @@ export const WithFocusScope = () => {
 
       {open ? (
         <DismissableLayer
+          as={Slot}
           onPointerDownOutside={(event) => {
             if (event.target === openButtonRef.current) {
               event.preventDefault();
@@ -159,30 +154,22 @@ export const WithFocusScope = () => {
           disableOutsidePointerEvents
           onDismiss={() => setOpen(false)}
         >
-          {(dismissableLayerProps) => (
-            <FocusScope trapped>
-              {(focusScopeProps) => (
-                <div
-                  {...dismissableLayerProps}
-                  {...focusScopeProps}
-                  style={{
-                    display: 'inline-flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    verticalAlign: 'middle',
-                    width: 400,
-                    height: 300,
-                    backgroundColor: 'black',
-                    borderRadius: 10,
-                    marginBottom: 20,
-                    ...dismissableLayerProps.style,
-                  }}
-                >
-                  <input type="text" />
-                </div>
-              )}
-            </FocusScope>
-          )}
+          <FocusScope
+            trapped
+            style={{
+              display: 'inline-flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              verticalAlign: 'middle',
+              width: 400,
+              height: 300,
+              backgroundColor: 'black',
+              borderRadius: 10,
+              marginBottom: 20,
+            }}
+          >
+            <input type="text" />
+          </FocusScope>
         </DismissableLayer>
       ) : null}
 
@@ -203,39 +190,35 @@ function DismissableBox(props: DismissableBoxProps) {
   const openButtonRef = React.useRef(null);
 
   return (
-    <DismissableLayer {...props}>
-      {(props) => (
-        <div
-          {...props}
-          style={{
-            display: 'inline-block',
-            verticalAlign: 'middle',
-            padding: 20,
-            backgroundColor: 'rgba(0, 0, 0, 0.2)',
-            borderRadius: 10,
-            marginTop: 20,
-            ...props.style,
-          }}
-        >
-          <div>
-            <button ref={openButtonRef} type="button" onClick={() => setOpen((open) => !open)}>
-              {open ? 'Close' : 'Open'} new layer
-            </button>
-          </div>
+    <DismissableLayer
+      {...props}
+      style={{
+        display: 'inline-block',
+        verticalAlign: 'middle',
+        padding: 20,
+        backgroundColor: 'rgba(0, 0, 0, 0.2)',
+        borderRadius: 10,
+        marginTop: 20,
+        ...props.style,
+      }}
+    >
+      <div>
+        <button ref={openButtonRef} type="button" onClick={() => setOpen((open) => !open)}>
+          {open ? 'Close' : 'Open'} new layer
+        </button>
+      </div>
 
-          {open ? (
-            <DismissableBox
-              onPointerDownOutside={(event) => {
-                if (event.target === openButtonRef.current) {
-                  event.preventDefault();
-                }
-              }}
-              onFocusOutside={(event) => event.preventDefault()}
-              onDismiss={() => setOpen(false)}
-            />
-          ) : null}
-        </div>
-      )}
+      {open ? (
+        <DismissableBox
+          onPointerDownOutside={(event) => {
+            if (event.target === openButtonRef.current) {
+              event.preventDefault();
+            }
+          }}
+          onFocusOutside={(event) => event.preventDefault()}
+          onDismiss={() => setOpen(false)}
+        />
+      ) : null}
     </DismissableLayer>
   );
 }
@@ -522,41 +505,37 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
           </Portal>
           <Portal>
             <RemoveScroll>
-              <DismissableLayer disableOutsidePointerEvents onDismiss={() => setOpen(false)}>
-                {(dismissableLayerProps) => (
-                  <FocusScope trapped>
-                    {(focusScopeProps) => (
-                      <div
-                        {...dismissableLayerProps}
-                        {...focusScopeProps}
-                        style={{
-                          boxSizing: 'border-box',
-                          display: 'flex',
-                          alignItems: 'start',
-                          gap: 10,
-                          position: 'fixed',
-                          top: '50%',
-                          left: '50%',
-                          transform: 'translate(-50%, -50%)',
-                          background: 'white',
-                          minWidth: 300,
-                          minHeight: 200,
-                          padding: 40,
-                          borderRadius: 10,
-                          backgroundColor: 'white',
-                          boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
-                          ...dismissableLayerProps.style,
-                        }}
-                      >
-                        {children}
-                        <button type="button" onClick={() => setOpen(false)}>
-                          {closeLabel}
-                        </button>
-                        <input type="text" defaultValue="hello world" />
-                      </div>
-                    )}
-                  </FocusScope>
-                )}
+              <DismissableLayer
+                as={Slot}
+                disableOutsidePointerEvents
+                onDismiss={() => setOpen(false)}
+              >
+                <FocusScope
+                  trapped
+                  style={{
+                    boxSizing: 'border-box',
+                    display: 'flex',
+                    alignItems: 'start',
+                    gap: 10,
+                    position: 'fixed',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    background: 'white',
+                    minWidth: 300,
+                    minHeight: 200,
+                    padding: 40,
+                    borderRadius: 10,
+                    backgroundColor: 'white',
+                    boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
+                  }}
+                >
+                  {children}
+                  <button type="button" onClick={() => setOpen(false)}>
+                    {closeLabel}
+                  </button>
+                  <input type="text" defaultValue="hello world" />
+                </FocusScope>
               </DismissableLayer>
             </RemoveScroll>
           </Portal>
@@ -609,6 +588,7 @@ function DummyPopover({
           <Portal>
             <ScrollContainer>
               <DismissableLayer
+                as={Slot}
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
                 onEscapeKeyDown={onEscapeKeyDown}
                 onPointerDownOutside={(event) => {
@@ -623,46 +603,40 @@ function DummyPopover({
                 onInteractOutside={onInteractOutside}
                 onDismiss={() => setOpen(false)}
               >
-                {(dismissableLayerProps) => (
-                  <FocusScope
-                    trapped={trapped}
-                    onUnmountAutoFocus={(event) => {
-                      if (skipUnmountAutoFocus) {
-                        event.preventDefault();
-                      }
-                      setSkipUnmountAutoFocus(false);
+                <FocusScope
+                  as={Slot}
+                  trapped={trapped}
+                  onUnmountAutoFocus={(event) => {
+                    if (skipUnmountAutoFocus) {
+                      event.preventDefault();
+                    }
+                    setSkipUnmountAutoFocus(false);
+                  }}
+                >
+                  <PopperContent
+                    style={{
+                      filter: 'drop-shadow(0 2px 10px rgba(0, 0, 0, 0.12))',
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 10,
+                      background: 'white',
+                      minWidth: 200,
+                      minHeight: 150,
+                      padding: 20,
+                      borderRadius: 4,
+                      backgroundColor: color,
                     }}
+                    side="bottom"
+                    sideOffset={10}
                   >
-                    {(focusScopeProps) => (
-                      <PopperContent
-                        {...dismissableLayerProps}
-                        {...focusScopeProps}
-                        style={{
-                          filter: 'drop-shadow(0 2px 10px rgba(0, 0, 0, 0.12))',
-                          display: 'flex',
-                          alignItems: 'flex-start',
-                          gap: 10,
-                          background: 'white',
-                          minWidth: 200,
-                          minHeight: 150,
-                          padding: 20,
-                          borderRadius: 4,
-                          backgroundColor: color,
-                          ...dismissableLayerProps.style,
-                        }}
-                        side="bottom"
-                        sideOffset={10}
-                      >
-                        {children}
-                        <button type="button" onClick={() => setOpen(false)}>
-                          {closeLabel}
-                        </button>
-                        <input type="text" defaultValue="hello world" />
-                        <PopperArrow width={10} height={4} style={{ fill: color }} offset={20} />
-                      </PopperContent>
-                    )}
-                  </FocusScope>
-                )}
+                    {children}
+                    <button type="button" onClick={() => setOpen(false)}>
+                      {closeLabel}
+                    </button>
+                    <input type="text" defaultValue="hello world" />
+                    <PopperArrow width={10} height={4} style={{ fill: color }} offset={20} />
+                  </PopperContent>
+                </FocusScope>
               </DismissableLayer>
             </ScrollContainer>
           </Portal>

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -18,6 +18,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@radix-ui/react-compose-refs": "workspace:*",
+    "@radix-ui/react-polymorphic": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/focus-scope/src/FocusScope.stories.tsx
+++ b/packages/react/focus-scope/src/FocusScope.stories.tsx
@@ -15,28 +15,25 @@ export const Basic = () => {
         <input /> <input />
       </div>
       {trapped ? (
-        <FocusScope trapped={trapped}>
-          {(props) => (
-            <form
-              {...props}
-              style={{
-                display: 'inline-flex',
-                flexDirection: 'column',
-                gap: 20,
-                padding: 20,
-                margin: 50,
-                maxWidth: 500,
-                border: '2px solid',
-              }}
-            >
-              <input type="text" placeholder="First name" />
-              <input type="text" placeholder="Last name" />
-              <input type="number" placeholder="Age" />
-              <button type="button" onClick={() => setTrapped(false)}>
-                Close
-              </button>
-            </form>
-          )}
+        <FocusScope
+          as="form"
+          trapped={trapped}
+          style={{
+            display: 'inline-flex',
+            flexDirection: 'column',
+            gap: 20,
+            padding: 20,
+            margin: 50,
+            maxWidth: 500,
+            border: '2px solid',
+          }}
+        >
+          <input type="text" placeholder="First name" />
+          <input type="text" placeholder="Last name" />
+          <input type="number" placeholder="Age" />
+          <button type="button" onClick={() => setTrapped(false)}>
+            Close
+          </button>
         </FocusScope>
       ) : null}
       <div>
@@ -58,28 +55,25 @@ export const Multiple = () => {
         </button>
       </div>
       {trapped1 ? (
-        <FocusScope trapped={trapped1}>
-          {(props) => (
-            <form
-              {...props}
-              style={{
-                display: 'inline-flex',
-                flexDirection: 'column',
-                gap: 20,
-                padding: 20,
-                maxWidth: 500,
-                border: '2px solid',
-              }}
-            >
-              <h1>One</h1>
-              <input type="text" placeholder="First name" />
-              <input type="text" placeholder="Last name" />
-              <input type="number" placeholder="Age" />
-              <button type="button" onClick={() => setTrapped1(false)}>
-                Close
-              </button>
-            </form>
-          )}
+        <FocusScope
+          as="form"
+          trapped={trapped1}
+          style={{
+            display: 'inline-flex',
+            flexDirection: 'column',
+            gap: 20,
+            padding: 20,
+            maxWidth: 500,
+            border: '2px solid',
+          }}
+        >
+          <h1>One</h1>
+          <input type="text" placeholder="First name" />
+          <input type="text" placeholder="Last name" />
+          <input type="number" placeholder="Age" />
+          <button type="button" onClick={() => setTrapped1(false)}>
+            Close
+          </button>
         </FocusScope>
       ) : null}
 
@@ -89,28 +83,25 @@ export const Multiple = () => {
         </button>
       </div>
       {trapped2 ? (
-        <FocusScope trapped={trapped2}>
-          {(props) => (
-            <form
-              {...props}
-              style={{
-                display: 'inline-flex',
-                flexDirection: 'column',
-                gap: 20,
-                padding: 20,
-                maxWidth: 500,
-                border: '2px solid',
-              }}
-            >
-              <h1>Two</h1>
-              <input type="text" placeholder="First name" />
-              <input type="text" placeholder="Last name" />
-              <input type="number" placeholder="Age" />
-              <button type="button" onClick={() => setTrapped2(false)}>
-                Close
-              </button>
-            </form>
-          )}
+        <FocusScope
+          as="form"
+          trapped={trapped2}
+          style={{
+            display: 'inline-flex',
+            flexDirection: 'column',
+            gap: 20,
+            padding: 20,
+            maxWidth: 500,
+            border: '2px solid',
+          }}
+        >
+          <h1>Two</h1>
+          <input type="text" placeholder="First name" />
+          <input type="text" placeholder="Last name" />
+          <input type="number" placeholder="Age" />
+          <button type="button" onClick={() => setTrapped2(false)}>
+            Close
+          </button>
         </FocusScope>
       ) : null}
       <div>
@@ -215,6 +206,8 @@ export const WithOptions = () => {
 
       {open ? (
         <FocusScope
+          key="form"
+          as="form"
           trapped={trapFocus}
           onMountAutoFocus={(event) => {
             if (focusOnMount !== true) {
@@ -228,32 +221,25 @@ export const WithOptions = () => {
               if (focusOnUnmount) focusOnUnmount.current?.focus();
             }
           }}
+          style={{
+            display: 'inline-flex',
+            flexDirection: 'column',
+            gap: 20,
+            padding: 20,
+            margin: 50,
+            maxWidth: 500,
+            border: '2px solid',
+          }}
         >
-          {(props) => (
-            <form
-              {...props}
-              key="form"
-              style={{
-                display: 'inline-flex',
-                flexDirection: 'column',
-                gap: 20,
-                padding: 20,
-                margin: 50,
-                maxWidth: 500,
-                border: '2px solid',
-              }}
-            >
-              {!isEmptyForm && (
-                <>
-                  <input type="text" placeholder="First name" />
-                  <input type="text" placeholder="Last name" />
-                  <input ref={ageFieldRef} type="number" placeholder="Age" />
-                  <button type="button" onClick={() => setOpen(false)}>
-                    Close
-                  </button>
-                </>
-              )}
-            </form>
+          {!isEmptyForm && (
+            <>
+              <input type="text" placeholder="First name" />
+              <input type="text" placeholder="Last name" />
+              <input ref={ageFieldRef} type="number" placeholder="Age" />
+              <button type="button" onClick={() => setOpen(false)}>
+                Close
+              </button>
+            </>
           )}
         </FocusScope>
       ) : null}

--- a/packages/react/focus-scope/src/FocusScope.test.tsx
+++ b/packages/react/focus-scope/src/FocusScope.test.tsx
@@ -19,15 +19,11 @@ describe('FocusScope', () => {
       rendered = render(
         <div>
           <FocusScope trapped>
-            {(props) => (
-              <div {...props}>
-                <form>
-                  <TestField label={INNER_NAME_INPUT_LABEL} />
-                  <TestField label={INNER_EMAIL_INPUT_LABEL} />
-                  <button>{INNER_SUBMIT_LABEL}</button>
-                </form>
-              </div>
-            )}
+            <form>
+              <TestField label={INNER_NAME_INPUT_LABEL} />
+              <TestField label={INNER_EMAIL_INPUT_LABEL} />
+              <button>{INNER_SUBMIT_LABEL}</button>
+            </form>
           </FocusScope>
           <TestField label="other" />
           <button>some outer button</button>
@@ -66,15 +62,11 @@ describe('FocusScope', () => {
       rendered = render(
         <div>
           <FocusScope trapped>
-            {(props) => (
-              <div {...props}>
-                <form>
-                  <TestField label={INNER_NAME_INPUT_LABEL} tabIndex={-1} />
-                  <TestField label={INNER_EMAIL_INPUT_LABEL} />
-                  <button>{INNER_SUBMIT_LABEL}</button>
-                </form>
-              </div>
-            )}
+            <form>
+              <TestField label={INNER_NAME_INPUT_LABEL} tabIndex={-1} />
+              <TestField label={INNER_EMAIL_INPUT_LABEL} />
+              <button>{INNER_SUBMIT_LABEL}</button>
+            </form>
           </FocusScope>
           <TestField label="other" />
           <button>some outer button</button>
@@ -105,14 +97,10 @@ describe('FocusScope', () => {
       rendered = render(
         <div>
           <FocusScope trapped>
-            {(props) => (
-              <div {...props}>
-                <form>
-                  <TestField label={INNER_NAME_INPUT_LABEL} />
-                  <button onBlur={handleLastFocusableElementBlur}>{INNER_SUBMIT_LABEL}</button>
-                </form>
-              </div>
-            )}
+            <form>
+              <TestField label={INNER_NAME_INPUT_LABEL} />
+              <button onBlur={handleLastFocusableElementBlur}>{INNER_SUBMIT_LABEL}</button>
+            </form>
           </FocusScope>
         </div>
       );

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { Primitive } from '@radix-ui/react-primitive';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 const AUTOFOCUS_ON_MOUNT = 'focusScope.autoFocusOnMount';
 const AUTOFOCUS_ON_UNMOUNT = 'focusScope.autoFocusOnUnmount';
@@ -7,38 +11,52 @@ const EVENT_OPTIONS = { bubbles: false, cancelable: true };
 
 type FocusableTarget = HTMLElement | { focus(): void };
 
-type FocusScopeProps = {
-  children: (args: {
-    ref: React.RefCallback<any>;
-    tabIndex: number;
-    onKeyDown: React.KeyboardEventHandler;
-  }) => React.ReactElement;
+/* -------------------------------------------------------------------------------------------------
+ * FocusScope
+ * -----------------------------------------------------------------------------------------------*/
 
-  /**
-   * Whether focus should be trapped within the FocusScope
-   * (default: false)
-   */
-  trapped?: boolean;
+const FOCUS_SCOPE_NAME = 'FocusScope';
 
-  /**
-   * Event handler called when auto-focusing on mount.
-   * Can be prevented.
-   */
-  onMountAutoFocus?: (event: Event) => void;
+type FocusScopeOwnProps = Polymorphic.Merge<
+  Polymorphic.OwnProps<typeof Primitive>,
+  {
+    /**
+     * Whether focus should be trapped within the FocusScope
+     * (default: false)
+     */
+    trapped?: boolean;
 
-  /**
-   * Event handler called when auto-focusing on unmount.
-   * Can be prevented.
-   */
-  onUnmountAutoFocus?: (event: Event) => void;
-};
+    /**
+     * Event handler called when auto-focusing on mount.
+     * Can be prevented.
+     */
+    onMountAutoFocus?: (event: Event) => void;
 
-function FocusScope(props: FocusScopeProps) {
-  const { children, trapped = false } = props;
+    /**
+     * Event handler called when auto-focusing on unmount.
+     * Can be prevented.
+     */
+    onUnmountAutoFocus?: (event: Event) => void;
+  }
+>;
+
+type FocusScopePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof Primitive>,
+  FocusScopeOwnProps
+>;
+
+const FocusScope = React.forwardRef((props, forwardedRef) => {
+  const {
+    trapped = false,
+    onMountAutoFocus: onMountAutoFocusProp,
+    onUnmountAutoFocus: onUnmountAutoFocusProp,
+    ...scopeProps
+  } = props;
   const [container, setContainer] = React.useState<HTMLElement | null>(null);
-  const onMountAutoFocus = useCallbackRef(props.onMountAutoFocus);
-  const onUnmountAutoFocus = useCallbackRef(props.onUnmountAutoFocus);
+  const onMountAutoFocus = useCallbackRef(onMountAutoFocusProp);
+  const onUnmountAutoFocus = useCallbackRef(onUnmountAutoFocusProp);
   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setContainer(node));
 
   const wrapped = trapped;
   const contained = trapped;
@@ -152,12 +170,10 @@ function FocusScope(props: FocusScopeProps) {
     [wrapped, contained, focusScope.paused]
   );
 
-  return children({
-    ref: React.useCallback((node) => setContainer(node), []),
-    tabIndex: -1,
-    onKeyDown: handleKeyDown,
-  });
-}
+  return <Primitive tabIndex={-1} onKeyDown={handleKeyDown} {...scopeProps} ref={composedRefs} />;
+}) as FocusScopePrimitive;
+
+FocusScope.displayName = FOCUS_SCOPE_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * Utils

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -170,7 +170,7 @@ const FocusScope = React.forwardRef((props, forwardedRef) => {
     [wrapped, contained, focusScope.paused]
   );
 
-  return <Primitive tabIndex={-1} onKeyDown={handleKeyDown} {...scopeProps} ref={composedRefs} />;
+  return <Primitive tabIndex={-1} {...scopeProps} ref={composedRefs} onKeyDown={handleKeyDown} />;
 }) as FocusScopePrimitive;
 
 FocusScope.displayName = FOCUS_SCOPE_NAME;

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -19,10 +19,6 @@ import { useMenuTypeahead, useMenuTypeaheadItem } from './useMenuTypeahead';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
-type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
-type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup>;
-
 const FIRST_KEYS = ['ArrowDown', 'PageUp', 'Home'];
 const LAST_KEYS = ['ArrowUp', 'PageDown', 'End'];
 const ALL_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
@@ -108,58 +104,30 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
   );
 }) as MenuContentPrimitive;
 
+type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
+type DismissableLayerOwnProps = Polymorphic.OwnProps<typeof DismissableLayer>;
+type RovingFocusGroupOwnProps = Polymorphic.OwnProps<typeof RovingFocusGroup>;
+
 type MenuContentImplOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof PopperPrimitive.Content>,
-  {
+  Omit<DismissableLayerOwnProps, 'onDismiss'> & {
     /**
      * Whether focus should be trapped within the `MenuContent`
      * (default: false)
      */
-    trapFocus?: FocusScopeProps['trapped'];
+    trapFocus?: FocusScopeOwnProps['trapped'];
 
     /**
      * Event handler called when auto-focusing on open.
      * Can be prevented.
      */
-    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+    onOpenAutoFocus?: FocusScopeOwnProps['onMountAutoFocus'];
 
     /**
      * Event handler called when auto-focusing on close.
      * Can be prevented.
      */
-    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-
-    /**
-     * When `true`, hover/focus/click interactions will be disabled on elements outside the `MenuContent`.
-     * Users will need to click twice on outside elements to interact with them:
-     * Once to close the `MenuContent`, and again to trigger the element.
-     */
-    disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
-
-    /**
-     * Event handler called when the escape key is down.
-     * Can be prevented.
-     */
-    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
-
-    /**
-     * Event handler called when the a pointer event happens outside of the `MenuContent`.
-     * Can be prevented.
-     */
-    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
-
-    /**
-     * Event handler called when the focus moves outside of the `MenuContent`.
-     * Can be prevented.
-     */
-    onFocusOutside?: DismissableLayerProps['onFocusOutside'];
-
-    /**
-     * Event handler called when an interaction happens outside the `MenuContent`.
-     * Specifically, when a pointer event happens outside of the `MenuContent` or focus moves outside of it.
-     * Can be prevented.
-     */
-    onInteractOutside?: DismissableLayerProps['onInteractOutside'];
+    onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
 
     /**
      * Whether scrolling outside the `MenuContent` should be prevented
@@ -171,13 +139,13 @@ type MenuContentImplOwnProps = Polymorphic.Merge<
      * The direction of navigation between menu items.
      * @defaultValue ltr
      */
-    dir?: RovingFocusGroupProps['dir'];
+    dir?: RovingFocusGroupOwnProps['dir'];
 
     /**
      * Whether keyboard navigation should loop around
      * @defaultValue false
      */
-    loop?: RovingFocusGroupProps['loop'];
+    loop?: RovingFocusGroupOwnProps['loop'];
 
     /**
      * Whether the `MenuContent` should render in a `Portal`
@@ -239,6 +207,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
           }, [])}
         >
           <FocusScope
+            as={Slot}
             // we make sure we're not trapping once it's been closed
             // (closed !== unmounted when animating out)
             trapped={trapFocus && context.open}
@@ -252,93 +221,66 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
               }
             }}
           >
-            {(focusScopeProps) => (
-              <DismissableLayer
-                disableOutsidePointerEvents={disableOutsidePointerEvents}
-                onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                  setSkipCloseAutoFocus(false);
-                })}
-                onPointerDownOutside={composeEventHandlers(
-                  onPointerDownOutside,
-                  (event) => {
-                    const originalEvent = event.detail.originalEvent as MouseEvent;
-                    const isLeftClick =
-                      originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                    setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onFocusOutside={composeEventHandlers(
-                  onFocusOutside,
-                  (event) => {
-                    // When focus is trapped, a focusout event may still happen.
-                    // We make sure we don't trigger our `onDismiss` in such case.
-                    if (trapFocus) event.preventDefault();
-                  },
-                  { checkForDefaultPrevented: false }
-                )}
-                onInteractOutside={onInteractOutside}
-                onDismiss={() => context.onOpenChange(false)}
+            <DismissableLayer
+              as={Slot}
+              disableOutsidePointerEvents={disableOutsidePointerEvents}
+              onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
+                setSkipCloseAutoFocus(false);
+              })}
+              onPointerDownOutside={composeEventHandlers(
+                onPointerDownOutside,
+                (event) => {
+                  const originalEvent = event.detail.originalEvent as MouseEvent;
+                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onFocusOutside={composeEventHandlers(
+                onFocusOutside,
+                (event) => {
+                  // When focus is trapped, a focusout event may still happen.
+                  // We make sure we don't trigger our `onDismiss` in such case.
+                  if (trapFocus) event.preventDefault();
+                },
+                { checkForDefaultPrevented: false }
+              )}
+              onInteractOutside={onInteractOutside}
+              onDismiss={() => context.onOpenChange(false)}
+            >
+              <RovingFocusGroup
+                as={Slot}
+                dir={dir}
+                orientation="vertical"
+                loop={loop}
+                currentTabStopId={currentItemId}
+                onCurrentTabStopIdChange={setCurrentItemId}
+                // we override the default behaviour which automatically focuses the first item
+                onEntryFocus={(event) => event.preventDefault()}
               >
-                {(dismissableLayerProps) => (
-                  <RovingFocusGroup
-                    as={Slot}
-                    dir={dir}
-                    orientation="vertical"
-                    loop={loop}
-                    currentTabStopId={currentItemId}
-                    onCurrentTabStopIdChange={setCurrentItemId}
-                    // we override the default behaviour which automatically focuses the first item
-                    onEntryFocus={(event) => event.preventDefault()}
-                  >
-                    <PopperPrimitive.Content
-                      role="menu"
-                      {...focusScopeProps}
-                      {...contentProps}
-                      ref={composeRefs(forwardedRef, contentRef, focusScopeProps.ref)}
-                      style={{
-                        ...dismissableLayerProps.style,
-                        outline: 'none',
-                        ...contentProps.style,
-                      }}
-                      onBlurCapture={composeEventHandlers(
-                        contentProps.onBlurCapture,
-                        dismissableLayerProps.onBlurCapture,
-                        { checkForDefaultPrevented: false }
-                      )}
-                      onFocusCapture={composeEventHandlers(
-                        contentProps.onFocusCapture,
-                        dismissableLayerProps.onFocusCapture,
-                        { checkForDefaultPrevented: false }
-                      )}
-                      onPointerDownCapture={composeEventHandlers(
-                        contentProps.onPointerDownCapture,
-                        dismissableLayerProps.onPointerDownCapture,
-                        { checkForDefaultPrevented: false }
-                      )}
-                      onKeyDownCapture={composeEventHandlers(
-                        contentProps.onKeyDownCapture,
-                        typeaheadProps.onKeyDownCapture
-                      )}
-                      // focus first/last item based on key pressed
-                      onKeyDown={composeEventHandlers(
-                        contentProps.onKeyDown,
-                        composeEventHandlers(focusScopeProps.onKeyDown, (event) => {
-                          const content = contentRef.current;
-                          if (event.target !== content) return;
-                          if (!ALL_KEYS.includes(event.key)) return;
-                          event.preventDefault();
-                          const items = getItems().filter((item) => !item.disabled);
-                          const candidateNodes = items.map((item) => item.ref.current!);
-                          if (LAST_KEYS.includes(event.key)) candidateNodes.reverse();
-                          focusFirst(candidateNodes);
-                        })
-                      )}
-                    />
-                  </RovingFocusGroup>
-                )}
-              </DismissableLayer>
-            )}
+                <PopperPrimitive.Content
+                  role="menu"
+                  {...contentProps}
+                  ref={composeRefs(forwardedRef, contentRef)}
+                  style={{ outline: 'none', ...contentProps.style }}
+                  onKeyDownCapture={composeEventHandlers(
+                    contentProps.onKeyDownCapture,
+                    typeaheadProps.onKeyDownCapture
+                  )}
+                  // focus first/last item based on key pressed
+                  onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
+                    const content = contentRef.current;
+                    if (event.target !== content) return;
+                    if (!ALL_KEYS.includes(event.key)) return;
+                    event.preventDefault();
+                    const items = getItems().filter((item) => !item.disabled);
+                    const candidateNodes = items.map((item) => item.ref.current!);
+                    if (LAST_KEYS.includes(event.key)) candidateNodes.reverse();
+                    focusFirst(candidateNodes);
+                  })}
+                />
+              </RovingFocusGroup>
+            </DismissableLayer>
           </FocusScope>
         </MenuContentProvider>
       </ScrollLockWrapper>

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -177,12 +177,11 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
     ...contentProps
   } = props;
   const context = useMenuContext(CONTENT_NAME);
-  const contentRef = React.useRef<HTMLDivElement>(null);
   const typeaheadProps = useMenuTypeahead();
   const { getItems } = useCollection();
-
   const [currentItemId, setCurrentItemId] = React.useState<string | null>(null);
   const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, contentRef);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -3,7 +3,7 @@ import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
-import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
@@ -183,6 +183,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
 
   const [currentItemId, setCurrentItemId] = React.useState<string | null>(null);
   const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -261,7 +262,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                 <PopperPrimitive.Content
                   role="menu"
                   {...contentProps}
-                  ref={composeRefs(forwardedRef, contentRef)}
+                  ref={composedRefs}
                   style={{ outline: 'none', ...contentProps.style }}
                   onKeyDownCapture={composeEventHandlers(
                     contentProps.onKeyDownCapture,

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -17,9 +17,6 @@ import { hideOthers } from 'aria-hidden';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
-type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
-
 /* -------------------------------------------------------------------------------------------------
  * Popover
  * -----------------------------------------------------------------------------------------------*/
@@ -179,59 +176,30 @@ const PopoverContent = React.forwardRef((props, forwardedRef) => {
   );
 }) as PopoverContentPrimitive;
 
+type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
+type DismissableLayerOwnProps = Polymorphic.OwnProps<typeof DismissableLayer>;
+
 type PopperPrimitiveOwnProps = Polymorphic.OwnProps<typeof PopperPrimitive.Content>;
 type PopoverContentImplOwnProps = Polymorphic.Merge<
   PopperPrimitiveOwnProps,
-  {
+  Omit<DismissableLayerOwnProps, 'onDismiss'> & {
     /**
      * Whether focus should be trapped within the `Popover`
      * (default: false)
      */
-    trapFocus?: FocusScopeProps['trapped'];
+    trapFocus?: FocusScopeOwnProps['trapped'];
 
     /**
      * Event handler called when auto-focusing on open.
      * Can be prevented.
      */
-    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+    onOpenAutoFocus?: FocusScopeOwnProps['onMountAutoFocus'];
 
     /**
      * Event handler called when auto-focusing on close.
      * Can be prevented.
      */
-    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-
-    /**
-     * When `true`, hover/focus/click interactions will be disabled on elements outside the `Popover`.
-     * Users will need to click twice on outside elements to interact with them:
-     * Once to close the `Popover`, and again to trigger the element.
-     */
-    disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'];
-
-    /**
-     * Event handler called when the escape key is down.
-     * Can be prevented.
-     */
-    onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
-
-    /**
-     * Event handler called when the a pointer event happens outside of the `Popover`.
-     * Can be prevented.
-     */
-    onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
-
-    /**
-     * Event handler called when the focus moves outside of the `Popover`.
-     * Can be prevented.
-     */
-    onFocusOutside?: DismissableLayerProps['onFocusOutside'];
-
-    /**
-     * Event handler called when an interaction happens outside the `Popover`.
-     * Specifically, when a pointer event happens outside of the `Popover` or focus moves outside of it.
-     * Can be prevented.
-     */
-    onInteractOutside?: DismissableLayerProps['onInteractOutside'];
+    onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
 
     /**
      * Whether scrolling outside the `Popover` should be prevented
@@ -287,6 +255,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     <PortalWrapper>
       <ScrollLockWrapper>
         <FocusScope
+          as={Slot}
           // we make sure we're not trapping once it's been closed
           // (closed !== unmounted when animating out)
           trapped={trapFocus && context.open}
@@ -299,77 +268,53 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
             }
           }}
         >
-          {(focusScopeProps) => (
-            <DismissableLayer
-              disableOutsidePointerEvents={disableOutsidePointerEvents}
-              onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                setSkipCloseAutoFocus(false);
-              })}
-              onPointerDownOutside={composeEventHandlers(
-                onPointerDownOutside,
-                (event) => {
-                  const originalEvent = event.detail.originalEvent as MouseEvent;
-                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                  setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
+          <DismissableLayer
+            as={Slot}
+            disableOutsidePointerEvents={disableOutsidePointerEvents}
+            onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
+              setSkipCloseAutoFocus(false);
+            })}
+            onPointerDownOutside={composeEventHandlers(
+              onPointerDownOutside,
+              (event) => {
+                const originalEvent = event.detail.originalEvent as MouseEvent;
+                const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+                setSkipCloseAutoFocus(!disableOutsidePointerEvents && isLeftClick);
 
-                  const targetIsTrigger = context.triggerRef.current?.contains(
-                    event.target as HTMLElement
-                  );
-                  // prevent dismissing when clicking the trigger
-                  // as it's already setup to close, otherwise it would close and immediately open.
-                  if (targetIsTrigger) event.preventDefault();
-                },
-                { checkForDefaultPrevented: false }
-              )}
-              onFocusOutside={composeEventHandlers(
-                onFocusOutside,
-                (event) => {
-                  // When focus is trapped, a focusout event may still happen.
-                  // We make sure we don't trigger our `onDismiss` in such case.
-                  if (trapFocus) event.preventDefault();
-                },
-                { checkForDefaultPrevented: false }
-              )}
-              onInteractOutside={onInteractOutside}
-              onDismiss={() => context.onOpenChange(false)}
-            >
-              {(dismissableLayerProps) => (
-                <PopperPrimitive.Content
-                  role="dialog"
-                  aria-modal
-                  id={context.contentId}
-                  {...focusScopeProps}
-                  {...contentProps}
-                  ref={composeRefs(forwardedRef, contentRef, focusScopeProps.ref)}
-                  onKeyDown={composeEventHandlers(
-                    contentProps.onKeyDown,
-                    focusScopeProps.onKeyDown
-                  )}
-                  style={{
-                    ...dismissableLayerProps.style,
-                    ...contentProps.style,
-                    // re-namespace exposed content custom property
-                    ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-                  }}
-                  onBlurCapture={composeEventHandlers(
-                    contentProps.onBlurCapture,
-                    dismissableLayerProps.onBlurCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onFocusCapture={composeEventHandlers(
-                    contentProps.onFocusCapture,
-                    dismissableLayerProps.onFocusCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                  onPointerDownCapture={composeEventHandlers(
-                    contentProps.onPointerDownCapture,
-                    dismissableLayerProps.onPointerDownCapture,
-                    { checkForDefaultPrevented: false }
-                  )}
-                />
-              )}
-            </DismissableLayer>
-          )}
+                const targetIsTrigger = context.triggerRef.current?.contains(
+                  event.target as HTMLElement
+                );
+                // prevent dismissing when clicking the trigger
+                // as it's already setup to close, otherwise it would close and immediately open.
+                if (targetIsTrigger) event.preventDefault();
+              },
+              { checkForDefaultPrevented: false }
+            )}
+            onFocusOutside={composeEventHandlers(
+              onFocusOutside,
+              (event) => {
+                // When focus is trapped, a focusout event may still happen.
+                // We make sure we don't trigger our `onDismiss` in such case.
+                if (trapFocus) event.preventDefault();
+              },
+              { checkForDefaultPrevented: false }
+            )}
+            onInteractOutside={onInteractOutside}
+            onDismiss={() => context.onOpenChange(false)}
+          >
+            <PopperPrimitive.Content
+              role="dialog"
+              aria-modal
+              id={context.contentId}
+              {...contentProps}
+              ref={composeRefs(forwardedRef, contentRef)}
+              style={{
+                ...contentProps.style,
+                // re-namespace exposed content custom property
+                ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+              }}
+            />
+          </DismissableLayer>
         </FocusScope>
       </ScrollLockWrapper>
     </PortalWrapper>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as PopperPrimitive from '@radix-ui/react-popper';
@@ -236,6 +236,8 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   } = props;
   const context = usePopoverContext(CONTENT_NAME);
   const [skipCloseAutoFocus, setSkipCloseAutoFocus] = React.useState(false);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -245,7 +247,6 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   useFocusGuards();
 
   // Hide everything from ARIA except the content
-  const contentRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const content = contentRef.current;
     if (content) return hideOthers(content);
@@ -307,7 +308,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
               aria-modal
               id={context.contentId}
               {...contentProps}
-              ref={composeRefs(forwardedRef, contentRef)}
+              ref={composedRefs}
               style={{
                 ...contentProps.style,
                 // re-namespace exposed content custom property

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -74,14 +74,18 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
   // all child props should override
   const overrideProps = { ...childProps };
 
-  // if it's a handler, modify the override by composing the base handler
   for (const propName in childProps) {
     const slotPropValue = slotProps[propName];
     const childPropValue = childProps[propName];
-    const isHandler = /^on[A-Z]/.test(propName);
 
+    const isHandler = /^on[A-Z]/.test(propName);
+    // if it's a handler, modify the override by composing the base handler
     if (isHandler) {
       overrideProps[propName] = composeHandlers(childPropValue, slotPropValue);
+    }
+    // if it's `style`, we merge them
+    else if (propName === 'style') {
+      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3433,6 +3433,7 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0
@@ -3447,6 +3448,9 @@ __metadata:
   resolution: "@radix-ui/react-dismissable-layer@workspace:packages/react/dismissable-layer"
   dependencies:
     "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-polymorphic": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-body-pointer-events": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-escape-keydown": "workspace:*"
@@ -3490,6 +3494,9 @@ __metadata:
   resolution: "@radix-ui/react-focus-scope@workspace:packages/react/focus-scope"
   dependencies:
     "@babel/runtime": ^7.13.10
+    "@radix-ui/react-compose-refs": "workspace:*"
+    "@radix-ui/react-polymorphic": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
> Note: Easier to review without whitespace.

Another preliminary PR for the upcoming modality changes.

@jjenzz and I had discussed this at some point, and it's easier to do it now, rather than in the midst of everything else.
It rejigs `FocusScope` and `DismissableLayer` as self-contained primitives using our usual paradigm.
This has the effect of simplifying how they are composed externally as previously render props made it look almost like leaky abstractions.