### PR TITLE
[ContextMenu][DropdownMenu] Add pointer grace for navigation to sub-menus

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -473,7 +473,7 @@ export const Chromatic = () => {
           </DropdownMenuItem>
           <DropdownMenuSeparator className={separatorClass} />
           <DropdownMenu open>
-            <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+            <DropdownMenuTriggerItem className={subTriggerClass}>Submenu →</DropdownMenuTriggerItem>
             <DropdownMenuContent className={contentClass} sideOffset={12} avoidCollisions={false}>
               <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
                 One
@@ -484,7 +484,9 @@ export const Chromatic = () => {
               </DropdownMenuItem>
               <DropdownMenuSeparator className={separatorClass} />
               <DropdownMenu open>
-                <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                <DropdownMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </DropdownMenuTriggerItem>
                 <DropdownMenuContent
                   className={contentClass}
                   sideOffset={12}
@@ -540,7 +542,7 @@ export const Chromatic = () => {
           </DropdownMenuItem>
           <DropdownMenuSeparator className={separatorClass} />
           <DropdownMenu open>
-            <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+            <DropdownMenuTriggerItem className={subTriggerClass}>Submenu →</DropdownMenuTriggerItem>
             <DropdownMenuContent
               className={contentClass}
               sideOffset={12}
@@ -556,7 +558,9 @@ export const Chromatic = () => {
               </DropdownMenuItem>
               <DropdownMenuSeparator className={separatorClass} />
               <DropdownMenu open>
-                <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                <DropdownMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </DropdownMenuTriggerItem>
                 <DropdownMenuContent
                   className={contentClass}
                   sideOffset={12}
@@ -615,7 +619,9 @@ export const Chromatic = () => {
             </DropdownMenuItem>
             <DropdownMenuSeparator className={separatorClass} />
             <DropdownMenu open>
-              <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+              <DropdownMenuTriggerItem className={subTriggerClass}>
+                Submenu →
+              </DropdownMenuTriggerItem>
               <DropdownMenuContent className={contentClass} sideOffset={12} avoidCollisions={false}>
                 <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
                   One
@@ -626,7 +632,9 @@ export const Chromatic = () => {
                 </DropdownMenuItem>
                 <DropdownMenuSeparator className={separatorClass} />
                 <DropdownMenu open>
-                  <DropdownMenuTrigger className={subTriggerClass}>Submenu →</DropdownMenuTrigger>
+                  <DropdownMenuTriggerItem className={subTriggerClass}>
+                    Submenu →
+                  </DropdownMenuTriggerItem>
                   <DropdownMenuContent
                     className={contentClass}
                     sideOffset={12}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -717,13 +717,13 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(SUB_TRIGGER_NAME);
   const contentContext = useMenuContentContext(SUB_TRIGGER_NAME);
   const contentRectRef = React.useRef<ClientRect | undefined>();
-  const openTimerRef = React.useRef<number | undefined>(undefined);
+  const openTimerRef = React.useRef<number | null>(null);
   const { onPointerGraceAreaChange } = contentContext;
   const pointerGraceDurationTimer = React.useRef(0);
 
   const clearOpenTimer = React.useCallback(() => {
-    window.clearTimeout(openTimerRef.current);
-    openTimerRef.current = undefined;
+    if (openTimerRef.current) window.clearTimeout(openTimerRef.current);
+    openTimerRef.current = null;
   }, []);
 
   React.useEffect(() => clearOpenTimer, [clearOpenTimer]);

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -756,7 +756,7 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
           const contentRect = context.content?.getBoundingClientRect();
           if (contentRect) {
             contentContext.onPointerGraceAreaChange([
-              { x: event.pageX, y: event.pageY },
+              { x: event.clientX, y: event.clientY },
               { x: contentRect.left, y: contentRect.top },
               { x: contentRect.left, y: contentRect.bottom },
             ]);
@@ -1029,7 +1029,7 @@ function isPointInTriangle(point: Point, a: Point, b: Point, c: Point) {
 
 function isMouseMovingToSubmenu(event: React.MouseEvent, triangle: Triangle | null) {
   if (triangle) {
-    const cursorPos = { x: event.pageX, y: event.pageY };
+    const cursorPos = { x: event.clientX, y: event.clientY };
     const isCursorInTriangle = isPointInTriangle(cursorPos, ...triangle);
     if (isCursorInTriangle) return true;
   }

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -735,6 +735,11 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
     };
   }, [onPointerGraceAreaChange]);
 
+  // clear content rect cache when it closes
+  React.useEffect(() => {
+    if (context.open === false) contentRectRef.current = undefined;
+  }, [context.open]);
+
   return context.isSubmenu ? (
     <MenuAnchor as={Slot}>
       <MenuItemImpl

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -716,7 +716,6 @@ type MenuSubTriggerPrimitive = Polymorphic.ForwardRefComponent<
 const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(SUB_TRIGGER_NAME);
   const contentContext = useMenuContentContext(SUB_TRIGGER_NAME);
-  const contentRectRef = React.useRef<ClientRect | undefined>();
   const openTimerRef = React.useRef<number | null>(null);
   const { onPointerGraceAreaChange } = contentContext;
   const pointerGraceDurationTimer = React.useRef(0);
@@ -734,11 +733,6 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
       onPointerGraceAreaChange(null);
     };
   }, [onPointerGraceAreaChange]);
-
-  // clear content rect cache when it closes
-  React.useEffect(() => {
-    if (context.open === false) contentRectRef.current = undefined;
-  }, [context.open]);
 
   return context.isSubmenu ? (
     <MenuAnchor as={Slot}>
@@ -762,17 +756,15 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
         onMouseLeave={composeEventHandlers(props.onMouseLeave, (event) => {
           clearOpenTimer();
 
-          contentRectRef.current =
-            contentRectRef.current || context.content?.getBoundingClientRect();
-          if (contentRectRef.current) {
+          const contentRect = context.content?.getBoundingClientRect();
+          if (contentRect) {
             // TODO: make sure to update this when we change positioning logic
             const side = context.content?.dataset.side;
-            const { top, left, right, bottom } = contentRectRef.current;
-            const contentEdge = side === 'right' ? left : right;
+            const contentEdge = side === 'right' ? contentRect.left : contentRect.right;
             contentContext.onPointerGraceAreaChange([
               { x: event.clientX, y: event.clientY },
-              { x: contentEdge, y: top },
-              { x: contentEdge, y: bottom },
+              { x: contentEdge, y: contentRect.top },
+              { x: contentEdge, y: contentRect.bottom },
             ]);
 
             pointerGraceDurationTimer.current = window.setTimeout(


### PR DESCRIPTION
This PR adds 2 things:
- adds 100ms delay to before opening a submenu so skimming over them isn't jarring (100ms is what native seems to do here, we've measured in a video recording)
- adds pointer grace for sub-menu navigation. This is a combination of 2 things:
  - a grace duration of 300ms where we check for a specific area (see below)
  - an area duration where we check the mouse pointer is in a specific triangle area

https://user-images.githubusercontent.com/1539897/120825726-95222d80-c551-11eb-84cc-588df78c561d.mov

