### PR TITLE
[Popover] Add support for modality

### DIFF
--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -264,8 +264,12 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           isPointerDownOutsideRef.current = isLeftClick;
         })}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           if (targetIsTrigger) event.preventDefault();
         })}

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -222,7 +222,11 @@ export const Chromatic = () => (
     <h2>Open</h2>
     <Popover defaultOpen>
       <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-      <PopoverContent className={contentClass} sideOffset={5}>
+      <PopoverContent
+        className={contentClass}
+        sideOffset={5}
+        onFocusOutside={(event) => event.preventDefault()}
+      >
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>
@@ -230,7 +234,11 @@ export const Chromatic = () => (
 
     <h2 style={{ marginTop: 100 }}>Open with reordered parts</h2>
     <Popover defaultOpen>
-      <PopoverContent className={contentClass} sideOffset={5}>
+      <PopoverContent
+        className={contentClass}
+        sideOffset={5}
+        onFocusOutside={(event) => event.preventDefault()}
+      >
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>
@@ -291,7 +299,7 @@ export const Chromatic = () => (
       <PopoverAnchor style={{ padding: 20, background: 'gainsboro' }}>
         <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
       </PopoverAnchor>
-      <PopoverContent className={contentClass}>
+      <PopoverContent className={contentClass} onFocusOutside={(event) => event.preventDefault()}>
         <PopoverClose className={closeClass}>close</PopoverClose>
         <PopoverArrow className={arrowClass} width={20} height={10} />
       </PopoverContent>

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -30,6 +30,21 @@ export const Styled = () => {
   );
 };
 
+export const NonModal = () => {
+  return (
+    <>
+      <Popover modal={false}>
+        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+        <PopoverContent className={contentClass} sideOffset={5}>
+          <PopoverClose className={closeClass}>close</PopoverClose>
+          <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
+        </PopoverContent>
+      </Popover>
+      <input style={{ marginLeft: 10 }} />
+    </>
+  );
+};
+
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
   return (
@@ -172,21 +187,6 @@ export const CustomAnchor = () => (
     </PopoverContent>
   </Popover>
 );
-
-export const NonModal = () => {
-  return (
-    <>
-      <Popover>
-        <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
-        <PopoverContent className={contentClass} sideOffset={5} trapFocus={false}>
-          <PopoverClose className={closeClass}>close</PopoverClose>
-          <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
-        </PopoverContent>
-      </Popover>
-      <input style={{ marginLeft: 10 }} />
-    </>
-  );
-};
 
 export const WithSlottedTrigger = () => {
   return (

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -30,10 +30,10 @@ export const Styled = () => {
   );
 };
 
-export const NonModal = () => {
+export const Modal = () => {
   return (
     <>
-      <Popover modal={false}>
+      <Popover modal>
         <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
         <PopoverContent className={contentClass} sideOffset={5}>
           <PopoverClose className={closeClass}>close</PopoverClose>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -261,8 +261,12 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           isPointerDownOutsideRef.current = isLeftClick;
         })}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
-          // prevent dismissing when clicking the trigger
-          // as it's already setup to close, otherwise it would close and immediately open.
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           if (targetIsTrigger) event.preventDefault();
         })}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -32,6 +32,7 @@ type PopoverContextValue = {
   hasCustomAnchor: boolean;
   onCustomAnchorAdd(): void;
   onCustomAnchorRemove(): void;
+  modal: boolean;
 };
 
 const [PopoverProvider, usePopoverContext] = createContext<PopoverContextValue>(POPOVER_NAME);
@@ -40,10 +41,11 @@ type PopoverOwnProps = {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
 };
 
 const Popover: React.FC<PopoverOwnProps> = (props) => {
-  const { children, open: openProp, defaultOpen, onOpenChange } = props;
+  const { children, open: openProp, defaultOpen, onOpenChange, modal = true } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [hasCustomAnchor, setHasCustomAnchor] = React.useState(false);
   const [open = false, setOpen] = useControllableState({
@@ -63,6 +65,7 @@ const Popover: React.FC<PopoverOwnProps> = (props) => {
         hasCustomAnchor={hasCustomAnchor}
         onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
         onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}
+        modal={modal}
       >
         {children}
       </PopoverProvider>
@@ -122,7 +125,7 @@ const PopoverTrigger = React.forwardRef((props, forwardedRef) => {
       aria-haspopup="dialog"
       aria-expanded={context.open}
       aria-controls={context.contentId}
-      data-state={context.open ? 'open' : 'closed'}
+      data-state={getState(context.open)}
       {...triggerProps}
       as={as}
       ref={composedTriggerRef}
@@ -146,7 +149,7 @@ PopoverTrigger.displayName = TRIGGER_NAME;
 const CONTENT_NAME = 'PopoverContent';
 
 type PopoverContentOwnProps = Polymorphic.Merge<
-  Polymorphic.OwnProps<typeof PopoverContentImpl>,
+  Polymorphic.OwnProps<typeof PopoverContentModal | typeof PopoverContentNonModal>,
   {
     /**
      * Used to force mounting when more control is needed. Useful when
@@ -157,7 +160,7 @@ type PopoverContentOwnProps = Polymorphic.Merge<
 >;
 
 type PopoverContentPrimitive = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
+  Polymorphic.IntrinsicElement<typeof PopoverContentModal | typeof PopoverContentNonModal>,
   PopoverContentOwnProps
 >;
 
@@ -167,14 +170,82 @@ const PopoverContent = React.forwardRef((props, forwardedRef) => {
 
   return (
     <Presence present={forceMount || context.open}>
-      <PopoverContentImpl
-        data-state={context.open ? 'open' : 'closed'}
-        {...contentProps}
-        ref={forwardedRef}
-      />
+      {context.modal ? (
+        <PopoverContentModal {...contentProps} ref={forwardedRef} />
+      ) : (
+        <PopoverContentNonModal {...contentProps} ref={forwardedRef} />
+      )}
     </Presence>
   );
 }) as PopoverContentPrimitive;
+
+PopoverContent.displayName = CONTENT_NAME;
+
+type PopoverContentTypeOwnProps = Omit<
+  Polymorphic.OwnProps<typeof PopoverContentImpl>,
+  'trapFocus' | 'disableOutsidePointerEvents'
+>;
+
+type PopoverContentTypePrimitive = Polymorphic.ForwardRefComponent<
+  Polymorphic.IntrinsicElement<typeof PopoverContentImpl>,
+  PopoverContentTypeOwnProps
+>;
+
+const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
+  const context = usePopoverContext(CONTENT_NAME);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, contentRef);
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  React.useEffect(() => {
+    const content = contentRef.current;
+    if (content) return hideOthers(content);
+  }, []);
+
+  return (
+    <PopoverContentImpl
+      {...props}
+      ref={composedRefs}
+      // we make sure we're not trapping once it's been closed
+      // (closed !== unmounted when animating out)
+      trapFocus={context.open}
+      disableOutsidePointerEvents
+      // When focus is trapped, a `focusout` event may still happen.
+      // We make sure we don't trigger our `onDismiss` in such case.
+      onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) => event.preventDefault())}
+    />
+  );
+}) as PopoverContentTypePrimitive;
+
+const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
+  const context = usePopoverContext(CONTENT_NAME);
+  const isPointerDownOutsideRef = React.useRef(false);
+
+  return (
+    <PopoverContentImpl
+      {...props}
+      ref={forwardedRef}
+      trapFocus={false}
+      onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+        if (isPointerDownOutsideRef.current) event.preventDefault();
+      })}
+      disableOutsidePointerEvents={false}
+      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+        isPointerDownOutsideRef.current = false;
+      })}
+      onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+        const { originalEvent } = event.detail;
+        const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
+        isPointerDownOutsideRef.current = isLeftClick;
+
+        // prevent dismissing when clicking the trigger
+        // as it's already setup to close, otherwise it would close and immediately open.
+        const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+        if (targetIsTrigger) event.preventDefault();
+      })}
+    />
+  );
+}) as PopoverContentTypePrimitive;
 
 type FocusScopeOwnProps = Polymorphic.OwnProps<typeof FocusScope>;
 type DismissableLayerOwnProps = Polymorphic.OwnProps<typeof DismissableLayer>;
@@ -222,10 +293,10 @@ type PopoverContentImplPrimitive = Polymorphic.ForwardRefComponent<
 
 const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   const {
-    trapFocus = true,
+    trapFocus,
     onOpenAutoFocus,
     onCloseAutoFocus,
-    disableOutsidePointerEvents = false,
+    disableOutsidePointerEvents,
     onEscapeKeyDown,
     onPointerDownOutside,
     onFocusOutside,
@@ -235,9 +306,6 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     ...contentProps
   } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const isPointerDownOutsideRef = React.useRef(false);
-  const contentRef = React.useRef<HTMLDivElement>(null);
-  const composedRefs = useComposedRefs(forwardedRef, contentRef);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
   const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
@@ -246,69 +314,31 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
   // the last element in the DOM (beacuse of the `Portal`)
   useFocusGuards();
 
-  // Hide everything from ARIA except the content
-  React.useEffect(() => {
-    const content = contentRef.current;
-    if (content) return hideOthers(content);
-  }, []);
-
   return (
     <PortalWrapper>
       <ScrollLockWrapper>
         <FocusScope
           as={Slot}
-          // we make sure we're not trapping once it's been closed
-          // (closed !== unmounted when animating out)
-          trapped={trapFocus && context.open}
+          loop
+          trapped={trapFocus}
           onMountAutoFocus={onOpenAutoFocus}
-          onUnmountAutoFocus={(event) => {
-            if (!disableOutsidePointerEvents && isPointerDownOutsideRef.current) {
-              event.preventDefault();
-            } else {
-              onCloseAutoFocus?.(event);
-            }
-          }}
+          onUnmountAutoFocus={onCloseAutoFocus}
         >
           <DismissableLayer
             as={Slot}
             disableOutsidePointerEvents={disableOutsidePointerEvents}
-            onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-              isPointerDownOutsideRef.current = false;
-            })}
-            onPointerDownOutside={composeEventHandlers(
-              onPointerDownOutside,
-              (event) => {
-                const originalEvent = event.detail.originalEvent as MouseEvent;
-                const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
-                isPointerDownOutsideRef.current = isLeftClick;
-
-                const targetIsTrigger = context.triggerRef.current?.contains(
-                  event.target as HTMLElement
-                );
-                // prevent dismissing when clicking the trigger
-                // as it's already setup to close, otherwise it would close and immediately open.
-                if (targetIsTrigger) event.preventDefault();
-              },
-              { checkForDefaultPrevented: false }
-            )}
-            onFocusOutside={composeEventHandlers(
-              onFocusOutside,
-              (event) => {
-                // When focus is trapped, a focusout event may still happen.
-                // We make sure we don't trigger our `onDismiss` in such case.
-                if (trapFocus) event.preventDefault();
-              },
-              { checkForDefaultPrevented: false }
-            )}
             onInteractOutside={onInteractOutside}
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+            onFocusOutside={onFocusOutside}
             onDismiss={() => context.onOpenChange(false)}
           >
             <PopperPrimitive.Content
+              data-state={getState(context.open)}
               role="dialog"
-              aria-modal
               id={context.contentId}
               {...contentProps}
-              ref={composedRefs}
+              ref={forwardedRef}
               style={{
                 ...contentProps.style,
                 // re-namespace exposed content custom property
@@ -321,8 +351,6 @@ const PopoverContentImpl = React.forwardRef((props, forwardedRef) => {
     </PortalWrapper>
   );
 }) as PopoverContentImplPrimitive;
-
-PopoverContent.displayName = CONTENT_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * PopoverClose
@@ -358,6 +386,10 @@ PopoverClose.displayName = CLOSE_NAME;
 const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'PopoverArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
+
+function getState(open: boolean) {
+  return open ? 'open' : 'closed';
+}
 
 const Root = Popover;
 const Anchor = PopoverAnchor;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -259,7 +259,8 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           const { originalEvent } = event.detail;
           const isLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === false;
           isPointerDownOutsideRef.current = isLeftClick;
-
+        })}
+        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
           // prevent dismissing when clicking the trigger
           // as it's already setup to close, otherwise it would close and immediately open.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);


### PR DESCRIPTION
This PR builds on top of #700 and adds support for modality options in popovers.

The approach taken here mirrors that of the [Dialog changes](https://github.com/radix-ui/primitives/pull/699).
