### PR TITLE
[Dialog] Add support for non-modal dialogs

### DIFF
--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -24,6 +24,30 @@ export const Styled = () => (
   </Dialog>
 );
 
+export const NonModal = () => (
+  <>
+    <Dialog modal={false}>
+      <DialogTrigger className={triggerClass}>open (non-modal)</DialogTrigger>
+      <DialogOverlay className={overlayClass} />
+      <DialogContent
+        className={contentSheetClass}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <DialogClose className={closeClass}>close</DialogClose>
+      </DialogContent>
+    </Dialog>
+
+    {Array.from({ length: 5 }, (_, i) => (
+      <div key={i} style={{ marginTop: 20 }}>
+        <textarea
+          style={{ width: 800, height: 400 }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    ))}
+  </>
+);
+
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
   return (
@@ -318,11 +342,23 @@ const contentClass = css({
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  background: 'white',
   minWidth: 300,
   minHeight: 150,
   padding: 50,
   borderRadius: 10,
+  backgroundColor: 'white',
+  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
+});
+
+const contentSheetClass = css({
+  ...RECOMMENDED_CSS__DIALOG__CONTENT,
+  left: undefined,
+  right: 0,
+  minWidth: 300,
+  minHeight: '100vh',
+  padding: 50,
+  borderTopLeftRadius: 10,
+  borderBottomLeftRadius: 10,
   backgroundColor: 'white',
   boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
 });

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -33,6 +33,7 @@ export const NonModal = () => (
         className={contentSheetClass}
         onInteractOutside={(event) => event.preventDefault()}
       >
+        <DialogTitle>Booking info</DialogTitle>
         <DialogClose className={closeClass}>close</DialogClose>
       </DialogContent>
     </Dialog>

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { axe } from 'jest-axe';
 import { RenderResult } from '@testing-library/react';
-import { render, fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import * as Dialog from './Dialog';
 
 const OPEN_TEXT = 'Open';

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -159,7 +159,7 @@ const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => {
 const CONTENT_NAME = 'DialogContent';
 
 type DialogContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof DialogContentModalImpl | typeof DialogContentNonModalImpl>,
+  Polymorphic.OwnProps<typeof DialogContentModal | typeof DialogContentNonModal>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -170,7 +170,7 @@ type DialogContentOwnProps = Polymorphic.Merge<
 >;
 
 type DialogContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof DialogContentModalImpl | typeof DialogContentNonModalImpl>,
+  Polymorphic.IntrinsicElement<typeof DialogContentModal | typeof DialogContentNonModal>,
   DialogContentOwnProps
 >;
 
@@ -180,9 +180,9 @@ const DialogContent = React.forwardRef((props, forwardedRef) => {
   return (
     <Presence present={forceMount || context.open}>
       {context.modal ? (
-        <DialogContentModalImpl {...contentProps} ref={forwardedRef} />
+        <DialogContentModal {...contentProps} ref={forwardedRef} />
       ) : (
-        <DialogContentNonModalImpl {...contentProps} ref={forwardedRef} />
+        <DialogContentNonModal {...contentProps} ref={forwardedRef} />
       )}
     </Presence>
   );
@@ -190,17 +190,17 @@ const DialogContent = React.forwardRef((props, forwardedRef) => {
 
 DialogContent.displayName = CONTENT_NAME;
 
-type DialogContentImplOwnProps = Omit<
-  Polymorphic.OwnProps<typeof DialogContentPart>,
+type DialogContentTypeOwnProps = Omit<
+  Polymorphic.OwnProps<typeof DialogContentImpl>,
   'trapFocus' | 'disableOutsidePointerEvents'
 >;
 
-type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof DialogContentPart>,
-  DialogContentImplOwnProps
+type DialogContentTypePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof DialogContentImpl>,
+  DialogContentTypeOwnProps
 >;
 
-const DialogContentModalImpl = React.forwardRef((props, forwardedRef) => {
+const DialogContentModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, contentRef);
@@ -214,10 +214,10 @@ const DialogContentModalImpl = React.forwardRef((props, forwardedRef) => {
   return (
     <Portal>
       <RemoveScroll>
-        <DialogContentPart
+        <DialogContentImpl
           {...props}
           ref={composedRefs}
-          // we make sure focus isn't contained once `DialogContent` has been closed
+          // we make sure focus isn't trapped once `DialogContent` has been closed
           // (closed !== unmounted when animating out)
           trapFocus={context.open}
           disableOutsidePointerEvents
@@ -240,14 +240,14 @@ const DialogContentModalImpl = React.forwardRef((props, forwardedRef) => {
       </RemoveScroll>
     </Portal>
   );
-}) as DialogContentImplPrimitive;
+}) as DialogContentTypePrimitive;
 
-const DialogContentNonModalImpl = React.forwardRef((props, forwardedRef) => {
+const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
   const isPointerDownOutsideRef = React.useRef(false);
   return (
     <Portal>
-      <DialogContentPart
+      <DialogContentImpl
         {...props}
         ref={forwardedRef}
         trapFocus={false}
@@ -271,11 +271,11 @@ const DialogContentNonModalImpl = React.forwardRef((props, forwardedRef) => {
       />
     </Portal>
   );
-}) as DialogContentImplPrimitive;
+}) as DialogContentTypePrimitive;
 
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 
-type DialogContentPartOwnProps = Polymorphic.Merge<
+type DialogContentImplOwnProps = Polymorphic.Merge<
   Omit<Polymorphic.OwnProps<typeof DismissableLayer>, 'onDismiss'>,
   {
     /**
@@ -299,12 +299,12 @@ type DialogContentPartOwnProps = Polymorphic.Merge<
   }
 >;
 
-type DialogContentPartPrimimitive = Polymorphic.ForwardRefComponent<
+type DialogContentImplPrimimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DismissableLayer>,
-  DialogContentPartOwnProps
+  DialogContentImplOwnProps
 >;
 
-const DialogContentPart = React.forwardRef((props, forwardedRef) => {
+const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
@@ -349,7 +349,7 @@ const DialogContentPart = React.forwardRef((props, forwardedRef) => {
       {process.env.NODE_ENV === 'development' && <LabelWarning contentRef={contentRef} />}
     </>
   );
-}) as DialogContentPartPrimimitive;
+}) as DialogContentImplPrimimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * DialogTitle

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -29,6 +29,8 @@ type DialogContextValue = {
   descriptionId: string;
   open: boolean;
   onOpenChange(open: boolean): void;
+  onOpenToggle(): void;
+  modal: boolean;
 };
 
 const [DialogProvider, useDialogContext] = createContext<DialogContextValue>(DIALOG_NAME);
@@ -37,10 +39,11 @@ type DialogOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
+  modal?: boolean;
 };
 
 const Dialog: React.FC<DialogOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange, modal = true } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
@@ -56,6 +59,8 @@ const Dialog: React.FC<DialogOwnProps> = (props) => {
       descriptionId={useId()}
       open={open}
       onOpenChange={setOpen}
+      onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+      modal={modal}
     >
       {children}
     </DialogProvider>
@@ -91,7 +96,7 @@ const DialogTrigger = React.forwardRef((props, forwardedRef) => {
       {...triggerProps}
       as={as}
       ref={composedTriggerRef}
-      onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(true))}
+      onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
     />
   );
 }) as DialogTriggerPrimitive;
@@ -123,12 +128,14 @@ type DialogOverlayPrimitive = Polymorphic.ForwardRefComponent<
 const DialogOverlay = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...overlayProps } = props;
   const context = useDialogContext(OVERLAY_NAME);
-  return (
+  return context.modal ? (
     <Presence present={forceMount || context.open}>
-      <DialogOverlayImpl data-state={getState(context.open)} {...overlayProps} ref={forwardedRef} />
+      <DialogOverlayImpl {...overlayProps} ref={forwardedRef} />
     </Presence>
-  );
+  ) : null;
 }) as DialogOverlayPrimitive;
+
+DialogOverlay.displayName = OVERLAY_NAME;
 
 type DialogOverlayImplOwnProps = Polymorphic.OwnProps<typeof Primitive>;
 type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
@@ -137,14 +144,13 @@ type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(OVERLAY_NAME);
   return (
     <Portal>
-      <Primitive {...props} ref={forwardedRef} />
+      <Primitive data-state={getState(context.open)} {...props} ref={forwardedRef} />
     </Portal>
   );
 }) as DialogOverlayImplPrimitive;
-
-DialogOverlay.displayName = OVERLAY_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * DialogContent
@@ -153,7 +159,7 @@ DialogOverlay.displayName = OVERLAY_NAME;
 const CONTENT_NAME = 'DialogContent';
 
 type DialogContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof DialogContentImpl>,
+  Polymorphic.OwnProps<typeof DialogContentModalImpl | typeof DialogContentNonModalImpl>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -164,7 +170,7 @@ type DialogContentOwnProps = Polymorphic.Merge<
 >;
 
 type DialogContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof DialogContentImpl>,
+  Polymorphic.IntrinsicElement<typeof DialogContentModalImpl | typeof DialogContentNonModalImpl>,
   DialogContentOwnProps
 >;
 
@@ -173,19 +179,112 @@ const DialogContent = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
   return (
     <Presence present={forceMount || context.open}>
-      <DialogContentImpl data-state={getState(context.open)} {...contentProps} ref={forwardedRef} />
+      {context.modal ? (
+        <DialogContentModalImpl {...contentProps} ref={forwardedRef} />
+      ) : (
+        <DialogContentNonModalImpl {...contentProps} ref={forwardedRef} />
+      )}
     </Presence>
   );
 }) as DialogContentPrimitive;
 
+DialogContent.displayName = CONTENT_NAME;
+
+type DialogContentImplOwnProps = Omit<
+  Polymorphic.OwnProps<typeof DialogContentPart>,
+  'trapFocus' | 'disableOutsidePointerEvents'
+>;
+
+type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof DialogContentPart>,
+  DialogContentImplOwnProps
+>;
+
+const DialogContentModalImpl = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <Portal>
+      <RemoveScroll>
+        <DialogContentPart
+          {...props}
+          ref={composedRefs}
+          // we make sure focus isn't contained once `DialogContent` has been closed
+          // (closed !== unmounted when animating out)
+          trapFocus={context.open}
+          disableOutsidePointerEvents
+          onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+            const originalEvent = event.detail.originalEvent as MouseEvent;
+            const isRightClick =
+              originalEvent.button === 2 ||
+              (originalEvent.button === 0 && originalEvent.ctrlKey === true);
+
+            // If the event is a right-click, we shouldn't close because
+            // it is effectively as if we right-clicked the `Overlay`.
+            if (isRightClick) event.preventDefault();
+          })}
+          // When focus is trapped, a `focusout` event may still happen.
+          // We make sure we don't trigger our `onDismiss` in such case.
+          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+            event.preventDefault()
+          )}
+        />
+      </RemoveScroll>
+    </Portal>
+  );
+}) as DialogContentImplPrimitive;
+
+const DialogContentNonModalImpl = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME);
+  const isPointerDownOutsideRef = React.useRef(false);
+  return (
+    <Portal>
+      <DialogContentPart
+        {...props}
+        ref={forwardedRef}
+        trapFocus={false}
+        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          if (isPointerDownOutsideRef.current) event.preventDefault();
+        })}
+        disableOutsidePointerEvents={false}
+        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+          isPointerDownOutsideRef.current = false;
+        })}
+        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+          const { originalEvent } = event.detail;
+          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+          isPointerDownOutsideRef.current = isLeftClick;
+
+          // prevent dismissing when clicking the trigger
+          // as it's already setup to close, otherwise it would close and immediately open.
+          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+          if (targetIsTrigger) event.preventDefault();
+        })}
+      />
+    </Portal>
+  );
+}) as DialogContentImplPrimitive;
+
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 
-type DialogContentImplOwnProps = Polymorphic.Merge<
-  Omit<
-    Polymorphic.OwnProps<typeof DismissableLayer>,
-    'disableOutsidePointerEvents' | 'onFocusOutside' | 'onInteractOutside' | 'onDismiss'
-  >,
+type DialogContentPartOwnProps = Polymorphic.Merge<
+  Omit<Polymorphic.OwnProps<typeof DismissableLayer>, 'onDismiss'>,
   {
+    /**
+     * When `true`, focus cannot escape the `Content` via keyboard,
+     * pointer, or a programmatic focus.
+     * @defaultValue false
+     */
+    trapFocus?: FocusScopeOwnProps['trapped'];
+
     /**
      * Event handler called when auto-focusing on open.
      * Can be prevented.
@@ -200,20 +299,19 @@ type DialogContentImplOwnProps = Polymorphic.Merge<
   }
 >;
 
-type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
+type DialogContentPartPrimimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DismissableLayer>,
-  DialogContentImplOwnProps
+  DialogContentPartOwnProps
 >;
 
-const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
+const DialogContentPart = React.forwardRef((props, forwardedRef) => {
   const {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     'aria-describedby': ariaDescribedBy,
+    trapFocus,
     onOpenAutoFocus,
     onCloseAutoFocus,
-    onEscapeKeyDown,
-    onPointerDownOutside,
     ...contentProps
   } = props;
   const context = useDialogContext(CONTENT_NAME);
@@ -224,62 +322,34 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
 
-  // Hide everything from ARIA except the content
-  React.useEffect(() => {
-    const content = contentRef.current;
-    if (content) return hideOthers(content);
-  }, []);
-
   return (
     <>
-      <Portal>
-        <RemoveScroll>
-          <FocusScope
-            as={Slot}
-            // we make sure we're not trapping once it's been closed
-            // (closed !== unmounted when animating out)
-            trapped={context.open}
-            onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={onCloseAutoFocus}
-          >
-            <DismissableLayer
-              role="dialog"
-              id={context.contentId}
-              aria-modal
-              aria-describedby={ariaDescribedBy || context.descriptionId}
-              // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
-              // Otherwise fallback to an explicit `aria-labelledby` or the ID used in the
-              // `DialogTitle`
-              aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || context.titleId}
-              aria-label={ariaLabel || undefined}
-              {...contentProps}
-              ref={composedRefs}
-              disableOutsidePointerEvents
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
-                const originalEvent = event.detail.originalEvent as MouseEvent;
-                const isRightClick =
-                  originalEvent.button === 2 ||
-                  (originalEvent.button === 0 && originalEvent.ctrlKey === true);
-
-                // If the event is a right-click, we shouldn't close because
-                // it is effectively as if we right-clicked the `Overlay`.
-                if (isRightClick) event.preventDefault();
-              })}
-              // When focus is trapped, a focusout event may still happen.
-              // We make sure we don't trigger our `onDismiss` in such case.
-              onFocusOutside={(event) => event.preventDefault()}
-              onDismiss={() => context.onOpenChange(false)}
-            />
-          </FocusScope>
-        </RemoveScroll>
-      </Portal>
+      <FocusScope
+        as={Slot}
+        loop
+        trapped={trapFocus}
+        onMountAutoFocus={onOpenAutoFocus}
+        onUnmountAutoFocus={onCloseAutoFocus}
+      >
+        <DismissableLayer
+          role="dialog"
+          id={context.contentId}
+          aria-describedby={ariaDescribedBy || context.descriptionId}
+          // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
+          // Otherwise fallback to an explicit `aria-labelledby` or the ID used in the
+          // `DialogTitle`
+          aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || context.titleId}
+          aria-label={ariaLabel || undefined}
+          data-state={getState(context.open)}
+          {...contentProps}
+          ref={composedRefs}
+          onDismiss={() => context.onOpenChange(false)}
+        />
+      </FocusScope>
       {process.env.NODE_ENV === 'development' && <LabelWarning contentRef={contentRef} />}
     </>
   );
-}) as DialogContentImplPrimitive;
-
-DialogContent.displayName = CONTENT_NAME;
+}) as DialogContentPartPrimimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * DialogTitle


### PR DESCRIPTION
This PR builds on top of #698 and adds support for non-modal dialogs.

I have done this by splitting the internals in a few components:

- `DialogContent` which will render:
  - `DialogContentModalImpl` or `DialogContentNonModalImpl` which will both render:
    - `DialogContentPart`

Before I go much further, I'm still in 2 minds about this whether it's any clearer or not so I'd love to get your thoughts on it.

What pushed me towards this was that otherwise with a single component, I ended up with lots of `context.modal ? ` checks or wiring throughout the component.