### PR TITLE
Add no-unused-var lint rule

### DIFF
--- a/.yarn/versions/7023f969.yml
+++ b/.yarn/versions/7023f969.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/package.json
+++ b/package.json
@@ -130,6 +130,12 @@
       }
     },
     "rules": {
+      "@typescript-eslint/no-unused-vars": [
+        1,
+        {
+          "vars": "local"
+        }
+      ],
       "prefer-const": [
         1,
         {

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { axe } from 'jest-axe';
 import { RenderResult } from '@testing-library/react';
-import { render, fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import * as Dialog from './Dialog';
 
 const OPEN_TEXT = 'Open';

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -438,7 +438,7 @@ export const PopoverNested = () => (
     <div style={{ display: 'flex', gap: 10 }}>
       <DummyPopover
         disableOutsidePointerEvents
-        onInteractOutside={(event) => {
+        onInteractOutside={() => {
           console.log('interact outside black');
         }}
       >
@@ -446,8 +446,7 @@ export const PopoverNested = () => (
           color="tomato"
           openLabel="Open red"
           closeLabel="Close red"
-          // disableOutsidePointerEvents
-          onInteractOutside={(event) => {
+          onInteractOutside={() => {
             console.log('interact outside red');
           }}
         >
@@ -456,7 +455,7 @@ export const PopoverNested = () => (
             openLabel="Open blue"
             closeLabel="Close blue"
             disableOutsidePointerEvents
-            onInteractOutside={(event) => {
+            onInteractOutside={() => {
               console.log('interact outside blue');
             }}
           ></DummyPopover>

--- a/packages/react/polymorphic/src/polymorphic.test.tsx
+++ b/packages/react/polymorphic/src/polymorphic.test.tsx
@@ -15,6 +15,7 @@ type ButtonProps = {
 };
 
 const Button = React.forwardRef((props, forwardedRef) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isDisabled, ...buttonProps } = props;
   return <Primitive as="button" {...buttonProps} ref={forwardedRef} />;
 }) as Polymorphic.ForwardRefComponent<
@@ -57,6 +58,7 @@ type ExtendedButtonButtonOwnProps = Omit<
 >;
 
 const ExtendedButton = React.forwardRef((props, forwardedRef) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { isExtended, ...extendedButtonProps } = props;
   return <Button {...extendedButtonProps} ref={forwardedRef} />;
 }) as Polymorphic.ForwardRefComponent<
@@ -91,6 +93,7 @@ type AnchorProps = {
 };
 
 const Anchor = React.forwardRef((props, forwardedRef) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { as: Comp = 'a', requiredProp, ...anchorProps } = props;
   /* Does not expect requiredProp */
   return <Comp {...anchorProps} ref={forwardedRef} />;

--- a/packages/react/portal/src/Portal.stories.tsx
+++ b/packages/react/portal/src/Portal.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Portal } from './Portal';
-import { css } from '../../../../stitches.config';
 
 export default { title: 'Components/Portal' };
 
@@ -57,7 +56,6 @@ export const CustomContainer = () => {
 
 export const Chromatic = () => {
   const portalContainerRef = React.useRef<HTMLDivElement>(null);
-  const portalContainerRef2 = React.useRef<HTMLDivElement>(null);
 
   return (
     <div style={{ padding: 150 }}>

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Presence } from './Presence';
-import { styled, css } from '../../../../stitches.config';
+import { css } from '../../../../stitches.config';
 
 export default { title: 'Components/Presence' };
 

--- a/packages/react/primitive/src/extendPrimitive.test.tsx
+++ b/packages/react/primitive/src/extendPrimitive.test.tsx
@@ -14,6 +14,7 @@ type ButtonProps = { isDisabled?: boolean };
 type ButtonPrimitive = Polymorphic.ForwardRefComponent<'button', ButtonProps>;
 
 const Button = React.forwardRef((props, forwardedRef) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { as: Comp = 'button', isDisabled, ...buttonProps } = props;
   return <Comp {...buttonProps} ref={forwardedRef} />;
 }) as ButtonPrimitive;

--- a/packages/react/slider/src/collection.stories.tsx
+++ b/packages/react/slider/src/collection.stories.tsx
@@ -155,10 +155,10 @@ function Item({ children, disabled = false, ...props }: ItemProps) {
 const [createTabsCollection, useTabsItem, useTabs] = createCollection('Tabs');
 const [createPanelsCollection, usePanelsItem, usePanels] = createCollection('Panels');
 
-const TabsContext = React.createContext({
-  selectedIndex: 0,
-  setSelectedIndex: (index: number) => {},
-});
+const TabsContext = React.createContext<{
+  selectedIndex: number;
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
+}>({ selectedIndex: 0, setSelectedIndex: () => {} });
 
 const Tabs = createTabsCollection(function Tabs({ children }) {
   const tabs = useTabs();


### PR DESCRIPTION
This PR adds `@typescript-eslint/no-unused-vars` to our lint rules.

I've been caught out a few times when passing destructured props down across several comps and not having a signal to let me know if i'd forgotten to thread a given prop. It should also help mitigate [small things like this](https://github.com/radix-ui/primitives/pull/724).

One drawback is that we'd trigger a warning when intentionally omitting a given prop via `...rest`, but it appears we currently don't do this very often outside of a couple of tests.

Let me know what you think.
