### PR TITLE
[DropdownMenu] Add `aria-labelledby` to follow spec

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -17,7 +17,7 @@ type Direction = 'ltr' | 'rtl';
 
 const DROPDOWN_MENU_NAME = 'DropdownMenu';
 
-type DropdownMenuContextValue = {
+type DropdownMenuRootContextValue = {
   isRootMenu: true;
   triggerId: string;
   triggerRef: React.RefObject<HTMLButtonElement>;
@@ -35,7 +35,7 @@ type DropdownMenuSubContextValue = {
 };
 
 const [DropdownMenuProvider, useDropdownMenuContext] = createContext<
-  DropdownMenuContextValue | DropdownMenuSubContextValue
+  DropdownMenuRootContextValue | DropdownMenuSubContextValue
 >(DROPDOWN_MENU_NAME);
 
 type DropdownMenuOwnProps = {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -54,6 +54,7 @@ type MenuContextValue = {
 type MenuSubContextValue = Omit<MenuContextValue, 'isSubmenu'> & {
   isSubmenu: true;
   contentId: string;
+  triggerId: string;
   trigger: MenuSubTriggerElement | null;
   onTriggerChange(trigger: MenuSubTriggerElement | null): void;
   onKeyOpen(): void;
@@ -135,6 +136,7 @@ const MenuSub: React.FC<MenuSubOwnProps> = (props) => {
         contentId={useId()}
         trigger={trigger}
         onTriggerChange={setTrigger}
+        triggerId={useId()}
         onKeyOpen={React.useCallback(() => {
           setFocusFirst(true);
           handleOpenChange(true);
@@ -280,6 +282,7 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
   return context.isSubmenu ? (
     <MenuContentImpl
       id={context.contentId}
+      aria-labelledby={context.triggerId}
       {...props}
       ref={composedRefs}
       align="start"
@@ -670,6 +673,7 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
   return context.isSubmenu ? (
     <MenuAnchor as={Slot}>
       <MenuItemImpl
+        id={context.triggerId}
         aria-haspopup="menu"
         aria-expanded={context.open || undefined}
         aria-controls={context.contentId}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -41,7 +41,7 @@ const SUB_CLOSE_KEYS: Record<Direction, string[]> = {
 
 const MENU_NAME = 'Menu';
 
-type MenuContextValue = {
+type MenuRootContextValue = {
   isSubmenu: false;
   dir: Direction;
   open: boolean;
@@ -51,7 +51,7 @@ type MenuContextValue = {
   onRootClose(): void;
 };
 
-type MenuSubContextValue = Omit<MenuContextValue, 'isSubmenu'> & {
+type MenuSubContextValue = Omit<MenuRootContextValue, 'isSubmenu'> & {
   isSubmenu: true;
   contentId: string;
   triggerId: string;
@@ -61,7 +61,7 @@ type MenuSubContextValue = Omit<MenuContextValue, 'isSubmenu'> & {
   onEntryFocus: RovingFocusGroupOwnProps['onEntryFocus'];
 };
 
-const [MenuProvider, useMenuContext] = createContext<MenuContextValue | MenuSubContextValue>(
+const [MenuProvider, useMenuContext] = createContext<MenuRootContextValue | MenuSubContextValue>(
   MENU_NAME
 );
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -675,7 +675,7 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
       <MenuItemImpl
         id={context.triggerId}
         aria-haspopup="menu"
-        aria-expanded={context.open || undefined}
+        aria-expanded={context.open}
         aria-controls={context.contentId}
         data-state={getOpenState(context.open)}
         {...props}


### PR DESCRIPTION
**This is the first PR of a few that I will be raising with various accessibility improvements.**

- Adds `aria-labelledby` to `MenuSubContent` and the root `DropdownMenuContent`. Annoyingly the label isn't being read aloud in NVDA but I will look into this separately.
- Creates a new `DropdownMenuRoot` part because there are a bunch of attributes on the root content that are not required in the sub dropdown menus. This was also needed because the root `aria-labelledby` would override the submenu `aria-labelledby` in `MenuSubContent` if this attribute was added to both types within the `DropdownMenu` composition which resulted in incorrect ids for submenus (they would be pointing at the `DropdownMenuTrigger` id).
- Updates `aria-expanded` for sub menu triggers to follow WAI-ARIA spec
	
	![image](https://user-images.githubusercontent.com/175330/121213746-6c15db80-c876-11eb-84bf-39bdd63957bf.png)
	![image](https://user-images.githubusercontent.com/175330/121213803-7c2dbb00-c876-11eb-9070-b29518ef2ad4.png)
