### PR TITLE
[Dialog][Popover][DropdownMenu] Adjust non-modal auto focus behaviour

### DIFF
--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -256,13 +256,30 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-          event.preventDefault();
-          if (!isPointerDownOutsideRef.current) context.triggerRef.current?.focus();
-        })}
         onPointerDownOutside={composeEventHandlers(
           props.onPointerDownOutside,
           () => (isPointerDownOutsideRef.current = true),
+          { checkForDefaultPrevented: false }
+        )}
+        onCloseAutoFocus={composeEventHandlers(
+          props.onCloseAutoFocus,
+          (event) => {
+            if (!event.defaultPrevented && !isPointerDownOutsideRef.current) {
+              context.triggerRef.current?.focus();
+            }
+            event.preventDefault();
+            isPointerDownOutsideRef.current = false;
+          },
+          { checkForDefaultPrevented: false }
+        )}
+        onEscapeKeyDown={composeEventHandlers(
+          props.onEscapeKeyDown,
+          () => (isPointerDownOutsideRef.current = false),
+          { checkForDefaultPrevented: false }
+        )}
+        onFocus={composeEventHandlers(
+          props.onFocus,
+          () => (isPointerDownOutsideRef.current = false),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -247,7 +247,8 @@ const DialogContentModal = React.forwardRef((props, forwardedRef) => {
 
 const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
-  const isEscapeKeyDownRef = React.useRef(false);
+  const isPointerDownOutsideRef = React.useRef(false);
+
   return (
     <Portal>
       <DialogContentImpl
@@ -257,11 +258,15 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         disableOutsidePointerEvents={false}
         onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
           event.preventDefault();
-          if (isEscapeKeyDownRef.current) context.triggerRef.current?.focus();
+          if (!isPointerDownOutsideRef.current) context.triggerRef.current?.focus();
         })}
-        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
-          isEscapeKeyDownRef.current = true;
-        })}
+        onPointerDownOutside={composeEventHandlers(
+          props.onPointerDownOutside,
+          () => {
+            isPointerDownOutsideRef.current = true;
+          },
+          { checkForDefaultPrevented: false }
+        )}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -258,18 +258,16 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         disableOutsidePointerEvents={false}
         onCloseAutoFocus={(event) => {
           props.onCloseAutoFocus?.(event);
-          const userPrevented = event.defaultPrevented;
 
-          if (!userPrevented) {
+          if (!event.defaultPrevented && !isInteractOutsideRef.current) {
             event.preventDefault();
-            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+            context.triggerRef.current?.focus();
           }
 
           isInteractOutsideRef.current = false;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
-          const userPrevented = event.defaultPrevented;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
@@ -280,7 +278,7 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           const target = event.target as HTMLElement;
           const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-          else if (!userPrevented) isInteractOutsideRef.current = true;
+          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
         }}
       />
     </Portal>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -247,7 +247,7 @@ const DialogContentModal = React.forwardRef((props, forwardedRef) => {
 
 const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
-  const isInteractOutsideRef = React.useRef(false);
+  const shouldFocusTriggerRef = React.useRef(true);
 
   return (
     <Portal>
@@ -260,14 +260,17 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           props.onCloseAutoFocus?.(event);
 
           if (!event.defaultPrevented) {
+            // Always prevent auto focus because we either focus manually or want user agent focus
             event.preventDefault();
-            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+            if (shouldFocusTriggerRef.current) context.triggerRef.current?.focus();
           }
 
-          isInteractOutsideRef.current = false;
+          shouldFocusTriggerRef.current = true;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
+
+          if (!event.defaultPrevented) shouldFocusTriggerRef.current = false;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
@@ -278,7 +281,6 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           const target = event.target as HTMLElement;
           const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
         }}
       />
     </Portal>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -247,7 +247,7 @@ const DialogContentModal = React.forwardRef((props, forwardedRef) => {
 
 const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
   const context = useDialogContext(CONTENT_NAME);
-  const isPointerDownOutsideRef = React.useRef(false);
+  const isInteractOutsideRef = React.useRef(false);
 
   return (
     <Portal>
@@ -256,30 +256,15 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onPointerDownOutside={composeEventHandlers(
-          props.onPointerDownOutside,
-          () => (isPointerDownOutsideRef.current = true),
-          { checkForDefaultPrevented: false }
-        )}
         onCloseAutoFocus={composeEventHandlers(
           props.onCloseAutoFocus,
           (event) => {
-            if (!event.defaultPrevented && !isPointerDownOutsideRef.current) {
+            if (!event.defaultPrevented && !isInteractOutsideRef.current) {
               context.triggerRef.current?.focus();
             }
             event.preventDefault();
-            isPointerDownOutsideRef.current = false;
+            isInteractOutsideRef.current = false;
           },
-          { checkForDefaultPrevented: false }
-        )}
-        onEscapeKeyDown={composeEventHandlers(
-          props.onEscapeKeyDown,
-          () => (isPointerDownOutsideRef.current = false),
-          { checkForDefaultPrevented: false }
-        )}
-        onFocus={composeEventHandlers(
-          props.onFocus,
-          () => (isPointerDownOutsideRef.current = false),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
@@ -291,6 +276,7 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
           // focus on pointer down, creating the same issue.
           const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
           if (targetIsTrigger) event.preventDefault();
+          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
         })}
       />
     </Portal>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -262,9 +262,7 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         })}
         onPointerDownOutside={composeEventHandlers(
           props.onPointerDownOutside,
-          () => {
-            isPointerDownOutsideRef.current = true;
-          },
+          () => (isPointerDownOutsideRef.current = true),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -259,9 +259,9 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         onCloseAutoFocus={(event) => {
           props.onCloseAutoFocus?.(event);
 
-          if (!event.defaultPrevented && !isInteractOutsideRef.current) {
+          if (!event.defaultPrevented) {
             event.preventDefault();
-            context.triggerRef.current?.focus();
+            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
           }
 
           isInteractOutsideRef.current = false;

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -256,28 +256,32 @@ const DialogContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onCloseAutoFocus={composeEventHandlers(
-          props.onCloseAutoFocus,
-          (event) => {
-            if (!event.defaultPrevented && !isInteractOutsideRef.current) {
-              context.triggerRef.current?.focus();
-            }
+        onCloseAutoFocus={(event) => {
+          props.onCloseAutoFocus?.(event);
+          const userPrevented = event.defaultPrevented;
+
+          if (!userPrevented) {
             event.preventDefault();
-            isInteractOutsideRef.current = false;
-          },
-          { checkForDefaultPrevented: false }
-        )}
-        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
+            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+          }
+
+          isInteractOutsideRef.current = false;
+        }}
+        onInteractOutside={(event) => {
+          props.onInteractOutside?.(event);
+          const userPrevented = event.defaultPrevented;
+
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
           // cause it to close and immediately open.
           //
           // We use `onInteractOutside` as some browsers also
           // focus on pointer down, creating the same issue.
-          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
+          const target = event.target as HTMLElement;
+          const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
-        })}
+          else if (!userPrevented) isInteractOutsideRef.current = true;
+        }}
       />
     </Portal>
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -229,8 +229,6 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
         event.preventDefault();
         if (!preventCloseAutoFocusRef.current) context.triggerRef.current?.focus();
-      })}
-      onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
         preventCloseAutoFocusRef.current = false;
       })}
       onPointerDownOutside={composeEventHandlers(

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -229,7 +229,7 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       onCloseAutoFocus={(event) => {
         props.onCloseAutoFocus?.(event);
 
-        if (!event.defaultPrevented && !isInteractOutsideRef.current) {
+        if (!event.defaultPrevented) {
           event.preventDefault();
           if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
         }

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -226,11 +226,6 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       {...contentProps}
       ref={forwardedRef}
       portalled={portalled}
-      onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-        event.preventDefault();
-        if (!preventCloseAutoFocusRef.current) context.triggerRef.current?.focus();
-        preventCloseAutoFocusRef.current = false;
-      })}
       onPointerDownOutside={composeEventHandlers(
         props.onPointerDownOutside,
         (event) => {
@@ -239,6 +234,27 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
           const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
           preventCloseAutoFocusRef.current = isRightClick || !context.modal;
         },
+        { checkForDefaultPrevented: false }
+      )}
+      onCloseAutoFocus={composeEventHandlers(
+        props.onCloseAutoFocus,
+        (event) => {
+          if (!event.defaultPrevented && !preventCloseAutoFocusRef.current) {
+            context.triggerRef.current?.focus();
+          }
+          event.preventDefault();
+          preventCloseAutoFocusRef.current = false;
+        },
+        { checkForDefaultPrevented: false }
+      )}
+      onEscapeKeyDown={composeEventHandlers(
+        props.onEscapeKeyDown,
+        () => (preventCloseAutoFocusRef.current = false),
+        { checkForDefaultPrevented: false }
+      )}
+      onFocus={composeEventHandlers(
+        props.onFocus,
+        () => (preventCloseAutoFocusRef.current = false),
         { checkForDefaultPrevented: false }
       )}
       onInteractOutside={composeEventHandlers(

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -228,9 +228,8 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       portalled={portalled}
       onCloseAutoFocus={(event) => {
         props.onCloseAutoFocus?.(event);
-        const userPrevented = event.defaultPrevented;
 
-        if (!userPrevented) {
+        if (!event.defaultPrevented && !isInteractOutsideRef.current) {
           event.preventDefault();
           if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
         }
@@ -239,7 +238,6 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       }}
       onInteractOutside={(event) => {
         props.onInteractOutside?.(event);
-        const userPrevented = event.defaultPrevented;
 
         // Prevent dismissing when clicking the trigger.
         // As the trigger is already setup to close, without doing so would
@@ -250,7 +248,7 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
         const target = event.target as HTMLElement;
         const targetIsTrigger = context.triggerRef.current?.contains(target);
         if (targetIsTrigger) event.preventDefault();
-        else if (!userPrevented) {
+        else if (!event.defaultPrevented) {
           const originalEvent = event.detail.originalEvent as PointerEvent;
           const isModalLeftClick = context.modal && originalEvent.button === 0;
           isInteractOutsideRef.current = !isModalLeftClick;

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -226,36 +226,36 @@ const DropdownMenuRootContent = React.forwardRef((props, forwardedRef) => {
       {...contentProps}
       ref={forwardedRef}
       portalled={portalled}
-      onCloseAutoFocus={composeEventHandlers(
-        props.onCloseAutoFocus,
-        (event) => {
-          if (!event.defaultPrevented && !isInteractOutsideRef.current) {
-            context.triggerRef.current?.focus();
-          }
+      onCloseAutoFocus={(event) => {
+        props.onCloseAutoFocus?.(event);
+        const userPrevented = event.defaultPrevented;
+
+        if (!userPrevented) {
           event.preventDefault();
-          isInteractOutsideRef.current = false;
-        },
-        { checkForDefaultPrevented: false }
-      )}
-      onInteractOutside={composeEventHandlers(
-        props.onInteractOutside,
-        (event) => {
-          // Prevent dismissing when clicking the trigger.
-          // As the trigger is already setup to close, without doing so would
-          // cause it to close and immediately open.
-          //
-          // We use `onInteractOutside` as some browsers also
-          // focus on pointer down, creating the same issue.
-          const targetIsTrigger = context.triggerRef.current?.contains(event.target as HTMLElement);
-          if (targetIsTrigger) event.preventDefault();
-          else if (!event.defaultPrevented) {
-            const originalEvent = event.detail.originalEvent as PointerEvent;
-            const isModalLeftClick = context.modal && originalEvent.button === 0;
-            isInteractOutsideRef.current = !isModalLeftClick;
-          }
-        },
-        { checkForDefaultPrevented: false }
-      )}
+          if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+        }
+
+        isInteractOutsideRef.current = false;
+      }}
+      onInteractOutside={(event) => {
+        props.onInteractOutside?.(event);
+        const userPrevented = event.defaultPrevented;
+
+        // Prevent dismissing when clicking the trigger.
+        // As the trigger is already setup to close, without doing so would
+        // cause it to close and immediately open.
+        //
+        // We use `onInteractOutside` as some browsers also
+        // focus on pointer down, creating the same issue.
+        const target = event.target as HTMLElement;
+        const targetIsTrigger = context.triggerRef.current?.contains(target);
+        if (targetIsTrigger) event.preventDefault();
+        else if (!userPrevented) {
+          const originalEvent = event.detail.originalEvent as PointerEvent;
+          const isModalLeftClick = context.modal && originalEvent.button === 0;
+          isInteractOutsideRef.current = !isModalLeftClick;
+        }
+      }}
     />
   ) : null;
 }) as DropdownMenuRootContentPrimitive;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -270,9 +270,9 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         onCloseAutoFocus={(event) => {
           props.onCloseAutoFocus?.(event);
 
-          if (!event.defaultPrevented && !isInteractOutsideRef.current) {
+          if (!event.defaultPrevented) {
             event.preventDefault();
-            context.triggerRef.current?.focus();
+            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
           }
 
           isInteractOutsideRef.current = false;

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -273,9 +273,7 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         })}
         onPointerDownOutside={composeEventHandlers(
           props.onPointerDownOutside,
-          () => {
-            isPointerDownOutsideRef.current = true;
-          },
+          () => (isPointerDownOutsideRef.current = true),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -269,18 +269,16 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         disableOutsidePointerEvents={false}
         onCloseAutoFocus={(event) => {
           props.onCloseAutoFocus?.(event);
-          const userPrevented = event.defaultPrevented;
 
-          if (!userPrevented) {
+          if (!event.defaultPrevented && !isInteractOutsideRef.current) {
             event.preventDefault();
-            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+            context.triggerRef.current?.focus();
           }
 
           isInteractOutsideRef.current = false;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
-          const userPrevented = event.defaultPrevented;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
@@ -291,7 +289,7 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           const target = event.target as HTMLElement;
           const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-          else if (!userPrevented) isInteractOutsideRef.current = true;
+          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
         }}
       />
     </PortalWrapper>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -267,33 +267,32 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onCloseAutoFocus={composeEventHandlers(
-          props.onCloseAutoFocus,
-          (event) => {
-            if (!event.defaultPrevented && !isInteractOutsideRef.current) {
-              context.triggerRef.current?.focus();
-            }
+        onCloseAutoFocus={(event) => {
+          props.onCloseAutoFocus?.(event);
+          const userPrevented = event.defaultPrevented;
+
+          if (!userPrevented) {
             event.preventDefault();
-            isInteractOutsideRef.current = false;
-          },
-          { checkForDefaultPrevented: false }
-        )}
-        onInteractOutside={composeEventHandlers(
-          props.onInteractOutside,
-          (event) => {
-            // Prevent dismissing when clicking the trigger.
-            // As the trigger is already setup to close, without doing so would
-            // cause it to close and immediately open.
-            //
-            // We use `onInteractOutside` as some browsers also
-            // focus on pointer down, creating the same issue.
-            const target = event.target as HTMLElement;
-            const targetIsTrigger = context.triggerRef.current?.contains(target);
-            if (targetIsTrigger) event.preventDefault();
-            else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
-          },
-          { checkForDefaultPrevented: false }
-        )}
+            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+          }
+
+          isInteractOutsideRef.current = false;
+        }}
+        onInteractOutside={(event) => {
+          props.onInteractOutside?.(event);
+          const userPrevented = event.defaultPrevented;
+
+          // Prevent dismissing when clicking the trigger.
+          // As the trigger is already setup to close, without doing so would
+          // cause it to close and immediately open.
+          //
+          // We use `onInteractOutside` as some browsers also
+          // focus on pointer down, creating the same issue.
+          const target = event.target as HTMLElement;
+          const targetIsTrigger = context.triggerRef.current?.contains(target);
+          if (targetIsTrigger) event.preventDefault();
+          else if (!userPrevented) isInteractOutsideRef.current = true;
+        }}
       />
     </PortalWrapper>
   );

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -256,7 +256,7 @@ const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
 const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
   const { portalled = true, ...contentNonModalProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const isInteractOutsideRef = React.useRef(false);
+  const shouldFocusTriggerRef = React.useRef(true);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
 
@@ -271,14 +271,17 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           props.onCloseAutoFocus?.(event);
 
           if (!event.defaultPrevented) {
+            // Always prevent auto focus because we either focus manually or want user agent focus
             event.preventDefault();
-            if (!isInteractOutsideRef.current) context.triggerRef.current?.focus();
+            if (shouldFocusTriggerRef.current) context.triggerRef.current?.focus();
           }
 
-          isInteractOutsideRef.current = false;
+          shouldFocusTriggerRef.current = true;
         }}
         onInteractOutside={(event) => {
           props.onInteractOutside?.(event);
+
+          if (!event.defaultPrevented) shouldFocusTriggerRef.current = false;
 
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
@@ -289,7 +292,6 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
           const target = event.target as HTMLElement;
           const targetIsTrigger = context.triggerRef.current?.contains(target);
           if (targetIsTrigger) event.preventDefault();
-          else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
         }}
       />
     </PortalWrapper>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -256,7 +256,7 @@ const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
 const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
   const { portalled = true, ...contentNonModalProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const isEscapeKeyDownRef = React.useRef(false);
+  const isPointerDownOutsideRef = React.useRef(false);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
 
@@ -269,11 +269,15 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         disableOutsidePointerEvents={false}
         onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
           event.preventDefault();
-          if (isEscapeKeyDownRef.current) context.triggerRef.current?.focus();
+          if (!isPointerDownOutsideRef.current) context.triggerRef.current?.focus();
         })}
-        onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, () => {
-          isEscapeKeyDownRef.current = true;
-        })}
+        onPointerDownOutside={composeEventHandlers(
+          props.onPointerDownOutside,
+          () => {
+            isPointerDownOutsideRef.current = true;
+          },
+          { checkForDefaultPrevented: false }
+        )}
         onInteractOutside={composeEventHandlers(
           props.onInteractOutside,
           (event) => {

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -256,7 +256,7 @@ const PopoverContentModal = React.forwardRef((props, forwardedRef) => {
 const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
   const { portalled = true, ...contentNonModalProps } = props;
   const context = usePopoverContext(CONTENT_NAME);
-  const isPointerDownOutsideRef = React.useRef(false);
+  const isInteractOutsideRef = React.useRef(false);
 
   const PortalWrapper = portalled ? Portal : React.Fragment;
 
@@ -267,30 +267,15 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onPointerDownOutside={composeEventHandlers(
-          props.onPointerDownOutside,
-          () => (isPointerDownOutsideRef.current = true),
-          { checkForDefaultPrevented: false }
-        )}
         onCloseAutoFocus={composeEventHandlers(
           props.onCloseAutoFocus,
           (event) => {
-            if (!event.defaultPrevented && !isPointerDownOutsideRef.current) {
+            if (!event.defaultPrevented && !isInteractOutsideRef.current) {
               context.triggerRef.current?.focus();
             }
             event.preventDefault();
-            isPointerDownOutsideRef.current = false;
+            isInteractOutsideRef.current = false;
           },
-          { checkForDefaultPrevented: false }
-        )}
-        onEscapeKeyDown={composeEventHandlers(
-          props.onEscapeKeyDown,
-          () => (isPointerDownOutsideRef.current = false),
-          { checkForDefaultPrevented: false }
-        )}
-        onFocus={composeEventHandlers(
-          props.onFocus,
-          () => (isPointerDownOutsideRef.current = false),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(
@@ -305,6 +290,7 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
             const target = event.target as HTMLElement;
             const targetIsTrigger = context.triggerRef.current?.contains(target);
             if (targetIsTrigger) event.preventDefault();
+            else if (!event.defaultPrevented) isInteractOutsideRef.current = true;
           },
           { checkForDefaultPrevented: false }
         )}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -267,13 +267,30 @@ const PopoverContentNonModal = React.forwardRef((props, forwardedRef) => {
         ref={forwardedRef}
         trapFocus={false}
         disableOutsidePointerEvents={false}
-        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-          event.preventDefault();
-          if (!isPointerDownOutsideRef.current) context.triggerRef.current?.focus();
-        })}
         onPointerDownOutside={composeEventHandlers(
           props.onPointerDownOutside,
           () => (isPointerDownOutsideRef.current = true),
+          { checkForDefaultPrevented: false }
+        )}
+        onCloseAutoFocus={composeEventHandlers(
+          props.onCloseAutoFocus,
+          (event) => {
+            if (!event.defaultPrevented && !isPointerDownOutsideRef.current) {
+              context.triggerRef.current?.focus();
+            }
+            event.preventDefault();
+            isPointerDownOutsideRef.current = false;
+          },
+          { checkForDefaultPrevented: false }
+        )}
+        onEscapeKeyDown={composeEventHandlers(
+          props.onEscapeKeyDown,
+          () => (isPointerDownOutsideRef.current = false),
+          { checkForDefaultPrevented: false }
+        )}
+        onFocus={composeEventHandlers(
+          props.onFocus,
+          () => (isPointerDownOutsideRef.current = false),
           { checkForDefaultPrevented: false }
         )}
         onInteractOutside={composeEventHandlers(


### PR DESCRIPTION
Previously non-modal auto focus was not covering use of the close button. This change applies auto focus for all interactions except when pointer down outside.