### PR TITLE
[Polymorphic] Allow `ComponentType` props to override

### DIFF
--- a/.yarn/versions/4a422b8c.yml
+++ b/.yarn/versions/4a422b8c.yml
@@ -1,0 +1,39 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/polymorphic/src/polymorphic.test.tsx
+++ b/packages/react/polymorphic/src/polymorphic.test.tsx
@@ -12,6 +12,7 @@ import type { RenderResult } from '@testing-library/react';
 type ButtonProps = {
   isDisabled?: boolean;
   another?: number;
+  common?: boolean;
 };
 
 const Button = React.forwardRef((props, forwardedRef) => {
@@ -73,6 +74,7 @@ const ExtendedButton = React.forwardRef((props, forwardedRef) => {
 type LinkProps = React.ComponentProps<'a'> & {
   isPrimary?: boolean;
   onToggle?(open: boolean): void;
+  common?: string;
 };
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
@@ -207,6 +209,11 @@ export function Test() {
 
       {/* Button as Anchor (Polymorphic.ForwardRefComponent) accepts requiredProp */}
       <Button as={Anchor} requiredProp />
+
+      {/* Button as Link expects Link props that conflict with Button props */}
+      {/* @ts-expect-error */}
+      <Button as={Link} common={true} />
+      <Button as={Link} common="string" />
     </>
   );
 }

--- a/packages/react/polymorphic/src/polymorphic.ts
+++ b/packages/react/polymorphic/src/polymorphic.ts
@@ -36,20 +36,18 @@ interface ForwardRefComponent<
   /**
    * When `as` prop is passed, use this overload.
    * Merges original own props (without DOM props) and the inferred props
-   * from `as` element with the own props taking precendence.
+   * from `as` element with the inferred taking precendence.
    *
    * We explicitly avoid `React.ElementType` and manually narrow the prop types
    * so that events are typed when using JSX.IntrinsicElements.
    */
-  <
-    As extends
-      | keyof JSX.IntrinsicElements
-      | React.ComponentType<any> = NarrowIntrinsic<IntrinsicElementString>
-  >(
+  <As = NarrowIntrinsic<IntrinsicElementString>>(
     props: As extends keyof JSX.IntrinsicElements
-      ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
+      ? Merge<OwnProps, Merge<JSX.IntrinsicElements[As], { as: As }>>
       : As extends React.ComponentType<infer P>
-      ? Merge<P, OwnProps & { as: As }>
+      ? Merge<OwnProps, Merge<P, { as: As }>>
+      : As extends ''
+      ? { as: keyof JSX.IntrinsicElements }
       : never
   ): React.ReactElement | null;
 }


### PR DESCRIPTION
I saw [this discussion](https://github.com/radix-ui/primitives/discussions/774) raised today and it got me wondering why we explicitly always made the `OwnProps` take precedence. I really can't seem to remember but all tests pass if the `as` component props take precedence. Do you recall why we did it the other way around @benoitgrelard ?

While I was there I had a brainwave on some perf improvements which I have also introduced here but want to test this all more thoroughly (including the prop override reorder) when I have time so will leave this in draft for now for discussion.

Quick test to show polymorphism still working:

https://user-images.githubusercontent.com/175330/125493802-7efd7119-0378-4927-9a97-0442b90be87c.mp4

