### PR TITLE
[AlertDialog][ContextMenu][Dialog][Popover][DropdownMenu] Fix pointer-events reset

### DIFF
--- a/.yarn/versions/658485e8.yml
+++ b/.yarn/versions/658485e8.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-use-body-pointer-events": patch
+
+declined:
+  - primitives

--- a/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
+++ b/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx
@@ -33,6 +33,7 @@ function useBodyPointerEvents({ disabled }: { disabled: boolean }) {
       }
 
       function resetPointerEvents() {
+        changeCount--;
         if (changeCount === 0) {
           document.body.style.pointerEvents = originalBodyPointerEvents;
         }
@@ -42,7 +43,6 @@ function useBodyPointerEvents({ disabled }: { disabled: boolean }) {
       changeCount++;
 
       return () => {
-        changeCount--;
         if (isTouchOrPenPressedRef.current) {
           /**
            * We force pointer-events to remain disabled until `click` fires on touch devices


### PR DESCRIPTION
Pointer events were not resetting correctly when pop ups were opening from within other pop ups. This was initially reported here regarding `Dropdown`/`Dialog` composition: https://discord.com/channels/752614004387610674/803656530259738674/874553651417477162

This change ensures we decrease the count at the same time as the reset (when the unmount events have executed).