### PR TITLE
[DropdownMenu][ContextMenu] Fix sub trigger focus in iOS Safari

### DIFF
--- a/.yarn/versions/7c9a0131.yml
+++ b/.yarn/versions/7c9a0131.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -739,25 +739,17 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
         data-state={getOpenState(context.open)}
         {...props}
         ref={composeRefs(forwardedRef, context.onTriggerChange)}
-        onPointerUp={composeEventHandlers(
-          props.onPointerUp,
-          whenTouchOrPen((event) => {
-            contentContext.onItemEnter(event);
-            if (event.defaultPrevented) return;
-            if (!props.disabled && !context.open) {
-              context.onOpenChange(true);
-              event.preventDefault();
-              /**
-               * We manually focus because iOS Safari:
-               * - doesn't focus the item if a pointerup mounts DOM that has a click handler.
-               * - doesn't focus `button`s (if someone changes as prop).
-               * Both issues mean our `onFocusOutside` logic wouldn't fire when switching
-               * between separate submenus.
-               */
-              event.currentTarget.focus();
-            }
-          })
-        )}
+        onClick={(event) => {
+          props.onClick?.(event);
+          if (event.defaultPrevented) return;
+          if (!props.disabled && !context.open) context.onOpenChange(true);
+          /**
+           * We manually focus because iOS Safari doesn't always focus on click (e.g. buttons)
+           * and we rely heavily on `onFocusOutside` for submenus to close when switching
+           * between separate submenus.
+           */
+          event.currentTarget.focus();
+        }}
         onPointerMove={composeEventHandlers(
           props.onPointerMove,
           whenMouse((event) => {
@@ -1167,10 +1159,6 @@ function isPointerInGraceArea(event: React.PointerEvent, area?: Polygon) {
 
 function whenMouse<E>(handler: React.PointerEventHandler<E>): React.PointerEventHandler<E> {
   return (event) => (event.pointerType === 'mouse' ? handler(event) : undefined);
-}
-
-function whenTouchOrPen<E>(handler: React.PointerEventHandler<E>): React.PointerEventHandler<E> {
-  return (event) => (event.pointerType !== 'mouse' ? handler(event) : undefined);
 }
 
 const Root = Menu;

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -739,16 +739,18 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
         data-state={getOpenState(context.open)}
         {...props}
         ref={composeRefs(forwardedRef, context.onTriggerChange)}
+        // This is redundant for mouse users but we cannot determine pointer type from
+        // click event and we cannot use pointerup event (see git history for reasons why)
         onClick={(event) => {
           props.onClick?.(event);
-          if (event.defaultPrevented) return;
-          if (!props.disabled && !context.open) context.onOpenChange(true);
+          if (props.disabled || event.defaultPrevented) return;
           /**
            * We manually focus because iOS Safari doesn't always focus on click (e.g. buttons)
            * and we rely heavily on `onFocusOutside` for submenus to close when switching
            * between separate submenus.
            */
           event.currentTarget.focus();
+          if (!context.open) context.onOpenChange(true);
         }}
         onPointerMove={composeEventHandlers(
           props.onPointerMove,

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -744,7 +744,18 @@ const MenuSubTrigger = React.forwardRef((props, forwardedRef) => {
           whenTouchOrPen((event) => {
             contentContext.onItemEnter(event);
             if (event.defaultPrevented) return;
-            if (!props.disabled && !context.open) context.onOpenChange(true);
+            if (!props.disabled && !context.open) {
+              context.onOpenChange(true);
+              event.preventDefault();
+              /**
+               * We manually focus because iOS Safari:
+               * - doesn't focus the item if a pointerup mounts DOM that has a click handler.
+               * - doesn't focus `button`s (if someone changes as prop).
+               * Both issues mean our `onFocusOutside` logic wouldn't fire when switching
+               * between separate submenus.
+               */
+              event.currentTarget.focus();
+            }
           })
         )}
         onPointerMove={composeEventHandlers(


### PR DESCRIPTION
After https://github.com/radix-ui/primitives/pull/818 was merged, we noticed that submenus weren't closing if you click another submenu trigger. The PR wasn't the cause of the issue, but uncovered some very strange iOS Safari behaviour because we introduced an `onClick` handler. 

In iOS Safari, if a `pointerup` event mounts DOM with an `onclick` handler (incl. noop), the target of the `pointerup` will not receive focus. You can test the following to see the issue (it is not React specific): https://codepen.io/jjenzz/pen/rNmRjWN

The lack of `focus` meant our `onFocusOutside` logic would not fire from submenus when opening a different submenu, leaving them both open.