### PR TITLE
[ContextMenu][DropdownMenu] Add `TriggerItem` part

### DIFF
--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuGroup,
   ContextMenuLabel,
   ContextMenuItem,
+  ContextMenuTriggerItem,
   ContextMenuCheckboxItem,
   ContextMenuRadioGroup,
   ContextMenuRadioItem,
@@ -100,7 +101,7 @@ export const Submenus = () => {
             </ContextMenuItem>
             <ContextMenuSeparator className={separatorClass} />
             <ContextMenu>
-              <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+              <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
               <ContextMenuContent className={contentClass} offset={12}>
                 <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
                   One
@@ -110,7 +111,9 @@ export const Submenus = () => {
                 </ContextMenuItem>
                 <ContextMenuSeparator className={separatorClass} />
                 <ContextMenu>
-                  <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+                  <ContextMenuTriggerItem className={subTriggerClass}>
+                    Submenu →
+                  </ContextMenuTriggerItem>
                   <ContextMenuContent className={contentClass} offset={12}>
                     <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
                       One

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -377,7 +377,7 @@ export const Nested = () => (
             </ContextMenuItem>
             <ContextMenuSeparator className={separatorClass} />
             <ContextMenu>
-              <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+              <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
               <ContextMenuContent className={contentClass} offset={12}>
                 <ContextMenuItem
                   className={itemClass}
@@ -408,7 +408,7 @@ export const Nested = () => (
         </ContextMenuItem>
         <ContextMenuSeparator className={separatorClass} />
         <ContextMenu>
-          <ContextMenuTrigger className={subTriggerClass}>Submenu →</ContextMenuTrigger>
+          <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
           <ContextMenuContent className={contentClass} offset={12}>
             <ContextMenuItem
               className={itemClass}

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -106,48 +106,15 @@ ContextMenu.displayName = CONTEXT_MENU_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TRIGGER_NAME = 'ContextMenuTrigger';
+const TRIGGER_DEFAULT_TAG = 'span';
 
-type ContextMenuTriggerOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof ContextMenuRootTrigger>,
-  Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>
->;
+type ContextMenuTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
 type ContextMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof ContextMenuRootTrigger>,
+  typeof TRIGGER_DEFAULT_TAG,
   ContextMenuTriggerOwnProps
 >;
 
 const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
-  const { as, ...triggerProps } = props;
-  const isSubmenu = React.useContext(SubmenuContext);
-
-  return (
-    <InsideContentContext.Provider value={false}>
-      {isSubmenu ? (
-        <MenuPrimitive.SubTrigger
-          {...triggerProps}
-          as={as as Polymorphic.IntrinsicElement<typeof ContextMenuRootTrigger>}
-          ref={forwardedRef}
-        />
-      ) : (
-        <ContextMenuRootTrigger {...triggerProps} as={as} ref={forwardedRef} />
-      )}
-    </InsideContentContext.Provider>
-  );
-}) as ContextMenuTriggerPrimitive;
-
-ContextMenuTrigger.displayName = TRIGGER_NAME;
-
-/* ---------------------------------------------------------------------------------------------- */
-
-const TRIGGER_DEFAULT_TAG = 'span';
-
-type ContextMenuRootTriggerOwnProps = Polymorphic.OwnProps<typeof Primitive>;
-type ContextMenuRootTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  typeof TRIGGER_DEFAULT_TAG,
-  ContextMenuRootTriggerOwnProps
->;
-
-const ContextMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useContextMenuContext(TRIGGER_NAME);
   const pointRef = React.useRef<Point>({ x: 0, y: 0 });
@@ -156,7 +123,7 @@ const ContextMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
   });
 
   return (
-    <>
+    <InsideContentContext.Provider value={false}>
       <MenuPrimitive.Anchor virtualRef={virtualRef} />
       <Primitive
         {...triggerProps}
@@ -168,9 +135,11 @@ const ContextMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
           context.onOpenChange(true);
         })}
       />
-    </>
+    </InsideContentContext.Provider>
   );
-}) as ContextMenuRootTriggerPrimitive;
+}) as ContextMenuTriggerPrimitive;
+
+ContextMenuTrigger.displayName = TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * ContextMenuContent
@@ -235,6 +204,25 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 
 ContextMenuContent.displayName = CONTENT_NAME;
 
+/* -------------------------------------------------------------------------------------------------
+ * ContextMenuTriggerItem
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_ITEM_NAME = 'ContextMenuTriggerItem';
+
+type ContextMenuTriggerItemOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>;
+type ContextMenuTriggerItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.SubTrigger>,
+  ContextMenuTriggerItemOwnProps
+>;
+
+const ContextMenuTriggerItem = React.forwardRef((props, forwardedRef) => {
+  const isSubmenu = React.useContext(SubmenuContext);
+  return isSubmenu ? <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} /> : null;
+}) as ContextMenuTriggerItemPrimitive;
+
+ContextMenuTriggerItem.displayName = TRIGGER_ITEM_NAME;
+
 /* ---------------------------------------------------------------------------------------------- */
 
 const ContextMenuGroup = extendPrimitive(MenuPrimitive.Group, { displayName: 'ContextMenuGroup' });
@@ -267,6 +255,7 @@ const Content = ContextMenuContent;
 const Group = ContextMenuGroup;
 const Label = ContextMenuLabel;
 const Item = ContextMenuItem;
+const TriggerItem = ContextMenuTriggerItem;
 const CheckboxItem = ContextMenuCheckboxItem;
 const RadioGroup = ContextMenuRadioGroup;
 const RadioItem = ContextMenuRadioItem;
@@ -281,6 +270,7 @@ export {
   ContextMenuGroup,
   ContextMenuLabel,
   ContextMenuItem,
+  ContextMenuTriggerItem,
   ContextMenuCheckboxItem,
   ContextMenuRadioGroup,
   ContextMenuRadioItem,
@@ -294,6 +284,7 @@ export {
   Group,
   Label,
   Item,
+  TriggerItem,
   CheckboxItem,
   RadioGroup,
   RadioItem,
@@ -301,4 +292,8 @@ export {
   Separator,
   Arrow,
 };
-export type { ContextMenuTriggerPrimitive, ContextMenuContentPrimitive };
+export type {
+  ContextMenuTriggerPrimitive,
+  ContextMenuContentPrimitive,
+  ContextMenuTriggerItemPrimitive,
+};

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuItem,
+  DropdownMenuTriggerItem,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -75,7 +76,9 @@ export const Submenus = () => {
             </DropdownMenuItem>
             <DropdownMenuSeparator className={separatorClass} />
             <DropdownMenu>
-              <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+              <DropdownMenuTriggerItem className={subTriggerClass}>
+                Submenu →
+              </DropdownMenuTriggerItem>
               <DropdownMenuContent className={contentClass} sideOffset={12}>
                 <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
                   One
@@ -86,7 +89,9 @@ export const Submenus = () => {
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className={separatorClass} />
                 <DropdownMenu>
-                  <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                  <DropdownMenuTriggerItem className={subTriggerClass}>
+                    Submenu →
+                  </DropdownMenuTriggerItem>
                   <DropdownMenuContent className={contentClass} sideOffset={12}>
                     <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
                       One

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -75,47 +75,18 @@ DropdownMenu.displayName = DROPDOWN_MENU_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TRIGGER_NAME = 'DropdownMenuTrigger';
+const TRIGGER_DEFAULT_TAG = 'button';
 
-type DropdownMenuTriggerOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof DropdownMenuRootTrigger>,
-  Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>
+type DropdownMenuTriggerOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuPrimitive.Anchor>,
+  'virtualRef'
 >;
 type DropdownMenuTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof DropdownMenuRootTrigger>,
+  typeof TRIGGER_DEFAULT_TAG,
   DropdownMenuTriggerOwnProps
 >;
 
 const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
-  const { as, ...triggerProps } = props;
-  const isSubmenu = React.useContext(SubmenuContext);
-
-  return isSubmenu ? (
-    <MenuPrimitive.SubTrigger
-      {...triggerProps}
-      as={as as Polymorphic.IntrinsicElement<typeof DropdownMenuRootTrigger>}
-      ref={forwardedRef}
-    />
-  ) : (
-    <DropdownMenuRootTrigger {...triggerProps} as={as} ref={forwardedRef} />
-  );
-}) as DropdownMenuTriggerPrimitive;
-
-DropdownMenuTrigger.displayName = TRIGGER_NAME;
-
-/* ---------------------------------------------------------------------------------------------- */
-
-const TRIGGER_DEFAULT_TAG = 'button';
-
-type DropdownMenuRootTriggerOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive.Anchor>,
-  'virtualRef'
->;
-type DropdownMenuRootTriggerPrimitive = Polymorphic.ForwardRefComponent<
-  typeof TRIGGER_DEFAULT_TAG,
-  DropdownMenuRootTriggerOwnProps
->;
-
-const DropdownMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
   const { as = TRIGGER_DEFAULT_TAG, ...triggerProps } = props;
   const context = useDropdownMenuContext(TRIGGER_NAME);
   const composedTriggerRef = useComposedRefs(forwardedRef, context.triggerRef);
@@ -145,7 +116,9 @@ const DropdownMenuRootTrigger = React.forwardRef((props, forwardedRef) => {
       })}
     />
   );
-}) as DropdownMenuRootTriggerPrimitive;
+}) as DropdownMenuTriggerPrimitive;
+
+DropdownMenuTrigger.displayName = TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * DropdownMenuContent
@@ -209,6 +182,25 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
 
 DropdownMenuContent.displayName = CONTENT_NAME;
 
+/* -------------------------------------------------------------------------------------------------
+ * DropdownMenuTriggerItem
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_ITEM_NAME = 'DropdownMenuTriggerItem';
+
+type DropdownMenuTriggerItemOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>;
+type DropdownMenuTriggerItemPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.SubTrigger>,
+  DropdownMenuTriggerItemOwnProps
+>;
+
+const DropdownMenuTriggerItem = React.forwardRef((props, forwardedRef) => {
+  const isSubmenu = React.useContext(SubmenuContext);
+  return isSubmenu ? <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} /> : null;
+}) as DropdownMenuTriggerItemPrimitive;
+
+DropdownMenuTriggerItem.displayName = TRIGGER_ITEM_NAME;
+
 /* ---------------------------------------------------------------------------------------------- */
 
 const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, {
@@ -245,6 +237,7 @@ const Content = DropdownMenuContent;
 const Group = DropdownMenuGroup;
 const Label = DropdownMenuLabel;
 const Item = DropdownMenuItem;
+const TriggerItem = DropdownMenuTriggerItem;
 const CheckboxItem = DropdownMenuCheckboxItem;
 const RadioGroup = DropdownMenuRadioGroup;
 const RadioItem = DropdownMenuRadioItem;
@@ -259,6 +252,7 @@ export {
   DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuItem,
+  DropdownMenuTriggerItem,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -272,6 +266,7 @@ export {
   Group,
   Label,
   Item,
+  TriggerItem,
   CheckboxItem,
   RadioGroup,
   RadioItem,
@@ -279,4 +274,8 @@ export {
   Separator,
   Arrow,
 };
-export type { DropdownMenuTriggerPrimitive, DropdownMenuContentPrimitive };
+export type {
+  DropdownMenuTriggerPrimitive,
+  DropdownMenuContentPrimitive,
+  DropdownMenuTriggerItemPrimitive,
+};


### PR DESCRIPTION
We realised that our initial approach of merging the sub trigger part with the trigger part for these would cause `ref` and TS issues. See original discussion here https://github.com/radix-ui/primitives/pull/629#discussion_r643042075

This exposes a new `TriggerItem` part for each component that should be used when rendering an item as a sub menu trigger.