### PR TITLE
[Presence] Replace `useEffect` with `useLayoutEffect`

### DIFF
--- a/.yarn/versions/07243d9a.yml
+++ b/.yarn/versions/07243d9a.yml
@@ -1,0 +1,18 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/react-compose-refs": "workspace:*"
+    "@radix-ui/react-compose-refs": "workspace:*",
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { useStateMachine } from './useStateMachine';
 
 type PresenceProps = {
@@ -46,7 +47,7 @@ function usePresence(present: boolean) {
     },
   });
 
-  React.useEffect(() => {
+  useLayoutEffect(() => {
     const styles = stylesRef.current;
     const wasPresent = prevPresentRef.current;
     const hasPresentChanged = wasPresent !== present;
@@ -81,7 +82,7 @@ function usePresence(present: boolean) {
     }
   }, [present, send]);
 
-  React.useEffect(() => {
+  useLayoutEffect(() => {
     if (node) {
       /**
        * Triggering an ANIMATION_OUT during an ANIMATION_IN will fire an `animationcancel`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3960,6 +3960,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/react-compose-refs": "workspace:*"
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ">=16.8"
   languageName: unknown


### PR DESCRIPTION
This change stems from an issue reported here https://github.com/reactwg/react-18/discussions/70#discussioncomment-981133

I was unable to test that it actually fixes the issue described (since we're React 17) but it doesn't break our stories and seems this is somewhere where we should be using `useLayoutEffect` regardless.