### PR TITLE
[Collection] Widen usage of items

### DIFF
--- a/.yarn/versions/94f36198.yml
+++ b/.yarn/versions/94f36198.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/collection/src/Collection.stories.tsx
+++ b/packages/react/collection/src/Collection.stories.tsx
@@ -125,16 +125,18 @@ export const Nested = () => (
 
 type ItemData = { disabled: boolean };
 
-const [ListSlot, ListItemSlot, useItems] = createCollection<
+const [ListProvider, ListRootSlot, ListItemSlot, useItems] = createCollection<
   React.ElementRef<typeof Item>,
   ItemData
 >();
 
 const List: React.FC = (props) => {
   return (
-    <ListSlot>
-      <ul style={{ width: 200 }} {...props} />
-    </ListSlot>
+    <ListProvider>
+      <ListRootSlot>
+        <ul style={{ width: 200 }} {...props} />
+      </ListRootSlot>
+    </ListProvider>
   );
 };
 

--- a/packages/react/collection/src/Collection.tsx
+++ b/packages/react/collection/src/Collection.tsx
@@ -4,8 +4,8 @@ import { Slot } from '@radix-ui/react-slot';
 
 // We have resorted to returning slots directly rather than exposing primitives that can then
 // be slotted like `<CollectionItem as={Slot}>…</CollectionItem>`.
-// This is because we encountered issues with generic types, static analysis 
-// and the dynamic function used to return the components.
+// This is because we encountered issues with generic types that cannot be statically analysed
+// due to creating them dynamically via createCollection.
 
 function createCollection<ItemElement extends HTMLElement, ItemData>() {
   /* -----------------------------------------------------------------------------------------------

--- a/packages/react/collection/src/Collection.tsx
+++ b/packages/react/collection/src/Collection.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Slot } from '@radix-ui/react-slot';
 
+// We have resorted to returning slots directly rather than exposing primitives that can then
+// be slotted like `<CollectionItem as={Slot}>…</CollectionItem>`. This is because we were having
+// issues with types because there are generics at play and it's not statically analyzable because
+// the components are returned by a dynamic function.
+
 function createCollection<ItemElement extends HTMLElement, ItemData>() {
   /* -----------------------------------------------------------------------------------------------
    * CollectionProvider
@@ -31,23 +36,21 @@ function createCollection<ItemElement extends HTMLElement, ItemData>() {
   CollectionProvider.displayName = PROVIDER_NAME;
 
   /* -----------------------------------------------------------------------------------------------
-   * CollectionRootSlot
+   * CollectionSlot
    * ---------------------------------------------------------------------------------------------*/
 
-  const ROOT_SLOT_NAME = 'CollectionRootSlot';
+  const COLLECTION_SLOT_NAME = 'CollectionSlot';
 
   type SlotProps = React.ComponentProps<typeof Slot>;
 
-  const CollectionRootSlot = React.forwardRef<CollectionElement, SlotProps>(
-    (props, forwardedRef) => {
-      const { children } = props;
-      const context = React.useContext(Context);
-      const composedRefs = useComposedRefs(forwardedRef, context.collectionRef);
-      return <Slot ref={composedRefs}>{children}</Slot>;
-    }
-  );
+  const CollectionSlot = React.forwardRef<CollectionElement, SlotProps>((props, forwardedRef) => {
+    const { children } = props;
+    const context = React.useContext(Context);
+    const composedRefs = useComposedRefs(forwardedRef, context.collectionRef);
+    return <Slot ref={composedRefs}>{children}</Slot>;
+  });
 
-  CollectionRootSlot.displayName = ROOT_SLOT_NAME;
+  CollectionSlot.displayName = COLLECTION_SLOT_NAME;
 
   /* -----------------------------------------------------------------------------------------------
    * CollectionItem
@@ -100,7 +103,7 @@ function createCollection<ItemElement extends HTMLElement, ItemData>() {
     };
   }
 
-  return [CollectionProvider, CollectionRootSlot, CollectionItemSlot, useCollection] as const;
+  return [CollectionProvider, CollectionSlot, CollectionItemSlot, useCollection] as const;
 }
 
 export { createCollection };

--- a/packages/react/collection/src/Collection.tsx
+++ b/packages/react/collection/src/Collection.tsx
@@ -3,9 +3,9 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Slot } from '@radix-ui/react-slot';
 
 // We have resorted to returning slots directly rather than exposing primitives that can then
-// be slotted like `<CollectionItem as={Slot}>…</CollectionItem>`. This is because we were having
-// issues with types because there are generics at play and it's not statically analyzable because
-// the components are returned by a dynamic function.
+// be slotted like `<CollectionItem as={Slot}>…</CollectionItem>`.
+// This is because we encountered issues with generic types, static analysis 
+// and the dynamic function used to return the components.
 
 function createCollection<ItemElement extends HTMLElement, ItemData>() {
   /* -----------------------------------------------------------------------------------------------

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -167,12 +167,10 @@ const CONTENT_NAME = 'MenuContent';
 type MenuContentElement = React.ElementRef<typeof MenuContent>;
 type ItemData = { disabled: boolean; textValue: string };
 
-const [
-  CollectionProvider,
-  CollectionRootSlot,
-  CollectionItemSlot,
-  useCollection,
-] = createCollection<React.ElementRef<typeof MenuItem>, ItemData>();
+const [CollectionProvider, CollectionSlot, CollectionItemSlot, useCollection] = createCollection<
+  React.ElementRef<typeof MenuItem>,
+  ItemData
+>();
 
 type MenuContentContextValue = {
   onItemEnter(event: React.PointerEvent): void;
@@ -213,13 +211,13 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
   return (
     <CollectionProvider>
       <Presence present={forceMount || context.open}>
-        <CollectionRootSlot>
+        <CollectionSlot>
           {context.isSubmenu ? (
             <MenuSubContent {...contentProps} ref={forwardedRef} />
           ) : (
             <MenuRootContent {...contentProps} ref={forwardedRef} />
           )}
-        </CollectionRootSlot>
+        </CollectionSlot>
       </Presence>
     </CollectionProvider>
   );

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -167,10 +167,12 @@ const CONTENT_NAME = 'MenuContent';
 type MenuContentElement = React.ElementRef<typeof MenuContent>;
 type ItemData = { disabled: boolean; textValue: string };
 
-const [CollectionSlot, CollectionItemSlot, useCollection] = createCollection<
-  React.ElementRef<typeof MenuItem>,
-  ItemData
->();
+const [
+  CollectionProvider,
+  CollectionRootSlot,
+  CollectionItemSlot,
+  useCollection,
+] = createCollection<React.ElementRef<typeof MenuItem>, ItemData>();
 
 type MenuContentContextValue = {
   onItemEnter(event: React.PointerEvent): void;
@@ -209,15 +211,17 @@ const MenuContent = React.forwardRef((props, forwardedRef) => {
   const { forceMount, ...contentProps } = props;
   const context = useMenuContext(CONTENT_NAME);
   return (
-    <Presence present={forceMount || context.open}>
-      <CollectionSlot>
-        {context.isSubmenu ? (
-          <MenuSubContent {...contentProps} ref={forwardedRef} />
-        ) : (
-          <MenuRootContent {...contentProps} ref={forwardedRef} />
-        )}
-      </CollectionSlot>
-    </Presence>
+    <CollectionProvider>
+      <Presence present={forceMount || context.open}>
+        <CollectionRootSlot>
+          {context.isSubmenu ? (
+            <MenuSubContent {...contentProps} ref={forwardedRef} />
+          ) : (
+            <MenuRootContent {...contentProps} ref={forwardedRef} />
+          )}
+        </CollectionRootSlot>
+      </Presence>
+    </CollectionProvider>
   );
 }) as MenuContentPrimitive;
 

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -14,10 +14,12 @@ const ENTRY_FOCUS = 'rovingFocusGroup.onEntryFocus';
 const EVENT_OPTIONS = { bubbles: false, cancelable: true };
 
 type ItemData = { id: string; focusable: boolean; active: boolean };
-const [CollectionSlot, CollectionItemSlot, useCollection] = createCollection<
-  HTMLSpanElement,
-  ItemData
->();
+const [
+  CollectionProvider,
+  CollectionRootSlot,
+  CollectionItemSlot,
+  useCollection,
+] = createCollection<HTMLSpanElement, ItemData>();
 
 /* -------------------------------------------------------------------------------------------------
  * RovingFocusGroup
@@ -64,9 +66,11 @@ type RovingFocusGroupPrimitive = Polymorphic.ForwardRefComponent<
 
 const RovingFocusGroup = React.forwardRef((props, forwardedRef) => {
   return (
-    <CollectionSlot>
-      <RovingFocusGroupImpl {...props} ref={forwardedRef} />
-    </CollectionSlot>
+    <CollectionProvider>
+      <CollectionRootSlot>
+        <RovingFocusGroupImpl {...props} ref={forwardedRef} />
+      </CollectionRootSlot>
+    </CollectionProvider>
   );
 }) as RovingFocusGroupPrimitive;
 

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -14,12 +14,10 @@ const ENTRY_FOCUS = 'rovingFocusGroup.onEntryFocus';
 const EVENT_OPTIONS = { bubbles: false, cancelable: true };
 
 type ItemData = { id: string; focusable: boolean; active: boolean };
-const [
-  CollectionProvider,
-  CollectionRootSlot,
-  CollectionItemSlot,
-  useCollection,
-] = createCollection<HTMLSpanElement, ItemData>();
+const [CollectionProvider, CollectionSlot, CollectionItemSlot, useCollection] = createCollection<
+  HTMLSpanElement,
+  ItemData
+>();
 
 /* -------------------------------------------------------------------------------------------------
  * RovingFocusGroup
@@ -67,9 +65,9 @@ type RovingFocusGroupPrimitive = Polymorphic.ForwardRefComponent<
 const RovingFocusGroup = React.forwardRef((props, forwardedRef) => {
   return (
     <CollectionProvider>
-      <CollectionRootSlot>
+      <CollectionSlot>
         <RovingFocusGroupImpl {...props} ref={forwardedRef} />
-      </CollectionRootSlot>
+      </CollectionSlot>
     </CollectionProvider>
   );
 }) as RovingFocusGroupPrimitive;


### PR DESCRIPTION
Previously `CollectionSlot` included the provider part, so it typically meant that whatever we decided was the root of the collection (in terms of DOM scoping) was also the subtree in which the items would be available.

This was fine for all current usage, but `Select` needs to be able to access the items, when typing whilst the trigger is focused, and we wouldn't necessarily want to add an extra element surrounding the entire select just in order to provide a root for DOM scoping.

So I've basically split up `CollectionSlot` in 2 separate components (`CollectionProvider` and `CollectionRootSlot`).
It doesn't really change the usage much for current components, and it means I can now bring the `CollectionProvider` much higher up the tree as necessary.