### PR TITLE
[DropdownMenu] Remove `ArrowUp` to open 🔥 

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -109,7 +109,7 @@ const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
         }
       })}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event: React.KeyboardEvent) => {
-        if ([' ', 'Enter', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+        if ([' ', 'Enter', 'ArrowDown'].includes(event.key)) {
           event.preventDefault();
           context.onOpenChange(true);
         }


### PR DESCRIPTION
Change sparked by this initial discussion https://github.com/radix-ui/primitives/pull/694#discussion_r649067345

Until we add logic to focus the last item on open then opening with `ArrowUp` is not accessible. It also isn't required WAI-ARIA keyboard support so we're removing for now until we can handle this more appropriately.

- Need to update [`ArrowUp` docs](https://radix-ui.com/primitives/docs/components/dropdown-menu#keyboard-interactions).