### PR TITLE
[ContextMenu] Bring inline with `DropdownMenu` changes

### DIFF
--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -23,8 +23,7 @@
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-use-callback-ref": "workspace:*",
-    "@radix-ui/react-use-controllable-state": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -130,7 +130,7 @@ type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
-  const { disableOutsidePointerEvents = true, offset, ...contentProps } = props;
+  const { offset, ...contentProps } = props;
   const context = useContextMenuContext(CONTENT_NAME);
 
   const commonProps = {
@@ -146,17 +146,7 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
   return (
     <ContentContext.Provider value={true}>
       {context.isRootMenu ? (
-        <MenuPrimitive.Content
-          {...commonProps}
-          ref={forwardedRef}
-          disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
-          trapFocus
-          disableOutsideScroll
-          portalled
-          side="bottom"
-          align="start"
-          alignOffset={2}
-        />
+        <ContextMenuRootContent {...commonProps} ref={forwardedRef} />
       ) : (
         <MenuPrimitive.Content {...commonProps} ref={forwardedRef} />
       )}
@@ -165,6 +155,32 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 }) as ContextMenuContentPrimitive;
 
 ContextMenuContent.displayName = CONTENT_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type ContextMenuRootContentOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.Content>;
+type ContextMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Content>,
+  ContextMenuRootContentOwnProps
+>;
+
+const ContextMenuRootContent = React.forwardRef((props, forwardedRef) => {
+  const { disableOutsidePointerEvents = true, ...contentProps } = props;
+  const context = useContextMenuContext(CONTENT_NAME);
+  return (
+    <MenuPrimitive.Content
+      {...contentProps}
+      ref={forwardedRef}
+      disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
+      trapFocus
+      disableOutsideScroll
+      portalled
+      side="bottom"
+      align="start"
+      alignOffset={2}
+    />
+  );
+}) as ContextMenuRootContentPrimitive;
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -135,7 +135,6 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 
   const commonProps = {
     ...contentProps,
-    disableOutsidePointerEvents,
     sideOffset: offset,
     style: {
       ...props.style,
@@ -167,29 +166,13 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 
 ContextMenuContent.displayName = CONTENT_NAME;
 
-/* -------------------------------------------------------------------------------------------------
- * ContextMenuTriggerItem
- * -----------------------------------------------------------------------------------------------*/
-
-const TRIGGER_ITEM_NAME = 'ContextMenuTriggerItem';
-
-type ContextMenuTriggerItemOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>;
-type ContextMenuTriggerItemPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuPrimitive.SubTrigger>,
-  ContextMenuTriggerItemOwnProps
->;
-
-const ContextMenuTriggerItem = React.forwardRef((props, forwardedRef) => {
-  const context = useContextMenuContext(TRIGGER_ITEM_NAME);
-  return context.isRootMenu ? null : <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} />;
-}) as ContextMenuTriggerItemPrimitive;
-
-ContextMenuTriggerItem.displayName = TRIGGER_ITEM_NAME;
-
 /* ---------------------------------------------------------------------------------------------- */
 
 const ContextMenuGroup = extendPrimitive(MenuPrimitive.Group, { displayName: 'ContextMenuGroup' });
 const ContextMenuLabel = extendPrimitive(MenuPrimitive.Label, { displayName: 'ContextMenuLabel' });
+const ContextMenuTriggerItem = extendPrimitive(MenuPrimitive.SubTrigger, {
+  displayName: 'ContextMenuTriggerItem',
+});
 const ContextMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'ContextMenuItem' });
 const ContextMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
   displayName: 'ContextMenuCheckboxItem',
@@ -255,8 +238,4 @@ export {
   Separator,
   Arrow,
 };
-export type {
-  ContextMenuTriggerPrimitive,
-  ContextMenuContentPrimitive,
-  ContextMenuTriggerItemPrimitive,
-};
+export type { ContextMenuTriggerPrimitive, ContextMenuContentPrimitive };

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -17,7 +17,7 @@ type Point = { x: number; y: number };
 const CONTEXT_MENU_NAME = 'ContextMenu';
 
 type ContextMenuContextValue = {
-  isSubmenu: boolean;
+  isRootMenu: boolean;
   open: boolean;
   onOpenChange(open: boolean): void;
 };
@@ -46,13 +46,13 @@ const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
   );
 
   return isInsideContent ? (
-    <ContextMenuProvider isSubmenu={true} open={open} onOpenChange={handleOpenChange}>
+    <ContextMenuProvider isRootMenu={false} open={open} onOpenChange={handleOpenChange}>
       <MenuPrimitive.Sub open={open} onOpenChange={handleOpenChange}>
         {children}
       </MenuPrimitive.Sub>
     </ContextMenuProvider>
   ) : (
-    <ContextMenuProvider isSubmenu={false} open={open} onOpenChange={handleOpenChange}>
+    <ContextMenuProvider isRootMenu={true} open={open} onOpenChange={handleOpenChange}>
       <MenuPrimitive.Root dir={dir} open={open} onOpenChange={handleOpenChange}>
         {children}
       </MenuPrimitive.Root>
@@ -135,6 +135,7 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 
   const commonProps = {
     ...contentProps,
+    disableOutsidePointerEvents,
     sideOffset: offset,
     style: {
       ...props.style,
@@ -145,9 +146,7 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
 
   return (
     <ContentContext.Provider value={true}>
-      {context.isSubmenu ? (
-        <MenuPrimitive.Content {...commonProps} ref={forwardedRef} />
-      ) : (
+      {context.isRootMenu ? (
         <MenuPrimitive.Content
           {...commonProps}
           ref={forwardedRef}
@@ -159,6 +158,8 @@ const ContextMenuContent = React.forwardRef((props, forwardedRef) => {
           align="start"
           alignOffset={2}
         />
+      ) : (
+        <MenuPrimitive.Content {...commonProps} ref={forwardedRef} />
       )}
     </ContentContext.Provider>
   );
@@ -180,7 +181,7 @@ type ContextMenuTriggerItemPrimitive = Polymorphic.ForwardRefComponent<
 
 const ContextMenuTriggerItem = React.forwardRef((props, forwardedRef) => {
   const context = useContextMenuContext(TRIGGER_ITEM_NAME);
-  return context.isSubmenu ? <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} /> : null;
+  return context.isRootMenu ? null : <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} />;
 }) as ContextMenuTriggerItemPrimitive;
 
 ContextMenuTriggerItem.displayName = TRIGGER_ITEM_NAME;

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -183,9 +183,6 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
 
   const commonProps = {
     ...contentProps,
-    disableOutsidePointerEvents,
-    disableOutsideScroll,
-    portalled,
     style: {
       ...contentProps.style,
       // re-namespace exposed content custom property
@@ -201,6 +198,9 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
           aria-labelledby={context.triggerId}
           {...commonProps}
           ref={forwardedRef}
+          disableOutsidePointerEvents={disableOutsidePointerEvents}
+          disableOutsideScroll={disableOutsideScroll}
+          portalled={portalled}
           trapFocus
           onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
             event.preventDefault();
@@ -227,25 +227,6 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
 
 DropdownMenuContent.displayName = CONTENT_NAME;
 
-/* -------------------------------------------------------------------------------------------------
- * DropdownMenuTriggerItem
- * -----------------------------------------------------------------------------------------------*/
-
-const TRIGGER_ITEM_NAME = 'DropdownMenuTriggerItem';
-
-type DropdownMenuTriggerItemOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.SubTrigger>;
-type DropdownMenuTriggerItemPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuPrimitive.SubTrigger>,
-  DropdownMenuTriggerItemOwnProps
->;
-
-const DropdownMenuTriggerItem = React.forwardRef((props, forwardedRef) => {
-  const context = useDropdownMenuContext(TRIGGER_ITEM_NAME);
-  return context.isRootMenu ? null : <MenuPrimitive.SubTrigger {...props} ref={forwardedRef} />;
-}) as DropdownMenuTriggerItemPrimitive;
-
-DropdownMenuTriggerItem.displayName = TRIGGER_ITEM_NAME;
-
 /* ---------------------------------------------------------------------------------------------- */
 
 const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, {
@@ -253,6 +234,9 @@ const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, {
 });
 const DropdownMenuLabel = extendPrimitive(MenuPrimitive.Label, {
   displayName: 'DropdownMenuLabel',
+});
+const DropdownMenuTriggerItem = extendPrimitive(MenuPrimitive.SubTrigger, {
+  displayName: 'DropdownMenuTriggerItem',
 });
 const DropdownMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'DropdownMenuItem' });
 const DropdownMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
@@ -319,8 +303,4 @@ export {
   Separator,
   Arrow,
 };
-export type {
-  DropdownMenuTriggerPrimitive,
-  DropdownMenuContentPrimitive,
-  DropdownMenuTriggerItemPrimitive,
-};
+export type { DropdownMenuTriggerPrimitive, DropdownMenuContentPrimitive };

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -173,18 +173,11 @@ type DropdownMenuContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
-  const {
-    disableOutsidePointerEvents = true,
-    disableOutsideScroll = true,
-    portalled = true,
-    ...contentProps
-  } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
-
   const commonProps = {
-    ...contentProps,
+    ...props,
     style: {
-      ...contentProps.style,
+      ...props.style,
       // re-namespace exposed content custom property
       ['--radix-dropdown-menu-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
     },
@@ -193,31 +186,7 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
   return (
     <ContentContext.Provider value={true}>
       {context.isRootMenu ? (
-        <MenuPrimitive.Content
-          id={context.contentId}
-          aria-labelledby={context.triggerId}
-          {...commonProps}
-          ref={forwardedRef}
-          disableOutsidePointerEvents={disableOutsidePointerEvents}
-          disableOutsideScroll={disableOutsideScroll}
-          portalled={portalled}
-          trapFocus
-          onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-            event.preventDefault();
-            context.triggerRef.current?.focus();
-          })}
-          onPointerDownOutside={composeEventHandlers(
-            props.onPointerDownOutside,
-            (event) => {
-              const target = event.target as HTMLElement;
-              const targetIsTrigger = context.triggerRef.current?.contains(target);
-              // prevent dismissing when clicking the trigger
-              // as it's already setup to close, otherwise it would close and immediately open.
-              if (targetIsTrigger) event.preventDefault();
-            },
-            { checkForDefaultPrevented: false }
-          )}
-        />
+        <DropdownMenuRootContent {...commonProps} ref={forwardedRef} />
       ) : (
         <MenuPrimitive.Content {...commonProps} ref={forwardedRef} />
       )}
@@ -226,6 +195,52 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
 }) as DropdownMenuContentPrimitive;
 
 DropdownMenuContent.displayName = CONTENT_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type DropdownMenuRootContentOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.Content>;
+type DropdownMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuPrimitive.Content>,
+  DropdownMenuRootContentOwnProps
+>;
+
+const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
+  const {
+    disableOutsidePointerEvents = true,
+    disableOutsideScroll = true,
+    portalled = true,
+    ...contentProps
+  } = props;
+  const context = useDropdownMenuContext(CONTENT_NAME);
+
+  return context.isRootMenu ? (
+    <MenuPrimitive.Content
+      id={context.contentId}
+      aria-labelledby={context.triggerId}
+      {...contentProps}
+      ref={forwardedRef}
+      disableOutsidePointerEvents={disableOutsidePointerEvents}
+      disableOutsideScroll={disableOutsideScroll}
+      portalled={portalled}
+      trapFocus
+      onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+        event.preventDefault();
+        context.triggerRef.current?.focus();
+      })}
+      onPointerDownOutside={composeEventHandlers(
+        props.onPointerDownOutside,
+        (event) => {
+          const target = event.target as HTMLElement;
+          const targetIsTrigger = context.triggerRef.current?.contains(target);
+          // prevent dismissing when clicking the trigger
+          // as it's already setup to close, otherwise it would close and immediately open.
+          if (targetIsTrigger) event.preventDefault();
+        },
+        { checkForDefaultPrevented: false }
+      )}
+    />
+  ) : null;
+}) as DropdownMenuRootContentPrimitive;
 
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,7 +3401,6 @@ __metadata:
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
-    "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0


### PR DESCRIPTION
- I realised when doing [the `DropdownMenu` bits](https://github.com/radix-ui/primitives/pull/692) that we didn't need two separate contexts for identifying `isInsideContent` and `isSubmenu` so updated this to follow the reduced approach in `DropdownMenu`
- I also thought there isn't much use us having `useControllableState` in sub context menus because the parent menu can't be controlled. They wouldn't be able to force open submenus without first forcing open parent menu which isn't possible. The only benefit the previous approach had was that they could automatically have submenus open after someone opened the parent menu via  `onContextMenu` event but I can't think when this use-case would be relevant. Thoughts?