### PR TITLE
[Dialog][AlertDialog][Popover][DropdownMenu] Prevent pointer-events reenabling prematurely (mobile)

### DIFF
--- a/.yarn/versions/ea4f707a.yml
+++ b/.yarn/versions/ea4f707a.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-use-body-pointer-events": patch
+
+declined:
+  - primitives

--- a/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
+++ b/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
@@ -24,7 +24,7 @@ function useBodyPointerEvents({ disabled }: { disabled: boolean }) {
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [isTouchOrPenPressedRef]);
+  }, []);
 
   useLayoutEffect(() => {
     if (disabled) {

--- a/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
+++ b/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
@@ -1,21 +1,62 @@
+import * as React from 'react';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
 let changeCount = 0;
 let originalBodyPointerEvents: string;
 
 function useBodyPointerEvents({ disabled }: { disabled: boolean }) {
+  const isTouchOrPenPressRef = React.useRef(false);
+
+  React.useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      isTouchOrPenPressRef.current = event.pointerType !== 'mouse';
+    };
+    const handlePointerUp = () => (isTouchOrPenPressRef.current = false);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('pointerup', handlePointerUp);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isTouchOrPenPressRef]);
+
   useLayoutEffect(() => {
     if (disabled) {
       if (changeCount === 0) {
         originalBodyPointerEvents = document.body.style.pointerEvents;
       }
+
+      function resetPointerEvents() {
+        if (changeCount === 0) {
+          document.body.style.pointerEvents = originalBodyPointerEvents;
+        }
+      }
+
       document.body.style.pointerEvents = 'none';
       changeCount++;
 
       return () => {
         changeCount--;
-        if (changeCount === 0) {
-          document.body.style.pointerEvents = originalBodyPointerEvents;
+        if (isTouchOrPenPressRef.current) {
+          /**
+           * On touch devices, browsers implement a ~350ms delay between the time the user stops
+           * touching the display and when the browser executes events. We need to ensure we
+           * don't reactivate pointer-events within this timeframe otherwise the browser may
+           * execute events that should have been prevented.
+           *
+           * We are aware that `touch-action: manipulation` shortens this delay for events,
+           * but it isn't enough to cover all cases. When there is an input on screen:
+           * - if a click event is bound to it, it will fire after a `pointerdown` which may
+           * have re-enabled pointer-events (regardless of `touch-action: manipulation`).
+           * - if clicking it causes the page to zoom, the events will wait for the zoom to
+           * finish before executing on the input.
+           * - if long pressesing it, the events will execute after the longpress delay.
+           *
+           * We've used 500ms to cover all cases.
+           */
+          setTimeout(resetPointerEvents, 500);
+        } else {
+          resetPointerEvents();
         }
       };
     }

--- a/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
+++ b/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
@@ -52,9 +52,10 @@ function useBodyPointerEvents({ disabled }: { disabled: boolean }) {
            * finish before executing on the input.
            * - if long pressesing it, the events will execute after the longpress delay.
            *
-           * We've used 500ms to cover all cases.
+           * Instead, we force pointer-events to remain disabled until the `click` event has
+           * executed when pressing on touch devices.
            */
-          setTimeout(resetPointerEvents, 500);
+          document.addEventListener('click', resetPointerEvents, { once: true });
         } else {
           resetPointerEvents();
         }


### PR DESCRIPTION
Fixes #631
Fixes #761 
Fixes #762 
Fixes #763

I managed to fix these all in one go eventually. 

@benoitgrelard  I believe I've also managed to provide a solution that merges both of our suggestions. My main concern was to keep the fix within `useBodyPointerEvents` since the issue is a side-effect of pointer-events enabling too soon, but I've only enabled the delay on `pointerdown` (because like you say, that's **when** it's an issue) and it's a touch or pen pointer.

Happy to continue to discuss alternate solutions as well if we have any because obviously, `setTimeout`s are never ideal. 

---------

UPDATE: Delay has been removed in favour of waiting for `click` event. I gave myself the idea here https://github.com/radix-ui/primitives/pull/767#issuecomment-874220750 😅 