### PR TITLE
[ContextMenu][DropdownMenu] Fix test flake

### DIFF
--- a/.yarn/versions/b45a43f5.yml
+++ b/.yarn/versions/b45a43f5.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives

--- a/cypress/integration/ContextMenu.spec.ts
+++ b/cypress/integration/ContextMenu.spec.ts
@@ -69,18 +69,21 @@ describe('ContextMenu', () => {
         // Disabled item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Bookmarks →');
         pointerOver('Print…');
         cy.findByText('Inbox').should('not.exist');
 
         // Trigger item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Bookmarks →');
         pointerOver('Tools →');
         cy.findByText('Inbox').should('not.exist');
 
         // Disabled trigger item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Inbox');
         pointerOver('History →');
         cy.findByText('Inbox').should('not.exist');
       });
@@ -242,7 +245,7 @@ describe('ContextMenu', () => {
   function pointerExitRightToLeft(elementText: string) {
     return cy
       .findByText(elementText)
-      .focus()
+      .should('be.visible')
       .realHover({ position: 'right' })
       .realHover({ position: 'bottomLeft' })
       .trigger('pointerout', 'bottomLeft', { pointerType: 'mouse' });
@@ -251,13 +254,13 @@ describe('ContextMenu', () => {
   function pointerExitLeftToRight(elementText: string) {
     return cy
       .findByText(elementText)
-      .focus()
+      .should('be.visible')
       .realHover({ position: 'left' })
       .realHover({ position: 'bottomRight' })
       .trigger('pointerout', 'bottomRight', { pointerType: 'mouse' });
   }
 
   function pointerOver(elementText: string) {
-    return cy.findByText(elementText).focus().realHover();
+    return cy.findByText(elementText).should('be.visible').realHover();
   }
 });

--- a/cypress/integration/ContextMenu.spec.ts
+++ b/cypress/integration/ContextMenu.spec.ts
@@ -59,43 +59,26 @@ describe('ContextMenu', () => {
         }
       );
 
-      it('should close submenu when moving pointer over any sibling item in parent menu', () => {
+      it('should close open submenu when moving pointer to any item in parent menu', () => {
         // Item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
+        pointerOver('Inbox');
         pointerOver('New Tab');
         cy.findByText('Inbox').should('not.exist');
 
         // Disabled item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Bookmarks →');
+        pointerOver('Inbox');
         pointerOver('Print…');
         cy.findByText('Inbox').should('not.exist');
 
         // Trigger item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Bookmarks →');
-        pointerOver('Tools →');
-        cy.findByText('Inbox').should('not.exist');
-
-        // Disabled trigger item
-        pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Inbox');
-        pointerOver('History →');
-        cy.findByText('Inbox').should('not.exist');
-      });
-
-      it('should close submenu when moving pointer from open submenu to enabled or disabled trigger siblings', () => {
-        // To submenu and then to sibling trigger in parent
-        pointerOver('Bookmarks →');
         pointerOver('Inbox');
         pointerOver('Tools →');
         cy.findByText('Inbox').should('not.exist');
 
-        // To submenu then to a disabled trigger sibling in parent
+        // Disabled trigger item
         pointerOver('Bookmarks →');
         pointerOver('Inbox');
         pointerOver('History →');

--- a/cypress/integration/DropdownMenu.spec.ts
+++ b/cypress/integration/DropdownMenu.spec.ts
@@ -61,18 +61,21 @@ describe('DropdownMenu', () => {
         // Disabled item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Bookmarks →');
         pointerOver('Print…');
         cy.findByText('Inbox').should('not.exist');
 
         // Trigger item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Bookmarks →');
         pointerOver('Tools →');
         cy.findByText('Inbox').should('not.exist');
 
         // Disabled trigger item
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
+        pointerExitRightToLeft('Inbox');
         pointerOver('History →');
         cy.findByText('Inbox').should('not.exist');
       });
@@ -234,7 +237,7 @@ describe('DropdownMenu', () => {
   function pointerExitRightToLeft(elementText: string) {
     return cy
       .findByText(elementText)
-      .focus()
+      .should('be.visible')
       .realHover({ position: 'right' })
       .realHover({ position: 'bottomLeft' })
       .trigger('pointerout', 'bottomLeft', { pointerType: 'mouse' });
@@ -243,13 +246,13 @@ describe('DropdownMenu', () => {
   function pointerExitLeftToRight(elementText: string) {
     return cy
       .findByText(elementText)
-      .focus()
+      .should('be.visible')
       .realHover({ position: 'left' })
       .realHover({ position: 'bottomRight' })
       .trigger('pointerout', 'bottomRight', { pointerType: 'mouse' });
   }
 
   function pointerOver(elementText: string) {
-    return cy.findByText(elementText).focus().realHover();
+    return cy.findByText(elementText).should('be.visible').realHover();
   }
 });

--- a/cypress/integration/DropdownMenu.spec.ts
+++ b/cypress/integration/DropdownMenu.spec.ts
@@ -51,43 +51,26 @@ describe('DropdownMenu', () => {
         }
       );
 
-      it('should close submenu when moving pointer over any sibling item in parent menu', () => {
+      it('should close open submenu when moving pointer to any item in parent menu', () => {
         // Item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
+        pointerOver('Inbox');
         pointerOver('New Tab');
         cy.findByText('Inbox').should('not.exist');
 
         // Disabled item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Bookmarks →');
+        pointerOver('Inbox');
         pointerOver('Print…');
         cy.findByText('Inbox').should('not.exist');
 
         // Trigger item
         pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Bookmarks →');
-        pointerOver('Tools →');
-        cy.findByText('Inbox').should('not.exist');
-
-        // Disabled trigger item
-        pointerOver('Bookmarks →');
-        cy.findByText('Inbox').should('be.visible');
-        pointerExitRightToLeft('Inbox');
-        pointerOver('History →');
-        cy.findByText('Inbox').should('not.exist');
-      });
-
-      it('should close submenu when moving pointer from open submenu to enabled or disabled trigger siblings', () => {
-        // To submenu and then to sibling trigger in parent
-        pointerOver('Bookmarks →');
         pointerOver('Inbox');
         pointerOver('Tools →');
         cy.findByText('Inbox').should('not.exist');
 
-        // To submenu then to a disabled trigger sibling in parent
+        // Disabled trigger item
         pointerOver('Bookmarks →');
         pointerOver('Inbox');
         pointerOver('History →');


### PR DESCRIPTION
It took me a while to figure this one out but the flake we were seeing in our Cypress tests is caused by the variability in measurement speed inside popper when it first renders.

See [here where we apply unmeasured styles](https://github.com/radix-ui/primitives/blob/207014676bce54a97bf61d0e703439765ea62a45/packages/core/popper/src/popper.ts#L355-L363) to position popper elements off screen, the tests don't have a problem with this in 90% of cases as it happens so fast not to cause a problem. The issue starts when these measurements don't happen fast enough and cypress starts it's interaction on the offscreen elements (as they technically exist in dom) this will make the menu visibility logic execute with inaccurate coords and remove the content, failing the test.

Important to note that this doesn't happen with synthetic events, but `realEvents` uses [CDP](https://chromedevtools.github.io/devtools-protocol/) to produce real native events and produces a technically valid failure.

The solution then is to simply assert on visibility before performing the hover interaction. This prompts Cypress to wait for the measurements to complete thus the element styles position content into visible space and all works as it should.

Here're my reduced test results:

![image](https://user-images.githubusercontent.com/11708259/127307056-4b3e0b50-fa8f-4be1-866c-cef20e7e13f7.png)