### PR TITLE
[Menu] Disable mouse open when focused in dev tool

### DIFF
--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -701,6 +701,8 @@ type MenuSubTriggerPrimitive = Polymorphic.ForwardRefComponent<
 const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(SUB_TRIGGER_NAME);
   const contentContext = useMenuContentContext(SUB_TRIGGER_NAME);
+  const mouseInteractionRef = React.useRef(false);
+
   return context.isSubmenu ? (
     <MenuAnchor as={Slot}>
       <MenuItemImpl
@@ -711,7 +713,18 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
         {...props}
         ref={composeRefs(forwardedRef, context.onTriggerChange)}
         onMouseMove={composeEventHandlers(props.onMouseMove, () => {
-          if (!props.disabled) context.onOpenChange(true);
+          mouseInteractionRef.current = true;
+        })}
+        onMouseLeave={composeEventHandlers(props.onMouseMove, () => {
+          mouseInteractionRef.current = false;
+        })}
+        // Handle `onOpenChange` within the focus event to prevent the open state
+        // from sticking when devtools are focused.
+        // This disables mouse interaction unless you're focused inside the window.
+        onFocus={composeEventHandlers(props.onFocus, () => {
+          if (!props.disabled && mouseInteractionRef.current) {
+            context.onOpenChange(true);
+          }
         })}
         onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
           const isTypingAhead = contentContext.searchRef.current !== '';


### PR DESCRIPTION
Leans on the `focus` event to prevent the open state when focused inside dev tool.

Not sure how I feel about it, or whether it's really necessary to do so.

Before:

https://user-images.githubusercontent.com/11708259/120682680-a3f6da80-c494-11eb-8598-20f574eda4f9.mp4

After:

https://user-images.githubusercontent.com/11708259/120682704-abb67f00-c494-11eb-87b7-4ea14665a86b.mp4



