### PR TITLE
[Checkbox][Switch][RadioGroup] Always emit `BubbleInput` event

### DIFF
--- a/.yarn/versions/91eebb70.yml
+++ b/.yarn/versions/91eebb70.yml
@@ -1,5 +1,7 @@
 releases:
+  "@radix-ui/react-checkbox": patch
   "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-switch": patch
 
 declined:
   - primitives

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -73,7 +73,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
       <Primitive
         type="button"
         role="checkbox"
-        aria-checked={checked === 'indeterminate' ? 'mixed' : checked}
+        aria-checked={isIndeterminate(checked) ? 'mixed' : checked}
         aria-labelledby={labelledBy}
         aria-required={required}
         data-state={getState(checked)}
@@ -84,7 +84,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
         as={as}
         ref={composedRefs}
         onClick={composeEventHandlers(props.onClick, (event) => {
-          setChecked((prevChecked) => (prevChecked === 'indeterminate' ? true : !prevChecked));
+          setChecked((prevChecked) => (isIndeterminate(prevChecked) ? true : !prevChecked));
           if (isFormControl) {
             hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
             // if checkbox is in a form, stop propagation from the button so that we only propagate
@@ -142,7 +142,7 @@ const CheckboxIndicator = React.forwardRef((props, forwardedRef) => {
   const { as = INDICATOR_DEFAULT_TAG, forceMount, ...indicatorProps } = props;
   const context = useCheckboxContext(INDICATOR_NAME);
   return (
-    <Presence present={forceMount || context.state === 'indeterminate' || context.state === true}>
+    <Presence present={forceMount || isIndeterminate(context.state) || context.state === true}>
       <Primitive
         data-state={getState(context.state)}
         data-disabled={context.disabled ? '' : undefined}
@@ -177,11 +177,11 @@ const BubbleInput = (props: BubbleInputProps) => {
     const inputProto = window.HTMLInputElement.prototype;
     const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
     const setChecked = descriptor.set;
-    const isIndeterminate = checked === 'indeterminate';
-      input.indeterminate = isIndeterminate;
-      setChecked.call(input, isIndeterminate ? false : checked);
+
     if (prevChecked !== checked && setChecked) {
       const event = new Event('click', { bubbles });
+      input.indeterminate = isIndeterminate(checked);
+      setChecked.call(input, isIndeterminate(checked) ? false : checked);
       input.dispatchEvent(event);
     }
   }, [prevChecked, checked, bubbles]);
@@ -189,6 +189,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="checkbox"
+      defaultChecked={isIndeterminate(checked) ? false : checked}
       {...inputProps}
       tabIndex={-1}
       ref={ref}
@@ -204,8 +205,12 @@ const BubbleInput = (props: BubbleInputProps) => {
   );
 };
 
+function isIndeterminate(checked?: CheckedState): checked is 'indeterminate' {
+  return checked === 'indeterminate';
+}
+
 function getState(checked: CheckedState) {
-  return checked === 'indeterminate' ? 'indeterminate' : checked ? 'checked' : 'unchecked';
+  return isIndeterminate(checked) ? 'indeterminate' : checked ? 'checked' : 'unchecked';
 }
 
 const Root = Checkbox;

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -97,7 +97,7 @@ const Checkbox = React.forwardRef((props, forwardedRef) => {
       {isFormControl && (
         <BubbleInput
           control={button}
-          stoppedPropagation={hasConsumerStoppedPropagationRef.current}
+          bubbles={!hasConsumerStoppedPropagationRef.current}
           name={name}
           value={value}
           checked={checked}
@@ -162,11 +162,11 @@ CheckboxIndicator.displayName = INDICATOR_NAME;
 type BubbleInputProps = Omit<React.ComponentProps<'input'>, 'checked'> & {
   checked: CheckedState;
   control: HTMLElement | null;
-  stoppedPropagation: boolean;
+  bubbles: boolean;
 };
 
 const BubbleInput = (props: BubbleInputProps) => {
-  const { control, checked, stoppedPropagation, ...inputProps } = props;
+  const { control, checked, bubbles = true, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const prevChecked = usePrevious(checked);
   const controlSize = useSize(control);
@@ -178,13 +178,13 @@ const BubbleInput = (props: BubbleInputProps) => {
     const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
     const setChecked = descriptor.set;
     const isIndeterminate = checked === 'indeterminate';
-    if (!stoppedPropagation && prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles: true });
       input.indeterminate = isIndeterminate;
       setChecked.call(input, isIndeterminate ? false : checked);
+    if (prevChecked !== checked && setChecked) {
+      const event = new Event('click', { bubbles });
       input.dispatchEvent(event);
     }
-  }, [prevChecked, checked, stoppedPropagation]);
+  }, [prevChecked, checked, bubbles]);
 
   return (
     <input

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -171,6 +171,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="radio"
+      defaultChecked={checked}
       {...inputProps}
       tabIndex={-1}
       ref={ref}

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -82,7 +82,7 @@ const Radio = React.forwardRef((props, forwardedRef) => {
       {isFormControl && (
         <BubbleInput
           control={button}
-          stoppedPropagation={hasConsumerStoppedPropagationRef.current}
+          bubbles={!hasConsumerStoppedPropagationRef.current}
           name={name}
           value={value}
           checked={checked}
@@ -146,11 +146,11 @@ RadioIndicator.displayName = INDICATOR_NAME;
 type BubbleInputProps = Omit<React.ComponentProps<'input'>, 'checked'> & {
   checked: boolean;
   control: HTMLElement | null;
-  stoppedPropagation: boolean;
+  bubbles: boolean;
 };
 
 const BubbleInput = (props: BubbleInputProps) => {
-  const { control, checked, stoppedPropagation, ...inputProps } = props;
+  const { control, checked, bubbles = true, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const prevChecked = usePrevious(checked);
   const controlSize = useSize(control);
@@ -161,12 +161,12 @@ const BubbleInput = (props: BubbleInputProps) => {
     const inputProto = window.HTMLInputElement.prototype;
     const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
     const setChecked = descriptor.set;
-    if (!stoppedPropagation && prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles: true });
+    if (prevChecked !== checked && setChecked) {
+      const event = new Event('click', { bubbles });
       setChecked.call(input, checked);
       input.dispatchEvent(event);
     }
-  }, [prevChecked, checked, stoppedPropagation]);
+  }, [prevChecked, checked, bubbles]);
 
   return (
     <input

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -89,7 +89,7 @@ const Switch = React.forwardRef((props, forwardedRef) => {
       {isFormControl && (
         <BubbleInput
           control={button}
-          stoppedPropagation={hasConsumerStoppedPropagationRef.current}
+          bubbles={!hasConsumerStoppedPropagationRef.current}
           name={name}
           value={value}
           checked={checked}
@@ -141,11 +141,11 @@ SwitchThumb.displayName = THUMB_NAME;
 type BubbleInputProps = Omit<React.ComponentProps<'input'>, 'checked'> & {
   checked: boolean;
   control: HTMLElement | null;
-  stoppedPropagation: boolean;
+  bubbles: boolean;
 };
 
 const BubbleInput = (props: BubbleInputProps) => {
-  const { control, checked, stoppedPropagation, ...inputProps } = props;
+  const { control, checked, bubbles = true, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const prevChecked = usePrevious(checked);
   const controlSize = useSize(control);
@@ -156,12 +156,12 @@ const BubbleInput = (props: BubbleInputProps) => {
     const inputProto = window.HTMLInputElement.prototype;
     const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
     const setChecked = descriptor.set;
-    if (!stoppedPropagation && prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles: true });
+    if (prevChecked !== checked && setChecked) {
+      const event = new Event('click', { bubbles });
       setChecked.call(input, checked);
       input.dispatchEvent(event);
     }
-  }, [prevChecked, checked, stoppedPropagation]);
+  }, [prevChecked, checked, bubbles]);
 
   return (
     <input

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -166,6 +166,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="checkbox"
+      defaultChecked={checked}
       {...inputProps}
       tabIndex={-1}
       ref={ref}


### PR DESCRIPTION
Makes sure we always emit the `BubbleInput` event even if propagation has been stopped. Without this the underlying checkbox/radio wouldn't become checked. We want it to check, we just don't want the event to propagate.

Also adds `defaultChecked` attributes to ensure the default state is submitted with forms.