### PR TITLE
[RadioGroup] Add `BubbleInput` 🔥 

### DIFF
--- a/.yarn/versions/91eebb70.yml
+++ b/.yarn/versions/91eebb70.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
+    "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-use-size": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -4,6 +4,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useSize } from '@radix-ui/react-use-size';
+import { usePrevious } from '@radix-ui/react-use-previous';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLabelContext } from '@radix-ui/react-label';
@@ -22,9 +23,7 @@ type RadioOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof Primitive>,
   {
     checked?: boolean;
-    defaultChecked?: boolean;
     required?: InputDOMProps['required'];
-    onCheckedChange?: InputDOMProps['onChange'];
   }
 >;
 
@@ -39,74 +38,60 @@ const Radio = React.forwardRef((props, forwardedRef) => {
     as = RADIO_DEFAULT_TAG,
     'aria-labelledby': ariaLabelledby,
     name,
-    checked: checkedProp,
-    defaultChecked,
+    checked = false,
     required,
     disabled,
     value = 'on',
-    onCheckedChange,
     ...radioProps
   } = props;
-  const inputRef = React.useRef<HTMLInputElement>(null);
   const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
   const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
-  const buttonSize = useSize(button);
   const labelId = useLabelContext(button);
   const labelledBy = ariaLabelledby || labelId;
-  const [checked = false, setChecked] = useControllableState({
-    prop: checkedProp,
-    defaultProp: defaultChecked,
-  });
+  const hasConsumerStoppedPropagationRef = React.useRef(false);
+  // We set this to true by default so that events bubble to forms without JS (SSR)
+  const isFormControl = button ? Boolean(button.closest('form')) : true;
 
   return (
-    /**
-     * The `input` is hidden from non-SR and SR users as it only exists to
-     * ensure form events fire when the value changes and that the value
-     * updates when clicking an associated label.
-     */
-    <>
-      <input
-        ref={inputRef}
-        type="radio"
-        name={name}
-        checked={checked}
-        required={required}
+    <RadioProvider checked={checked} disabled={disabled}>
+      <Primitive
+        type="button"
+        role="radio"
+        aria-checked={checked}
+        aria-labelledby={labelledBy}
+        data-state={getState(checked)}
+        data-disabled={disabled ? '' : undefined}
         disabled={disabled}
         value={value}
-        style={{
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-          ...buttonSize,
-        }}
-        onChange={composeEventHandlers(onCheckedChange, (event) => {
-          setChecked(event.target.checked);
+        {...radioProps}
+        as={as}
+        ref={composedRefs}
+        onClick={composeEventHandlers(props.onClick, (event) => {
+          if (isFormControl) {
+            hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+            // if radio is in a form, stop propagation from the button so that we only propagate
+            // one click event (from the input). We propagate changes from an input so that native
+            // form validation works and form events reflect radio updates.
+            if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+          }
         })}
       />
-      <RadioProvider checked={checked} disabled={disabled}>
-        <Primitive
-          type="button"
-          role="radio"
-          aria-checked={checked}
-          aria-labelledby={labelledBy}
-          data-state={getState(checked)}
-          data-disabled={disabled ? '' : undefined}
-          disabled={disabled}
+      {isFormControl && (
+        <BubbleInput
+          control={button}
+          stoppedPropagation={hasConsumerStoppedPropagationRef.current}
+          name={name}
           value={value}
-          {...radioProps}
-          as={as}
-          ref={composedRefs}
-          /**
-           * The `input` is hidden, so when the button is clicked we trigger
-           * the input manually
-           */
-          onClick={composeEventHandlers(props.onClick, () => inputRef.current?.click(), {
-            checkForDefaultPrevented: false,
-          })}
+          checked={checked}
+          required={required}
+          disabled={disabled}
+          // We transform because the input is absolutely positioned but we have
+          // rendered it **after** the button. This pulls it back to sit on top
+          // of the button.
+          style={{ transform: 'translateX(-100%)' }}
         />
-      </RadioProvider>
-    </>
+      )}
+    </RadioProvider>
   );
 }) as RadioPrimitive;
 
@@ -154,6 +139,49 @@ const RadioIndicator = React.forwardRef((props, forwardedRef) => {
 RadioIndicator.displayName = INDICATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
+
+type BubbleInputProps = Omit<React.ComponentProps<'input'>, 'checked'> & {
+  checked: boolean;
+  control: HTMLElement | null;
+  stoppedPropagation: boolean;
+};
+
+const BubbleInput = (props: BubbleInputProps) => {
+  const { control, checked, stoppedPropagation, ...inputProps } = props;
+  const ref = React.useRef<HTMLInputElement>(null);
+  const prevChecked = usePrevious(checked);
+  const controlSize = useSize(control);
+
+  // Bubble checked change to parents (e.g form change event)
+  React.useEffect(() => {
+    const input = ref.current!;
+    const inputProto = window.HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
+    const setChecked = descriptor.set;
+    if (!stoppedPropagation && prevChecked !== checked && setChecked) {
+      const event = new Event('click', { bubbles: true });
+      setChecked.call(input, checked);
+      input.dispatchEvent(event);
+    }
+  }, [prevChecked, checked, stoppedPropagation]);
+
+  return (
+    <input
+      type="radio"
+      {...inputProps}
+      tabIndex={-1}
+      ref={ref}
+      style={{
+        ...props.style,
+        ...controlSize,
+        position: 'absolute',
+        pointerEvents: 'none',
+        opacity: 0,
+        margin: 0,
+      }}
+    />
+  );
+};
 
 function getState(checked: boolean) {
   return checked ? 'checked' : 'unchecked';

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext } from '@radix-ui/react-context';
-import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useSize } from '@radix-ui/react-use-size';
 import { usePrevious } from '@radix-ui/react-use-previous';
 import { Presence } from '@radix-ui/react-presence';
@@ -24,6 +23,7 @@ type RadioOwnProps = Polymorphic.Merge<
   {
     checked?: boolean;
     required?: InputDOMProps['required'];
+    onCheck?(): void;
   }
 >;
 
@@ -42,6 +42,7 @@ const Radio = React.forwardRef((props, forwardedRef) => {
     required,
     disabled,
     value = 'on',
+    onCheck,
     ...radioProps
   } = props;
   const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
@@ -67,6 +68,8 @@ const Radio = React.forwardRef((props, forwardedRef) => {
         as={as}
         ref={composedRefs}
         onClick={composeEventHandlers(props.onClick, (event) => {
+          // radios cannot be unchecked so we only communicate a checked state
+          if (!checked) onCheck?.();
           if (isFormControl) {
             hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
             // if radio is in a form, stop propagation from the button so that we only propagate

--- a/packages/react/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/react/radio-group/src/RadioGroup.stories.tsx
@@ -36,11 +36,7 @@ export const Controlled = () => {
   const [value, setValue] = React.useState('2');
 
   return (
-    <RadioGroup
-      className={rootClass}
-      value={value}
-      onValueChange={(event) => setValue(event.target.value)}
-    >
+    <RadioGroup className={rootClass} value={value} onValueChange={setValue}>
       <RadioGroupItem className={itemClass} value="1">
         <RadioGroupIndicator className={indicatorClass} />
       </RadioGroupItem>
@@ -81,7 +77,7 @@ export const Unset = () => (
 );
 
 export const WithinForm = () => {
-  const [data, setData] = React.useState({ optional: '', required: '' });
+  const [data, setData] = React.useState({ optional: '', required: '', stopprop: '' });
 
   return (
     <form
@@ -91,32 +87,68 @@ export const WithinForm = () => {
         setData((prevData) => ({ ...prevData, [radio.name]: radio.value }));
       }}
     >
-      <p>optional value: {data.optional}</p>
+      <fieldset>
+        <legend>ooptional value: {data.optional}</legend>
+        <RadioGroup className={rootClass} name="optional">
+          <RadioGroupItem className={itemClass} value="1">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem className={itemClass} value="2">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem className={itemClass} value="3">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+        </RadioGroup>
+      </fieldset>
 
-      <RadioGroup className={rootClass} name="optional">
-        <RadioGroupItem className={itemClass} value="1">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-        <RadioGroupItem className={itemClass} value="2">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-        <RadioGroupItem className={itemClass} value="3">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-      </RadioGroup>
+      <br />
+      <br />
 
-      <p>required value: {data.required}</p>
-      <RadioGroup className={rootClass} name="required" required>
-        <RadioGroupItem className={itemClass} value="1">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-        <RadioGroupItem className={itemClass} value="2">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-        <RadioGroupItem className={itemClass} value="3">
-          <RadioGroupIndicator className={indicatorClass} />
-        </RadioGroupItem>
-      </RadioGroup>
+      <fieldset>
+        <legend>required value: {data.required}</legend>
+        <RadioGroup className={rootClass} name="required" required>
+          <RadioGroupItem className={itemClass} value="1">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem className={itemClass} value="2">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem className={itemClass} value="3">
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+        </RadioGroup>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>stop propagation value: {data.stopprop}</legend>
+        <RadioGroup className={rootClass} name="stopprop" required>
+          <RadioGroupItem
+            className={itemClass}
+            value="1"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem
+            className={itemClass}
+            value="2"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+          <RadioGroupItem
+            className={itemClass}
+            value="3"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <RadioGroupIndicator className={indicatorClass} />
+          </RadioGroupItem>
+        </RadioGroup>
+      </fieldset>
 
       <br />
       <br />

--- a/packages/react/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/react/radio-group/src/RadioGroup.stories.tsx
@@ -88,7 +88,7 @@ export const WithinForm = () => {
       }}
     >
       <fieldset>
-        <legend>ooptional value: {data.optional}</legend>
+        <legend>optional value: {data.optional}</legend>
         <RadioGroup className={rootClass} name="optional">
           <RadioGroupItem className={itemClass} value="1">
             <RadioGroupIndicator className={indicatorClass} />
@@ -125,7 +125,7 @@ export const WithinForm = () => {
 
       <fieldset>
         <legend>stop propagation value: {data.stopprop}</legend>
-        <RadioGroup className={rootClass} name="stopprop" required>
+        <RadioGroup className={rootClass} name="stopprop">
           <RadioGroupItem
             className={itemClass}
             value="1"

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -95,7 +95,7 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 const ITEM_NAME = 'RadioGroupItem';
 
 type RadioGroupItemOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof Radio>,
+  Omit<Polymorphic.OwnProps<typeof Radio>, 'onCheck'>,
   { value: string; name?: never }
 >;
 type RadioGroupItemPrimitive = Polymorphic.ForwardRefComponent<
@@ -119,7 +119,7 @@ const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
         {...itemProps}
         name={context.name}
         ref={composedRefs}
-        onClick={composeEventHandlers(props.onClick, () => context.onValueChange(itemProps.value))}
+        onCheck={() => context.onValueChange(itemProps.value)}
         onFocus={composeEventHandlers(itemProps.onFocus, () => {
           /**
            * Roving index will focus the radio and we need to check it when this happens.

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -28,7 +28,7 @@ type RadioGroupOwnProps = Polymorphic.Merge<
     value?: string;
     defaultValue?: string;
     required?: React.ComponentProps<typeof Radio>['required'];
-    onValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onValueChange?(value: string): void;
   }
 >;
 
@@ -64,22 +64,14 @@ const RadioGroup = React.forwardRef((props, forwardedRef) => {
   } = props;
   const labelId = useLabelContext();
   const labelledBy = ariaLabelledby || labelId;
-  const handleValueChange = useCallbackRef(onValueChange);
   const [value, setValue] = useControllableState({
     prop: valueProp,
     defaultProp: defaultValue,
+    onChange: onValueChange,
   });
 
   return (
-    <RadioGroupProvider
-      name={name}
-      value={value}
-      required={required}
-      onValueChange={React.useCallback(
-        composeEventHandlers(handleValueChange, (event) => setValue(event.target.value)),
-        [handleValueChange]
-      )}
-    >
+    <RadioGroupProvider name={name} value={value} required={required} onValueChange={setValue}>
       <RovingFocusGroup
         role="radiogroup"
         aria-labelledby={labelledBy}
@@ -127,16 +119,14 @@ const RadioGroupItem = React.forwardRef((props, forwardedRef) => {
         {...itemProps}
         name={context.name}
         ref={composedRefs}
-        onCheckedChange={composeEventHandlers(props.onCheckedChange, context.onValueChange)}
+        onClick={composeEventHandlers(props.onClick, () => context.onValueChange(itemProps.value))}
         onFocus={composeEventHandlers(itemProps.onFocus, () => {
           /**
            * Roving index will focus the radio and we need to check it when this happens.
            * We do this imperatively instead of updating `context.value` because changing via
            * state would not trigger change events (e.g. when in a form).
            */
-          if (context.value !== undefined) {
-            ref.current?.click();
-          }
+          if (context.value !== undefined) ref.current?.click();
         })}
       />
     </RovingFocusItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,6 +3697,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
+    "@radix-ui/react-use-previous": "workspace:*"
     "@radix-ui/react-use-size": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
- Fixes `event.stopPropagation`
- Prevents duplicate click events from firing
- Changes `onValueChange` shape to `onValueChange?(value: string): void` - Finally matches docs 🔥
- Converts `Radio` to a controlled component only because we only use it in `RadioGroup` which controls it. This allowed me to remove `onCheckedChange` from `Radio` because `onCheckedChange` never actually fires with `false` so the name confused me. We just `setValue(props.value)` when a radio is clicked.

https://user-images.githubusercontent.com/175330/120681102-efa88480-c492-11eb-9eae-c2f94555f34d.mp4

