### PR TITLE
[Menu] Fix stuck open state on click

### DIFF
--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -311,12 +311,6 @@ const MenuSubContent = React.forwardRef((props, forwardedRef) => {
           context.trigger?.focus();
         }
       })}
-      onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
-        const targetIsTrigger = context.trigger?.contains(event.target as HTMLElement);
-        if (!targetIsTrigger) {
-          context.onOpenChange(false);
-        }
-      })}
     />
   ) : null;
 }) as MenuSubContentPrimitive;


### PR DESCRIPTION
See https://github.com/radix-ui/primitives/pull/682#issuecomment-860507424

https://user-images.githubusercontent.com/11708259/121894194-c13e6b00-cd16-11eb-8fe7-7dc79b5b1b51.mp4

This is caused by the `onPointerDownOutside` handler closing the submenu before `onFocusOutside` can run, placing the menu in a state where it can no longer perform focus outside thus leaving it stuck in the open state.

Originally started trying to work around but realised that `DropdownMenu` and `ContextMenu` need to handle their own closing behaviour in `onPointerDownOutside` anyway, and so having this in `Menu` is probably at the wrong level.