### PR TITLE
[DropdownMenu][ContextMenu] Add modality support

### DIFF
--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -63,6 +63,89 @@ export const Styled = () => {
   );
 };
 
+export const NonModal = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100vw',
+        height: '100vh',
+        gap: 20,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <ContextMenu onOpenChange={setOpen} modal={false}>
+          <ContextMenuTrigger
+            className={triggerClass}
+            style={{ background: open ? 'lightblue' : undefined }}
+          />
+          <ContextMenuContent className={contentClass} alignOffset={-5}>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </ContextMenuItem>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenu>
+              <ContextMenuTriggerItem className={subTriggerClass}>Submenu →</ContextMenuTriggerItem>
+              <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </ContextMenuItem>
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </ContextMenuItem>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenu>
+                  <ContextMenuTriggerItem className={subTriggerClass}>
+                    Submenu →
+                  </ContextMenuTriggerItem>
+                  <ContextMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                      One
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                      Two
+                    </ContextMenuItem>
+                    <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                      Three
+                    </ContextMenuItem>
+                    <ContextMenuArrow offset={14} />
+                  </ContextMenuContent>
+                </ContextMenu>
+                <ContextMenuSeparator className={separatorClass} />
+                <ContextMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </ContextMenuItem>
+                <ContextMenuArrow offset={14} />
+              </ContextMenuContent>
+            </ContextMenu>
+            <ContextMenuSeparator className={separatorClass} />
+            <ContextMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </ContextMenuItem>
+            <ContextMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+        <textarea
+          style={{ width: 500, height: 200, marginTop: 10 }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    </div>
+  );
+};
+
 export const Submenus = () => {
   const [open, setOpen] = React.useState(false);
   const [rtl, setRtl] = React.useState(false);

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -29,10 +29,11 @@ const [ContextMenuProvider, useContextMenuContext] = createContext<ContextMenuCo
 type ContextMenuOwnProps = {
   onOpenChange?(open: boolean): void;
   dir?: Direction;
+  modal?: boolean;
 };
 
 const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
-  const { children, onOpenChange, dir } = props;
+  const { children, onOpenChange, dir, modal } = props;
   const [open, setOpen] = React.useState(false);
   const isInsideContent = React.useContext(ContentContext);
   const handleOpenChangeProp = useCallbackRef(onOpenChange);
@@ -53,7 +54,7 @@ const ContextMenu: React.FC<ContextMenuOwnProps> = (props) => {
     </ContextMenuProvider>
   ) : (
     <ContextMenuProvider isRootMenu={true} open={open} onOpenChange={handleOpenChange}>
-      <MenuPrimitive.Root dir={dir} open={open} onOpenChange={handleOpenChange}>
+      <MenuPrimitive.Root dir={dir} open={open} onOpenChange={handleOpenChange} modal={modal}>
         {children}
       </MenuPrimitive.Root>
     </ContextMenuProvider>
@@ -141,7 +142,7 @@ const ContentContext = React.createContext(false);
 
 type ContextMenuContentOwnProps = Omit<
   Polymorphic.OwnProps<typeof MenuPrimitive.Content>,
-  'trapFocus' | 'disableOutsideScroll' | 'portalled' | 'side' | 'align'
+  'portalled' | 'side' | 'align'
 >;
 
 type ContextMenuContentPrimitive = Polymorphic.ForwardRefComponent<
@@ -183,15 +184,10 @@ type ContextMenuRootContentPrimitive = Polymorphic.ForwardRefComponent<
 >;
 
 const ContextMenuRootContent = React.forwardRef((props, forwardedRef) => {
-  const { disableOutsidePointerEvents = true, ...contentProps } = props;
-  const context = useContextMenuContext(CONTENT_NAME);
   return (
     <MenuPrimitive.Content
-      {...contentProps}
+      {...props}
       ref={forwardedRef}
-      disableOutsidePointerEvents={context.open ? disableOutsidePointerEvents : false}
-      trapFocus
-      disableOutsideScroll
       portalled
       side="right"
       sideOffset={2}

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -50,6 +50,61 @@ export const Styled = () => (
   </div>
 );
 
+export const NonModal = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}
+    >
+      <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+          <DropdownMenuContent className={contentClass} sideOffset={5}>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenu>
+              <DropdownMenuTriggerItem className={subTriggerClass}>
+                Submenu →
+              </DropdownMenuTriggerItem>
+              <DropdownMenuContent className={contentClass} sideOffset={12} alignOffset={-6}>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('one')}>
+                  One
+                </DropdownMenuItem>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('two')}>
+                  Two
+                </DropdownMenuItem>
+                <DropdownMenuItem className={itemClass} onSelect={() => console.log('three')}>
+                  Three
+                </DropdownMenuItem>
+                <DropdownMenuArrow offset={14} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenuSeparator className={separatorClass} />
+            <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenuItem>
+            <DropdownMenuArrow />
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <textarea
+          style={{ width: 500, height: 200, marginTop: 10, display: 'block' }}
+          defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
+        />
+      </div>
+    </div>
+  );
+};
+
 export const Submenus = () => {
   const [rtl, setRtl] = React.useState(false);
   return (
@@ -328,14 +383,9 @@ export const Chromatic = () => {
     <div style={{ padding: 200, paddingBottom: 800 }}>
       <h1>Uncontrolled</h1>
       <h2>Closed</h2>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -357,13 +407,13 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu defaultOpen>
+      <DropdownMenu defaultOpen modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
         <DropdownMenuContent
           className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
-          disableOutsideScroll={false}
+          onFocusOutside={(event) => event.preventDefault()}
         >
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
@@ -386,12 +436,12 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
-      <DropdownMenu defaultOpen>
+      <DropdownMenu defaultOpen modal={false}>
         <DropdownMenuContent
           className={contentClass}
           sideOffset={5}
           avoidCollisions={false}
-          disableOutsideScroll={false}
+          onFocusOutside={(event) => event.preventDefault()}
         >
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
@@ -416,14 +466,9 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 200 }}>Controlled</h1>
       <h2>Closed</h2>
-      <DropdownMenu open={false}>
+      <DropdownMenu open={false} modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -445,14 +490,9 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -474,13 +514,8 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
-      <DropdownMenu open>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+      <DropdownMenu open modal={false}>
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -504,13 +539,8 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 200 }}>Submenus</h1>
       <h2>Open</h2>
-      <DropdownMenu open>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+      <DropdownMenu open modal={false}>
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
             Undo
           </DropdownMenuItem>
@@ -580,13 +610,8 @@ export const Chromatic = () => {
 
       <h2 style={{ marginTop: 275 }}>RTL</h2>
       <div dir="rtl">
-        <DropdownMenu open dir="rtl">
-          <DropdownMenuContent
-            className={contentClass}
-            sideOffset={5}
-            avoidCollisions={false}
-            disableOutsideScroll={false}
-          >
+        <DropdownMenu open dir="rtl" modal={false}>
+          <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
             <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
               Undo
             </DropdownMenuItem>
@@ -663,14 +688,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -689,14 +713,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -718,14 +741,13 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
                 side={side}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -749,7 +771,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -757,7 +779,6 @@ export const Chromatic = () => {
                 sideOffset={5}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -774,7 +795,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -782,7 +803,6 @@ export const Chromatic = () => {
                 sideOffset={-10}
                 align={align}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -801,7 +821,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -809,7 +829,6 @@ export const Chromatic = () => {
                 align={align}
                 alignOffset={20}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -826,7 +845,7 @@ export const Chromatic = () => {
       <div className={gridClass}>
         {SIDES.map((side) =>
           ALIGN_OPTIONS.map((align) => (
-            <DropdownMenu key={`${side}-${align}`} open>
+            <DropdownMenu key={`${side}-${align}`} open modal={false}>
               <DropdownMenuTrigger className={chromaticTriggerClass} />
               <DropdownMenuContent
                 className={chromaticContentClass}
@@ -834,7 +853,6 @@ export const Chromatic = () => {
                 align={align}
                 alignOffset={-10}
                 avoidCollisions={false}
-                disableOutsideScroll={false}
               >
                 <p style={{ textAlign: 'center' }}>
                   {side}
@@ -852,7 +870,7 @@ export const Chromatic = () => {
       <p>See instances on the periphery of the page.</p>
       {SIDES.map((side) =>
         ALIGN_OPTIONS.map((align) => (
-          <DropdownMenu key={`${side}-${align}`} open>
+          <DropdownMenu key={`${side}-${align}`} open modal={false}>
             <DropdownMenuTrigger
               className={chromaticTriggerClass}
               style={{
@@ -872,12 +890,7 @@ export const Chromatic = () => {
                     : { left: 10 })),
               }}
             />
-            <DropdownMenuContent
-              className={chromaticContentClass}
-              side={side}
-              align={align}
-              disableOutsideScroll={false}
-            >
+            <DropdownMenuContent className={chromaticContentClass} side={side} align={align}>
               <p style={{ textAlign: 'center' }}>
                 {side}
                 <br />
@@ -890,14 +903,9 @@ export const Chromatic = () => {
       )}
 
       <h1>With labels</h1>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           {foodGroups.map((foodGroup, index) => (
             <DropdownMenuGroup key={index}>
               {foodGroup.label && (
@@ -925,14 +933,9 @@ export const Chromatic = () => {
       </DropdownMenu>
 
       <h1 style={{ marginTop: 600 }}>With checkbox and radio items</h1>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemClass} onSelect={() => console.log('show')}>
             Show fonts
           </DropdownMenuItem>
@@ -974,25 +977,15 @@ export const Chromatic = () => {
 
       <h1 style={{ marginTop: 500 }}>State attributes</h1>
       <h2>Closed</h2>
-      <DropdownMenu open={false}>
+      <DropdownMenu open={false} modal={false}>
         <DropdownMenuTrigger className={triggerAttrClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentAttrClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        />
+        <DropdownMenuContent className={contentAttrClass} sideOffset={5} avoidCollisions={false} />
       </DropdownMenu>
 
       <h2>Open</h2>
-      <DropdownMenu open>
+      <DropdownMenu open modal={false}>
         <DropdownMenuTrigger className={triggerAttrClass}>Open</DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={contentAttrClass}
-          sideOffset={5}
-          avoidCollisions={false}
-          disableOutsideScroll={false}
-        >
+        <DropdownMenuContent className={contentAttrClass} sideOffset={5} avoidCollisions={false}>
           <DropdownMenuItem className={itemAttrClass} onSelect={() => console.log('show')}>
             Show fonts
           </DropdownMenuItem>

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -97,7 +97,7 @@ export const NonModal = () => {
           </DropdownMenuContent>
         </DropdownMenu>
         <textarea
-          style={{ width: 500, height: 200, marginTop: 10, display: 'block' }}
+          style={{ width: 500, height: 200, marginTop: 10 }}
           defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet, minima expedita alias et fugit voluptate laborum placeat odio dolore ab!"
         />
       </div>

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -143,7 +143,7 @@ const DropdownMenuTrigger = React.forwardRef((props, forwardedRef) => {
       {...triggerProps}
       as={as}
       ref={composeRefs(forwardedRef, context.triggerRef)}
-      onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
+      onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
         // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
         // but not when the control key is pressed (avoiding MacOS right click)
         if (event.button === 0 && event.ctrlKey === false) {

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -376,16 +376,13 @@ type MenuOwnProps = Omit<
 const MenuWithAnchor: React.FC<MenuOwnProps> = (props) => {
   const { open = true, children, ...contentProps } = props;
   return (
-    <Menu open={open} onOpenChange={() => {}}>
+    <Menu open={open} onOpenChange={() => {}} modal={false}>
       {/* inline-block allows anchor to move when rtl changes on document */}
       <MenuAnchor style={{ display: 'inline-block' }} />
       <MenuContent
         className={contentClass}
         portalled
-        trapFocus={false}
         onCloseAutoFocus={(event) => event.preventDefault()}
-        disableOutsidePointerEvents={false}
-        disableOutsideScroll={false}
         align="start"
         {...contentProps}
       >


### PR DESCRIPTION
This PR adds modality support via the `modal` prop in `DropdownMenu` and `ContextMenu`.

I've made the changes in the underlying `Menu` prim. It differs slightly from `Dialog` / `Popover` because `MenuContentImpl` also provides common functionality for submenus and I didn't want to conflate the `Modal` modes straight away in case the submenu impl needs to change in the near term.

