### PR TITLE
[DropdownMenu][ContextMenu] Prevent text selection on menu close in Firefox

### DIFF
--- a/.yarn/versions/48277b4f.yml
+++ b/.yarn/versions/48277b4f.yml
@@ -1,0 +1,3 @@
+declined:
+  - primitives
+  - "@radix-ui/react-menu"

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -672,7 +672,8 @@ const MenuItem = React.forwardRef((props, forwardedRef) => {
       }}
       onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
         // Pointer down can move to a different menu item which should activate it on pointer up.
-        // We dispatch a click for selection to allow composition with click based triggers.
+        // We dispatch a click for selection to allow composition with click based triggers and to
+        // prevent Firefox from getting stuck in text selection mode when the menu closes.
         if (!isPointerDownRef.current) event.currentTarget?.click();
       })}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {


### PR DESCRIPTION
Hopefully the code comments explain clearly what is going on here 🤞 

Fixes #742.

--------------

UPDATE: The original change I made here was no longer needed as the changes I made to [fix `Dialog.Trigger` / `DropdownMenu.Item` composition](https://github.com/radix-ui/primitives/pull/818) also fixed this.

I've updated the code comments to explain that it covers this case too and the explanation as to why it fixes this is as follows:

>  Browsers wait for our handler logic to execute before executing their own implementation in case we have prevented their default behaviour. Therefore, the menu will unmount before the browser's `pointerup` logic has executed causing `pointerdown` to be stuck in some browsers. In FF this resulted in text selection occurring on the page when moving the mouse after close. We move the unmount logic till after the browser receives the pointerup to avoid this.