### PR TITLE
[Tooltip] Prevent tooltip from opening on tab change

### DIFF
--- a/.yarn/versions/b521ae54.yml
+++ b/.yarn/versions/b521ae54.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -115,10 +115,16 @@ const Tooltip: React.FC<TooltipOwnProps> = (props) => {
   }, [contentId]);
 
   React.useEffect(() => {
-    const handleFocus = () => (hasWindowFocusedRef.current = true);
+    let previouslyFocusedElement: Element | null;
+    const handleFocus = () => (hasWindowFocusedRef.current = previouslyFocusedElement === trigger);
+    const handleBlur = () => (previouslyFocusedElement = document.activeElement);
     window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
-  }, []);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [trigger]);
 
   const handleFocus = React.useCallback(() => {
     // Some browsers trigger a new focus event on the previously focused element when

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -73,7 +73,7 @@ const Tooltip: React.FC<TooltipOwnProps> = (props) => {
     skipDelayDuration = 300,
   } = props;
   const [trigger, setTrigger] = React.useState<HTMLButtonElement | null>(null);
-  const isTabChangeRef = React.useRef(false);
+  const hasWindowFocusedRef = React.useRef(false);
   const contentId = useId();
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
@@ -115,16 +115,16 @@ const Tooltip: React.FC<TooltipOwnProps> = (props) => {
   }, [contentId]);
 
   React.useEffect(() => {
-    const handleTabChange = () => (isTabChangeRef.current = document.visibilityState === 'visible');
-    document.addEventListener('visibilitychange', handleTabChange);
-    return () => document.removeEventListener('visibilitychange', handleTabChange);
+    const handleFocus = () => (hasWindowFocusedRef.current = true);
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
   }, []);
 
   const handleFocus = React.useCallback(() => {
-    // Some browsers trigger a new focus event on the previously focused element when switching
-    // between browser tabs. We prevent the tooltip from reopening in this case.
-    if (!isTabChangeRef.current) stateMachine.send({ type: 'FOCUS', id: contentId });
-    isTabChangeRef.current = false;
+    // Some browsers trigger a new focus event on the previously focused element when
+    // refocusing browser tabs. We prevent the tooltip from reopening in this case.
+    if (!hasWindowFocusedRef.current) stateMachine.send({ type: 'FOCUS', id: contentId });
+    hasWindowFocusedRef.current = false;
   }, [contentId]);
 
   const handleOpen = React.useCallback(


### PR DESCRIPTION
Fixes #705 

This seemed like a simple enough fix so jumped on it quick for a break.

It's different to #617 which happens because the content that the trigger opens is considered to be outside the tooltip tree, so returning to the tooltip trigger behaves like a brand new focus.

Happy to close this if we think the two issues can be resolved by the same solution, I'm just not sure if they can.