### PR TITLE
[DismissableLayer] Remove `onInteractOutside` and rename `onFocusOutside` to `onFocusLeave` 🔥 

### DIFF
--- a/.yarn/versions/b475d886.yml
+++ b/.yarn/versions/b475d886.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -174,7 +174,7 @@ type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 type DialogContentImplOwnProps = Polymorphic.Merge<
   Omit<
     Polymorphic.OwnProps<typeof DismissableLayer>,
-    'disableOutsidePointerEvents' | 'onFocusOutside' | 'onInteractOutside' | 'onDismiss'
+    'disableOutsidePointerEvents' | 'onFocusLeave' | 'onDismiss'
   >,
   {
     /**
@@ -248,9 +248,9 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
               // it is effectively as if we right-clicked the `Overlay`.
               if (isRightClick) event.preventDefault();
             })}
-            // When focus is trapped, a focusout event may still happen.
+            // When focus is trapped, the focus may still leave temporarily.
             // We make sure we don't trigger our `onDismiss` in such case.
-            onFocusOutside={(event) => event.preventDefault()}
+            onFocusLeave={(event) => event.preventDefault()}
             onDismiss={() => context.onOpenChange(false)}
           />
         </FocusScope>

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -88,7 +88,7 @@ export const Basic = () => {
               event.preventDefault();
             }
           }}
-          onFocusOutside={(event) => {
+          onFocusLeave={(event) => {
             if (dismissOnFocusOutside === false) {
               event.preventDefault();
             }
@@ -215,7 +215,7 @@ function DismissableBox(props: DismissableBoxProps) {
               event.preventDefault();
             }
           }}
-          onFocusOutside={(event) => event.preventDefault()}
+          onFocusLeave={(event) => event.preventDefault()}
           onDismiss={() => setOpen(false)}
         />
       ) : null}
@@ -438,8 +438,8 @@ export const PopoverNested = () => (
     <div style={{ display: 'flex', gap: 10 }}>
       <DummyPopover
         disableOutsidePointerEvents
-        onInteractOutside={(event) => {
-          console.log('interact outside black');
+        onPointerDownOutside={(event) => {
+          console.log('pointerdown outside black');
         }}
       >
         <DummyPopover
@@ -447,8 +447,8 @@ export const PopoverNested = () => (
           openLabel="Open red"
           closeLabel="Close red"
           // disableOutsidePointerEvents
-          onInteractOutside={(event) => {
-            console.log('interact outside red');
+          onPointerDownOutside={(event) => {
+            console.log('pointerdown outside red');
           }}
         >
           <DummyPopover
@@ -456,8 +456,8 @@ export const PopoverNested = () => (
             openLabel="Open blue"
             closeLabel="Close blue"
             disableOutsidePointerEvents
-            onInteractOutside={(event) => {
-              console.log('interact outside blue');
+            onPointerDownOutside={(event) => {
+              console.log('pointerdown outside blue');
             }}
           ></DummyPopover>
         </DummyPopover>
@@ -564,8 +564,7 @@ function DummyPopover({
   trapped = true,
   onEscapeKeyDown,
   onPointerDownOutside,
-  onFocusOutside,
-  onInteractOutside,
+  onFocusLeave,
   disableOutsidePointerEvents = false,
   preventScroll = false,
 }: DummyPopoverProps) {
@@ -599,8 +598,7 @@ function DummyPopover({
                     onPointerDownOutside?.(event);
                   }
                 }}
-                onFocusOutside={onFocusOutside}
-                onInteractOutside={onInteractOutside}
+                onFocusLeave={onFocusLeave}
                 onDismiss={() => setOpen(false)}
               >
                 <FocusScope

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -15,8 +15,8 @@ const [TotalLayerCountProvider, useTotalLayerCount] = createTotalLayerCount();
 const [RunningLayerCountProvider, usePreviousRunningLayerCount] = createRunningLayerCount();
 
 // We need to compute the total count of layers which set `disableOutsidePointerEvents` to `true` AND
-// a running count of all the layers which set `disableOutsidePointerEvents` to `true` in order to determine
-// which layers should be dismissed when interacting outside.
+// a running count of all the layers which set `disableOutsidePointerEvents` to `true` in order to
+// determine which layers should be dismissed when interacting outside.
 // (ie. all layers that do not have a child layer which sets `disableOutsidePointerEvents` to `true`)
 const [
   TotalLayerCountWithDisabledOutsidePointerEventsProvider,
@@ -75,23 +75,16 @@ type DismissableLayerImplOwnProps = Polymorphic.Merge<
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
 
     /**
-     * Event handler called when the a pointer event happens outside of the `DismissableLayer`.
+     * Event handler called when the a `pointerdown` event happens outside of the `DismissableLayer`.
      * Can be prevented.
      */
     onPointerDownOutside?: (event: PointerDownOutsideEvent) => void;
 
     /**
-     * Event handler called when the focus moves outside of the `DismissableLayer`.
+     * Event handler called when the focus leaves the `DismissableLayer`'s react subtree.
      * Can be prevented.
      */
-    onFocusOutside?: (event: React.FocusEvent) => void;
-
-    /**
-     * Event handler called when an interaction happens outside the `DismissableLayer`.
-     * Specifically, when a pointer event happens outside of the `DismissableLayer` or focus moves outside of it.
-     * Can be prevented.
-     */
-    onInteractOutside?: (event: PointerDownOutsideEvent | React.FocusEvent) => void;
+    onFocusLeave?: (event: React.FocusEvent) => void;
 
     /** Callback called when the `DismissableLayer` should be dismissed */
     onDismiss?: () => void;
@@ -108,8 +101,7 @@ const DismissableLayerImpl = React.forwardRef((props, forwardedRef) => {
     disableOutsidePointerEvents = false,
     onEscapeKeyDown,
     onPointerDownOutside,
-    onFocusOutside,
-    onInteractOutside,
+    onFocusLeave,
     onDismiss,
     ...layerProps
   } = props;
@@ -149,7 +141,6 @@ const DismissableLayerImpl = React.forwardRef((props, forwardedRef) => {
     // Only dismiss if there's no deeper layer which disabled pointer events outside itself
     if (!containsChildLayerWithDisabledOutsidePointerEvents) {
       onPointerDownOutside?.(event);
-      onInteractOutside?.(event);
       if (!event.defaultPrevented) {
         onDismiss?.();
       }
@@ -157,10 +148,9 @@ const DismissableLayerImpl = React.forwardRef((props, forwardedRef) => {
   });
 
   // Dismiss on focus outside
-  const { onBlurCapture: handleBlurCapture, onFocusCapture: handleFocusCapture } = useFocusOutside(
+  const { onBlurCapture: handleBlurCapture, onFocusCapture: handleFocusCapture } = useFocusLeave(
     (event) => {
-      onFocusOutside?.(event);
-      onInteractOutside?.(event);
+      onFocusLeave?.(event);
       if (!event.defaultPrevented) {
         onDismiss?.();
       }
@@ -254,10 +244,10 @@ function usePointerDownOutside(
 }
 
 /**
- * Listens for when focus moves outside a react subtree.
+ * Listens for when focus leaves a react subtree.
  * Returns props to pass to the root (node) of the subtree we want to check.
  */
-function useFocusOutside(onFocusOutside?: (event: React.FocusEvent) => void) {
+function useFocusLeave(onFocusLeave?: (event: React.FocusEvent) => void) {
   const timerRef = React.useRef<number>(0);
 
   // Cleanup timer if an unmount occurs before onFocusCapture fires
@@ -269,7 +259,7 @@ function useFocusOutside(onFocusOutside?: (event: React.FocusEvent) => void) {
     onBlurCapture: (event: React.FocusEvent) => {
       event.persist();
       timerRef.current = window.setTimeout(() => {
-        onFocusOutside?.(event);
+        onFocusLeave?.(event);
       }, 0);
     },
     onFocusCapture: () => {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -170,8 +170,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
     disableOutsidePointerEvents,
     onEscapeKeyDown,
     onPointerDownOutside,
-    onFocusOutside,
-    onInteractOutside,
+    onFocusLeave,
     disableOutsideScroll,
     portalled,
     ...contentProps
@@ -236,16 +235,15 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                 },
                 { checkForDefaultPrevented: false }
               )}
-              onFocusOutside={composeEventHandlers(
-                onFocusOutside,
+              onFocusLeave={composeEventHandlers(
+                onFocusLeave,
                 (event) => {
-                  // When focus is trapped, a focusout event may still happen.
+                  // When focus is trapped, the focus may still leave temporarily.
                   // We make sure we don't trigger our `onDismiss` in such case.
                   if (trapFocus) event.preventDefault();
                 },
                 { checkForDefaultPrevented: false }
               )}
-              onInteractOutside={onInteractOutside}
               onDismiss={() => context.onOpenChange(false)}
             >
               <RovingFocusGroup

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -228,8 +228,7 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     disableOutsidePointerEvents = false,
     onEscapeKeyDown,
     onPointerDownOutside,
-    onFocusOutside,
-    onInteractOutside,
+    onFocusLeave,
     disableOutsideScroll = false,
     portalled = true,
     ...contentProps
@@ -291,16 +290,15 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
               },
               { checkForDefaultPrevented: false }
             )}
-            onFocusOutside={composeEventHandlers(
-              onFocusOutside,
+            onFocusLeave={composeEventHandlers(
+              onFocusLeave,
               (event) => {
-                // When focus is trapped, a focusout event may still happen.
+                // When focus is trapped, the focus may still leave temporarily.
                 // We make sure we don't trigger our `onDismiss` in such case.
                 if (trapFocus) event.preventDefault();
               },
               { checkForDefaultPrevented: false }
             )}
-            onInteractOutside={onInteractOutside}
             onDismiss={() => context.onOpenChange(false)}
           >
             <PopperPrimitive.Content


### PR DESCRIPTION
Something I had discussed with @jjenzz, I regretted adding `onInteractOutside` as a convenience for the already 2 existing callbacks, as it's mostly unnecessary and gives a weird handler signature (both types of events) so I've decided to remove it.

Additionally, it dawned on me that `onFocusOutside` isn't actually accurate as it's not a focus event happening outside, but rather a focus event leaving a particular subtree so I'm renaming it to `onFocusLeave` which is much more accurate.

> Note for docs updates:

- 🔥 Remove `onInteractOutside` from all concerned components
- 🔥 Rename `onFocusOutside` to `onFocusLeave` on all concerned components 