### PR TITLE
[Dialog][AlertDialog][Popover][DropdownMenu][ContextMenu] Modality

### DIFF
--- a/.yarn/versions/ffb28263.yml
+++ b/.yarn/versions/ffb28263.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -37,9 +37,14 @@ const [
   useAlertDialogContentContext,
 ] = createContext<AlertDialogContentContextValue>(CONTENT_NAME);
 
+type AlertDialogContentProps = Omit<
+  Polymorphic.OwnProps<typeof DialogPrimitive.Content>,
+  'onPointerDownOutside'
+>;
+
 type AlertDialogContentPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DialogPrimitive.Content>,
-  Polymorphic.OwnProps<typeof DialogPrimitive.Content>
+  AlertDialogContentProps
 >;
 
 const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
@@ -64,9 +69,7 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
             event.preventDefault();
             cancelRef.current?.focus({ preventScroll: true });
           })}
-          onPointerDownOutside={composeEventHandlers(contentProps.onPointerDownOutside, (event) =>
-            event.preventDefault()
-          )}
+          onPointerDownOutside={(event) => event.preventDefault()}
         >
           {/**
            * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -14,8 +14,10 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 const ROOT_NAME = 'AlertDialog';
 
-const AlertDialog: React.FC<React.ComponentProps<typeof DialogPrimitive.Root>> = (props) => (
-  <DialogPrimitive.Root {...props} />
+type AlertDialogProps = Omit<React.ComponentProps<typeof DialogPrimitive.Root>, 'modal'>;
+
+const AlertDialog: React.FC<AlertDialogProps> = (props) => (
+  <DialogPrimitive.Root {...props} modal={true} />
 );
 
 AlertDialog.displayName = ROOT_NAME;
@@ -62,6 +64,9 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
             event.preventDefault();
             cancelRef.current?.focus({ preventScroll: true });
           })}
+          onPointerDownOutside={composeEventHandlers(contentProps.onPointerDownOutside, (event) =>
+            event.preventDefault()
+          )}
         >
           {/**
            * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -65,6 +65,89 @@ export const Styled = () => {
   );
 };
 
+export const NonModal = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100vw',
+        height: '100vh',
+        gap: 20,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <ContextMenu onOpenChange={setOpen} modal={false}>
+          <ContextMenuTrigger
+            className={triggerClass}
+            style={{ background: open ? 'lightblue' : undefined }}
+          />
+          <ContextMenuContent className={contentClass} alignOffset={-5}>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </ContextMenuItem>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenu>
+              <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
+              <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </ContextMenuItem>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </ContextMenuItem>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenu>
+                  <ContextMenuTriggerItem className={subTriggerClass}>
+                    Submenu →
+                  </ContextMenuTriggerItem>
+                  <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                      One
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                      Two
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                      Three
+                    </ContextMenuItem>
+                    <ContextMenuArrow offset={14} />
+                  </ContextMenuContent>
+                </ContextMenu>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </ContextMenuItem>
+                <ContextMenuArrow offset={14} />
+              </ContextMenuContent>
+            </ContextMenu>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+        <textarea
+          style={{ width: 500, height: 200, marginTop: 10 }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    </div>
+  );
+};
+
 export const Submenus = () => {
   const [open, setOpen] = React.useState(false);
   const [rtl, setRtl] = React.useState(false);

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -65,84 +65,151 @@ export const Styled = () => {
   );
 };
 
-export const NonModal = () => {
-  const [open, setOpen] = React.useState(false);
+export const Modality = () => {
+  const [open1, setOpen1] = React.useState(false);
+  const [open2, setOpen2] = React.useState(false);
 
   return (
     <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100vw',
-        height: '100vh',
-        gap: 20,
-      }}
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '110vh' }}
     >
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <ContextMenu onOpenChange={setOpen} modal={false}>
-          <ContextMenuTrigger
-            className={triggerClass}
-            style={{ background: open ? 'lightblue' : undefined }}
+      <div style={{ display: 'grid', gridGap: 50 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Modal (default)</h1>
+          <ContextMenu onOpenChange={setOpen1}>
+            <ContextMenuTrigger
+              className={triggerClass}
+              style={{ background: open1 ? 'lightblue' : undefined }}
+            />
+            <ContextMenuContent className={contentClass} alignOffset={-5}>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+                Undo
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+                Redo
+              </ContextMenuItem>
+              <ContextMenuSeparator className={separatorClass} />
+              <ContextMenu>
+                <ContextMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </ContextMenuTriggerItem>
+                <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </ContextMenuItem>
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </ContextMenuItem>
+                  <ContextMenuSeparator className={separatorClass} />
+                  <ContextMenu>
+                    <ContextMenuTriggerItem className={subTriggerClass}>
+                      Submenu →
+                    </ContextMenuTriggerItem>
+                    <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                        One
+                      </ContextMenuItem>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                        Two
+                      </ContextMenuItem>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                        Three
+                      </ContextMenuItem>
+                      <ContextMenuArrow offset={14} />
+                    </ContextMenuContent>
+                  </ContextMenu>
+                  <ContextMenuSeparator className={separatorClass} />
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </ContextMenuItem>
+                  <ContextMenuArrow offset={14} />
+                </ContextMenuContent>
+              </ContextMenu>
+              <ContextMenuSeparator className={separatorClass} />
+              <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+                Cut
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+                Copy
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+                Paste
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
           />
-          <ContextMenuContent className={contentClass} alignOffset={-5}>
-            <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
-              Undo
-            </ContextMenuItem>
-            <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
-              Redo
-            </ContextMenuItem>
-            <ContextMenuSeparator className={separatorClass} />
-            <ContextMenu>
-              <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
-              <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
-                <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
-                  One
-                </ContextMenuItem>
-                <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
-                  Two
-                </ContextMenuItem>
-                <ContextMenuSeparator className={separatorClass} />
-                <ContextMenu>
-                  <ContextMenuTriggerItem className={subTriggerClass}>
-                    Submenu →
-                  </ContextMenuTriggerItem>
-                  <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
-                    <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
-                      One
-                    </ContextMenuItem>
-                    <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
-                      Two
-                    </ContextMenuItem>
-                    <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
-                      Three
-                    </ContextMenuItem>
-                    <ContextMenuArrow offset={14} />
-                  </ContextMenuContent>
-                </ContextMenu>
-                <ContextMenuSeparator className={separatorClass} />
-                <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
-                  Three
-                </ContextMenuItem>
-                <ContextMenuArrow offset={14} />
-              </ContextMenuContent>
-            </ContextMenu>
-            <ContextMenuSeparator className={separatorClass} />
-            <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
-              Cut
-            </ContextMenuItem>
-            <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
-              Copy
-            </ContextMenuItem>
-            <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
-              Paste
-            </ContextMenuItem>
-          </ContextMenuContent>
-        </ContextMenu>
-        <textarea
-          style={{ width: 500, height: 200, marginTop: 10 }}
-          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
-        />
+        </div>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Non modal</h1>
+          <ContextMenu onOpenChange={setOpen2} modal={false}>
+            <ContextMenuTrigger
+              className={triggerClass}
+              style={{ background: open2 ? 'lightblue' : undefined }}
+            />
+            <ContextMenuContent className={contentClass} alignOffset={-5}>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+                Undo
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+                Redo
+              </ContextMenuItem>
+              <ContextMenuSeparator className={separatorClass} />
+              <ContextMenu>
+                <ContextMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </ContextMenuTriggerItem>
+                <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </ContextMenuItem>
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </ContextMenuItem>
+                  <ContextMenuSeparator className={separatorClass} />
+                  <ContextMenu>
+                    <ContextMenuTriggerItem className={subTriggerClass}>
+                      Submenu →
+                    </ContextMenuTriggerItem>
+                    <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                        One
+                      </ContextMenuItem>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                        Two
+                      </ContextMenuItem>
+                      <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                        Three
+                      </ContextMenuItem>
+                      <ContextMenuArrow offset={14} />
+                    </ContextMenuContent>
+                  </ContextMenu>
+                  <ContextMenuSeparator className={separatorClass} />
+                  <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </ContextMenuItem>
+                  <ContextMenuArrow offset={14} />
+                </ContextMenuContent>
+              </ContextMenu>
+              <ContextMenuSeparator className={separatorClass} />
+              <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+                Cut
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+                Copy
+              </ContextMenuItem>
+              <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+                Paste
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -29,10 +29,11 @@ const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuCo
 type ContextMenuOwnProps = {
   onOpenChange?(open: boolean): void;
   dir?: Direction;
+  modal?: boolean;
 };
 
 const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
-  const { children, onOpenChange, dir } = props;
+  const { children, onOpenChange, dir, modal } = props;
   const [open, setOpen] = React.useState(false);
   const isInsideContent = React.useContext(ContentContext);
   const handleOpenChangeProp = useCallbackRef(onOpenChange);
@@ -53,7 +54,7 @@ const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
     </ContextMenuProvider>
   ) : (
     <ContextMenuProvider isRootMenu={true} open={open} onOpenChange={handleOpenChange}>
-      <MenuPrimitive.Root dir={dir} open={open} onOpenChange={handleOpenChange}>
+      <MenuPrimitive.Root dir={dir} open={open} onOpenChange={handleOpenChange} modal={modal}>
         {children}
       </MenuPrimitive.Root>
     </ContextMenuProvider>
@@ -141,7 +142,7 @@ const ContentContext = React.createContext(false);
 
 type ContextMenuContentOwnProps = Omit<
   Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-  'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'side' | 'align'
+  'portalled' | 'side' | 'align'
 >;
 
 type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
@@ -183,15 +184,10 @@ type ContextMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuRootContent = React.forwardRef((props, forwardedRef) => {
-  const { disableOutsidePointerEvents = true, ...contentProps } = props;
-  const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Content
-      {...contentProps}
+      {...props}
       ref={forwardedRef}
-      disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
-      trapFocus
-      disableOutsideScroll
       portalled
       side="right"
       sideOffset={2}

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -196,7 +196,7 @@ type ContextMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
 
 const ContextMenuRootContent = React.forwardRef((props, forwardedRef) => {
   const context = useContextMenuContext(CONTENT_NAME);
-  const shouldPreventFocusRef = React.useRef(false);
+  const hasInteractedOutsideRef = React.useRef(false);
 
   return (
     <MenuPrimitive.Content
@@ -209,18 +209,16 @@ const ContextMenuRootContent = React.forwardRef((props, forwardedRef) => {
       onCloseAutoFocus={(event) => {
         props.onCloseAutoFocus?.(event);
 
-        if (!event.defaultPrevented && shouldPreventFocusRef.current) {
+        if (!event.defaultPrevented && hasInteractedOutsideRef.current) {
           event.preventDefault();
         }
 
-        shouldPreventFocusRef.current = false;
+        hasInteractedOutsideRef.current = false;
       }}
       onInteractOutside={(event) => {
         props.onInteractOutside?.(event);
 
-        if (!event.defaultPrevented && !context.modal) {
-          shouldPreventFocusRef.current = true;
-        }
+        if (!event.defaultPrevented && !context.modal) hasInteractedOutsideRef.current = true;
       }}
     />
   );

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -24,6 +24,31 @@ export const Styled = () => (
   </Dialog>
 );
 
+export const NonModal = () => (
+  <>
+    <Dialog modal={false}>
+      <DialogTrigger className={triggerClass}>open (non-modal)</DialogTrigger>
+      <DialogOverlay className={overlayClass} />
+      <DialogContent
+        className={contentSheetClass}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <DialogTitle>Booking info</DialogTitle>
+        <DialogClose className={closeClass}>close</DialogClose>
+      </DialogContent>
+    </Dialog>
+
+    {Array.from({ length: 5 }, (_, i) => (
+      <div key={i} style={{ marginTop: 20 }}>
+        <textarea
+          style={{ width: 800, height: 400 }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    ))}
+  </>
+);
+
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
   return (
@@ -318,11 +343,23 @@ const contentClass = css({
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  background: 'white',
   minWidth: 300,
   minHeight: 150,
   padding: 50,
   borderRadius: 10,
+  backgroundColor: 'white',
+  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
+});
+
+const contentSheetClass = css({
+  ...RECOMMENDED_CSS__DIALOG__CONTENT,
+  left: undefined,
+  right: 0,
+  minWidth: 300,
+  minHeight: '100vh',
+  padding: 50,
+  borderTopLeftRadius: 10,
+  borderBottomLeftRadius: 10,
   backgroundColor: 'white',
   boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
 });

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -247,7 +247,8 @@ const DialogContentModal = React.forwardRef((props, forwardedRef) => {
 
 const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
-  const isEscapeKeyDownRef = React.useRef(false);
+  const shouldFocusTriggerRef = React.useRef(true);
+
   return (
     <Portal>
       <DialogContentImpl
@@ -255,23 +256,32 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-          event.preventDefault();
-          if (isEscapeKeyDownRef.current) context.triggerRef.current?.focus();
-        })}
-        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
-          isEscapeKeyDownRef.current = true;
-        })}
-        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
+        onCloseAutoFocus={(event) => {
+          props.onCloseAutoFocus?.(event);
+
+          if (!event.defaultPrevented) {
+            // Always prevent auto focus because we either focus manually or want user agent focus
+            event.preventDefault();
+            if (shouldFocusTriggerRef.current) context.triggerRef.current?.focus();
+          }
+
+          shouldFocusTriggerRef.current = true;
+        }}
+        onInteractOutside={(event) => {
+          props.onInteractOutside?.(event);
+
+          if (!event.defaultPrevented) shouldFocusTriggerRef.current = false;
+
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
           // cause it to close and immediately open.
           //
           // We use `onInteractOutside` as some browsers also
           // focus on pointer down, creating the same issue.
-          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+          const target = event.target as HTMLElement;
+          const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-        })}
+        }}
       />
     </Portal>
   );

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -247,7 +247,7 @@ const DialogContentModal = React.forwardRef((props, forwardedRef) => {
 
 const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
-  const shouldFocusTriggerRef = React.useRef(true);
+  const hasInteractedOutsideRef = React.useRef(false);
 
   return (
     <Portal>
@@ -260,17 +260,17 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           props.onCloseAutoFocus?.(event);
 
           if (!event.defaultPrevented) {
+            if (!hasInteractedOutsideRef.current) context.triggerRef.current?.focus();
             // Always prevent auto focus because we either focus manually or want user agent focus
             event.preventDefault();
-            if (shouldFocusTriggerRef.current) context.triggerRef.current?.focus();
           }
 
-          shouldFocusTriggerRef.current = true;
+          hasInteractedOutsideRef.current = false;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
 
-          if (!event.defaultPrevented) shouldFocusTriggerRef.current = false;
+          if (!event.defaultPrevented) hasInteractedOutsideRef.current = true;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -264,8 +264,12 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           isPointerDownOutsideRef.current = isLeftClick;
         })}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           if (targetIsTrigger) event.preventDefault();
         })}

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -262,7 +262,8 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           const { originalEvent } = event.detail;
           const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
           isPointerDownOutsideRef.current = isLeftClick;
-
+        })}
+        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
           // prevent dismissing when clicking the trigger
           // as it's already setup to close, otherwise it would close and immediately open.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -29,6 +29,8 @@ type DialogContextValue = {
   descriptionId: string;
   open: boolean;
   onOpenChange(open: boolean): void;
+  onOpenToggle(): void;
+  modal: boolean;
 };
 
 const [DialogProvider, useDialogContext] = createContext<DialogContextValue>(DIALOG_NAME);
@@ -37,10 +39,11 @@ type DialogOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
+  modal?: boolean;
 };
 
 const Dialog: React.FC<DialogOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange, modal = true } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
@@ -56,6 +59,8 @@ const Dialog: React.FC<DialogOwnProps> = (props) => {
       descriptionId={useId()}
       open={open}
       onOpenChange={setOpen}
+      onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+      modal={modal}
     >
       {children}
     </DialogProvider>
@@ -91,7 +96,7 @@ const DialogTrigger = React.forwardRef((props, forwardedRef) => {
       {...triggerProps}
       as={as}
       ref={composedTriggerRef}
-      onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(true))}
+      onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
     />
   );
 }) as DialogTriggerPrimitive;
@@ -123,12 +128,14 @@ type DialogOverlayPrimitive = Polymorphic.ForwardRefComponent<
 const DialogOverlay = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...overlayProps } = props;
   const context = useDialogContext(OVERLAY_NAME);
-  return (
+  return context.modal ? (
     <Presence present={forceMount || context.open}>
-      <DialogOverlayImpl data-state={getState(context.open)} {...overlayProps} ref={forwardedRef} />
+      <DialogOverlayImpl {...overlayProps} ref={forwardedRef} />
     </Presence>
-  );
+  ) : null;
 }) as DialogOverlayPrimitive;
+
+DialogOverlay.displayName = OVERLAY_NAME;
 
 type DialogOverlayImplOwnProps = Polymorphic.OwnProps<typeof Primitive>;
 type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
@@ -137,14 +144,13 @@ type DialogOverlayImplPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DialogOverlayImpl = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(OVERLAY_NAME);
   return (
     <Portal>
-      <Primitive {...props} ref={forwardedRef} />
+      <Primitive data-state={getState(context.open)} {...props} ref={forwardedRef} />
     </Portal>
   );
 }) as DialogOverlayImplPrimitive;
-
-DialogOverlay.displayName = OVERLAY_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * DialogContent
@@ -153,7 +159,7 @@ DialogOverlay.displayName = OVERLAY_NAME;
 const CONTENT_NAME = 'DialogContent';
 
 type DialogContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof DialogContentImpl>,
+  Polymorphic.OwnProps<typeof DialogContentModal | typeof DialogContentNonModal>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -164,7 +170,7 @@ type DialogContentOwnProps = Polymorphic.Merge<
 >;
 
 type DialogContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof DialogContentImpl>,
+  Polymorphic.IntrinsicElement<typeof DialogContentModal | typeof DialogContentNonModal>,
   DialogContentOwnProps
 >;
 
@@ -173,19 +179,112 @@ const DialogContent = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
   return (
     <Presence present={forceMount || context.open}>
-      <DialogContentImpl data-state={getState(context.open)} {...contentProps} ref={forwardedRef} />
+      {context.modal ? (
+        <DialogContentModal {...contentProps} ref={forwardedRef} />
+      ) : (
+        <DialogContentNonModal {...contentProps} ref={forwardedRef} />
+      )}
     </Presence>
   );
 }) as DialogContentPrimitive;
 
+DialogContent.displayName = CONTENT_NAME;
+
+type DialogContentTypeOwnProps = Omit<
+  Polymorphic.OwnProps<typeof DialogContentImpl>,
+  'trapFocus' | 'disableOutsidePointerEvents'
+>;
+
+type DialogContentTypePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof DialogContentImpl>,
+  DialogContentTypeOwnProps
+>;
+
+const DialogContentModal = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <Portal>
+      <RemoveScroll>
+        <DialogContentImpl
+          {...props}
+          ref={composedRefs}
+          // we make sure focus isn't trapped once `DialogContent` has been closed
+          // (closed !== unmounted when animating out)
+          trapFocus={context.open}
+          disableOutsidePointerEvents
+          onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+            const originalEvent = event.detail.originalEvent as MouseEvent;
+            const isRightClick =
+              originalEvent.button === 2 ||
+              (originalEvent.button === 0 && originalEvent.ctrlKey === true);
+
+            // If the event is a right-click, we shouldn't close because
+            // it is effectively as if we right-clicked the `Overlay`.
+            if (isRightClick) event.preventDefault();
+          })}
+          // When focus is trapped, a `focusout` event may still happen.
+          // We make sure we don't trigger our `onDismiss` in such case.
+          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+            event.preventDefault()
+          )}
+        />
+      </RemoveScroll>
+    </Portal>
+  );
+}) as DialogContentTypePrimitive;
+
+const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
+  const context = useDialogContext(CONTENT_NAME);
+  const isPointerDownOutsideRef = React.useRef(false);
+  return (
+    <Portal>
+      <DialogContentImpl
+        {...props}
+        ref={forwardedRef}
+        trapFocus={false}
+        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          if (isPointerDownOutsideRef.current) event.preventDefault();
+        })}
+        disableOutsidePointerEvents={false}
+        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+          isPointerDownOutsideRef.current = false;
+        })}
+        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+          const { originalEvent } = event.detail;
+          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+          isPointerDownOutsideRef.current = isLeftClick;
+
+          // prevent dismissing when clicking the trigger
+          // as it's already setup to close, otherwise it would close and immediately open.
+          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+          if (targetIsTrigger) event.preventDefault();
+        })}
+      />
+    </Portal>
+  );
+}) as DialogContentTypePrimitive;
+
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 
 type DialogContentImplOwnProps = Polymorphic.Merge<
-  Omit<
-    Polymorphic.OwnProps<typeof DismissableLayer>,
-    'disableOutsidePointerEvents' | 'onFocusOutside' | 'onInteractOutside' | 'onDismiss'
-  >,
+  Omit<Polymorphic.OwnProps<typeof DismissableLayer>, 'onDismiss'>,
   {
+    /**
+     * When `true`, focus cannot escape the `Content` via keyboard,
+     * pointer, or a programmatic focus.
+     * @defaultValue false
+     */
+    trapFocus?: FocusScopeOwnProps['trapped'];
+
     /**
      * Event handler called when auto-focusing on open.
      * Can be prevented.
@@ -200,7 +299,7 @@ type DialogContentImplOwnProps = Polymorphic.Merge<
   }
 >;
 
-type DialogContentImplPrimitive = Polymorphic.ForwardRefComponent<
+type DialogContentImplPrimimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DismissableLayer>,
   DialogContentImplOwnProps
 >;
@@ -210,10 +309,9 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     'aria-describedby': ariaDescribedBy,
+    trapFocus,
     onOpenAutoFocus,
     onCloseAutoFocus,
-    onEscapeKeyDown,
-    onPointerDownOutside,
     ...contentProps
   } = props;
   const context = useDialogContext(CONTENT_NAME);
@@ -224,65 +322,34 @@ const DialogContentImpl = React.forwardRef((props, forwardedRef) => {
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
 
-  // Hide everything from ARIA except the content
-  React.useEffect(() => {
-    const content = contentRef.current;
-    if (content) return hideOthers(content);
-  }, []);
-
   return (
     <>
-      <Portal>
-        <RemoveScroll>
-          <FocusScope
-            as={Slot}
-            // we make sure we're not trapping once it's been closed
-            // (closed !== unmounted when animating out)
-            trapped={context.open}
-            onMountAutoFocus={onOpenAutoFocus}
-            onUnmountAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
-              event.preventDefault();
-              context.triggerRef.current?.focus();
-            })}
-          >
-            <DismissableLayer
-              role="dialog"
-              id={context.contentId}
-              aria-modal
-              aria-describedby={ariaDescribedBy || context.descriptionId}
-              // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
-              // Otherwise fallback to an explicit `aria-labelledby` or the ID used in the
-              // `DialogTitle`
-              aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || context.titleId}
-              aria-label={ariaLabel || undefined}
-              {...contentProps}
-              ref={composedRefs}
-              disableOutsidePointerEvents
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={composeEventHandlers(onPointerDownOutside, (event) => {
-                const originalEvent = event.detail.originalEvent as MouseEvent;
-                const isRightClick =
-                  originalEvent.button === 2 ||
-                  (originalEvent.button === 0 && originalEvent.ctrlKey === true);
-
-                // If the event is a right-click, we shouldn't close because
-                // it is effectively as if we right-clicked the `Overlay`.
-                if (isRightClick) event.preventDefault();
-              })}
-              // When focus is trapped, a focusout event may still happen.
-              // We make sure we don't trigger our `onDismiss` in such case.
-              onFocusOutside={(event) => event.preventDefault()}
-              onDismiss={() => context.onOpenChange(false)}
-            />
-          </FocusScope>
-        </RemoveScroll>
-      </Portal>
+      <FocusScope
+        as={Slot}
+        loop
+        trapped={trapFocus}
+        onMountAutoFocus={onOpenAutoFocus}
+        onUnmountAutoFocus={onCloseAutoFocus}
+      >
+        <DismissableLayer
+          role="dialog"
+          id={context.contentId}
+          aria-describedby={ariaDescribedBy || context.descriptionId}
+          // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
+          // Otherwise fallback to an explicit `aria-labelledby` or the ID used in the
+          // `DialogTitle`
+          aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || context.titleId}
+          aria-label={ariaLabel || undefined}
+          data-state={getState(context.open)}
+          {...contentProps}
+          ref={composedRefs}
+          onDismiss={() => context.onOpenChange(false)}
+        />
+      </FocusScope>
       {process.env.NODE_ENV === 'development' && <LabelWarning contentRef={contentRef} />}
     </>
   );
-}) as DialogContentImplPrimitive;
-
-DialogContent.displayName = CONTENT_NAME;
+}) as DialogContentImplPrimimitive;
 
 /* -------------------------------------------------------------------------------------------------
  * DialogTitle

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -62,9 +62,9 @@ type DismissableLayerImplOwnProps = Polymorphic.Merge<
   Polymorphic.OwnProps<typeof Primitive>,
   {
     /**
-     * When `true`, hover/focus/click interactions will be disabled on elements outside the `DismissableLayer`.
-     * Users will need to click twice on outside elements to interact with them:
-     * Once to close the `DismissableLayer`, and again to trigger the element.
+     * When `true`, hover/focus/click interactions will be disabled on elements outside
+     * the `DismissableLayer`. Users will need to click twice on outside elements to
+     * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
      */
     disableOutsidePointerEvents?: boolean;
 
@@ -75,7 +75,7 @@ type DismissableLayerImplOwnProps = Polymorphic.Merge<
     onEscapeKeyDown?: (event: KeyboardEvent) => void;
 
     /**
-     * Event handler called when the a pointer event happens outside of the `DismissableLayer`.
+     * Event handler called when the a `pointerdown` event happens outside of the `DismissableLayer`.
      * Can be prevented.
      */
     onPointerDownOutside?: (event: PointerDownOutsideEvent) => void;
@@ -88,7 +88,7 @@ type DismissableLayerImplOwnProps = Polymorphic.Merge<
 
     /**
      * Event handler called when an interaction happens outside the `DismissableLayer`.
-     * Specifically, when a pointer event happens outside of the `DismissableLayer` or focus moves outside of it.
+     * Specifically, when a `pointerdown` event happens outside or focus moves outside of it.
      * Can be prevented.
      */
     onInteractOutside?: (event: PointerDownOutsideEvent | FocusOutsideEvent) => void;

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -50,56 +50,106 @@ export const Styled = () => (
   </div>
 );
 
-export const NonModal = () => {
+export const Modality = () => {
   return (
     <div
-      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '110vh' }}
     >
-      <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-          <DropdownMenuContent className={contentClass} sideOffset={5}>
-            <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
-              Undo
-            </DropdownMenuItem>
-            <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
-              Redo
-            </DropdownMenuItem>
-            <DropdownMenuSeparator className={separatorClass} />
-            <DropdownMenu>
-              <DropdownMenuTriggerItem className={subTriggerClass}>
-                Submenu →
-              </DropdownMenuTriggerItem>
-              <DropdownMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
-                <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
-                  One
-                </DropdownMenuItem>
-                <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
-                  Two
-                </DropdownMenuItem>
-                <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
-                  Three
-                </DropdownMenuItem>
-                <DropdownMenuArrow offset={14} />
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <DropdownMenuSeparator className={separatorClass} />
-            <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
-              Cut
-            </DropdownMenuItem>
-            <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
-              Copy
-            </DropdownMenuItem>
-            <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
-              Paste
-            </DropdownMenuItem>
-            <DropdownMenuArrow />
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <textarea
-          style={{ width: 500, height: 200, marginTop: 10 }}
-          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
-        />
+      <div style={{ display: 'grid', gridGap: 50 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Modal (default)</h1>
+          <DropdownMenu>
+            <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+            <DropdownMenuContent className={contentClass} sideOffset={5}>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+                Undo
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+                Redo
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenu>
+                <DropdownMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </DropdownMenuTriggerItem>
+                <DropdownMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenuItem>
+                  <DropdownMenuArrow offset={14} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+                Cut
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+                Copy
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+                Paste
+              </DropdownMenuItem>
+              <DropdownMenuArrow />
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Non modal</h1>
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+            <DropdownMenuContent className={contentClass} sideOffset={5}>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+                Undo
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+                Redo
+              </DropdownMenuItem>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenu>
+                <DropdownMenuTriggerItem className={subTriggerClass}>
+                  Submenu →
+                </DropdownMenuTriggerItem>
+                <DropdownMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenuItem>
+                  <DropdownMenuArrow offset={14} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenuSeparator className={separatorClass} />
+              <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+                Cut
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+                Copy
+              </DropdownMenuItem>
+              <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+                Paste
+              </DropdownMenuItem>
+              <DropdownMenuArrow />
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -50,6 +50,61 @@ export const Styled = () => (
   </div>
 );
 
+export const NonModal = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}
+    >
+      <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+          <DropdownMenuContent className={contentClass} sideOffset={5}>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenu>
+              <DropdownMenuTriggerItem className={subTriggerClass}>
+                Submenu →
+              </DropdownMenuTriggerItem>
+              <DropdownMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </DropdownMenuItem>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </DropdownMenuItem>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </DropdownMenuItem>
+                <DropdownMenuArrow offset={14} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenuItem>
+            <DropdownMenuArrow />
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <textarea
+          style={{ width: 500, height: 200, marginTop: 10 }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    </div>
+  );
+};
+
 export const Submenus = () => {
   const [rtl, setRtl] = React.useState(false);
   return (
@@ -328,14 +383,9 @@ export const Chromatic = () => {
     <div style={{ padding: 200, paddingBottom: 800 }}>
       <h1>Uncontrolled</h1>
       <h2>Closed</h2>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -357,13 +407,13 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu defaultOpen>
+      <DropdownMenu defaultOpen modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
           className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
-          disableOutsideScroll={false}
+          onFocusOutside={(event) => event.preventDefault()}
         >
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
@@ -386,12 +436,12 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
-      <DropdownMenu defaultOpen>
+      <DropdownMenu defaultOpen modal={false}>
         <DropdownMenuContent
           className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
-          disableOutsideScroll={false}
+          onFocusOutside={(event) => event.preventDefault()}
         >
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
@@ -416,14 +466,9 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 200 }}>Controlled</h1>
       <h2>Closed</h2>
-      <DropdownMenu open={false}>
+      <DropdownMenu open={false} modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -445,14 +490,9 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -474,13 +514,8 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
-      <DropdownMenu open>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+      <DropdownMenu open modal={false}>
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -504,13 +539,8 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 200 }}>Submenus</h1>
       <h2>Open</h2>
-      <DropdownMenu open>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+      <DropdownMenu open modal={false}>
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -580,13 +610,8 @@ export const Chromatic = () => {
 
       <h2 style={{ marginTop: 275 }}>RTL</h2>
       <div dir="rtl">
-        <DropdownMenu open dir="rtl">
-          <DropdownMenuContent
-            className={contentClass}
-            sideOffset={5}
-            avoidCollisions={false}
-            disableOutsideScroll={false}
-          >
+        <DropdownMenu open dir="rtl" modal={false}>
+          <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
             <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
               Undo
             </DropdownMenuItem>
@@ -663,14 +688,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -689,14 +713,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -718,14 +741,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -749,7 +771,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -757,7 +779,6 @@ export const Chromatic = () => {
                 sideOffset={5}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -774,7 +795,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -782,7 +803,6 @@ export const Chromatic = () => {
                 sideOffset={-10}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -801,7 +821,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -809,7 +829,6 @@ export const Chromatic = () => {
                 align={align}
                 alignOffset={20}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -826,7 +845,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -834,7 +853,6 @@ export const Chromatic = () => {
                 align={align}
                 alignOffset={-10}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -852,7 +870,7 @@ export const Chromatic = () => {
       <p>See instances on the periphery of the page.</p>
       {SIDES.map((side) =>
         ALIGN_OPTIONS.map((align) => (
-          <DropdownMenu key={`${side}-${align}`} open>
+          <DropdownMenu key={`${side}-${align}`} open modal={false}>
             <DropdownMenuTrigger
               className={chromaticTriggerClass}
               style={{
@@ -872,12 +890,7 @@ export const Chromatic = () => {
                     : { left: 10 })),
               }}
             />
-            <DropdownMenuContent
-              className={chromaticContentClass}
-              side={side}
-              align={align}
-              disableOutsideScroll={false}
-            >
+            <DropdownMenuContent className={chromaticContentClass} side={side} align={align}>
               <p style={{ textAlign: 'center' }}>
                 {side}
                 <br />
@@ -890,14 +903,9 @@ export const Chromatic = () => {
       )}
 
       <h1>With labels</h1>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           {foodGroups.map((foodGroup, index) => (
             <DropdownMenuGroup key={index}>
               {foodGroup.label && (
@@ -925,14 +933,9 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h1 style={{ marginTop: 600 }}>With checkbox and radio items</h1>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </DropdownMenuItem>
@@ -974,25 +977,15 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 500 }}>State attributes</h1>
       <h2>Closed</h2>
-      <DropdownMenu open={false}>
+      <DropdownMenu open={false} modal={false}>
         <DropdownMenuTrigger className={triggerAttrClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentAttrClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        />
+        <DropdownMenuContent className={contentAttrClass} sideOffset={5} avoidCollisions={false} />
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerAttrClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentAttrClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentAttrClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemAttrClass} onSelect={() => console.log('show')}>
             Show fonts
           </DropdownMenuItem>

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -43,10 +43,11 @@ type DropdownMenuOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
+  modal?: boolean;
 };
 
 const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange, dir } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange, dir, modal } = props;
   const isInsideContent = React.useContext(ContentContext);
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
@@ -68,7 +69,13 @@ const DropdownMenu: React.FC<DropdownMenuOwnProps> = (props) => {
       </MenuPrimitive.Sub>
     </DropdownMenuProvider>
   ) : (
-    <DropdownMenuRoot dir={dir} open={open} onOpenChange={setOpen} onOpenToggle={handleOpenToggle}>
+    <DropdownMenuRoot
+      dir={dir}
+      open={open}
+      onOpenChange={setOpen}
+      onOpenToggle={handleOpenToggle}
+      modal={modal}
+    >
       {children}
     </DropdownMenuRoot>
   );
@@ -83,10 +90,11 @@ type DropdownMenuRootOwnProps = {
   open: boolean;
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
+  modal?: boolean;
 };
 
 const DropdownMenuRoot: React.FC<DropdownMenuRootOwnProps> = (props) => {
-  const { children, dir, open, onOpenChange, onOpenToggle } = props;
+  const { children, dir, open, onOpenChange, onOpenToggle, modal = true } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   return (
     <DropdownMenuProvider
@@ -98,7 +106,7 @@ const DropdownMenuRoot: React.FC<DropdownMenuRootOwnProps> = (props) => {
       onOpenChange={onOpenChange}
       onOpenToggle={onOpenToggle}
     >
-      <MenuPrimitive.Root open={open} onOpenChange={onOpenChange} dir={dir}>
+      <MenuPrimitive.Root open={open} onOpenChange={onOpenChange} dir={dir} modal={modal}>
         {children}
       </MenuPrimitive.Root>
     </DropdownMenuProvider>
@@ -135,10 +143,13 @@ const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
       {...triggerProps}
       as={as}
       ref={composeRefs(forwardedRef, context.triggerRef)}
-      onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
+      onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
         // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
         // but not when the control key is pressed (avoiding MacOS right click)
         if (event.button === 0 && event.ctrlKey === false) {
+          // prevent trigger focusing when opening
+          // this allows the content to be given focus without competition
+          if (!context.open) event.preventDefault();
           context.onOpenToggle();
         }
       })}
@@ -162,10 +173,7 @@ const CONTENT_NAME = 'DropdownMenuContent';
 
 const ContentContext = React.createContext(false);
 
-type DropdownMenuContentOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-  'trapFocus'
->;
+type DropdownMenuContentOwnProps = Polymorphic.OwnProps<typeof MenuPrimitive.Content>;
 
 type DropdownMenuContentPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof MenuPrimitive.Content>,
@@ -205,12 +213,7 @@ type DropdownMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
-  const {
-    disableOutsidePointerEvents = true,
-    disableOutsideScroll = true,
-    portalled = true,
-    ...contentProps
-  } = props;
+  const { portalled = true, ...contentProps } = props;
   const context = useDropdownMenuContext(CONTENT_NAME);
 
   return context.isRootMenu ? (
@@ -219,21 +222,21 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       aria-labelledby={context.triggerId}
       {...contentProps}
       ref={forwardedRef}
-      disableOutsidePointerEvents={disableOutsidePointerEvents}
-      disableOutsideScroll={disableOutsideScroll}
       portalled={portalled}
-      trapFocus
       onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
         event.preventDefault();
         context.triggerRef.current?.focus();
       })}
-      onPointerDownOutside={composeEventHandlers(
-        props.onPointerDownOutside,
+      onInteractOutside={composeEventHandlers(
+        props.onInteractOutside,
         (event) => {
-          const target = event.target as HTMLElement;
-          const targetIsTrigger = context.triggerRef.current?.contains(target);
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
+          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           if (targetIsTrigger) event.preventDefault();
         },
         { checkForDefaultPrevented: false }

--- a/packages/react/focus-scope/src/FocusScope.stories.tsx
+++ b/packages/react/focus-scope/src/FocusScope.stories.tsx
@@ -17,6 +17,7 @@ export const Basic = () => {
       {trapped ? (
         <FocusScope
           as="form"
+          loop={trapped}
           trapped={trapped}
           style={{
             display: 'inline-flex',
@@ -57,6 +58,7 @@ export const Multiple = () => {
       {trapped1 ? (
         <FocusScope
           as="form"
+          loop={trapped1}
           trapped={trapped1}
           style={{
             display: 'inline-flex',
@@ -85,6 +87,7 @@ export const Multiple = () => {
       {trapped2 ? (
         <FocusScope
           as="form"
+          loop={trapped2}
           trapped={trapped2}
           style={{
             display: 'inline-flex',
@@ -208,6 +211,7 @@ export const WithOptions = () => {
         <FocusScope
           key="form"
           as="form"
+          loop={trapFocus}
           trapped={trapFocus}
           onMountAutoFocus={(event) => {
             if (focusOnMount !== true) {

--- a/packages/react/focus-scope/src/FocusScope.test.tsx
+++ b/packages/react/focus-scope/src/FocusScope.test.tsx
@@ -18,12 +18,10 @@ describe('FocusScope', () => {
     beforeEach(() => {
       rendered = render(
         <div>
-          <FocusScope trapped>
-            <form>
-              <TestField label={INNER_NAME_INPUT_LABEL} />
-              <TestField label={INNER_EMAIL_INPUT_LABEL} />
-              <button>{INNER_SUBMIT_LABEL}</button>
-            </form>
+          <FocusScope as="form" loop trapped>
+            <TestField label={INNER_NAME_INPUT_LABEL} />
+            <TestField label={INNER_EMAIL_INPUT_LABEL} />
+            <button>{INNER_SUBMIT_LABEL}</button>
           </FocusScope>
           <TestField label="other" />
           <button>some outer button</button>
@@ -61,12 +59,10 @@ describe('FocusScope', () => {
     beforeEach(() => {
       rendered = render(
         <div>
-          <FocusScope trapped>
-            <form>
-              <TestField label={INNER_NAME_INPUT_LABEL} tabIndex={-1} />
-              <TestField label={INNER_EMAIL_INPUT_LABEL} />
-              <button>{INNER_SUBMIT_LABEL}</button>
-            </form>
+          <FocusScope as="form" loop trapped>
+            <TestField label={INNER_NAME_INPUT_LABEL} tabIndex={-1} />
+            <TestField label={INNER_EMAIL_INPUT_LABEL} />
+            <button>{INNER_SUBMIT_LABEL}</button>
           </FocusScope>
           <TestField label="other" />
           <button>some outer button</button>
@@ -96,11 +92,9 @@ describe('FocusScope', () => {
     beforeEach(() => {
       rendered = render(
         <div>
-          <FocusScope trapped>
-            <form>
-              <TestField label={INNER_NAME_INPUT_LABEL} />
-              <button onBlur={handleLastFocusableElementBlur}>{INNER_SUBMIT_LABEL}</button>
-            </form>
+          <FocusScope as="form" loop trapped>
+            <TestField label={INNER_NAME_INPUT_LABEL} />
+            <button onBlur={handleLastFocusableElementBlur}>{INNER_SUBMIT_LABEL}</button>
           </FocusScope>
         </div>
       );

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -376,16 +376,13 @@ type MenuOwnProps = Omit<
 const MenuWithAnchor: React.FC<MenuOwnProps> = (props) => {
   const { open = true, children, ...contentProps } = props;
   return (
-    <Menu open={open} onOpenChange={() => {}}>
+    <Menu open={open} onOpenChange={() => {}} modal={false}>
       {/* inline-block allows anchor to move when rtl changes on document */}
       <MenuAnchor style={{ display: 'inline-block' }} />
       <MenuContent
         className={contentClass}
         portalled
-        trapFocus={false}
         onCloseAutoFocus={(event) => event.preventDefault()}
-        disableOutsidePointerEvents={false}
-        disableOutsideScroll={false}
         align="start"
         {...contentProps}
       >

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -294,7 +294,6 @@ const MenuRootContentModal = React.forwardRef((props, forwardedRef) => {
 
 const MenuRootContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(CONTENT_NAME);
-  const isPointerDownOutsideRef = React.useRef(false);
 
   return (
     <MenuContentImpl
@@ -303,25 +302,6 @@ const MenuRootContentNonModal = React.forwardRef((props, forwardedRef) => {
       trapFocus={false}
       disableOutsidePointerEvents={false}
       disableOutsideScroll={false}
-      onCloseAutoFocus={(event) => {
-        if (isPointerDownOutsideRef.current) {
-          event.preventDefault();
-        } else {
-          props.onCloseAutoFocus?.(event);
-        }
-      }}
-      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
-        isPointerDownOutsideRef.current = false;
-      })}
-      onPointerDownOutside={composeEventHandlers(
-        props.onPointerDownOutside,
-        (event) => {
-          const originalEvent = event.detail.originalEvent as MouseEvent;
-          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-          isPointerDownOutsideRef.current = isLeftClick;
-        },
-        { checkForDefaultPrevented: false }
-      )}
       onDismiss={() => context.onOpenChange(false)}
     />
   );

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -50,6 +50,7 @@ type MenuRootContextValue = {
   content: MenuContentElement | null;
   onContentChange(content: MenuContentElement | null): void;
   onRootClose(): void;
+  modal: boolean;
 };
 
 type MenuSubContextValue = Omit<MenuRootContextValue, 'isSubmenu'> & {
@@ -68,10 +69,11 @@ type MenuOwnProps = {
   open?: boolean;
   onOpenChange?(open: boolean): void;
   dir?: Direction;
+  modal?: boolean;
 };
 
 const Menu: React.FC<MenuOwnProps> = (props) => {
-  const { open = false, children, onOpenChange } = props;
+  const { open = false, children, onOpenChange, modal = true } = props;
   const [content, setContent] = React.useState<MenuContentElement | null>(null);
   const isUsingKeyboardRef = React.useRef(false);
   const handleOpenChange = useCallbackRef(onOpenChange);
@@ -103,6 +105,7 @@ const Menu: React.FC<MenuOwnProps> = (props) => {
         content={content}
         onContentChange={setContent}
         onRootClose={React.useCallback(() => handleOpenChange(false), [handleOpenChange])}
+        modal={modal}
       >
         {children}
       </MenuProvider>
@@ -149,6 +152,7 @@ const MenuSub: React.FC<MenuSubOwnProps> = (props) => {
         trigger={trigger}
         onTriggerChange={setTrigger}
         triggerId={useId()}
+        modal={false}
       >
         {children}
       </MenuProvider>
@@ -226,15 +230,35 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
 /* ---------------------------------------------------------------------------------------------- */
 
 type MenuRootContentOwnProps = Omit<
-  Polymorphic.OwnProps<typeof MenuContentImpl>,
+  Polymorphic.OwnProps<typeof MenuRootContentModal | typeof MenuRootContentNonModal>,
   keyof MenuContentImplPrivateProps
 >;
 type MenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof MenuContentImpl>,
+  Polymorphic.IntrinsicElement<typeof MenuRootContentModal | typeof MenuRootContentNonModal>,
   MenuRootContentOwnProps
 >;
 
 const MenuRootContent = React.forwardRef((props, forwardedRef) => {
+  const context = useMenuContext(CONTENT_NAME);
+
+  return context.modal ? (
+    <MenuRootContentModal {...props} ref={forwardedRef} />
+  ) : (
+    <MenuRootContentNonModal {...props} ref={forwardedRef} />
+  );
+}) as MenuRootContentPrimitive;
+
+type MenuRootContentTypeOwnProps = Omit<
+  Polymorphic.OwnProps<typeof MenuContentImpl>,
+  'trapFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'
+>;
+
+type MenuRootContentTypePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof MenuContentImpl>,
+  MenuRootContentTypeOwnProps
+>;
+
+const MenuRootContentModal = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(CONTENT_NAME);
   const ref = React.useRef<React.ElementRef<typeof MenuContentImpl>>(null);
   const composedRefs = useComposedRefs(forwardedRef, ref);
@@ -246,9 +270,62 @@ const MenuRootContent = React.forwardRef((props, forwardedRef) => {
   }, []);
 
   return (
-    <MenuContentImpl {...props} ref={composedRefs} onDismiss={() => context.onOpenChange(false)} />
+    <MenuContentImpl
+      {...props}
+      ref={composedRefs}
+      // we make sure we're not trapping once it's been closed
+      // (closed !== unmounted when animating out)
+      trapFocus={context.open}
+      // make sure to only disable pointer events when open
+      // this avoids blocking interactions while animating out
+      disableOutsidePointerEvents={context.open}
+      disableOutsideScroll
+      // When focus is trapped, a `focusout` event may still happen.
+      // We make sure we don't trigger our `onDismiss` in such case.
+      onFocusOutside={composeEventHandlers(
+        props.onFocusOutside,
+        (event) => event.preventDefault(),
+        { checkForDefaultPrevented: false }
+      )}
+      onDismiss={() => context.onOpenChange(false)}
+    />
   );
-}) as MenuRootContentPrimitive;
+}) as MenuRootContentTypePrimitive;
+
+const MenuRootContentNonModal = React.forwardRef((props, forwardedRef) => {
+  const context = useMenuContext(CONTENT_NAME);
+  const isPointerDownOutsideRef = React.useRef(false);
+
+  return (
+    <MenuContentImpl
+      {...props}
+      ref={forwardedRef}
+      trapFocus={false}
+      disableOutsidePointerEvents={false}
+      disableOutsideScroll={false}
+      onCloseAutoFocus={(event) => {
+        if (isPointerDownOutsideRef.current) {
+          event.preventDefault();
+        } else {
+          props.onCloseAutoFocus?.(event);
+        }
+      }}
+      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+        isPointerDownOutsideRef.current = false;
+      })}
+      onPointerDownOutside={composeEventHandlers(
+        props.onPointerDownOutside,
+        (event) => {
+          const originalEvent = event.detail.originalEvent as MouseEvent;
+          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+          isPointerDownOutsideRef.current = isLeftClick;
+        },
+        { checkForDefaultPrevented: false }
+      )}
+      onDismiss={() => context.onOpenChange(false)}
+    />
+  );
+}) as MenuRootContentTypePrimitive;
 
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -392,7 +469,6 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   const [currentItemId, setCurrentItemId] = React.useState<string | null>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, contentRef, context.onContentChange);
-  const isPointerDownOutsideRef = React.useRef(false);
   const timerRef = React.useRef(0);
   const searchRef = React.useRef('');
   const pointerGraceTimerRef = React.useRef(0);
@@ -473,46 +549,21 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
         >
           <FocusScope
             as={Slot}
-            // we make sure we're not trapping once it's been closed
-            // (closed !== unmounted when animating out)
-            trapped={trapFocus && context.open}
+            trapped={trapFocus}
             onMountAutoFocus={composeEventHandlers(onOpenAutoFocus, (event) => {
               // when opening, explicitly focus the content area only and leave
               // `onEntryFocus` in  control of focusing first item
               event.preventDefault();
               contentRef.current?.focus();
             })}
-            onUnmountAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
-              // skip autofocus on unmount if clicking outside is permitted and it happened
-              if (!disableOutsidePointerEvents && isPointerDownOutsideRef.current) {
-                event.preventDefault();
-              }
-            })}
+            onUnmountAutoFocus={onCloseAutoFocus}
           >
             <DismissableLayer
               as={Slot}
               disableOutsidePointerEvents={disableOutsidePointerEvents}
-              onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                isPointerDownOutsideRef.current = false;
-              })}
-              onPointerDownOutside={composeEventHandlers(
-                onPointerDownOutside,
-                (event) => {
-                  const originalEvent = event.detail.originalEvent as MouseEvent;
-                  const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                  isPointerDownOutsideRef.current = isLeftClick;
-                },
-                { checkForDefaultPrevented: false }
-              )}
-              onFocusOutside={composeEventHandlers(
-                onFocusOutside,
-                (event) => {
-                  // When focus is trapped, a focusout event may still happen.
-                  // We make sure we don't trigger our `onDismiss` in such case.
-                  if (trapFocus) event.preventDefault();
-                },
-                { checkForDefaultPrevented: false }
-              )}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={onPointerDownOutside}
+              onFocusOutside={onFocusOutside}
               onInteractOutside={onInteractOutside}
               onDismiss={onDismiss}
             >

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -30,6 +30,21 @@ export const Styled = () => {
   );
 };
 
+export const Modal = () => {
+  return (
+    <>
+      <Popover modal>
+        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+        <PopoverContent className={contentClass} sideOffset={5}>
+          <PopoverClose className={closeClass}>close</PopoverClose>
+          <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
+        </PopoverContent>
+      </Popover>
+      <input style={{ marginLeft: 10 }} />
+    </>
+  );
+};
+
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
   return (
@@ -173,21 +188,6 @@ export const CustomAnchor = () => (
   </Popover>
 );
 
-export const NonModal = () => {
-  return (
-    <>
-      <Popover>
-        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-        <PopoverContent className={contentClass} sideOffset={5} trapFocus={false}>
-          <PopoverClose className={closeClass}>close</PopoverClose>
-          <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
-        </PopoverContent>
-      </Popover>
-      <input style={{ marginLeft: 10 }} />
-    </>
-  );
-};
-
 export const WithSlottedTrigger = () => {
   return (
     <Popover>
@@ -222,7 +222,11 @@ export const Chromatic = () => (
     <h2>Open</h2>
     <Popover defaultOpen>
       <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-      <PopoverContent className={contentClass} sideOffset={5}>
+      <PopoverContent
+        className={contentClass}
+        sideOffset={5}
+        onFocusOutside={(event) => event.preventDefault()}
+      >
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>
@@ -230,7 +234,11 @@ export const Chromatic = () => (
 
     <h2 style={{ marginTop: 100 }}>Open with reordered parts</h2>
     <Popover defaultOpen>
-      <PopoverContent className={contentClass} sideOffset={5}>
+      <PopoverContent
+        className={contentClass}
+        sideOffset={5}
+        onFocusOutside={(event) => event.preventDefault()}
+      >
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>
@@ -291,7 +299,7 @@ export const Chromatic = () => (
       <PopoverAnchor style={{ padding: 20, background: 'gainsboro' }}>
         <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent className={contentClass}>
+      <PopoverContent className={contentClass} onFocusOutside={(event) => event.preventDefault()}>
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -30,18 +30,42 @@ export const Styled = () => {
   );
 };
 
-export const Modal = () => {
+export const Modality = () => {
   return (
-    <>
-      <Popover modal>
-        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-        <PopoverContent className={contentClass} sideOffset={5}>
-          <PopoverClose className={closeClass}>close</PopoverClose>
-          <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
-        </PopoverContent>
-      </Popover>
-      <input style={{ marginLeft: 10 }} />
-    </>
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '110vh' }}
+    >
+      <div style={{ display: 'grid', gridGap: 50 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Non modal (default)</h1>
+          <Popover>
+            <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+            <PopoverContent className={contentClass} sideOffset={5}>
+              <PopoverClose className={closeClass}>close</PopoverClose>
+              <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
+            </PopoverContent>
+          </Popover>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Modal</h1>
+          <Popover modal>
+            <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+            <PopoverContent className={contentClass} sideOffset={5}>
+              <PopoverClose className={closeClass}>close</PopoverClose>
+              <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
+            </PopoverContent>
+          </Popover>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -32,6 +32,7 @@ type PopoverContextValue = {
   hasCustomAnchor: boolean;
   onCustomAnchorAdd(): void;
   onCustomAnchorRemove(): void;
+  modal: boolean;
 };
 
 const [PopoverProvider, usePopoverContext] = createContext<PopoverContextValue>(POPOVER_NAME);
@@ -40,10 +41,11 @@ type PopoverOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
 };
 
 const Popover: React.FC<PopoverOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange, modal = false } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [hasCustomAnchor, setHasCustomAnchor] = React.useState(false);
   const [open = false, setOpen] = useControllableState({
@@ -63,6 +65,7 @@ const Popover: React.FC<PopoverOwnProps> = (props) => {
         hasCustomAnchor={hasCustomAnchor}
         onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
         onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}
+        modal={modal}
       >
         {children}
       </PopoverProvider>
@@ -122,7 +125,7 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
       aria-haspopup="dialog"
       aria-expanded={context.open}
       aria-controls={context.contentId}
-      data-state={context.open ? 'open' : 'closed'}
+      data-state={getState(context.open)}
       {...triggerProps}
       as={as}
       ref={composedTriggerRef}
@@ -146,7 +149,7 @@ PopoverTrigger.displayName = TRIGGER_NAME;
 const CONTENT_NAME = 'PopoverContent';
 
 type PopoverContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof PopoverContentImpl>,
+  Polymorphic.OwnProps<typeof PopoverContentModal | typeof PopoverContentNonModal>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -157,7 +160,7 @@ type PopoverContentOwnProps = Polymorphic.Merge<
 >;
 
 type PopoverContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
+  Polymorphic.IntrinsicElement<typeof PopoverContentModal | typeof PopoverContentNonModal>,
   PopoverContentOwnProps
 >;
 
@@ -167,14 +170,110 @@ const PopoverContent = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Presence present={forceMount || context.open}>
-      <PopoverContentImpl
-        data-state={context.open ? 'open' : 'closed'}
-        {...contentProps}
-        ref={forwardedRef}
-      />
+      {context.modal ? (
+        <PopoverContentModal {...contentProps} ref={forwardedRef} />
+      ) : (
+        <PopoverContentNonModal {...contentProps} ref={forwardedRef} />
+      )}
     </Presence>
   );
 }) as PopoverContentPrimitive;
+
+PopoverContent.displayName = CONTENT_NAME;
+
+type PopoverContentTypeOwnProps = Polymorphic.Merge<
+  Omit<
+    Polymorphic.OwnProps<typeof PopoverContentImpl>,
+    'trapFocus' | 'disableOutsidePointerEvents'
+  >,
+  {
+    /**
+     * Whether the `Popover` should render in a `Portal`
+     * (default: `true`)
+     */
+    portalled?: boolean;
+  }
+>;
+
+type PopoverContentTypePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
+  PopoverContentTypeOwnProps
+>;
+
+const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
+  const { portalled = true, ...contentModalProps } = props;
+  const context = usePopoverContext(CONTENT_NAME);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+
+  return (
+    <PortalWrapper>
+      <RemoveScroll>
+        <PopoverContentImpl
+          {...contentModalProps}
+          ref={composedRefs}
+          // we make sure we're not trapping once it's been closed
+          // (closed !== unmounted when animating out)
+          trapFocus={context.open}
+          disableOutsidePointerEvents
+          // When focus is trapped, a `focusout` event may still happen.
+          // We make sure we don't trigger our `onDismiss` in such case.
+          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+            event.preventDefault()
+          )}
+        />
+      </RemoveScroll>
+    </PortalWrapper>
+  );
+}) as PopoverContentTypePrimitive;
+
+const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
+  const { portalled = true, ...contentNonModalProps } = props;
+  const context = usePopoverContext(CONTENT_NAME);
+  const isPointerDownOutsideRef = React.useRef(false);
+
+  const PortalWrapper = portalled ? Portal : React.Fragment;
+
+  return (
+    <PortalWrapper>
+      <PopoverContentImpl
+        {...contentNonModalProps}
+        ref={forwardedRef}
+        trapFocus={false}
+        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          if (isPointerDownOutsideRef.current) event.preventDefault();
+        })}
+        disableOutsidePointerEvents={false}
+        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+          isPointerDownOutsideRef.current = false;
+        })}
+        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+          const { originalEvent } = event.detail;
+          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+          isPointerDownOutsideRef.current = isLeftClick;
+        })}
+        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
+          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+          if (targetIsTrigger) event.preventDefault();
+        })}
+      />
+    </PortalWrapper>
+  );
+}) as PopoverContentTypePrimitive;
 
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 type DismissableLayerOwnProps = Polymorphic.OwnProps<typeof DismissableLayer>;
@@ -200,18 +299,6 @@ type PopoverContentImplOwnProps = Polymorphic.Merge<
      * Can be prevented.
      */
     onCloseAutoFocus?: FocusScopeOwnProps['onUnmountAutoFocus'];
-
-    /**
-     * Whether scrolling outside the `Popover` should be prevented
-     * (default: `false`)
-     */
-    disableOutsideScroll?: boolean;
-
-    /**
-     * Whether the `Popover` should render in a `Portal`
-     * (default: `true`)
-     */
-    portalled?: boolean;
   }
 >;
 
@@ -222,106 +309,55 @@ type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
-    trapFocus = true,
+    trapFocus,
     onOpenAutoFocus,
     onCloseAutoFocus,
-    disableOutsidePointerEvents = false,
+    disableOutsidePointerEvents,
     onEscapeKeyDown,
     onPointerDownOutside,
     onFocusOutside,
     onInteractOutside,
-    disableOutsideScroll = false,
-    portalled = true,
     ...contentProps
   } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const isPointerDownOutsideRef = React.useRef(false);
-  const contentRef = React.useRef<HTMLDivElement>(null);
-  const composedRefs = useComposedRefs(forwardedRef, contentRef);
-
-  const PortalWrapper = portalled ? Portal : React.Fragment;
-  const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
 
   // Make sure the whole tree has focus guards as our `Popover` may be
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
 
-  // Hide everything from ARIA except the content
-  React.useEffect(() => {
-    const content = contentRef.current;
-    if (content) return hideOthers(content);
-  }, []);
-
   return (
-    <PortalWrapper>
-      <ScrollLockWrapper>
-        <FocusScope
-          as={Slot}
-          // we make sure we're not trapping once it's been closed
-          // (closed !== unmounted when animating out)
-          trapped={trapFocus && context.open}
-          onMountAutoFocus={onOpenAutoFocus}
-          onUnmountAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
-            const isPointerOutside = isPointerDownOutsideRef.current;
-            const isAllowedPointerOutside = isPointerOutside && !disableOutsidePointerEvents;
-            event.preventDefault();
-            if (!isAllowedPointerOutside) context.triggerRef.current?.focus();
-          })}
-        >
-          <DismissableLayer
-            as={Slot}
-            disableOutsidePointerEvents={disableOutsidePointerEvents}
-            onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-              isPointerDownOutsideRef.current = false;
-            })}
-            onPointerDownOutside={composeEventHandlers(
-              onPointerDownOutside,
-              (event) => {
-                const originalEvent = event.detail.originalEvent as MouseEvent;
-                const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                isPointerDownOutsideRef.current = isLeftClick;
-
-                const targetIsTrigger = context.triggerRef.current?.contains(
-                  event.target as HTMLElement
-                );
-                // prevent dismissing when clicking the trigger
-                // as it's already setup to close, otherwise it would close and immediately open.
-                if (targetIsTrigger) event.preventDefault();
-              },
-              { checkForDefaultPrevented: false }
-            )}
-            onFocusOutside={composeEventHandlers(
-              onFocusOutside,
-              (event) => {
-                // When focus is trapped, a focusout event may still happen.
-                // We make sure we don't trigger our `onDismiss` in such case.
-                if (trapFocus) event.preventDefault();
-              },
-              { checkForDefaultPrevented: false }
-            )}
-            onInteractOutside={onInteractOutside}
-            onDismiss={() => context.onOpenChange(false)}
-          >
-            <PopperPrimitive.Content
-              role="dialog"
-              aria-modal
-              id={context.contentId}
-              {...contentProps}
-              ref={composedRefs}
-              style={{
-                ...contentProps.style,
-                // re-namespace exposed content custom property
-                ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
-              }}
-            />
-          </DismissableLayer>
-        </FocusScope>
-      </ScrollLockWrapper>
-    </PortalWrapper>
+    <FocusScope
+      as={Slot}
+      loop
+      trapped={trapFocus}
+      onMountAutoFocus={onOpenAutoFocus}
+      onUnmountAutoFocus={onCloseAutoFocus}
+    >
+      <DismissableLayer
+        as={Slot}
+        disableOutsidePointerEvents={disableOutsidePointerEvents}
+        onInteractOutside={onInteractOutside}
+        onEscapeKeyDown={onEscapeKeyDown}
+        onPointerDownOutside={onPointerDownOutside}
+        onFocusOutside={onFocusOutside}
+        onDismiss={() => context.onOpenChange(false)}
+      >
+        <PopperPrimitive.Content
+          data-state={getState(context.open)}
+          role="dialog"
+          id={context.contentId}
+          {...contentProps}
+          ref={forwardedRef}
+          style={{
+            ...contentProps.style,
+            // re-namespace exposed content custom property
+            ['--radix-popover-content-transform-origin' as any]: 'var(--radix-popper-transform-origin)',
+          }}
+        />
+      </DismissableLayer>
+    </FocusScope>
   );
 }) as PopoverContentImplPrimitive;
-
-PopoverContent.displayName = CONTENT_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * PopoverClose
@@ -357,6 +393,10 @@ PopoverClose.displayName = CLOSE_NAME;
 const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'PopoverArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
+
+function getState(open: boolean) {
+  return open ? 'open' : 'closed';
+}
 
 const Root = Popover;
 const Anchor = PopoverAnchor;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -256,7 +256,7 @@ const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
 const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
   const { portalled = true, ...contentNonModalProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const shouldFocusTriggerRef = React.useRef(true);
+  const hasInteractedOutsideRef = React.useRef(false);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
 
@@ -271,17 +271,17 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           props.onCloseAutoFocus?.(event);
 
           if (!event.defaultPrevented) {
+            if (!hasInteractedOutsideRef.current) context.triggerRef.current?.focus();
             // Always prevent auto focus because we either focus manually or want user agent focus
             event.preventDefault();
-            if (shouldFocusTriggerRef.current) context.triggerRef.current?.focus();
           }
 
-          shouldFocusTriggerRef.current = true;
+          hasInteractedOutsideRef.current = false;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
 
-          if (!event.defaultPrevented) shouldFocusTriggerRef.current = false;
+          if (!event.defaultPrevented) hasInteractedOutsideRef.current = true;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -226,8 +226,10 @@ const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
           disableOutsidePointerEvents
           // When focus is trapped, a `focusout` event may still happen.
           // We make sure we don't trigger our `onDismiss` in such case.
-          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
-            event.preventDefault()
+          onFocusOutside={composeEventHandlers(
+            props.onFocusOutside,
+            (event) => event.preventDefault(),
+            { checkForDefaultPrevented: false }
           )}
         />
       </RemoveScroll>
@@ -255,21 +257,30 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
           isPointerDownOutsideRef.current = false;
         })}
-        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
-          const { originalEvent } = event.detail;
-          const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-          isPointerDownOutsideRef.current = isLeftClick;
-        })}
-        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
-          // Prevent dismissing when clicking the trigger.
-          // As the trigger is already setup to close, without doing so would
-          // cause it to close and immediately open.
-          //
-          // We use `onInteractOutside` as some browsers also
-          // focus on pointer down, creating the same issue.
-          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
-          if (targetIsTrigger) event.preventDefault();
-        })}
+        onPointerDownOutside={composeEventHandlers(
+          props.onPointerDownOutside,
+          (event) => {
+            const { originalEvent } = event.detail;
+            const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+            isPointerDownOutsideRef.current = isLeftClick;
+          },
+          { checkForDefaultPrevented: false }
+        )}
+        onInteractOutside={composeEventHandlers(
+          props.onInteractOutside,
+          (event) => {
+            // Prevent dismissing when clicking the trigger.
+            // As the trigger is already setup to close, without doing so would
+            // cause it to close and immediately open.
+            //
+            // We use `onInteractOutside` as some browsers also
+            // focus on pointer down, creating the same issue.
+            const target = event.target as HTMLElement;
+            const targetIsTrigger = context.triggerRef.current?.contains(target);
+            if (targetIsTrigger) event.preventDefault();
+          },
+          { checkForDefaultPrevented: false }
+        )}
       />
     </PortalWrapper>
   );


### PR DESCRIPTION
Closes #585
Closes #566

This PR adds modality support to menus, dialogs and popovers. Originally we exposed a very granular api for managing pointer events, scroll locks and focus control. The most common use case for these props was to apply differing levels of modality depending on consumer needs.

By consolidating and streamlining these into a single `modal` prop we are able to reduce the api surface while making the outcome easier and faster to achieve. This change also allows us to provide consistent handling across components and improve some additional handling under the hood.


### Example (DropdownMenu)

https://user-images.githubusercontent.com/11708259/125466947-c6f22aaa-c5be-4546-ae5e-b8acacfd477e.mp4



