### PR TITLE
[ContextMenu] Add long press support for touch/pen

### DIFF
--- a/.yarn/versions/d3fb587e.yml
+++ b/.yarn/versions/d3fb587e.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -82,6 +82,17 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
   const virtualRef = React.useRef({
     getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, ...pointRef.current }),
   });
+  const longPressTimerRef = React.useRef(0);
+  const clearLongPress = React.useCallback(
+    () => window.clearTimeout(longPressTimerRef.current),
+    []
+  );
+  const open = (event: React.MouseEvent | React.PointerEvent) => {
+    pointRef.current = { x: event.clientX, y: event.clientY };
+    context.onOpenChange(true);
+  };
+
+  React.useEffect(() => clearLongPress, [clearLongPress]);
 
   return (
     <ContentContext.Provider value={false}>
@@ -91,10 +102,24 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
         as={as}
         ref={forwardedRef}
         onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
+          // clearing the long press here because some platforms already supports
+          // long press to trigger a `contextmenu` event
+          clearLongPress();
           event.preventDefault();
-          pointRef.current = { x: event.clientX, y: event.clientY };
-          context.onOpenChange(true);
+          open(event);
         })}
+        onPointerDown={composeEventHandlers(
+          props.onPointerDown,
+          whenTouchOrPen((event) => {
+            longPressTimerRef.current = window.setTimeout(() => open(event), 700);
+          })
+        )}
+        onPointerMove={composeEventHandlers(props.onPointerMove, whenTouchOrPen(clearLongPress))}
+        onPointerCancel={composeEventHandlers(
+          props.onPointerCancel,
+          whenTouchOrPen(clearLongPress)
+        )}
+        onPointerUp={composeEventHandlers(props.onPointerUp, whenTouchOrPen(clearLongPress))}
       />
     </ContentContext.Provider>
   );
@@ -199,6 +224,10 @@ const ContextMenuArrow = extendPrimitive(MenuPrimitive.Arrow, {
 });
 
 /* -----------------------------------------------------------------------------------------------*/
+
+function whenTouchOrPen<E>(handler: React.PointerEventHandler<E>): React.PointerEventHandler<E> {
+  return (event) => (event.pointerType !== 'mouse' ? handler(event) : undefined);
+}
 
 const Root = ContextMenu;
 const Trigger = ContextMenuTrigger;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -87,7 +87,7 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
     () => window.clearTimeout(longPressTimerRef.current),
     []
   );
-  const open = (event: React.MouseEvent | React.PointerEvent) => {
+  const handleOpen = (event: React.MouseEvent | React.PointerEvent) => {
     pointRef.current = { x: event.clientX, y: event.clientY };
     context.onOpenChange(true);
   };
@@ -101,17 +101,19 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
         {...triggerProps}
         as={as}
         ref={forwardedRef}
+        // prevent iOS context menu from appearing
+        style={{ WebkitTouchCallout: 'none', ...triggerProps.style }}
         onContextMenu={composeEventHandlers(props.onContextMenu, (event) => {
-          // clearing the long press here because some platforms already supports
+          // clearing the long press here because some platforms already support
           // long press to trigger a `contextmenu` event
           clearLongPress();
           event.preventDefault();
-          open(event);
+          handleOpen(event);
         })}
         onPointerDown={composeEventHandlers(
           props.onPointerDown,
           whenTouchOrPen((event) => {
-            longPressTimerRef.current = window.setTimeout(() => open(event), 700);
+            longPressTimerRef.current = window.setTimeout(() => handleOpen(event), 700);
           })
         )}
         onPointerMove={composeEventHandlers(props.onPointerMove, whenTouchOrPen(clearLongPress))}

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -113,6 +113,8 @@ const ContextMenuTrigger = React.forwardRef((props, forwardedRef) => {
         onPointerDown={composeEventHandlers(
           props.onPointerDown,
           whenTouchOrPen((event) => {
+            // clear the long press here in case there's multiple touch points
+            clearLongPress();
             longPressTimerRef.current = window.setTimeout(() => handleOpen(event), 700);
           })
         )}


### PR DESCRIPTION
Closes #701

This PR adds support for long press to trigger opening `ContextMenu` with touch/pen.