### PR TITLE
[Slider] Prevent form change event on initial render

### DIFF
--- a/.yarn/versions/f5ce1c6e.yml
+++ b/.yarn/versions/f5ce1c6e.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-slider": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -57,10 +57,11 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
   } = props;
   const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
   const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
-  const buttonSize = useSize(button);
   const labelId = useLabelContext(button);
   const labelledBy = ariaLabelledby || labelId;
   const hasConsumerStoppedPropagationRef = React.useRef(false);
+  // We set this to true by default so that events bubble to forms without JS (SSR)
+  const isFormControl = button ? button.closest('form') : true;
   const [checked = false, setChecked] = useControllableState({
     prop: checkedProp,
     defaultProp: defaultChecked,
@@ -84,28 +85,27 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
         ref={composedRefs}
         onClick={composeEventHandlers(props.onClick, (event) => {
           setChecked((prevChecked) => (prevChecked === 'indeterminate' ? true : !prevChecked));
-          hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
-          // Stop propagation from the button so that we only propagate one click event (from the input).
-          // We propagate changes from an input so that form events reflect checkbox updates.
-          if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+          if (isFormControl) {
+            hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+            // if checkxbox is in a form, stop propagation from the button so that we only propagate
+            // one click event (from the input). We propagate changes from an input so that native
+            // form validation works and form events reflect checkbox updates.
+            if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+          }
         })}
       />
-      <BubbleInput
-        stoppedPropagation={hasConsumerStoppedPropagationRef.current}
-        name={name}
-        value={value}
-        checked={checked}
-        required={required}
-        disabled={disabled}
-        style={{
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-          transform: 'translateX(-100%)',
-          ...buttonSize,
-        }}
-      />
+      {isFormControl && (
+        <BubbleInput
+          control={button}
+          stoppedPropagation={hasConsumerStoppedPropagationRef.current}
+          name={name}
+          value={value}
+          checked={checked}
+          required={required}
+          disabled={disabled}
+          style={{ transform: 'translateX(-100%)' }}
+        />
+      )}
     </CheckboxProvider>
   );
 }) as CheckboxPrimitive;
@@ -158,13 +158,15 @@ CheckboxIndicator.displayName = INDICATOR_NAME;
 
 type BubbleInputProps = Omit<React.ComponentProps<'input'>, 'checked'> & {
   checked: CheckedState;
+  control: HTMLElement | null;
   stoppedPropagation: boolean;
 };
 
 const BubbleInput = (props: BubbleInputProps) => {
-  const { stoppedPropagation, checked, ...inputProps } = props;
+  const { control, checked, stoppedPropagation, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const prevChecked = usePrevious(checked);
+  const controlSize = useSize(control);
 
   // Bubble checked change to parents (e.g form change event)
   React.useEffect(() => {
@@ -179,9 +181,24 @@ const BubbleInput = (props: BubbleInputProps) => {
       setChecked.call(input, isIndeterminate ? false : checked);
       input.dispatchEvent(event);
     }
-  }, [prevChecked, stoppedPropagation, checked]);
+  }, [prevChecked, checked, stoppedPropagation]);
 
-  return <input type="checkbox" {...inputProps} tabIndex={-1} ref={ref} />;
+  return (
+    <input
+      type="checkbox"
+      {...inputProps}
+      tabIndex={-1}
+      ref={ref}
+      style={{
+        ...props.style,
+        ...controlSize,
+        position: 'absolute',
+        pointerEvents: 'none',
+        opacity: 0,
+        margin: 0,
+      }}
+    />
+  );
 };
 
 function getState(checked: CheckedState) {

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -61,7 +61,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
   const labelledBy = ariaLabelledby || labelId;
   const hasConsumerStoppedPropagationRef = React.useRef(false);
   // We set this to true by default so that events bubble to forms without JS (SSR)
-  const isFormControl = button ? button.closest('form') : true;
+  const isFormControl = button ? Boolean(button.closest('form')) : true;
   const [checked = false, setChecked] = useControllableState({
     prop: checkedProp,
     defaultProp: defaultChecked,
@@ -87,7 +87,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
           setChecked((prevChecked) => (prevChecked === 'indeterminate' ? true : !prevChecked));
           if (isFormControl) {
             hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
-            // if checkxbox is in a form, stop propagation from the button so that we only propagate
+            // if checkbox is in a form, stop propagation from the button so that we only propagate
             // one click event (from the input). We propagate changes from an input so that native
             // form validation works and form events reflect checkbox updates.
             if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
@@ -103,6 +103,9 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
           checked={checked}
           required={required}
           disabled={disabled}
+          // We transform because the input is absolutely positioned but we have
+          // rendered it **after** the button. This pulls it back to sit on top
+          // of the button.
           style={{ transform: 'translateX(-100%)' }}
         />
       )}

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -27,7 +27,12 @@
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "@radix-ui/react-use-direction": "workspace:*",
+    "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-use-size": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/form-serialize": "^0",
+    "form-serialize": "^0.7.2"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0"

--- a/packages/react/slider/src/Slider.stories.tsx
+++ b/packages/react/slider/src/Slider.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Slider, SliderTrack, SliderRange, SliderThumb } from './Slider';
 import { css } from '../../../../stitches.config';
+import serialize from 'form-serialize';
 
 export default { title: 'Components/Slider' };
 
@@ -133,6 +134,45 @@ export const SmallSteps = () => {
       </Slider>
       <div>{value}</div>
     </>
+  );
+};
+
+export const WithinForm = () => {
+  const [data, setData] = React.useState({ single: [0], multiple: [10, 15, 20, 80] });
+  return (
+    <form
+      onSubmit={(event) => event.preventDefault()}
+      onChange={(event) => {
+        const formData = serialize(event.currentTarget, { hash: true });
+        setData(formData as any);
+      }}
+    >
+      <fieldset>
+        <legend>Single value: {String(data.single)}</legend>
+        <Slider name="single" defaultValue={data.single} className={rootClass}>
+          <SliderTrack className={trackClass}>
+            <SliderRange className={rangeClass} />
+          </SliderTrack>
+          <SliderThumb className={thumbClass} />
+        </Slider>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>Multiple value: {String(data.multiple)}</legend>
+        <Slider name="multiple" defaultValue={data.multiple} className={rootClass}>
+          <SliderTrack className={trackClass}>
+            <SliderRange className={rangeClass} />
+          </SliderTrack>
+          <SliderThumb className={thumbClass} />
+          <SliderThumb className={thumbClass} />
+          <SliderThumb className={thumbClass} />
+          <SliderThumb className={thumbClass} />
+        </Slider>
+      </fieldset>
+    </form>
   );
 };
 

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -6,6 +6,7 @@ import { createContext } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useDirection } from '@radix-ui/react-use-direction';
+import { usePrevious } from '@radix-ui/react-use-previous';
 import { useSize } from '@radix-ui/react-use-size';
 import { Primitive } from '@radix-ui/react-primitive';
 import { createCollection } from './collection';
@@ -79,11 +80,13 @@ const Slider = React.forwardRef((props, forwardedRef) => {
     onValueChange = () => {},
     ...sliderProps
   } = props;
-  const sliderRef = React.useRef<HTMLSpanElement>(null);
-  const composedRefs = useComposedRefs(forwardedRef, sliderRef);
+  const [slider, setSlider] = React.useState<HTMLSpanElement | null>(null);
+  const composedRefs = useComposedRefs(forwardedRef, (node) => setSlider(node));
   const thumbRefs = React.useRef<SliderContextValue['thumbs']>(new Set());
   const valueIndexToChangeRef = React.useRef<number>(0);
   const isHorizontal = orientation === 'horizontal';
+  // We set this to true by default so that events bubble to forms without JS (SSR)
+  const isFormControl = slider ? slider.closest('form') : true;
   const SliderOrientation = isHorizontal ? SliderHorizontal : SliderVertical;
 
   const [values = [], setValues] = useControllableState({
@@ -173,14 +176,13 @@ const Slider = React.forwardRef((props, forwardedRef) => {
             }
           }}
         />
-
-        {/**
-         * When consumer provides `name`, they are most likely uncontrolling so
-         * we render `input`s that will bubble the value change.
-         */}
-        {name &&
+        {isFormControl &&
           values.map((value, index) => (
-            <BubbleInput key={index} name={name + (values.length > 1 ? '[]' : '')} value={value} />
+            <BubbleInput
+              key={index}
+              name={name ? name + (values.length > 1 ? '[]' : '') : undefined}
+              value={value}
+            />
           ))}
       </SliderCollectionProvider>
     </SliderProvider>
@@ -653,19 +655,20 @@ SliderThumb.displayName = THUMB_NAME;
 const BubbleInput = (props: React.ComponentProps<'input'>) => {
   const { value, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
+  const prevValue = usePrevious(value);
 
   // Bubble value change to parents (e.g form change event)
   React.useEffect(() => {
     const input = ref.current!;
     const inputProto = window.HTMLInputElement.prototype;
-    const { set } = Object.getOwnPropertyDescriptor(inputProto, 'value') as PropertyDescriptor;
-
-    if (set) {
+    const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'value') as PropertyDescriptor;
+    const setValue = descriptor.set;
+    if (prevValue !== value && setValue) {
       const event = new Event('input', { bubbles: true });
-      set.call(input, value);
+      setValue.call(input, value);
       input.dispatchEvent(event);
     }
-  }, [value]);
+  }, [prevValue, value]);
 
   /**
    * We purposefully do not use `type="hidden"` here otherwise forms that
@@ -676,7 +679,7 @@ const BubbleInput = (props: React.ComponentProps<'input'>) => {
    * Adding the `value` will cause React to consider the programatic
    * dispatch a duplicate and it will get swallowed.
    */
-  return <input style={{ display: 'none' }} {...inputProps} ref={ref} />;
+  return <input style={{ display: 'none' }} {...inputProps} ref={ref} defaultValue={value} />;
 };
 
 function getNextSortedValues(prevValues: number[] = [], nextValue: number, atIndex: number) {

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -86,7 +86,7 @@ const Slider = React.forwardRef((props, forwardedRef) => {
   const valueIndexToChangeRef = React.useRef<number>(0);
   const isHorizontal = orientation === 'horizontal';
   // We set this to true by default so that events bubble to forms without JS (SSR)
-  const isFormControl = slider ? slider.closest('form') : true;
+  const isFormControl = slider ? Boolean(slider.closest('form')) : true;
   const SliderOrientation = isHorizontal ? SliderHorizontal : SliderVertical;
 
   const [values = [], setValues] = useControllableState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3579,7 +3579,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-polymorphic@workspace:packages/react/polymorphic"
   dependencies:
-    "@babel/runtime": ^7.13.10
     "@testing-library/react": ^10.4.8
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -3770,7 +3769,10 @@ __metadata:
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     "@radix-ui/react-use-direction": "workspace:*"
+    "@radix-ui/react-use-previous": "workspace:*"
     "@radix-ui/react-use-size": "workspace:*"
+    "@types/form-serialize": ^0
+    form-serialize: ^0.7.2
   peerDependencies:
     react: ^16.8 || ^17.0
   languageName: unknown
@@ -4831,6 +4833,13 @@ __metadata:
   version: 0.0.46
   resolution: "@types/estree@npm:0.0.46"
   checksum: 69fcf647706f5b6a475ec2f9aacf73b40866f577eef6c6f33de95cc3b4897381c2a8257646f13cd5d91fffc5debfe6289b6864ba29ad349ae68703f8b993c9f6
+  languageName: node
+  linkType: hard
+
+"@types/form-serialize@npm:^0":
+  version: 0.7.1
+  resolution: "@types/form-serialize@npm:0.7.1"
+  checksum: 82bf3b5944804caaf6759b36770a6706834bf0101d6a3f420682f0df1b6b512252dce2321551c4d757e796d53a84cd6380d7f0529c57a0f7997ba951952792fe
   languageName: node
   linkType: hard
 
@@ -10351,6 +10360,13 @@ __metadata:
     combined-stream: ^1.0.6
     mime-types: ^2.1.12
   checksum: 862e686b105634222db77138d5f5ae08ba85f88c04925de5be86b2b9d03cf671d86566ad10f1dd5217634c0f1634069dfc1a663a1cc13e8fbac0ce8f670ad070
+  languageName: node
+  linkType: hard
+
+"form-serialize@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "form-serialize@npm:0.7.2"
+  checksum: 8de6b74d7f2423fe117d04a50bceea1fafa05227285580be637c7df5387d4411fdcb53b3112d25b1ccd1f0a773f358a44a262368daba4b2838e393730349363f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds `usePrevious` to prevent `BubbleInput` from bubbling change on initial render
- Adds an `isFormControl` check to `Slider` and `Checkbox` so that `BubbleInput` only renders if these controls are used in forms
- Added stories to show form change event working (multiple thumb version was strangely satisfying to play with 😄 ).

https://user-images.githubusercontent.com/175330/120327568-cdbbd000-c2e1-11eb-8ef6-998e1cf7746b.mp4

