### PR TITLE
Fix broken link in release doc

### DIFF
--- a/.yarn/versions/23cbe1a8.yml
+++ b/.yarn/versions/23cbe1a8.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/release-process.md
+++ b/release-process.md
@@ -22,9 +22,9 @@ The easiest way to track changes before raising your PR is to run `yarn version 
 
 ## Updating documentation
 
-Our documentation is in a [separate repository](https://github.com/radix-ui/website) and updating it is a manual process. This is typically a three step process:
+Our documentation is in a [separate repository](https://github.com/radix-ui/website) and updating it is a three step process:
 
-1. Write and update the [change log](https://github.com/radix-ui/website/blob/main/pages/primitives/docs/overview/releases.mdx)
+1. Write and update the [change log](https://github.com/radix-ui/website/blob/main/data/primitives/overview/releases.mdx)
 2. Bump package version/s and create / update the pages for each version change
 3. Perform documentation updates
 
@@ -35,4 +35,4 @@ Steps 2 and 3 are typically raised as separate pull requests to make changes eas
 This is as simple as duplicating the latest page and updating the version number to match the release. Some things to keep in mind:
 
 - We only provide live demos for the latest version of a package so you must remember to disable/remove the previous live demo (this avoids breaking changes affecting old versions in our docs)
-- If the incoming version is a patch which doesn't require a docs update then you can simply change the page name to match the new version rather than duplicating all of the same content
+- If the incoming version is a patch which doesn't require a docs update then you can simply change the page name to match the new version rather than duplicating the same content


### PR DESCRIPTION
Noticed while reviewing the process. I guess it changed when the docs structure was updated.