### PR TITLE
[Dialog][Popover][DropdownMenu] Adjust non-modal SR navigation

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -229,8 +229,9 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
         event.preventDefault();
         if (!preventCloseAutoFocusRef.current) context.triggerRef.current?.focus();
-      })}
-      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
+
+        // we clear the ref after each auto focus attempt as
+        // this component remains mounted independently of content
         preventCloseAutoFocusRef.current = false;
       })}
       onPointerDownOutside={composeEventHandlers(

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -263,7 +263,7 @@ const MenuRootContentModal = React.forwardRef((props, forwardedRef) => {
   const ref = React.useRef<React.ElementRef<typeof MenuContentImpl>>(null);
   const composedRefs = useComposedRefs(forwardedRef, ref);
 
-  // Hide everything from ARIA except the `MenuContent`
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
   React.useEffect(() => {
     const content = ref.current;
     if (content) return hideOthers(content);
@@ -294,11 +294,19 @@ const MenuRootContentModal = React.forwardRef((props, forwardedRef) => {
 
 const MenuRootContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useMenuContext(CONTENT_NAME);
+  const ref = React.useRef<React.ElementRef<typeof MenuContentImpl>>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+  React.useEffect(() => {
+    const content = ref.current;
+    if (content) return hideOthers(content);
+  }, []);
 
   return (
     <MenuContentImpl
       {...props}
-      ref={forwardedRef}
+      ref={composedRefs}
       trapFocus={false}
       disableOutsidePointerEvents={false}
       disableOutsideScroll={false}


### PR DESCRIPTION
TLDR: This PR updates non-modal to use the modal SR navigation pattern of trap and require close to return to original trigger.

### The problem
In the current modality branch, when navigating outside of the non-modal in reverse you will be placed incorrectly at the end of the document

https://user-images.githubusercontent.com/11708259/126491422-9eb46547-6b83-42e5-9b19-6b717426cc31.mp4



As a solution we decided to try to make the virtual cursor loop within the container, matching that of keyboard users and thus i've been beating my head against the wall trying to coerce virtual cursors to do so. We originally thought we'd found a solution by using guards to proxy focus to the start / end of focusable elements.

Original POC:
https://codesandbox.io/s/stoic-lovelace-425pe?file=/src/App.js

The main takeaway there is a force update of `key` will prompt the virtual cursor to update its position, without it the cursor will get "stuck" announcing an empty group (the guard).

It wasn't until I started testing further that I found this to still be inconsistent and not always reliable. If we change to having only a single focusable element we can see the issue returns:

https://codesandbox.io/s/laughing-booth-bx5o4?file=/src/App.js

Another option is to nudge the cursor to update with a `setTimeout` or `requestAnimationFrame` but this performs inconsistently depending on the delay duration, at best it announces the empty group briefly before moving and at worst the cursor will "stick" on the guard again.

All of this adds up to something that, to me, feels more problematic for SRs when compared to simply trapping and requiring a close to return focus to the original trigger.

The spec and general sentiment regarding non-modal handling is inconsistent, this problem wouldn't exist if we could guarantee source order and simply move through the content and out of the other side, but because of portal behaviour this is not always possible.

For the portal case then, theres the question of how we would handle navigating into and out of non-modals, some suggest [using the F6 key for this](https://github.com/w3c/aria-practices/issues/599) but this can clash with other browser controls, others suggest [to try and keep in source order](https://accessuse.eu/en/non-modal-dialogs.html) but that's not always possible as mentioned.

So my recommendation for the time being is to change the non-modal SR navigation pattern to trap and require a close to return to the original trigger until we can solidify an approach for properly getting out of, and back into non-modals.


