### PR TITLE
[DropdownMenu][ContextMenu] Submenu Safari compat

### DIFF
--- a/.yarn/versions/68034758.yml
+++ b/.yarn/versions/68034758.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -566,11 +566,11 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                     props.onPointerMove,
                     whenMouse((event) => {
                       const target = event.target as HTMLElement;
-                      const valueHasChanged = lastPointerXRef.current !== event.clientX;
+                      const pointerXHasChanged = lastPointerXRef.current !== event.clientX;
 
                       // We don't use `event.movementX` for this check because Safari will
                       // always return `0` on a pointer event.
-                      if (event.currentTarget.contains(target) && valueHasChanged) {
+                      if (event.currentTarget.contains(target) && pointerXHasChanged) {
                         const newDir = event.clientX > lastPointerXRef.current ? 'right' : 'left';
                         pointerDirRef.current = newDir;
                         lastPointerXRef.current = event.clientX;

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -396,6 +396,7 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
   const pointerGraceTimerRef = React.useRef(0);
   const pointerGraceIntentRef = React.useRef<GraceIntent | null>(null);
   const pointerDirRef = React.useRef<Side>('right');
+  const lastPointerXRef = React.useRef(0);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -565,8 +566,14 @@ const MenuContentImpl = React.forwardRef((props, forwardedRef) => {
                     props.onPointerMove,
                     whenMouse((event) => {
                       const target = event.target as HTMLElement;
-                      if (event.currentTarget.contains(target) && event.movementX !== 0) {
-                        pointerDirRef.current = event.movementX > 0 ? 'right' : 'left';
+                      const valueHasChanged = lastPointerXRef.current !== event.clientX;
+
+                      // We don't use `event.movementX` for this check because Safari will
+                      // always return `0` on a pointer event.
+                      if (event.currentTarget.contains(target) && valueHasChanged) {
+                        const newDir = event.clientX > lastPointerXRef.current ? 'right' : 'left';
+                        pointerDirRef.current = newDir;
+                        lastPointerXRef.current = event.clientX;
                       }
                     })
                   )}


### PR DESCRIPTION
Fixes https://github.com/radix-ui/primitives/issues/714

The issue was caused by a wrongly reported direction in Safari because it [inconsistently always returns `0`](https://codesandbox.io/s/silent-currying-wn7ny) on `event.movementX` only when it's a pointer event.
