### PR TITLE
[Polymorphic] Improve performance

### DIFF
--- a/.yarn/versions/8b08b58b.yml
+++ b/.yarn/versions/8b08b58b.yml
@@ -1,0 +1,39 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-polymorphic": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/polymorphic/src/polymorphic.ts
+++ b/packages/react/polymorphic/src/polymorphic.ts
@@ -15,8 +15,6 @@ type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : {};
  */
 type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : never;
 
-type NarrowIntrinsic<E> = E extends keyof JSX.IntrinsicElements ? E : never;
-
 type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
   Merge<E extends React.ElementType ? React.ComponentPropsWithRef<E> : never, OwnProps & { as?: E }>
 >;
@@ -41,7 +39,7 @@ interface ForwardRefComponent<
    * We explicitly avoid `React.ElementType` and manually narrow the prop types
    * so that events are typed when using JSX.IntrinsicElements.
    */
-  <As = NarrowIntrinsic<IntrinsicElementString>>(
+  <As = IntrinsicElementString>(
     props: As extends ''
       ? { as: keyof JSX.IntrinsicElements }
       : As extends React.ComponentType<infer P>

--- a/packages/react/polymorphic/src/polymorphic.ts
+++ b/packages/react/polymorphic/src/polymorphic.ts
@@ -41,15 +41,13 @@ interface ForwardRefComponent<
    * We explicitly avoid `React.ElementType` and manually narrow the prop types
    * so that events are typed when using JSX.IntrinsicElements.
    */
-  <
-    As extends
-      | keyof JSX.IntrinsicElements
-      | React.ComponentType<any> = NarrowIntrinsic<IntrinsicElementString>
-  >(
-    props: As extends keyof JSX.IntrinsicElements
-      ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
+  <As = NarrowIntrinsic<IntrinsicElementString>>(
+    props: As extends ''
+      ? { as: keyof JSX.IntrinsicElements }
       : As extends React.ComponentType<infer P>
       ? Merge<P, OwnProps & { as: As }>
+      : As extends keyof JSX.IntrinsicElements
+      ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
       : never
   ): React.ReactElement | null;
 }


### PR DESCRIPTION
It's really hard to know for sure if tweaks to polymorphic types are improving performance but I picked a huge component (`ScrollArea`) and recorded a video of me tweaking its types (with and without these changes) to show how TS is able to more quickly report issues now.

The main change here is to remove the `extends keyof JSX.IntrinsicElements` from the generic which would have been slowing down **all components** regardless of whether the `as` prop was being used.

Instead, I check to see if `as` extends an empty string and if so, I type it as `keyof JSX.IntrinsicElements` to enable intellisense when used.

**INTELLISENSE**

https://user-images.githubusercontent.com/175330/125993174-b89e107b-4caa-4485-af6a-55c18b1e9347.mp4

**BEFORE** (~8s)

https://user-images.githubusercontent.com/175330/125992071-b1aa176b-6e08-4717-9b84-d6bb2ec77b22.mp4

**AFTER** (~5s)

https://user-images.githubusercontent.com/175330/125992101-02282990-5ddf-470c-b721-6421b83c7a77.mp4

I'll continue to think of ways to improve it further but this definitely feels better.