### PR TITLE
[Dialog] Add optional `Title` and `Description` parts

### DIFF
--- a/.yarn/versions/f6a8ffd8.yml
+++ b/.yarn/versions/f6a8ffd8.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -22,10 +22,8 @@
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dialog": "workspace:*",
-    "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dialog": "workspace:*",
     "@radix-ui/react-polymorphic": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -34,11 +34,9 @@ const [
   useAlertDialogContentContext,
 ] = createContext<AlertDialogContentContextValue>(CONTENT_NAME);
 
-type AlertDialogContentOwnProps = Omit<Polymorphic.OwnProps<typeof DialogPrimitive.Content>, 'id'>;
-
 type AlertDialogContentPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DialogPrimitive.Content>,
-  AlertDialogContentOwnProps
+  Polymorphic.OwnProps<typeof DialogPrimitive.Content>
 >;
 
 const AlertDialogContent = React.forwardRef((props, forwardedRef) => {

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -47,7 +47,7 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
   const cancelRef = React.useRef<React.ElementRef<typeof AlertDialogCancel> | null>(null);
 
   return (
-    <DialogPrimitive.LabelWarningContext.Provider
+    <DialogPrimitive.LabelWarningProvider
       value={React.useMemo(
         () => ({ contentName: CONTENT_NAME, titleName: TITLE_NAME, docsSlug: 'alert-dialog' }),
         []
@@ -73,7 +73,7 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
           {process.env.NODE_ENV === 'development' && <DescriptionWarning contentRef={contentRef} />}
         </DialogPrimitive.Content>
       </AlertDialogContentProvider>
-    </DialogPrimitive.LabelWarningContext.Provider>
+    </DialogPrimitive.LabelWarningProvider>
   );
 }) as AlertDialogContentPrimitive;
 

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -2,10 +2,8 @@ import * as React from 'react';
 import { createContext } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { Primitive, extendPrimitive } from '@radix-ui/react-primitive';
+import { extendPrimitive } from '@radix-ui/react-primitive';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { useId } from '@radix-ui/react-id';
-import { Slottable } from '@radix-ui/react-slot';
 
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
@@ -15,19 +13,8 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 const ROOT_NAME = 'AlertDialog';
 
-type AlertDialogContextValue = {
-  descriptionId: string;
-  titleId: string;
-};
-
-const [AlertDialogProvider, useAlertDialogContext] = createContext<AlertDialogContextValue>(
-  ROOT_NAME
-);
-
 const AlertDialog: React.FC<React.ComponentProps<typeof DialogPrimitive.Root>> = (props) => (
-  <AlertDialogProvider descriptionId={useId()} titleId={useId()}>
-    <DialogPrimitive.Root {...props} />
-  </AlertDialogProvider>
+  <DialogPrimitive.Root {...props} />
 );
 
 AlertDialog.displayName = ROOT_NAME;
@@ -47,10 +34,7 @@ const [
   useAlertDialogContentContext,
 ] = createContext<AlertDialogContentContextValue>(CONTENT_NAME);
 
-type AlertDialogContentOwnProps = Omit<
-  Polymorphic.OwnProps<typeof DialogPrimitive.Content>,
-  'refToFocusOnOpen' | 'id'
->;
+type AlertDialogContentOwnProps = Omit<Polymorphic.OwnProps<typeof DialogPrimitive.Content>, 'id'>;
 
 type AlertDialogContentPrimitive = Polymorphic.ForwardRefComponent<
   Polymorphic.IntrinsicElement<typeof DialogPrimitive.Content>,
@@ -58,100 +42,35 @@ type AlertDialogContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
-  const {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    'aria-describedby': ariaDescribedBy,
-    children,
-    ...dialogContentProps
-  } = props;
-  const { descriptionId, titleId } = useAlertDialogContext(CONTENT_NAME);
   const cancelRef = React.useRef<React.ElementRef<typeof AlertDialogCancel> | null>(null);
 
   return (
-    <DialogPrimitive.Content
-      role="alertdialog"
-      aria-describedby={ariaDescribedBy || descriptionId}
-      // If `aria-label` is set, ensure `aria-labelledby` is undefined as to avoid confusion.
-      // Otherwise fallback to an explicit `aria-labelledby` or the ID used in the
-      // `AlertDialogTitle`
-      aria-labelledby={ariaLabel ? undefined : ariaLabelledBy || titleId}
-      aria-label={ariaLabel || undefined}
-      {...dialogContentProps}
-      ref={forwardedRef}
-      onOpenAutoFocus={composeEventHandlers(dialogContentProps.onOpenAutoFocus, (event) => {
-        event.preventDefault();
-        cancelRef.current?.focus({ preventScroll: true });
-      })}
+    <DialogPrimitive.AccessibilityDevWarningsContext.Provider
+      value={React.useMemo(
+        () => ({
+          descriptionRequired: true,
+          partNames: { content: CONTENT_NAME, title: TITLE_NAME, description: DESCRIPTION_NAME },
+          docsUrl: 'https://radix-ui.com/primitives/docs/components/alert-dialog',
+        }),
+        []
+      )}
     >
       <AlertDialogContentProvider cancelRef={cancelRef}>
-        {process.env.NODE_ENV === 'development' && (
-          <AccessibilityDevWarnings
-            ariaLabel={ariaLabel}
-            ariaLabelledBy={ariaLabelledBy}
-            ariaDescribedBy={ariaDescribedBy}
-          />
-        )}
-        {/**
-         * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
-         * around everything, otherwise the `AccessibilityDevWarnings` would be rendered straight away.
-         * This is because we want the accessibility checks to run only once the content is actually
-         * open and that behaviour is already encapsulated in `DialogContent`.
-         */}
-        <Slottable>{children}</Slottable>
+        <DialogPrimitive.Content
+          role="alertdialog"
+          {...props}
+          ref={forwardedRef}
+          onOpenAutoFocus={composeEventHandlers(props.onOpenAutoFocus, (event) => {
+            event.preventDefault();
+            cancelRef.current?.focus({ preventScroll: true });
+          })}
+        />
       </AlertDialogContentProvider>
-    </DialogPrimitive.Content>
+    </DialogPrimitive.AccessibilityDevWarningsContext.Provider>
   );
 }) as AlertDialogContentPrimitive;
 
 AlertDialogContent.displayName = CONTENT_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * AlertDialogTitle
- * -----------------------------------------------------------------------------------------------*/
-
-// Because `AlertDialog` depends more heavily on both a title and description for proper screen
-// reader announcements, we provide explicit components for each to reduce the friction and make it
-// simpler to get these right. These are optional if the consumer prefers to pass appropriate aria
-// labelling props directly.
-
-const TITLE_NAME = 'AlertDialogTitle';
-const TITLE_DEFAULT_TAG = 'h2';
-
-type AlertDialogTitleOwnProps = Polymorphic.OwnProps<typeof Primitive>;
-type AlertDialogTitlePrimitive = Polymorphic.ForwardRefComponent<
-  typeof TITLE_DEFAULT_TAG,
-  AlertDialogTitleOwnProps
->;
-
-const AlertDialogTitle = React.forwardRef((props, forwardedRef) => {
-  const { as = TITLE_DEFAULT_TAG, ...titleProps } = props;
-  const { titleId } = useAlertDialogContext(TITLE_NAME);
-  return <Primitive id={titleId} {...titleProps} as={as} ref={forwardedRef} />;
-}) as AlertDialogTitlePrimitive;
-
-AlertDialogTitle.displayName = TITLE_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * AlertDialogDescription
- * -----------------------------------------------------------------------------------------------*/
-
-const DESCRIPTION_NAME = 'AlertDialogDescription';
-const DESCRIPTION_DEFAULT_TAG = 'p';
-
-type AlertDialogDescriptionOwnProps = Polymorphic.OwnProps<typeof Primitive>;
-type AlertDialogDescriptionPrimitive = Polymorphic.ForwardRefComponent<
-  typeof DESCRIPTION_DEFAULT_TAG,
-  AlertDialogDescriptionOwnProps
->;
-
-const AlertDialogDescription = React.forwardRef((props, forwardedRef) => {
-  const { as = DESCRIPTION_DEFAULT_TAG, ...descriptionProps } = props;
-  const { descriptionId } = useAlertDialogContext(DESCRIPTION_NAME);
-  return <Primitive id={descriptionId} {...descriptionProps} as={as} ref={forwardedRef} />;
-}) as AlertDialogDescriptionPrimitive;
-
-AlertDialogDescription.displayName = DESCRIPTION_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * AlertDialogCancel
@@ -184,93 +103,43 @@ const AlertDialogOverlay = extendPrimitive(DialogPrimitive.Overlay, {
 const AlertDialogAction = extendPrimitive(DialogPrimitive.Close, {
   displayName: 'AlertDialogAction',
 });
+const TITLE_NAME = 'AlertDialogTitle';
+const AlertDialogTitle = extendPrimitive(DialogPrimitive.Title, {
+  displayName: TITLE_NAME,
+});
+const DESCRIPTION_NAME = 'AlertDialogDescription';
+const AlertDialogDescription = extendPrimitive(DialogPrimitive.Description, {
+  displayName: DESCRIPTION_NAME,
+});
 
 /* ---------------------------------------------------------------------------------------------- */
 
-// TODO: Add link to docs when available
-const LABEL_WARNING = `${CONTENT_NAME} requires a label for the component to be accessible for screen reader users.
-
-You can label the ${CONTENT_NAME} by passing a ${TITLE_NAME} component as a child, which also benefits sighted users by adding visible context to the dialog.
-
-Alternatively, you can use your own component as a title by assigning it an \`id\` and passing the same value to the \`aria-labelledby\` prop in ${CONTENT_NAME}. If the label is confusing or duplicative for sighted users, you can also pass a label directly by using the \`aria-label\` prop.
-
-For more information, see https://LINK-TO-DOCS.com`;
-
-const DESC_WARNING = `${CONTENT_NAME} requires a description for the component to be accessible for screen reader users.
-
-You can add a description to the ${CONTENT_NAME} by passing a ${DESCRIPTION_NAME} component as a child, which also benefits sighted users by adding visible context to the dialog.
-
-Alternatively, you can use your own component as a description by assigning it an \`id\` and passing the same value to the \`aria-describedby\` prop in ${CONTENT_NAME}. If the description is confusing or duplicative for sighted users, you can use the \`@radix-ui/react-visually-hidden\` primitive as a wrapper around your description component.
-
-For more information, see https://LINK-TO-DOCS.com`;
-
-// We need some effects to fire when DialogContent is mounted that will give us some useful dev
-// warnings. DialogContent returns `null` when the Dialog is closed, meaning that if we put these
-// effects up in AlertDialog.Content these effects only fire on its initial mount, NOT when the
-// underlying DialogContent mounts. We stick this inner component inside DialogContent to make
-// sure the effects fire as expected. This component is only useful in a dev environment, so we
-// won't bother rendering it in production.
-const AccessibilityDevWarnings: React.FC<{
-  ariaLabel?: string;
-  ariaLabelledBy?: string;
-  ariaDescribedBy?: string;
-}> = (props) => {
-  const { ariaLabel, ariaLabelledBy, ariaDescribedBy } = props;
-  const context = useAlertDialogContext('AlertDialogContent');
-
-  React.useEffect(() => {
-    const hasLabel = Boolean(
-      ariaLabel ||
-        (ariaLabelledBy && document.getElementById(ariaLabelledBy)) ||
-        (context.titleId && document.getElementById(context.titleId))
-    );
-    if (!hasLabel) {
-      console.warn(LABEL_WARNING);
-    }
-
-    const hasDescription = Boolean(
-      (ariaDescribedBy && document.getElementById(ariaDescribedBy)) ||
-        (context.descriptionId && document.getElementById(context.descriptionId))
-    );
-    if (!hasDescription) {
-      console.warn(DESC_WARNING);
-    }
-  }, [context.titleId, ariaLabel, ariaDescribedBy, context.descriptionId, ariaLabelledBy]);
-
-  return null;
-};
-
 const Root = AlertDialog;
-const Title = AlertDialogTitle;
-const Cancel = AlertDialogCancel;
-const Action = AlertDialogAction;
-const Content = AlertDialogContent;
-const Description = AlertDialogDescription;
-const Overlay = AlertDialogOverlay;
 const Trigger = AlertDialogTrigger;
+const Overlay = AlertDialogOverlay;
+const Content = AlertDialogContent;
+const Action = AlertDialogAction;
+const Cancel = AlertDialogCancel;
+const Title = AlertDialogTitle;
+const Description = AlertDialogDescription;
 
 export {
   AlertDialog,
-  AlertDialogTitle,
-  AlertDialogCancel,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogOverlay,
   AlertDialogTrigger,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogTitle,
+  AlertDialogDescription,
   //
   Root,
-  Title,
-  Cancel,
-  Action,
-  Content,
-  Description,
-  Overlay,
   Trigger,
+  Overlay,
+  Content,
+  Action,
+  Cancel,
+  Title,
+  Description,
 };
-export type {
-  AlertDialogTitlePrimitive,
-  AlertDialogCancelPrimitive,
-  AlertDialogContentPrimitive,
-  AlertDialogDescriptionPrimitive,
-};
+export type { AlertDialogContentPrimitive, AlertDialogCancelPrimitive };

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -135,8 +135,9 @@ Alternatively, you can use your own component as a description by assigning it a
 For more information, see https://radix-ui.com/primitives/docs/components/alert-dialog`;
 
   React.useEffect(() => {
-    const content = contentRef.current;
-    const hasDescription = document.getElementById(content?.getAttribute('aria-describedby')!);
+    const hasDescription = document.getElementById(
+      contentRef.current?.getAttribute('aria-describedby')!
+    );
     if (!hasDescription) console.warn(MESSAGE);
   }, [MESSAGE, contentRef]);
 

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -63,6 +63,12 @@ const AlertDialogContent = React.forwardRef((props, forwardedRef) => {
             cancelRef.current?.focus({ preventScroll: true });
           })}
         >
+          {/**
+           * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
+           * around everything, otherwise the `DescriptionWarning` would be rendered straight away.
+           * This is because we want the accessibility checks to run only once the content is actually
+           * open and that behaviour is already encapsulated in `DialogContent`.
+           */}
           <Slottable>{children}</Slottable>
           {process.env.NODE_ENV === 'development' && <DescriptionWarning contentRef={contentRef} />}
         </DialogPrimitive.Content>

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Dialog, DialogTrigger, DialogOverlay, DialogContent, DialogClose } from './Dialog';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogOverlay,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from './Dialog';
 import { css } from '../../../../stitches.config';
 
 export default { title: 'Components/Dialog' };
@@ -9,6 +17,8 @@ export const Styled = () => (
     <DialogTrigger className={triggerClass}>open</DialogTrigger>
     <DialogOverlay className={overlayClass} />
     <DialogContent className={contentClass}>
+      <DialogTitle>Booking info</DialogTitle>
+      <DialogDescription>Please enter the info for your booking below.</DialogDescription>
       <DialogClose className={closeClass}>close</DialogClose>
     </DialogContent>
   </Dialog>
@@ -21,6 +31,7 @@ export const Controlled = () => {
       <DialogTrigger>{open ? 'close' : 'open'}</DialogTrigger>
       <DialogOverlay className={overlayClass} />
       <DialogContent className={contentClass}>
+        <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </Dialog>
@@ -34,6 +45,7 @@ export const FocusTrap = () => (
       <DialogOverlay className={overlayClass} />
       <DialogContent className={contentClass}>
         <DialogClose>close</DialogClose>
+        <DialogTitle>Title</DialogTitle>
         <div>
           <label htmlFor="firstName">First Name</label>
           <input type="text" id="firstName" placeholder="John" />
@@ -74,6 +86,7 @@ export const CustomFocus = () => {
           <DialogClose>close</DialogClose>
 
           <div>
+            <DialogTitle>Title</DialogTitle>
             <p>The first name input will receive the focus after opening the dialog.</p>
             <label htmlFor="firstName">First Name</label>
             <input type="text" id="firstName" placeholder="John" ref={firstNameRef} />
@@ -99,6 +112,7 @@ export const NoEscapeDismiss = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogOverlay className={overlayClass} />
     <DialogContent className={contentClass} onEscapeKeyDown={(event) => event.preventDefault()}>
+      <DialogTitle>Title</DialogTitle>
       <DialogClose>close</DialogClose>
     </DialogContent>
   </Dialog>
@@ -112,6 +126,7 @@ export const NoPointerDownOutsideDismiss = () => (
       className={contentClass}
       onPointerDownOutside={(event) => event.preventDefault()}
     >
+      <DialogTitle>Title</DialogTitle>
       <DialogClose>close</DialogClose>
     </DialogContent>
   </Dialog>
@@ -122,6 +137,7 @@ export const Animated = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogOverlay className={animatedOverlayClass} />
     <DialogContent className={animatedContentClass}>
+      <DialogTitle>Title</DialogTitle>
       <DialogClose>close</DialogClose>
     </DialogContent>
   </Dialog>
@@ -132,6 +148,7 @@ export const ForcedMount = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogOverlay className={overlayClass} forceMount />
     <DialogContent className={contentClass} forceMount>
+      <DialogTitle>Title</DialogTitle>
       <DialogClose>close</DialogClose>
     </DialogContent>
   </Dialog>
@@ -153,6 +170,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
         <DialogOverlay className={overlayClass} />
         <DialogContent className={chromaticContentClass}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
       </Dialog>
@@ -162,6 +180,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
         <DialogOverlay className={overlayClass} style={{ left: 0, bottom: '50%', width: '25%' }} />
         <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '12%' }}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
       </Dialog>
@@ -173,6 +192,7 @@ export const Chromatic = () => (
       <Dialog>
         <DialogOverlay className={overlayClass} />
         <DialogContent className={chromaticContentClass}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
@@ -185,6 +205,7 @@ export const Chromatic = () => (
           style={{ left: '25%', bottom: '50%', width: '25%' }}
         />
         <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '37%' }}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
@@ -198,6 +219,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
         <DialogOverlay className={overlayClass} />
         <DialogContent className={chromaticContentClass}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
       </Dialog>
@@ -210,6 +232,7 @@ export const Chromatic = () => (
           style={{ left: '50%', bottom: '50%', width: '25%' }}
         />
         <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '62%' }}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
       </Dialog>
@@ -221,6 +244,7 @@ export const Chromatic = () => (
       <Dialog open={false}>
         <DialogOverlay className={overlayClass} />
         <DialogContent className={chromaticContentClass}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
@@ -233,6 +257,7 @@ export const Chromatic = () => (
           style={{ left: '75%', bottom: '50%', width: '25%' }}
         />
         <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '88%' }}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
@@ -246,6 +271,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
         <DialogOverlay className={overlayAttrClass} />
         <DialogContent className={contentAttrClass}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeAttrClass}>close</DialogClose>
         </DialogContent>
       </Dialog>
@@ -255,6 +281,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
         <DialogOverlay className={overlayAttrClass} style={{ top: '50%' }} />
         <DialogContent className={contentAttrClass} style={{ top: '75%' }}>
+          <DialogTitle>Title</DialogTitle>
           <DialogClose className={closeAttrClass}>close</DialogClose>
         </DialogContent>
       </Dialog>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -364,6 +364,8 @@ const LabelWarningContext = React.createContext({
   docsSlug: 'dialog',
 });
 
+const LabelWarningProvider = LabelWarningContext.Provider;
+
 type LabelWarningProps = {
   contentRef: React.RefObject<React.ElementRef<typeof DialogContent>>;
 };
@@ -415,7 +417,7 @@ export {
   Description,
   Close,
   //
-  LabelWarningContext,
+  LabelWarningProvider,
 };
 export type {
   DialogTriggerPrimitive,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,10 +3574,8 @@ __metadata:
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-dialog": "workspace:*"
-    "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
-    "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ">=16.8"
     react-dom: ^16.8 || ^17.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,6 +3576,7 @@ __metadata:
     "@radix-ui/react-dialog": "workspace:*"
     "@radix-ui/react-polymorphic": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ">=16.8"
     react-dom: ^16.8 || ^17.0


### PR DESCRIPTION
Closes #729

This PR:
- brings `Title` and `Description` from `AlertDialog` into `Dialog` itself
- improves upon existing dev warnings with new requirements
  - description is optional for `Dialog` but required for `AlertDialog` so that's reflected in the warnings
  - "localizes" the messages based on which primitive it is
  - links to docs