### PR TITLE
[All] Avoid inlining built type declarations

### DIFF
--- a/.yarn/versions/4c05b7ba.yml
+++ b/.yarn/versions/4c05b7ba.yml
@@ -1,0 +1,41 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/accessible-icon/src/AccessibleIcon.tsx
+++ b/packages/react/accessible-icon/src/AccessibleIcon.tsx
@@ -3,13 +3,13 @@ import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
 const NAME = 'AccessibleIcon';
 
-type AccessibleIconProps = {
+interface AccessibleIconProps {
   /**
    * The accessible label for the icon. This label will be visually hidden but announced to screen
    * reader users, similar to `alt` text for `img` tags.
    */
   label: string;
-};
+}
 
 const AccessibleIcon: React.FC<AccessibleIconProps> = ({ children, label }) => {
   const child = React.Children.only(children);
@@ -34,3 +34,4 @@ export {
   //
   Root,
 };
+export type { AccessibleIconProps };

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -317,8 +317,8 @@ AccordionItem.displayName = ITEM_NAME;
 const HEADER_NAME = 'AccordionHeader';
 
 type AccordionHeaderElement = React.ElementRef<typeof Primitive.h3>;
-type PrimitiveHeadingProps = Radix.ComponentPropsWithoutRef<typeof Primitive.h3>;
-interface AccordionHeaderProps extends PrimitiveHeadingProps {}
+type PrimitiveHeading3Props = Radix.ComponentPropsWithoutRef<typeof Primitive.h3>;
+interface AccordionHeaderProps extends PrimitiveHeading3Props {}
 
 /**
  * `AccordionHeader` contains the content for the parts of an `AccordionItem` that will be visible

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -16,23 +16,27 @@ import type * as Radix from '@radix-ui/react-primitive';
 const ACCORDION_NAME = 'Accordion';
 const ACCORDION_KEYS = ['Home', 'End', 'ArrowDown', 'ArrowUp'];
 
-type AccordionElement = React.ElementRef<typeof AccordionMultiple | typeof AccordionSingle>;
-type AccordionProps =
-  | ({ type: 'single' } & Radix.ComponentPropsWithoutRef<typeof AccordionSingle>)
-  | ({ type: 'multiple' } & Radix.ComponentPropsWithoutRef<typeof AccordionMultiple>);
+type AccordionElement = AccordionMultipleElement | AccordionSingleElement;
+interface AccordionWithSingleProps extends AccordionSingleProps {
+  type: 'single';
+}
+interface AccordionWithMultipleProps extends AccordionMultipleProps {
+  type: 'multiple';
+}
 
-const Accordion = React.forwardRef<AccordionElement, AccordionProps>((props, forwardedRef) => {
+const Accordion = React.forwardRef<
+  AccordionElement,
+  AccordionWithSingleProps | AccordionWithMultipleProps
+>((props, forwardedRef) => {
   const { type, ...accordionProps } = props;
 
   if (type === 'single') {
-    const singleProps = accordionProps as Radix.ComponentPropsWithoutRef<typeof AccordionSingle>;
+    const singleProps = accordionProps as AccordionSingleProps;
     return <AccordionSingle {...singleProps} ref={forwardedRef} />;
   }
 
   if (type === 'multiple') {
-    const multipleProps = accordionProps as Radix.ComponentPropsWithoutRef<
-      typeof AccordionMultiple
-    >;
+    const multipleProps = accordionProps as AccordionMultipleProps;
     return <AccordionMultiple {...multipleProps} ref={forwardedRef} />;
   }
 
@@ -54,30 +58,27 @@ const [AccordionValueProvider, useAccordionValueContext] =
 
 const AccordionCollapsibleContext = React.createContext(false);
 
-type AccordionSingleElement = React.ElementRef<typeof AccordionImpl>;
-type AccordionSingleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof AccordionImpl>,
-  {
-    /**
-     * The controlled stateful value of the accordion item whose content is expanded.
-     */
-    value?: string;
-    /**
-     * The value of the item whose content is expanded when the accordion is initially rendered. Use
-     * `defaultValue` if you do not need to control the state of an accordion.
-     */
-    defaultValue?: string;
-    /**
-     * The callback that fires when the state of the accordion changes.
-     */
-    onValueChange?(value: string): void;
-    /**
-     * Whether an accordion item can be collapsed after it has been opened.
-     * @default false
-     */
-    collapsible?: boolean;
-  }
->;
+type AccordionSingleElement = AccordionImplElement;
+interface AccordionSingleProps extends AccordionImplProps {
+  /**
+   * The controlled stateful value of the accordion item whose content is expanded.
+   */
+  value?: string;
+  /**
+   * The value of the item whose content is expanded when the accordion is initially rendered. Use
+   * `defaultValue` if you do not need to control the state of an accordion.
+   */
+  defaultValue?: string;
+  /**
+   * The callback that fires when the state of the accordion changes.
+   */
+  onValueChange?(value: string): void;
+  /**
+   * Whether an accordion item can be collapsed after it has been opened.
+   * @default false
+   */
+  collapsible?: boolean;
+}
 
 const AccordionSingle = React.forwardRef<AccordionSingleElement, AccordionSingleProps>(
   (props, forwardedRef) => {
@@ -111,25 +112,22 @@ const AccordionSingle = React.forwardRef<AccordionSingleElement, AccordionSingle
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type AccordionMultipleElement = React.ElementRef<typeof AccordionImpl>;
-type AccordionMultipleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof AccordionImpl>,
-  {
-    /**
-     * The controlled stateful value of the accordion items whose contents are expanded.
-     */
-    value?: string[];
-    /**
-     * The value of the items whose contents are expanded when the accordion is initially rendered. Use
-     * `defaultValue` if you do not need to control the state of an accordion.
-     */
-    defaultValue?: string[];
-    /**
-     * The callback that fires when the state of the accordion changes.
-     */
-    onValueChange?(value: string[]): void;
-  }
->;
+type AccordionMultipleElement = AccordionImplElement;
+interface AccordionMultipleProps extends AccordionImplProps {
+  /**
+   * The controlled stateful value of the accordion items whose contents are expanded.
+   */
+  value?: string[];
+  /**
+   * The value of the items whose contents are expanded when the accordion is initially rendered. Use
+   * `defaultValue` if you do not need to control the state of an accordion.
+   */
+  defaultValue?: string[];
+  /**
+   * The callback that fires when the state of the accordion changes.
+   */
+  onValueChange?(value: string[]): void;
+}
 
 const AccordionMultiple = React.forwardRef<AccordionMultipleElement, AccordionMultipleProps>(
   (props, forwardedRef) => {
@@ -181,17 +179,15 @@ const [AccordionImplProvider, useAccordionContext] =
   createContext<AccordionImplContextValue>(ACCORDION_NAME);
 
 type AccordionImplElement = React.ElementRef<typeof Primitive.div>;
-type AccordionImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * Whether or not an accordion is disabled from user interaction.
-     *
-     * @defaultValue false
-     */
-    disabled?: boolean;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface AccordionImplProps extends PrimitiveDivProps {
+  /**
+   * Whether or not an accordion is disabled from user interaction.
+   *
+   * @defaultValue false
+   */
+  disabled?: boolean;
+}
 
 const AccordionImpl = React.forwardRef<AccordionImplElement, AccordionImplProps>(
   (props, forwardedRef) => {
@@ -264,24 +260,20 @@ const [AccordionItemProvider, useAccordionItemContext] =
   createContext<AccordionItemContextValue>(ITEM_NAME);
 
 type AccordionItemElement = React.ElementRef<typeof CollapsiblePrimitive.Root>;
-type AccordionItemProps = Radix.MergeProps<
-  Omit<
-    Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root>,
-    'open' | 'defaultOpen' | 'onOpenChange'
-  >,
-  {
-    /**
-     * Whether or not an accordion item is disabled from user interaction.
-     *
-     * @defaultValue false
-     */
-    disabled?: boolean;
-    /**
-     * A string value for the accordion item. All items within an accordion should use a unique value.
-     */
-    value: string;
-  }
->;
+type CollapsibleProps = Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root>;
+interface AccordionItemProps
+  extends Omit<CollapsibleProps, 'open' | 'defaultOpen' | 'onOpenChange'> {
+  /**
+   * Whether or not an accordion item is disabled from user interaction.
+   *
+   * @defaultValue false
+   */
+  disabled?: boolean;
+  /**
+   * A string value for the accordion item. All items within an accordion should use a unique value.
+   */
+  value: string;
+}
 
 /**
  * `AccordionItem` contains all of the parts of a collapsible section inside of an `Accordion`.
@@ -325,7 +317,9 @@ AccordionItem.displayName = ITEM_NAME;
 const HEADER_NAME = 'AccordionHeader';
 
 type AccordionHeaderElement = React.ElementRef<typeof Primitive.h3>;
-type AccordionHeaderProps = Radix.ComponentPropsWithoutRef<typeof Primitive.h3>;
+type PrimitiveHeadingProps = Radix.ComponentPropsWithoutRef<typeof Primitive.h3>;
+interface AccordionHeaderProps extends PrimitiveHeadingProps {}
+
 /**
  * `AccordionHeader` contains the content for the parts of an `AccordionItem` that will be visible
  * whether or not its content is collapsed.
@@ -353,7 +347,8 @@ AccordionHeader.displayName = HEADER_NAME;
 const TRIGGER_NAME = 'AccordionTrigger';
 
 type AccordionTriggerElement = React.ElementRef<typeof CollapsiblePrimitive.Trigger>;
-type AccordionTriggerProps = Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>;
+type CollapsibleTriggerProps = Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>;
+interface AccordionTriggerProps extends CollapsibleTriggerProps {}
 
 /**
  * `AccordionTrigger` is the trigger that toggles the collapsed state of an `AccordionItem`. It
@@ -401,7 +396,9 @@ AccordionTrigger.displayName = TRIGGER_NAME;
 const CONTENT_NAME = 'AccordionContent';
 
 type AccordionContentElement = React.ElementRef<typeof CollapsiblePrimitive.Content>;
-type AccordionContentProps = Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>;
+type CollapsibleContentProps = Radix.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>;
+interface AccordionContentProps extends CollapsibleContentProps {}
+
 /**
  * `AccordionContent` contains the collapsible content for an `AccordionItem`.
  */
@@ -453,4 +450,10 @@ export {
   Header,
   Trigger,
   Content,
+};
+export type {
+  AccordionItemProps,
+  AccordionHeaderProps,
+  AccordionTriggerProps,
+  AccordionContentProps,
 };

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -105,21 +105,33 @@ const AlertDialogCancel = React.forwardRef<AlertDialogCancelElement, AlertDialog
 AlertDialogCancel.displayName = CANCEL_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
-
+type DialogTriggerProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>;
+interface AlertDialogTriggerProps extends DialogTriggerProps {}
 const AlertDialogTrigger = extendPrimitive(DialogPrimitive.Trigger, {
   displayName: 'AlertDialogTrigger',
 });
+
+type DialogOverlayProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>;
+interface AlertDialogOverlayProps extends DialogOverlayProps {}
 const AlertDialogOverlay = extendPrimitive(DialogPrimitive.Overlay, {
   displayName: 'AlertDialogOverlay',
 });
+
+interface AlertDialogActionProps extends DialogCloseProps {}
 const AlertDialogAction = extendPrimitive(DialogPrimitive.Close, {
   displayName: 'AlertDialogAction',
 });
+
 const TITLE_NAME = 'AlertDialogTitle';
+type DialogTitleProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>;
+interface AlertDialogTitleProps extends DialogTitleProps {}
 const AlertDialogTitle = extendPrimitive(DialogPrimitive.Title, {
   displayName: TITLE_NAME,
 });
+
 const DESCRIPTION_NAME = 'AlertDialogDescription';
+type DialogDescriptionProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>;
+interface AlertDialogDescriptionProps extends DialogDescriptionProps {}
 const AlertDialogDescription = extendPrimitive(DialogPrimitive.Description, {
   displayName: DESCRIPTION_NAME,
 });
@@ -177,4 +189,13 @@ export {
   Title,
   Description,
 };
-export type { AlertDialogProps, AlertDialogContentProps, AlertDialogCancelProps };
+export type {
+  AlertDialogProps,
+  AlertDialogTriggerProps,
+  AlertDialogOverlayProps,
+  AlertDialogContentProps,
+  AlertDialogActionProps,
+  AlertDialogCancelProps,
+  AlertDialogTitleProps,
+  AlertDialogDescriptionProps,
+};

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -14,7 +14,8 @@ import type * as Radix from '@radix-ui/react-primitive';
 
 const ROOT_NAME = 'AlertDialog';
 
-type AlertDialogProps = Omit<Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>, 'modal'>;
+type DialogProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>;
+interface AlertDialogProps extends Omit<DialogProps, 'modal'> {}
 
 const AlertDialog: React.FC<AlertDialogProps> = (props) => (
   <DialogPrimitive.Root {...props} modal={true} />
@@ -36,10 +37,8 @@ const [AlertDialogContentProvider, useAlertDialogContentContext] =
   createContext<AlertDialogContentContextValue>(CONTENT_NAME);
 
 type AlertDialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
-type AlertDialogContentProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
-  'onPointerDownOutside'
->;
+type DialogContentProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
+interface AlertDialogContentProps extends Omit<DialogContentProps, 'onPointerDownOutside'> {}
 
 const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
   (props, forwardedRef) => {
@@ -92,7 +91,8 @@ AlertDialogContent.displayName = CONTENT_NAME;
 const CANCEL_NAME = 'AlertDialogCancel';
 
 type AlertDialogCancelElement = React.ElementRef<typeof DialogPrimitive.Close>;
-type AlertDialogCancelProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>;
+type DialogCloseProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>;
+interface AlertDialogCancelProps extends DialogCloseProps {}
 
 const AlertDialogCancel = React.forwardRef<AlertDialogCancelElement, AlertDialogCancelProps>(
   (props, forwardedRef) => {
@@ -177,3 +177,4 @@ export {
   Title,
   Description,
 };
+export type { AlertDialogProps, AlertDialogContentProps, AlertDialogCancelProps };

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -8,7 +8,6 @@ import type * as Radix from '@radix-ui/react-primitive';
 
 type RegionType = 'polite' | 'assertive' | 'off';
 type RegionRole = 'status' | 'alert' | 'log' | 'none';
-type AriaRelevantOptions = 'additions' | 'removals' | 'text';
 
 const ROLES: { [key in RegionType]: RegionRole } = {
   polite: 'status',
@@ -25,67 +24,65 @@ const listenerMap = new Map<Element, number>();
 const NAME = 'Announce';
 
 type AnnounceElement = React.ElementRef<typeof Primitive.div>;
-type AnnounceProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * Mirrors the `aria-atomic` DOM attribute for live regions. It is an optional attribute that
-     * indicates whether assistive technologies will present all, or only parts of, the changed region
-     * based on the change notifications defined by the `aria-relevant` attribute.
-     *
-     * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-atomic
-     * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
-     */
-    'aria-atomic'?: boolean;
-    /**
-     * Mirrors the `aria-relevant` DOM attribute for live regions. It is an optional attribute used to
-     * describe what types of changes have occurred to the region, and which changes are relevant and
-     * should be announced. Any change that is not relevant acts in the same manner it would if the
-     * `aria-live` attribute were set to off.
-     *
-     * Unfortunately, `aria-relevant` doesn't behave as expected across all device/screen reader
-     * combinations. It's important to test its implementation before relying on it to work for your
-     * users. The attribute is omitted by default.
-     *
-     * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-relevant
-     * @see MDN      https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute
-     * @see Opinion  https://medium.com/dev-channel/why-authors-should-avoid-aria-relevant-5d3164fab1e3
-     * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
-     */
-    'aria-relevant'?: string | AriaRelevantOptions[];
-    /**
-     * React children of your component. Children can be mirrored directly or modified to optimize for
-     * screen reader user experience.
-     */
-    children: React.ReactNode;
-    /**
-     * An optional unique identifier for the live region.
-     *
-     * By default, `Announce` components create, at most, two unique `aria-live` regions in the
-     * document (one for all `polite` notifications, one for all `assertive` notifications). In some
-     * cases you may wish to append additional `aria-live` regions for distinct purposes (for example,
-     * simple status updates may need to be separated from a stack of toast-style notifications). By
-     * passing an id, you indicate that any content rendered by components with the same identifier
-     * should be mirrored in a separate `aria-live` region.
-     */
-    regionIdentifier?: string;
-    /**
-     * Mirrors the `role` DOM attribute. This is optional and may be useful as an override in some
-     * cases. By default, the role is determined by the `type` prop.
-     *
-     * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Preferring_specialized_live_region_roles
-     */
-    role?: RegionRole;
-    /**
-     * Mirrors the `aria-live` DOM attribute. The `aria-live=POLITENESS_SETTING` is used to set the
-     * priority with which screen reader should treat updates to live regions. Its possible settings
-     * are: off, polite or assertive. Defaults to `polite`.
-     *
-     * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
-     */
-    type?: RegionType;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface AnnounceProps extends PrimitiveDivProps {
+  /**
+   * Mirrors the `aria-atomic` DOM attribute for live regions. It is an optional attribute that
+   * indicates whether assistive technologies will present all, or only parts of, the changed region
+   * based on the change notifications defined by the `aria-relevant` attribute.
+   *
+   * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-atomic
+   * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
+   */
+  'aria-atomic'?: boolean;
+  /**
+   * Mirrors the `aria-relevant` DOM attribute for live regions. It is an optional attribute used to
+   * describe what types of changes have occurred to the region, and which changes are relevant and
+   * should be announced. Any change that is not relevant acts in the same manner it would if the
+   * `aria-live` attribute were set to off.
+   *
+   * Unfortunately, `aria-relevant` doesn't behave as expected across all device/screen reader
+   * combinations. It's important to test its implementation before relying on it to work for your
+   * users. The attribute is omitted by default.
+   *
+   * @see WAI-ARIA https://www.w3.org/TR/wai-aria-1.2/#aria-relevant
+   * @see MDN      https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute
+   * @see Opinion  https://medium.com/dev-channel/why-authors-should-avoid-aria-relevant-5d3164fab1e3
+   * @see Demo     http://pauljadam.com/demos/aria-atomic-relevant.html
+   */
+  'aria-relevant'?: PrimitiveDivProps['aria-relevant'];
+  /**
+   * React children of your component. Children can be mirrored directly or modified to optimize for
+   * screen reader user experience.
+   */
+  children: React.ReactNode;
+  /**
+   * An optional unique identifier for the live region.
+   *
+   * By default, `Announce` components create, at most, two unique `aria-live` regions in the
+   * document (one for all `polite` notifications, one for all `assertive` notifications). In some
+   * cases you may wish to append additional `aria-live` regions for distinct purposes (for example,
+   * simple status updates may need to be separated from a stack of toast-style notifications). By
+   * passing an id, you indicate that any content rendered by components with the same identifier
+   * should be mirrored in a separate `aria-live` region.
+   */
+  regionIdentifier?: string;
+  /**
+   * Mirrors the `role` DOM attribute. This is optional and may be useful as an override in some
+   * cases. By default, the role is determined by the `type` prop.
+   *
+   * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Preferring_specialized_live_region_roles
+   */
+  role?: RegionRole;
+  /**
+   * Mirrors the `aria-live` DOM attribute. The `aria-live=POLITENESS_SETTING` is used to set the
+   * priority with which screen reader should treat updates to live regions. Its possible settings
+   * are: off, polite or assertive. Defaults to `polite`.
+   *
+   * @see MDN https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
+   */
+  type?: RegionType;
+}
 
 const Announce = React.forwardRef<AnnounceElement, AnnounceProps>((props, forwardedRef) => {
   const {
@@ -238,3 +235,4 @@ export {
   //
   Root,
 };
+export type { AnnounceProps };

--- a/packages/react/arrow/src/Arrow.tsx
+++ b/packages/react/arrow/src/Arrow.tsx
@@ -10,7 +10,8 @@ import type * as Radix from '@radix-ui/react-primitive';
 const NAME = 'Arrow';
 
 type ArrowElement = React.ElementRef<typeof Primitive.svg>;
-type ArrowProps = Radix.ComponentPropsWithoutRef<typeof Primitive.svg>;
+type PrimitiveSvgProps = Radix.ComponentPropsWithoutRef<typeof Primitive.svg>;
+interface ArrowProps extends PrimitiveSvgProps {}
 
 const Arrow = React.forwardRef<ArrowElement, ArrowProps>((props, forwardedRef) => {
   const { children, width = 10, height = 5, ...arrowProps } = props;
@@ -40,3 +41,4 @@ export {
   //
   Root,
 };
+export type { ArrowProps };

--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -10,10 +10,10 @@ import type * as Radix from '@radix-ui/react-primitive';
 const NAME = 'AspectRatio';
 
 type AspectRatioElement = React.ElementRef<typeof Primitive.div>;
-type AspectRatioProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { ratio?: number }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface AspectRatioProps extends PrimitiveDivProps {
+  ratio?: number;
+}
 
 const AspectRatio = React.forwardRef<AspectRatioElement, AspectRatioProps>(
   (props, forwardedRef) => {
@@ -58,3 +58,4 @@ export {
   //
   Root,
 };
+export type { AspectRatioProps };

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -22,7 +22,8 @@ type AvatarContextValue = {
 const [AvatarProvider, useAvatarContext] = createContext<AvatarContextValue>(AVATAR_NAME);
 
 type AvatarElement = React.ElementRef<typeof Primitive.span>;
-type AvatarProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface AvatarProps extends PrimitiveSpanProps {}
 
 const Avatar = React.forwardRef<AvatarElement, AvatarProps>((props, forwardedRef) => {
   const [imageLoadingStatus, setImageLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
@@ -45,10 +46,10 @@ Avatar.displayName = AVATAR_NAME;
 const IMAGE_NAME = 'AvatarImage';
 
 type AvatarImageElement = React.ElementRef<typeof Primitive.img>;
-type AvatarImageProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.img>,
-  { onLoadingStatusChange?: (status: ImageLoadingStatus) => void }
->;
+type PrimitiveImageProps = Radix.ComponentPropsWithoutRef<typeof Primitive.img>;
+interface AvatarImageProps extends PrimitiveImageProps {
+  onLoadingStatusChange?: (status: ImageLoadingStatus) => void;
+}
 
 const AvatarImage = React.forwardRef<AvatarImageElement, AvatarImageProps>(
   (props, forwardedRef) => {
@@ -81,10 +82,9 @@ AvatarImage.displayName = IMAGE_NAME;
 const FALLBACK_NAME = 'AvatarFallback';
 
 type AvatarFallbackElement = React.ElementRef<typeof Primitive.span>;
-type AvatarFallbackProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  { delayMs?: number }
->;
+interface AvatarFallbackProps extends PrimitiveSpanProps {
+  delayMs?: number;
+}
 
 const AvatarFallback = React.forwardRef<AvatarFallbackElement, AvatarFallbackProps>(
   (props, forwardedRef) => {
@@ -151,3 +151,4 @@ export {
   Image,
   Fallback,
 };
+export type { AvatarProps, AvatarImageProps, AvatarFallbackProps };

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -27,15 +27,13 @@ type CheckboxContextValue = {
 const [CheckboxProvider, useCheckboxContext] = createContext<CheckboxContextValue>(CHECKBOX_NAME);
 
 type CheckboxElement = React.ElementRef<typeof Primitive.button>;
-type CheckboxProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.button>,
-  {
-    checked?: CheckedState;
-    defaultChecked?: CheckedState;
-    required?: boolean;
-    onCheckedChange?(checked: CheckedState): void;
-  }
->;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface CheckboxProps extends Omit<PrimitiveButtonProps, 'checked' | 'defaultChecked'> {
+  checked?: CheckedState;
+  defaultChecked?: CheckedState;
+  required?: boolean;
+  onCheckedChange?(checked: CheckedState): void;
+}
 
 const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>((props, forwardedRef) => {
   const {
@@ -115,16 +113,14 @@ Checkbox.displayName = CHECKBOX_NAME;
 const INDICATOR_NAME = 'CheckboxIndicator';
 
 type CheckboxIndicatorElement = React.ElementRef<typeof Primitive.span>;
-type CheckboxIndicatorProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface CheckboxIndicatorProps extends PrimitiveSpanProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const CheckboxIndicator = React.forwardRef<CheckboxIndicatorElement, CheckboxIndicatorProps>(
   (props, forwardedRef) => {
@@ -148,11 +144,12 @@ CheckboxIndicator.displayName = INDICATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type BubbleInputProps = Omit<Radix.ComponentPropsWithoutRef<'input'>, 'checked'> & {
+type InputProps = Radix.ComponentPropsWithoutRef<'input'>;
+interface BubbleInputProps extends Omit<InputProps, 'checked'> {
   checked: CheckedState;
   control: HTMLElement | null;
   bubbles: boolean;
-};
+}
 
 const BubbleInput = (props: BubbleInputProps) => {
   const { control, checked, bubbles = true, ...inputProps } = props;
@@ -212,3 +209,4 @@ export {
   Root,
   Indicator,
 };
+export type { CheckboxProps, CheckboxIndicatorProps };

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -27,15 +27,13 @@ const [CollapsibleProvider, useCollapsibleContext] =
   createContext<CollapsibleContextValue>(COLLAPSIBLE_NAME);
 
 type CollapsibleElement = React.ElementRef<typeof Primitive.div>;
-type CollapsibleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    defaultOpen?: boolean;
-    open?: boolean;
-    disabled?: boolean;
-    onOpenChange?(open?: boolean): void;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface CollapsibleProps extends PrimitiveDivProps {
+  defaultOpen?: boolean;
+  open?: boolean;
+  disabled?: boolean;
+  onOpenChange?(open?: boolean): void;
+}
 
 const Collapsible = React.forwardRef<CollapsibleElement, CollapsibleProps>(
   (props, forwardedRef) => {
@@ -74,7 +72,8 @@ Collapsible.displayName = COLLAPSIBLE_NAME;
 const TRIGGER_NAME = 'CollapsibleTrigger';
 
 type CollapsibleTriggerElement = React.ElementRef<typeof Primitive.button>;
-type CollapsibleTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface CollapsibleTriggerProps extends PrimitiveButtonProps {}
 
 const CollapsibleTrigger = React.forwardRef<CollapsibleTriggerElement, CollapsibleTriggerProps>(
   (props, forwardedRef) => {
@@ -102,17 +101,14 @@ CollapsibleTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'CollapsibleContent';
 
-type CollapsibleContentElement = React.ElementRef<typeof CollapsibleContentImpl>;
-type CollapsibleContentProps = Radix.MergeProps<
-  Omit<Radix.ComponentPropsWithoutRef<typeof CollapsibleContentImpl>, 'present'>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type CollapsibleContentElement = CollapsibleContentImplElement;
+interface CollapsibleContentProps extends Omit<CollapsibleContentImplProps, 'present'> {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const CollapsibleContent = React.forwardRef<CollapsibleContentElement, CollapsibleContentProps>(
   (props, forwardedRef) => {
@@ -133,10 +129,9 @@ CollapsibleContent.displayName = CONTENT_NAME;
 /* -----------------------------------------------------------------------------------------------*/
 
 type CollapsibleContentImplElement = React.ElementRef<typeof Primitive.div>;
-type CollapsibleContentImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { present: boolean }
->;
+interface CollapsibleContentImplProps extends PrimitiveDivProps {
+  present: boolean;
+}
 
 const CollapsibleContentImpl = React.forwardRef<
   CollapsibleContentImplElement,
@@ -216,3 +211,4 @@ export {
   Trigger,
   Content,
 };
+export type { CollapsibleProps, CollapsibleTriggerProps, CollapsibleContentProps };

--- a/packages/react/collection/src/Collection.tsx
+++ b/packages/react/collection/src/Collection.tsx
@@ -4,6 +4,9 @@ import { Slot } from '@radix-ui/react-slot';
 
 import type * as Radix from '@radix-ui/react-primitive';
 
+type SlotProps = Radix.ComponentPropsWithoutRef<typeof Slot>;
+interface CollectionProps extends SlotProps {}
+
 // We have resorted to returning slots directly rather than exposing primitives that can then
 // be slotted like `<CollectionItem as={Slot}>…</CollectionItem>`.
 // This is because we encountered issues with generic types that cannot be statically analysed
@@ -43,14 +46,14 @@ function createCollection<ItemElement extends HTMLElement, ItemData>() {
 
   const COLLECTION_SLOT_NAME = 'CollectionSlot';
 
-  type SlotProps = Radix.ComponentPropsWithoutRef<typeof Slot>;
-
-  const CollectionSlot = React.forwardRef<CollectionElement, SlotProps>((props, forwardedRef) => {
-    const { children } = props;
-    const context = React.useContext(Context);
-    const composedRefs = useComposedRefs(forwardedRef, context.collectionRef);
-    return <Slot ref={composedRefs}>{children}</Slot>;
-  });
+  const CollectionSlot = React.forwardRef<CollectionElement, CollectionProps>(
+    (props, forwardedRef) => {
+      const { children } = props;
+      const context = React.useContext(Context);
+      const composedRefs = useComposedRefs(forwardedRef, context.collectionRef);
+      return <Slot ref={composedRefs}>{children}</Slot>;
+    }
+  );
 
   CollectionSlot.displayName = COLLECTION_SLOT_NAME;
 
@@ -61,7 +64,9 @@ function createCollection<ItemElement extends HTMLElement, ItemData>() {
   const ITEM_SLOT_NAME = 'CollectionItemSlot';
   const ITEM_DATA_ATTR = 'data-radix-collection-item';
 
-  type CollectionItemSlotProps = { children: React.ReactNode } & ItemData;
+  type CollectionItemSlotProps = ItemData & {
+    children: React.ReactNode;
+  };
 
   const CollectionItemSlot = React.forwardRef<ItemElement, CollectionItemSlotProps>(
     (props, forwardedRef) => {
@@ -109,3 +114,4 @@ function createCollection<ItemElement extends HTMLElement, ItemData>() {
 }
 
 export { createCollection };
+export type { CollectionProps };

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -26,11 +26,11 @@ type ContextMenuContextValue = {
 const [ContextMenuProvider, useContextMenuContext] =
   createContext<ContextMenuContextValue>(CONTEXT_MENU_NAME);
 
-type ContextMenuProps = {
+interface ContextMenuProps {
   onOpenChange?(open: boolean): void;
   dir?: Direction;
   modal?: boolean;
-};
+}
 
 const ContextMenu: React.FC<ContextMenuProps> = (props) => {
   const { children, onOpenChange, dir, modal = true } = props;
@@ -80,7 +80,8 @@ ContextMenu.displayName = CONTEXT_MENU_NAME;
 const TRIGGER_NAME = 'ContextMenuTrigger';
 
 type ContextMenuTriggerElement = React.ElementRef<typeof Primitive.span>;
-type ContextMenuTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface ContextMenuTriggerProps extends PrimitiveSpanProps {}
 
 const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMenuTriggerProps>(
   (props, forwardedRef) => {
@@ -147,10 +148,8 @@ const CONTENT_NAME = 'ContextMenuContent';
 const ContentContext = React.createContext(false);
 
 type ContextMenuContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-type ContextMenuContentProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>,
-  'portalled' | 'side' | 'align'
->;
+type MenuProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+interface ContextMenuContentProps extends Omit<MenuProps, 'portalled' | 'side' | 'align'> {}
 
 const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMenuContentProps>(
   (props, forwardedRef) => {
@@ -183,7 +182,8 @@ ContextMenuContent.displayName = CONTENT_NAME;
 /* ---------------------------------------------------------------------------------------------- */
 
 type ContextMenuRootContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-type ContextMenuRootContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+type MenuContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+interface ContextMenuRootContentProps extends MenuContentProps {}
 
 const ContextMenuRootContent = React.forwardRef<
   ContextMenuRootContentElement,
@@ -293,3 +293,4 @@ export {
   Separator,
   Arrow,
 };
+export type { ContextMenuProps, ContextMenuTriggerProps, ContextMenuContentProps };

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -148,8 +148,8 @@ const CONTENT_NAME = 'ContextMenuContent';
 const ContentContext = React.createContext(false);
 
 type ContextMenuContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-type MenuProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
-interface ContextMenuContentProps extends Omit<MenuProps, 'portalled' | 'side' | 'align'> {}
+type MenuContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+interface ContextMenuContentProps extends Omit<MenuContentProps, 'portalled' | 'side' | 'align'> {}
 
 const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMenuContentProps>(
   (props, forwardedRef) => {
@@ -182,7 +182,6 @@ ContextMenuContent.displayName = CONTENT_NAME;
 /* ---------------------------------------------------------------------------------------------- */
 
 type ContextMenuRootContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-type MenuContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
 interface ContextMenuRootContentProps extends MenuContentProps {}
 
 const ContextMenuRootContent = React.forwardRef<

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -219,27 +219,56 @@ const ContextMenuRootContent = React.forwardRef<
 
 /* ---------------------------------------------------------------------------------------------- */
 
+type MenuGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Group>;
+interface ContextMenuGroupProps extends MenuGroupProps {}
 const ContextMenuGroup = extendPrimitive(MenuPrimitive.Group, { displayName: 'ContextMenuGroup' });
+
+type MenuLabelProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Label>;
+interface ContextMenuLabelProps extends MenuLabelProps {}
 const ContextMenuLabel = extendPrimitive(MenuPrimitive.Label, { displayName: 'ContextMenuLabel' });
+
+type MenuSubTriggerProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.SubTrigger>;
+interface ContextMenuTriggerItemProps extends MenuSubTriggerProps {}
 const ContextMenuTriggerItem = extendPrimitive(MenuPrimitive.SubTrigger, {
   displayName: 'ContextMenuTriggerItem',
 });
+
+type MenuItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Item>;
+interface ContextMenuItemProps extends MenuItemProps {}
 const ContextMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'ContextMenuItem' });
+
+type MenuCheckboxItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.CheckboxItem>;
+interface ContextMenuCheckboxItemProps extends MenuCheckboxItemProps {}
 const ContextMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
   displayName: 'ContextMenuCheckboxItem',
 });
+
+type MenuRadioGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.RadioGroup>;
+interface ContextMenuRadioGroupProps extends MenuRadioGroupProps {}
 const ContextMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, {
   displayName: 'ContextMenuRadioGroup',
 });
+
+type MenuRadioItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.RadioItem>;
+interface ContextMenuRadioItemProps extends MenuRadioItemProps {}
 const ContextMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, {
   displayName: 'ContextMenuRadioItem',
 });
+
+type MenuItemIndicatorProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.ItemIndicator>;
+interface ContextMenuItemIndicatorProps extends MenuItemIndicatorProps {}
 const ContextMenuItemIndicator = extendPrimitive(MenuPrimitive.ItemIndicator, {
   displayName: 'ContextMenuItemIndicator',
 });
+
+type MenuSeparatorProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Separator>;
+interface ContextMenuSeparatorProps extends MenuSeparatorProps {}
 const ContextMenuSeparator = extendPrimitive(MenuPrimitive.Separator, {
   displayName: 'ContextMenuSeparator',
 });
+
+type MenuArrowProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Arrow>;
+interface ContextMenuArrowProps extends MenuArrowProps {}
 const ContextMenuArrow = extendPrimitive(MenuPrimitive.Arrow, {
   displayName: 'ContextMenuArrow',
 });
@@ -293,4 +322,18 @@ export {
   Separator,
   Arrow,
 };
-export type { ContextMenuProps, ContextMenuTriggerProps, ContextMenuContentProps };
+export type {
+  ContextMenuProps,
+  ContextMenuTriggerProps,
+  ContextMenuContentProps,
+  ContextMenuGroupProps,
+  ContextMenuLabelProps,
+  ContextMenuItemProps,
+  ContextMenuTriggerItemProps,
+  ContextMenuCheckboxItemProps,
+  ContextMenuRadioGroupProps,
+  ContextMenuRadioItemProps,
+  ContextMenuItemIndicatorProps,
+  ContextMenuSeparatorProps,
+  ContextMenuArrowProps,
+};

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -34,12 +34,12 @@ type DialogContextValue = {
 
 const [DialogProvider, useDialogContext] = createContext<DialogContextValue>(DIALOG_NAME);
 
-type DialogProps = {
+interface DialogProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   modal?: boolean;
-};
+}
 
 const Dialog: React.FC<DialogProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange, modal = true } = props;
@@ -75,7 +75,8 @@ Dialog.displayName = DIALOG_NAME;
 const TRIGGER_NAME = 'DialogTrigger';
 
 type DialogTriggerElement = React.ElementRef<typeof Primitive.button>;
-type DialogTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface DialogTriggerProps extends PrimitiveButtonProps {}
 
 const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>(
   (props, forwardedRef) => {
@@ -104,17 +105,14 @@ DialogTrigger.displayName = TRIGGER_NAME;
 
 const OVERLAY_NAME = 'DialogOverlay';
 
-type DialogOverlayElement = React.ElementRef<typeof DialogOverlayImpl>;
-type DialogOverlayProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof DialogOverlayImpl>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type DialogOverlayElement = DialogOverlayImplElement;
+interface DialogOverlayProps extends DialogOverlayImplProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const DialogOverlay = React.forwardRef<DialogOverlayElement, DialogOverlayProps>(
   (props, forwardedRef) => {
@@ -131,7 +129,8 @@ const DialogOverlay = React.forwardRef<DialogOverlayElement, DialogOverlayProps>
 DialogOverlay.displayName = OVERLAY_NAME;
 
 type DialogOverlayImplElement = React.ElementRef<typeof Primitive.div>;
-type DialogOverlayImplProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface DialogOverlayImplProps extends PrimitiveDivProps {}
 
 const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverlayImplProps>(
   (props, forwardedRef) => {
@@ -150,19 +149,14 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
 
 const CONTENT_NAME = 'DialogContent';
 
-type DialogContentElement = React.ElementRef<
-  typeof DialogContentModal | typeof DialogContentNonModal
->;
-type DialogContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof DialogContentModal | typeof DialogContentNonModal>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type DialogContentElement = DialogContentTypeElement;
+interface DialogContentProps extends DialogContentTypeProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const DialogContent = React.forwardRef<DialogContentElement, DialogContentProps>(
   (props, forwardedRef) => {
@@ -184,11 +178,9 @@ DialogContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type DialogContentTypeElement = React.ElementRef<typeof DialogContentImpl>;
-type DialogContentTypeProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof DialogContentImpl>,
-  'trapFocus' | 'disableOutsidePointerEvents'
->;
+type DialogContentTypeElement = DialogContentImplElement;
+interface DialogContentTypeProps
+  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {}
 
 const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogContentTypeProps>(
   (props, forwardedRef) => {
@@ -285,31 +277,29 @@ const DialogContentNonModal = React.forwardRef<DialogContentTypeElement, DialogC
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type FocusScopeProps = Radix.ComponentPropsWithoutRef<typeof FocusScope>;
 type DialogContentImplElement = React.ElementRef<typeof DismissableLayer>;
-type DialogContentImplProps = Radix.MergeProps<
-  Omit<Radix.ComponentPropsWithoutRef<typeof DismissableLayer>, 'onDismiss'>,
-  {
-    /**
-     * When `true`, focus cannot escape the `Content` via keyboard,
-     * pointer, or a programmatic focus.
-     * @defaultValue false
-     */
-    trapFocus?: FocusScopeProps['trapped'];
+type DismissableLayerProps = Radix.ComponentPropsWithoutRef<typeof DismissableLayer>;
+type FocusScopeProps = Radix.ComponentPropsWithoutRef<typeof FocusScope>;
+interface DialogContentImplProps extends Omit<DismissableLayerProps, 'onDismiss'> {
+  /**
+   * When `true`, focus cannot escape the `Content` via keyboard,
+   * pointer, or a programmatic focus.
+   * @defaultValue false
+   */
+  trapFocus?: FocusScopeProps['trapped'];
 
-    /**
-     * Event handler called when auto-focusing on open.
-     * Can be prevented.
-     */
-    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
+  /**
+   * Event handler called when auto-focusing on open.
+   * Can be prevented.
+   */
+  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
 
-    /**
-     * Event handler called when auto-focusing on close.
-     * Can be prevented.
-     */
-    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-  }
->;
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+}
 
 const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogContentImplProps>(
   (props, forwardedRef) => {
@@ -367,7 +357,8 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
 const TITLE_NAME = 'DialogTitle';
 
 type DialogTitleElement = React.ElementRef<typeof Primitive.h2>;
-type DialogTitleProps = Radix.ComponentPropsWithoutRef<typeof Primitive.h2>;
+type PrimitiveHeading2Props = Radix.ComponentPropsWithoutRef<typeof Primitive.h2>;
+interface DialogTitleProps extends PrimitiveHeading2Props {}
 
 const DialogTitle = React.forwardRef<DialogTitleElement, DialogTitleProps>(
   (props, forwardedRef) => {
@@ -385,7 +376,8 @@ DialogTitle.displayName = TITLE_NAME;
 const DESCRIPTION_NAME = 'DialogDescription';
 
 type DialogDescriptionElement = React.ElementRef<typeof Primitive.p>;
-type DialogDescriptionProps = Radix.ComponentPropsWithoutRef<typeof Primitive.p>;
+type PrimitiveParagraphProps = Radix.ComponentPropsWithoutRef<typeof Primitive.p>;
+interface DialogDescriptionProps extends PrimitiveParagraphProps {}
 
 const DialogDescription = React.forwardRef<DialogDescriptionElement, DialogDescriptionProps>(
   (props, forwardedRef) => {
@@ -403,7 +395,7 @@ DialogDescription.displayName = DESCRIPTION_NAME;
 const CLOSE_NAME = 'DialogClose';
 
 type DialogCloseElement = React.ElementRef<typeof Primitive.button>;
-type DialogCloseProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface DialogCloseProps extends PrimitiveButtonProps {}
 
 const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(
   (props, forwardedRef) => {
@@ -487,4 +479,13 @@ export {
   Close,
   //
   LabelWarningProvider,
+};
+export type {
+  DialogProps,
+  DialogTriggerProps,
+  DialogOverlayProps,
+  DialogContentProps,
+  DialogTitleProps,
+  DialogDescriptionProps,
+  DialogCloseProps,
 };

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -33,8 +33,8 @@ const [
 
 const DISMISSABLE_LAYER_NAME = 'DismissableLayer';
 
-type DismissableLayerElement = React.ElementRef<typeof DismissableLayerImpl>;
-type DismissableLayerProps = Radix.ComponentPropsWithoutRef<typeof DismissableLayerImpl>;
+type DismissableLayerElement = DismissableLayerImplElement;
+interface DismissableLayerProps extends DismissableLayerImplProps {}
 
 const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLayerProps>(
   (props, forwardedRef) => {
@@ -61,45 +61,43 @@ DismissableLayer.displayName = DISMISSABLE_LAYER_NAME;
 /* -----------------------------------------------------------------------------------------------*/
 
 type DismissableLayerImplElement = React.ElementRef<typeof Primitive.div>;
-type DismissableLayerImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * When `true`, hover/focus/click interactions will be disabled on elements outside
-     * the `DismissableLayer`. Users will need to click twice on outside elements to
-     * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
-     */
-    disableOutsidePointerEvents?: boolean;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface DismissableLayerImplProps extends PrimitiveDivProps {
+  /**
+   * When `true`, hover/focus/click interactions will be disabled on elements outside
+   * the `DismissableLayer`. Users will need to click twice on outside elements to
+   * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
+   */
+  disableOutsidePointerEvents?: boolean;
 
-    /**
-     * Event handler called when the escape key is down.
-     * Can be prevented.
-     */
-    onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  /**
+   * Event handler called when the escape key is down.
+   * Can be prevented.
+   */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
 
-    /**
-     * Event handler called when the a `pointerdown` event happens outside of the `DismissableLayer`.
-     * Can be prevented.
-     */
-    onPointerDownOutside?: (event: PointerDownOutsideEvent) => void;
+  /**
+   * Event handler called when the a `pointerdown` event happens outside of the `DismissableLayer`.
+   * Can be prevented.
+   */
+  onPointerDownOutside?: (event: PointerDownOutsideEvent) => void;
 
-    /**
-     * Event handler called when the focus moves outside of the `DismissableLayer`.
-     * Can be prevented.
-     */
-    onFocusOutside?: (event: FocusOutsideEvent) => void;
+  /**
+   * Event handler called when the focus moves outside of the `DismissableLayer`.
+   * Can be prevented.
+   */
+  onFocusOutside?: (event: FocusOutsideEvent) => void;
 
-    /**
-     * Event handler called when an interaction happens outside the `DismissableLayer`.
-     * Specifically, when a `pointerdown` event happens outside or focus moves outside of it.
-     * Can be prevented.
-     */
-    onInteractOutside?: (event: PointerDownOutsideEvent | FocusOutsideEvent) => void;
+  /**
+   * Event handler called when an interaction happens outside the `DismissableLayer`.
+   * Specifically, when a `pointerdown` event happens outside or focus moves outside of it.
+   * Can be prevented.
+   */
+  onInteractOutside?: (event: PointerDownOutsideEvent | FocusOutsideEvent) => void;
 
-    /** Callback called when the `DismissableLayer` should be dismissed */
-    onDismiss?: () => void;
-  }
->;
+  /** Callback called when the `DismissableLayer` should be dismissed */
+  onDismiss?: () => void;
+}
 
 const DismissableLayerImpl = React.forwardRef<
   DismissableLayerImplElement,
@@ -364,3 +362,4 @@ export {
   //
   Root,
 };
+export type { DismissableLayerProps };

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -262,31 +262,60 @@ const DropdownMenuRootContent = React.forwardRef<
 
 /* ---------------------------------------------------------------------------------------------- */
 
+type MenuGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Group>;
+interface DropdownMenuGroupProps extends MenuGroupProps {}
 const DropdownMenuGroup = extendPrimitive(MenuPrimitive.Group, {
   displayName: 'DropdownMenuGroup',
 });
+
+type MenuLabelProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Label>;
+interface DropdownMenuLabelProps extends MenuLabelProps {}
 const DropdownMenuLabel = extendPrimitive(MenuPrimitive.Label, {
   displayName: 'DropdownMenuLabel',
 });
+
+type MenuSubTriggerProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.SubTrigger>;
+interface DropdownMenuTriggerItemProps extends MenuSubTriggerProps {}
 const DropdownMenuTriggerItem = extendPrimitive(MenuPrimitive.SubTrigger, {
   displayName: 'DropdownMenuTriggerItem',
 });
+
+type MenuItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Item>;
+interface DropdownMenuItemProps extends MenuItemProps {}
 const DropdownMenuItem = extendPrimitive(MenuPrimitive.Item, { displayName: 'DropdownMenuItem' });
+
+type MenuCheckboxItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.CheckboxItem>;
+interface DropdownMenuCheckboxItemProps extends MenuCheckboxItemProps {}
 const DropdownMenuCheckboxItem = extendPrimitive(MenuPrimitive.CheckboxItem, {
   displayName: 'DropdownMenuCheckboxItem',
 });
+
+type MenuRadioGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.RadioGroup>;
+interface DropdownMenuRadioGroupProps extends MenuRadioGroupProps {}
 const DropdownMenuRadioGroup = extendPrimitive(MenuPrimitive.RadioGroup, {
   displayName: 'DropdownMenuRadioGroup',
 });
+
+type MenuRadioItemProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.RadioItem>;
+interface DropdownMenuRadioItemProps extends MenuRadioItemProps {}
 const DropdownMenuRadioItem = extendPrimitive(MenuPrimitive.RadioItem, {
   displayName: 'DropdownMenuRadioItem',
 });
+
+type MenuItemIndicatorProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.ItemIndicator>;
+interface DropdownMenuItemIndicatorProps extends MenuItemIndicatorProps {}
 const DropdownMenuItemIndicator = extendPrimitive(MenuPrimitive.ItemIndicator, {
   displayName: 'DropdownMenuItemIndicator',
 });
+
+type MenuSeparatorProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Separator>;
+interface DropdownMenuSeparatorProps extends MenuSeparatorProps {}
 const DropdownMenuSeparator = extendPrimitive(MenuPrimitive.Separator, {
   displayName: 'DropdownMenuSeparator',
 });
+
+type MenuArrowProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Arrow>;
+interface DropdownMenuArrowProps extends MenuArrowProps {}
 const DropdownMenuArrow = extendPrimitive(MenuPrimitive.Arrow, {
   displayName: 'DropdownMenuArrow',
 });
@@ -336,4 +365,18 @@ export {
   Separator,
   Arrow,
 };
-export type { DropdownMenuProps, DropdownMenuTriggerProps, DropdownMenuContentProps };
+export type {
+  DropdownMenuProps,
+  DropdownMenuTriggerProps,
+  DropdownMenuContentProps,
+  DropdownMenuGroupProps,
+  DropdownMenuLabelProps,
+  DropdownMenuItemProps,
+  DropdownMenuTriggerItemProps,
+  DropdownMenuCheckboxItemProps,
+  DropdownMenuRadioGroupProps,
+  DropdownMenuRadioItemProps,
+  DropdownMenuItemIndicatorProps,
+  DropdownMenuSeparatorProps,
+  DropdownMenuArrowProps,
+};

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -39,13 +39,13 @@ const [DropdownMenuProvider, useDropdownMenuContext] = createContext<
   DropdownMenuRootContextValue | DropdownMenuSubContextValue
 >(DROPDOWN_MENU_NAME);
 
-type DropdownMenuProps = {
+interface DropdownMenuProps {
   dir?: Direction;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   modal?: boolean;
-};
+}
 
 const DropdownMenu: React.FC<DropdownMenuProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange, dir, modal = true } = props;
@@ -86,13 +86,13 @@ DropdownMenu.displayName = DROPDOWN_MENU_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type DropdownMenuRootProps = {
+interface DropdownMenuRootProps {
   dir?: Direction;
   open: boolean;
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
   modal?: boolean;
-};
+}
 
 const DropdownMenuRoot: React.FC<DropdownMenuRootProps> = (props) => {
   const { children, dir, open, onOpenChange, onOpenToggle, modal = true } = props;
@@ -122,7 +122,8 @@ const DropdownMenuRoot: React.FC<DropdownMenuRootProps> = (props) => {
 const TRIGGER_NAME = 'DropdownMenuTrigger';
 
 type DropdownMenuTriggerElement = React.ElementRef<typeof Primitive.button>;
-type DropdownMenuTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface DropdownMenuTriggerProps extends PrimitiveButtonProps {}
 
 const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, DropdownMenuTriggerProps>(
   (props, forwardedRef) => {
@@ -170,12 +171,11 @@ const CONTENT_NAME = 'DropdownMenuContent';
 
 const ContentContext = React.createContext(false);
 
-type DropdownMenuContentElement = React.ElementRef<
-  typeof DropdownMenuRootContent | typeof MenuPrimitive.Content
->;
-type DropdownMenuContentProps = Radix.ComponentPropsWithoutRef<
-  typeof DropdownMenuRootContent | typeof MenuPrimitive.Content
->;
+type DropdownMenuContentElement =
+  | DropdownMenuRootContentElement
+  | React.ElementRef<typeof MenuPrimitive.Content>;
+type MenuContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+interface DropdownMenuContentProps extends DropdownMenuRootContentProps, MenuContentProps {}
 
 const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, DropdownMenuContentProps>(
   (props, forwardedRef) => {
@@ -207,7 +207,7 @@ DropdownMenuContent.displayName = CONTENT_NAME;
 /* ---------------------------------------------------------------------------------------------- */
 
 type DropdownMenuRootContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-type DropdownMenuRootContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
+interface DropdownMenuRootContentProps extends MenuContentProps {}
 
 const DropdownMenuRootContent = React.forwardRef<
   DropdownMenuRootContentElement,
@@ -336,3 +336,4 @@ export {
   Separator,
   Arrow,
 };
+export type { DropdownMenuProps, DropdownMenuTriggerProps, DropdownMenuContentProps };

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -18,36 +18,34 @@ type FocusableTarget = HTMLElement | { focus(): void };
 const FOCUS_SCOPE_NAME = 'FocusScope';
 
 type FocusScopeElement = React.ElementRef<typeof Primitive.div>;
-type FocusScopeProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * When `true`, tabbing from last item will focus first tabbable
-     * and shift+tab from first item will focus last tababble.
-     * @defaultValue false
-     */
-    loop?: boolean;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface FocusScopeProps extends PrimitiveDivProps {
+  /**
+   * When `true`, tabbing from last item will focus first tabbable
+   * and shift+tab from first item will focus last tababble.
+   * @defaultValue false
+   */
+  loop?: boolean;
 
-    /**
-     * When `true`, focus cannot escape the focus scope via keyboard,
-     * pointer, or a programmatic focus.
-     * @defaultValue false
-     */
-    trapped?: boolean;
+  /**
+   * When `true`, focus cannot escape the focus scope via keyboard,
+   * pointer, or a programmatic focus.
+   * @defaultValue false
+   */
+  trapped?: boolean;
 
-    /**
-     * Event handler called when auto-focusing on mount.
-     * Can be prevented.
-     */
-    onMountAutoFocus?: (event: Event) => void;
+  /**
+   * Event handler called when auto-focusing on mount.
+   * Can be prevented.
+   */
+  onMountAutoFocus?: (event: Event) => void;
 
-    /**
-     * Event handler called when auto-focusing on unmount.
-     * Can be prevented.
-     */
-    onUnmountAutoFocus?: (event: Event) => void;
-  }
->;
+  /**
+   * Event handler called when auto-focusing on unmount.
+   * Can be prevented.
+   */
+  onUnmountAutoFocus?: (event: Event) => void;
+}
 
 const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, forwardedRef) => {
   const {
@@ -318,3 +316,4 @@ export {
   //
   Root,
 };
+export type { FocusScopeProps };

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -24,13 +24,13 @@ type HoverCardContextValue = {
 const [HoverCardProvider, useHoverCardContext] =
   createContext<HoverCardContextValue>(HOVERCARD_NAME);
 
-type HoverCardProps = {
+interface HoverCardProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   openDelay?: number;
   closeDelay?: number;
-};
+}
 
 const HoverCard: React.FC<HoverCardProps> = (props) => {
   const {
@@ -84,7 +84,8 @@ HoverCard.displayName = HOVERCARD_NAME;
 const TRIGGER_NAME = 'HoverCardTrigger';
 
 type HoverCardTriggerElement = React.ElementRef<typeof Primitive.a>;
-type HoverCardTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.a>;
+type PrimitiveLinkProps = Radix.ComponentPropsWithoutRef<typeof Primitive.a>;
+interface HoverCardTriggerProps extends PrimitiveLinkProps {}
 
 const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTriggerProps>(
   (props, forwardedRef) => {
@@ -111,17 +112,14 @@ HoverCardTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'HoverCardContent';
 
-type HoverCardContentElement = React.ElementRef<typeof HoverCardContentImpl>;
-type HoverCardContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof HoverCardContentImpl>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type HoverCardContentElement = HoverCardContentImplElement;
+interface HoverCardContentProps extends HoverCardContentImplProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const HoverCardContent = React.forwardRef<HoverCardContentElement, HoverCardContentProps>(
   (props, forwardedRef) => {
@@ -146,16 +144,14 @@ HoverCardContent.displayName = CONTENT_NAME;
 /* ---------------------------------------------------------------------------------------------- */
 
 type HoverCardContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
-type HoverCardContentImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>,
-  {
-    /**
-     * Whether the `HoverCard` should render in a `Portal`
-     * (default: `true`)
-     */
-    portalled?: boolean;
-  }
->;
+type PopperContentProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>;
+interface HoverCardContentImplProps extends PopperContentProps {
+  /**
+   * Whether the `HoverCard` should render in a `Portal`
+   * (default: `true`)
+   */
+  portalled?: boolean;
+}
 
 const HoverCardContentImpl = React.forwardRef<
   HoverCardContentImplElement,
@@ -206,3 +202,4 @@ export {
   Content,
   Arrow,
 };
+export type { HoverCardProps, HoverCardTriggerProps, HoverCardContentProps };

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -177,6 +177,8 @@ const HoverCardContentImpl = React.forwardRef<
 
 /* ---------------------------------------------------------------------------------------------- */
 
+type PopperArrowProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
+interface HoverCardArrowProps extends PopperArrowProps {}
 const HoverCardArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'HoverCardArrow' });
 
 /* -----------------------------------------------------------------------------------------------*/
@@ -202,4 +204,4 @@ export {
   Content,
   Arrow,
 };
-export type { HoverCardProps, HoverCardTriggerProps, HoverCardContentProps };
+export type { HoverCardProps, HoverCardTriggerProps, HoverCardContentProps, HoverCardArrowProps };

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -15,10 +15,10 @@ type LabelContextValue = { id: string; ref: React.RefObject<HTMLSpanElement> };
 const LabelContext = React.createContext<LabelContextValue | undefined>(undefined);
 
 type LabelElement = React.ElementRef<typeof Primitive.span>;
-type LabelProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  { htmlFor?: string }
->;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface LabelProps extends PrimitiveSpanProps {
+  htmlFor?: string;
+}
 
 const Label = React.forwardRef<LabelElement, LabelProps>((props, forwardedRef) => {
   const { htmlFor, id: idProp, ...labelProps } = props;
@@ -123,3 +123,4 @@ export {
   //
   useLabelContext,
 };
+export type { LabelProps };

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -916,7 +916,6 @@ const RADIO_GROUP_NAME = 'MenuRadioGroup';
 const RadioGroupContext = React.createContext<MenuRadioGroupProps>({} as any);
 
 type MenuRadioGroupElement = React.ElementRef<typeof MenuGroup>;
-type MenuGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuGroup>;
 interface MenuRadioGroupProps extends MenuGroupProps {
   value?: string;
   onValueChange?: (value: string) => void;
@@ -1015,17 +1014,32 @@ MenuItemIndicator.displayName = ITEM_INDICATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const MenuAnchor = extendPrimitive(PopperPrimitive.Anchor, { displayName: 'MenuAnchor' });
+type PopperAnchorProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Anchor>;
+interface MenuAnchorProps extends PopperAnchorProps {}
+const MenuAnchor = extendPrimitive(PopperPrimitive.Anchor, {
+  displayName: 'MenuAnchor',
+});
+
+interface MenuGroupProps extends PrimitiveDivProps {}
 const MenuGroup = extendPrimitive(Primitive.div, {
   defaultProps: { role: 'group' },
   displayName: 'MenuGroup',
 });
+
+interface MenuLabelProps extends PrimitiveDivProps {}
 const MenuLabel = extendPrimitive(Primitive.div, { displayName: 'MenuLabel' });
+
+interface MenuSeparatorProps extends PrimitiveDivProps {}
 const MenuSeparator = extendPrimitive(Primitive.div, {
   defaultProps: { role: 'separator', 'aria-orientation': 'horizontal' },
   displayName: 'MenuSeparator ',
 });
-const MenuArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'MenuArrow' });
+
+type PopperArrowProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
+interface MenuArrowProps extends PopperArrowProps {}
+const MenuArrow = extendPrimitive(PopperPrimitive.Arrow, {
+  displayName: 'MenuArrow',
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -1168,12 +1182,16 @@ export {
 export type {
   MenuProps,
   MenuSubProps,
+  MenuAnchorProps,
   MenuSubTriggerProps,
   MenuContentProps,
   MenuGroupProps,
+  MenuLabelProps,
   MenuItemProps,
   MenuCheckboxItemProps,
   MenuRadioGroupProps,
   MenuRadioItemProps,
   MenuItemIndicatorProps,
+  MenuSeparatorProps,
+  MenuArrowProps,
 };

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -64,12 +64,12 @@ const [MenuProvider, useMenuContext] = createContext<MenuRootContextValue | Menu
   MENU_NAME
 );
 
-type MenuProps = {
+interface MenuProps {
   open?: boolean;
   onOpenChange?(open: boolean): void;
   dir?: Direction;
   modal?: boolean;
-};
+}
 
 const Menu: React.FC<MenuProps> = (props) => {
   const { open = false, children, onOpenChange, modal = true } = props;
@@ -118,10 +118,10 @@ Menu.displayName = MENU_NAME;
 
 const SUB_NAME = 'MenuSub';
 
-type MenuSubProps = {
+interface MenuSubProps {
   open?: boolean;
   onOpenChange?(open: boolean): void;
-};
+}
 
 const MenuSub: React.FC<MenuSubProps> = (props) => {
   const { children, open = false, onOpenChange } = props;
@@ -185,22 +185,19 @@ type MenuContentContextValue = {
 const [MenuContentProvider, useMenuContentContext] =
   createContext<MenuContentContextValue>(CONTENT_NAME);
 
-type MenuContentElement = React.ElementRef<typeof MenuRootContent | typeof MenuSubContent>;
-type MenuContentProps = Radix.MergeProps<
+type MenuContentElement = MenuRootContentElement | MenuSubContentElement;
+/**
+ * We purposefully don't union MenuRootContent and MenuSubContent props here because
+ * they have conflicting prop types. We agreed that we would allow MenuSubContent to
+ * accept props that it would just ignore.
+ */
+interface MenuContentProps extends MenuRootContentProps {
   /**
-   * We purposefully don't union MenuRootContent and MenuSubContent props here because
-   * they have conflicting prop types. We agreed that we would allow MenuSubContent to
-   * accept props that it would just ignore.
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
    */
-  Radix.ComponentPropsWithoutRef<typeof MenuRootContent>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+  forceMount?: true;
+}
 
 const MenuContent = React.forwardRef<MenuContentElement, MenuContentProps>(
   (props, forwardedRef) => {
@@ -224,13 +221,9 @@ const MenuContent = React.forwardRef<MenuContentElement, MenuContentProps>(
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type MenuRootContentElement = React.ElementRef<
-  typeof MenuRootContentModal | typeof MenuRootContentNonModal
->;
-type MenuRootContentProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof MenuRootContentModal | typeof MenuRootContentNonModal>,
-  keyof MenuContentImplPrivateProps
->;
+type MenuRootContentElement = MenuRootContentTypeElement;
+interface MenuRootContentProps
+  extends Omit<MenuRootContentTypeProps, keyof MenuContentImplPrivateProps> {}
 
 const MenuRootContent = React.forwardRef<MenuRootContentElement, MenuRootContentProps>(
   (props, forwardedRef) => {
@@ -243,11 +236,12 @@ const MenuRootContent = React.forwardRef<MenuRootContentElement, MenuRootContent
   }
 );
 
-type MenuRootContentTypeElement = React.ElementRef<typeof MenuContentImpl>;
-type MenuRootContentTypeProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof MenuContentImpl>,
-  'trapFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'
->;
+type MenuRootContentTypeElement = MenuContentImplElement;
+interface MenuRootContentTypeProps
+  extends Omit<
+    MenuContentImplProps,
+    'trapFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'
+  > {}
 
 const MenuRootContentModal = React.forwardRef<MenuRootContentTypeElement, MenuRootContentTypeProps>(
   (props, forwardedRef) => {
@@ -304,18 +298,19 @@ const MenuRootContentNonModal = React.forwardRef<
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type MenuSubContentElement = React.ElementRef<typeof MenuContentImpl>;
-type MenuSubContentProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof MenuContentImpl>,
-  | keyof MenuContentImplPrivateProps
-  | 'align'
-  | 'side'
-  | 'portalled'
-  | 'disabledOutsidePointerEvents'
-  | 'disableOutsideScroll'
-  | 'trapFocus'
-  | 'onCloseAutoFocus'
->;
+type MenuSubContentElement = MenuContentImplElement;
+interface MenuSubContentProps
+  extends Omit<
+    MenuContentImplProps,
+    | keyof MenuContentImplPrivateProps
+    | 'align'
+    | 'side'
+    | 'portalled'
+    | 'disabledOutsidePointerEvents'
+    | 'disableOutsideScroll'
+    | 'trapFocus'
+    | 'onCloseAutoFocus'
+  > {}
 
 const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentProps>(
   (props, forwardedRef) => {
@@ -365,56 +360,55 @@ const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentPro
 
 /* ---------------------------------------------------------------------------------------------- */
 
+type MenuContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
 type FocusScopeProps = Radix.ComponentPropsWithoutRef<typeof FocusScope>;
 type DismissableLayerProps = Radix.ComponentPropsWithoutRef<typeof DismissableLayer>;
 type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
-
-type MenuContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
+type PopperContentProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>;
 type MenuContentImplPrivateProps = {
   onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
   onDismiss?: DismissableLayerProps['onDismiss'];
 };
-type MenuContentImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>,
-  Omit<DismissableLayerProps, 'onDismiss'> &
-    MenuContentImplPrivateProps & {
-      /**
-       * Whether focus should be trapped within the `MenuContent`
-       * (default: false)
-       */
-      trapFocus?: FocusScopeProps['trapped'];
+interface MenuContentImplProps
+  extends MenuContentImplPrivateProps,
+    PopperContentProps,
+    Omit<DismissableLayerProps, 'onDismiss'> {
+  /**
+   * Whether focus should be trapped within the `MenuContent`
+   * (default: false)
+   */
+  trapFocus?: FocusScopeProps['trapped'];
 
-      /**
-       * Event handler called when auto-focusing on close.
-       * Can be prevented.
-       */
-      onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
 
-      /**
-       * Whether scrolling outside the `MenuContent` should be prevented
-       * (default: `false`)
-       */
-      disableOutsideScroll?: boolean;
+  /**
+   * Whether scrolling outside the `MenuContent` should be prevented
+   * (default: `false`)
+   */
+  disableOutsideScroll?: boolean;
 
-      /**
-       * The direction of navigation between menu items.
-       * @defaultValue ltr
-       */
-      dir?: RovingFocusGroupProps['dir'];
+  /**
+   * The direction of navigation between menu items.
+   * @defaultValue ltr
+   */
+  dir?: RovingFocusGroupProps['dir'];
 
-      /**
-       * Whether keyboard navigation should loop around
-       * @defaultValue false
-       */
-      loop?: RovingFocusGroupProps['loop'];
+  /**
+   * Whether keyboard navigation should loop around
+   * @defaultValue false
+   */
+  loop?: RovingFocusGroupProps['loop'];
 
-      /**
-       * Whether the `MenuContent` should render in a `Portal`
-       * (default: `true`)
-       */
-      portalled?: boolean;
-    }
->;
+  /**
+   * Whether the `MenuContent` should render in a `Portal`
+   * (default: `true`)
+   */
+  portalled?: boolean;
+}
 
 const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImplProps>(
   (props, forwardedRef) => {
@@ -617,11 +611,10 @@ MenuContent.displayName = CONTENT_NAME;
 const ITEM_NAME = 'MenuItem';
 const ITEM_SELECT = 'menu.itemSelect';
 
-type MenuItemElement = React.ElementRef<typeof MenuItemImpl>;
-type MenuItemProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof MenuItemImpl>,
-  { onSelect?: (event: Event) => void }
->;
+type MenuItemElement = MenuItemImplElement;
+interface MenuItemProps extends Omit<MenuItemImplProps, 'onSelect'> {
+  onSelect?: (event: Event) => void;
+}
 
 const MenuItem = React.forwardRef<MenuItemElement, MenuItemProps>((props, forwardedRef) => {
   const { disabled = false, onSelect, ...itemProps } = props;
@@ -687,8 +680,8 @@ MenuItem.displayName = ITEM_NAME;
 
 const SUB_TRIGGER_NAME = 'MenuSubTrigger';
 
-type MenuSubTriggerElement = React.ElementRef<typeof MenuItemImpl>;
-type MenuSubTriggerProps = Radix.ComponentPropsWithoutRef<typeof MenuItemImpl>;
+type MenuSubTriggerElement = MenuItemImplElement;
+interface MenuSubTriggerProps extends MenuItemImplProps {}
 
 const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, MenuSubTriggerProps>(
   (props, forwardedRef) => {
@@ -811,13 +804,11 @@ MenuSubTrigger.displayName = SUB_TRIGGER_NAME;
 /* ---------------------------------------------------------------------------------------------- */
 
 type MenuItemImplElement = React.ElementRef<typeof Primitive.div>;
-type MenuItemImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    disabled?: boolean;
-    textValue?: string;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface MenuItemImplProps extends PrimitiveDivProps {
+  disabled?: boolean;
+  textValue?: string;
+}
 
 const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
   (props, forwardedRef) => {
@@ -886,14 +877,11 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
 
 const CHECKBOX_ITEM_NAME = 'MenuCheckboxItem';
 
-type MenuCheckboxItemElement = React.ElementRef<typeof MenuItem>;
-type MenuCheckboxItemProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof MenuItem>,
-  {
-    checked?: boolean;
-    onCheckedChange?: (checked: boolean) => void;
-  }
->;
+type MenuCheckboxItemElement = MenuItemElement;
+interface MenuCheckboxItemProps extends MenuItemProps {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
 
 const MenuCheckboxItem = React.forwardRef<MenuCheckboxItemElement, MenuCheckboxItemProps>(
   (props, forwardedRef) => {
@@ -928,13 +916,11 @@ const RADIO_GROUP_NAME = 'MenuRadioGroup';
 const RadioGroupContext = React.createContext<MenuRadioGroupProps>({} as any);
 
 type MenuRadioGroupElement = React.ElementRef<typeof MenuGroup>;
-type MenuRadioGroupProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof MenuGroup>,
-  {
-    value?: string;
-    onValueChange?: (value: string) => void;
-  }
->;
+type MenuGroupProps = Radix.ComponentPropsWithoutRef<typeof MenuGroup>;
+interface MenuRadioGroupProps extends MenuGroupProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
 
 const MenuRadioGroup = React.forwardRef<MenuRadioGroupElement, MenuRadioGroupProps>(
   (props, forwardedRef) => {
@@ -961,10 +947,9 @@ MenuRadioGroup.displayName = RADIO_GROUP_NAME;
 const RADIO_ITEM_NAME = 'MenuRadioItem';
 
 type MenuRadioItemElement = React.ElementRef<typeof MenuItem>;
-type MenuRadioItemProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof MenuItem>,
-  { value: string }
->;
+interface MenuRadioItemProps extends MenuItemProps {
+  value: string;
+}
 
 const MenuRadioItem = React.forwardRef<MenuRadioItemElement, MenuRadioItemProps>(
   (props, forwardedRef) => {
@@ -1001,16 +986,14 @@ const ITEM_INDICATOR_NAME = 'MenuItemIndicator';
 const ItemIndicatorContext = React.createContext(false);
 
 type MenuItemIndicatorElement = React.ElementRef<typeof Primitive.span>;
-type MenuItemIndicatorProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface MenuItemIndicatorProps extends PrimitiveSpanProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const MenuItemIndicator = React.forwardRef<MenuItemIndicatorElement, MenuItemIndicatorProps>(
   (props, forwardedRef) => {
@@ -1181,4 +1164,16 @@ export {
   ItemIndicator,
   Separator,
   Arrow,
+};
+export type {
+  MenuProps,
+  MenuSubProps,
+  MenuSubTriggerProps,
+  MenuContentProps,
+  MenuGroupProps,
+  MenuItemProps,
+  MenuCheckboxItemProps,
+  MenuRadioGroupProps,
+  MenuRadioItemProps,
+  MenuItemIndicatorProps,
 };

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -36,12 +36,12 @@ type PopoverContextValue = {
 
 const [PopoverProvider, usePopoverContext] = createContext<PopoverContextValue>(POPOVER_NAME);
 
-type PopoverProps = {
+interface PopoverProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   modal?: boolean;
-};
+}
 
 const Popover: React.FC<PopoverProps> = (props) => {
   const { children, open: openProp, defaultOpen, onOpenChange, modal = false } = props;
@@ -81,7 +81,8 @@ Popover.displayName = POPOVER_NAME;
 const ANCHOR_NAME = 'PopoverAnchor';
 
 type PopoverAnchorElement = React.ElementRef<typeof PopperPrimitive.Anchor>;
-type PopoverAnchorProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Anchor>;
+type PopperAnchorProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Anchor>;
+interface PopoverAnchorProps extends PopperAnchorProps {}
 
 const PopoverAnchor = React.forwardRef<PopoverAnchorElement, PopoverAnchorProps>(
   (props, forwardedRef) => {
@@ -106,7 +107,8 @@ PopoverAnchor.displayName = ANCHOR_NAME;
 const TRIGGER_NAME = 'PopoverTrigger';
 
 type PopoverTriggerElement = React.ElementRef<typeof Primitive.button>;
-type PopoverTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface PopoverTriggerProps extends PrimitiveButtonProps {}
 
 const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerProps>(
   (props, forwardedRef) => {
@@ -142,21 +144,15 @@ PopoverTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'PopoverContent';
 
-type PopoverContentElement = React.ElementRef<
-  typeof PopoverContentModal | typeof PopoverContentNonModal
->;
-type PopoverContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof PopoverContentModal | typeof PopoverContentNonModal>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+interface PopoverContentProps extends PopoverContentTypeProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
-const PopoverContent = React.forwardRef<PopoverContentElement, PopoverContentProps>(
+const PopoverContent = React.forwardRef<PopoverContentTypeElement, PopoverContentProps>(
   (props, forwardedRef) => {
     const { forceMount, ...contentProps } = props;
     const context = usePopoverContext(CONTENT_NAME);
@@ -176,20 +172,15 @@ PopoverContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type PopoverContentTypeElement = React.ElementRef<typeof PopoverContentImpl>;
-type PopoverContentTypeProps = Radix.MergeProps<
-  Omit<
-    Radix.ComponentPropsWithoutRef<typeof PopoverContentImpl>,
-    'trapFocus' | 'disableOutsidePointerEvents'
-  >,
-  {
-    /**
-     * Whether the `Popover` should render in a `Portal`
-     * (default: `true`)
-     */
-    portalled?: boolean;
-  }
->;
+type PopoverContentTypeElement = PopoverContentImplElement;
+interface PopoverContentTypeProps
+  extends Omit<PopoverContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {
+  /**
+   * Whether the `Popover` should render in a `Portal`
+   * (default: `true`)
+   */
+  portalled?: boolean;
+}
 
 const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverContentTypeProps>(
   (props, forwardedRef) => {
@@ -295,32 +286,31 @@ const PopoverContentNonModal = React.forwardRef<PopoverContentTypeElement, Popov
 
 /* -----------------------------------------------------------------------------------------------*/
 
+type PopoverContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
 type FocusScopeProps = Radix.ComponentPropsWithoutRef<typeof FocusScope>;
 type DismissableLayerProps = Radix.ComponentPropsWithoutRef<typeof DismissableLayer>;
+type PopperContentProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>;
+interface PopoverContentImplProps
+  extends PopperContentProps,
+    Omit<DismissableLayerProps, 'onDismiss'> {
+  /**
+   * Whether focus should be trapped within the `Popover`
+   * (default: false)
+   */
+  trapFocus?: FocusScopeProps['trapped'];
 
-type PopoverContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
-type PopoverContentImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>,
-  Omit<DismissableLayerProps, 'onDismiss'> & {
-    /**
-     * Whether focus should be trapped within the `Popover`
-     * (default: false)
-     */
-    trapFocus?: FocusScopeProps['trapped'];
+  /**
+   * Event handler called when auto-focusing on open.
+   * Can be prevented.
+   */
+  onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
 
-    /**
-     * Event handler called when auto-focusing on open.
-     * Can be prevented.
-     */
-    onOpenAutoFocus?: FocusScopeProps['onMountAutoFocus'];
-
-    /**
-     * Event handler called when auto-focusing on close.
-     * Can be prevented.
-     */
-    onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
-  }
->;
+  /**
+   * Event handler called when auto-focusing on close.
+   * Can be prevented.
+   */
+  onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+}
 
 const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverContentImplProps>(
   (props, forwardedRef) => {
@@ -384,7 +374,7 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
 const CLOSE_NAME = 'PopoverClose';
 
 type PopoverCloseElement = React.ElementRef<typeof Primitive.button>;
-type PopoverCloseProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface PopoverCloseProps extends PrimitiveButtonProps {}
 
 const PopoverClose = React.forwardRef<PopoverCloseElement, PopoverCloseProps>(
   (props, forwardedRef) => {
@@ -433,4 +423,11 @@ export {
   Content,
   Close,
   Arrow,
+};
+export type {
+  PopoverProps,
+  PopoverAnchorProps,
+  PopoverTriggerProps,
+  PopoverContentProps,
+  PopoverCloseProps,
 };

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -394,7 +394,11 @@ PopoverClose.displayName = CLOSE_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'PopoverArrow' });
+type PopperArrowProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
+interface PopoverArrowProps extends PopperArrowProps {}
+const PopoverArrow = extendPrimitive(PopperPrimitive.Arrow, {
+  displayName: 'PopoverArrow',
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -430,4 +434,5 @@ export type {
   PopoverTriggerProps,
   PopoverContentProps,
   PopoverCloseProps,
+  PopoverArrowProps,
 };

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -41,10 +41,10 @@ Popper.displayName = POPPER_NAME;
 const ANCHOR_NAME = 'PopperAnchor';
 
 type PopperAnchorElement = React.ElementRef<typeof Primitive.div>;
-type PopperAnchorProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { virtualRef?: React.RefObject<Measurable> }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface PopperAnchorProps extends PrimitiveDivProps {
+  virtualRef?: React.RefObject<Measurable>;
+}
 
 const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
   (props, forwardedRef) => {
@@ -82,17 +82,14 @@ const [PopperContentProvider, useContentContext] =
   createContext<PopperContentContextValue>(CONTENT_NAME);
 
 type PopperContentElement = React.ElementRef<typeof Primitive.div>;
-type PopperContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    side?: Side;
-    sideOffset?: number;
-    align?: Align;
-    alignOffset?: number;
-    collisionTolerance?: number;
-    avoidCollisions?: boolean;
-  }
->;
+interface PopperContentProps extends PrimitiveDivProps {
+  side?: Side;
+  sideOffset?: number;
+  align?: Align;
+  alignOffset?: number;
+  collisionTolerance?: number;
+  avoidCollisions?: boolean;
+}
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
   (props, forwardedRef) => {
@@ -172,10 +169,10 @@ PopperContent.displayName = CONTENT_NAME;
 const ARROW_NAME = 'PopperArrow';
 
 type PopperArrowElement = React.ElementRef<typeof ArrowPrimitive.Root>;
-type PopperArrowProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ArrowPrimitive.Root>,
-  { offset?: number }
->;
+type ArrowProps = Radix.ComponentPropsWithoutRef<typeof ArrowPrimitive.Root>;
+interface PopperArrowProps extends ArrowProps {
+  offset?: number;
+}
 
 const PopperArrow = React.forwardRef<PopperArrowElement, PopperArrowProps>(function PopperArrow(
   props,
@@ -262,3 +259,4 @@ export {
   Content,
   Arrow,
 };
+export type { PopperAnchorProps, PopperContentProps, PopperArrowProps };

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -14,10 +14,10 @@ const MAX_Z_INDEX = 2147483647;
 const PORTAL_NAME = 'Portal';
 
 type PortalElement = React.ElementRef<typeof Primitive.div>;
-type PortalProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { containerRef?: React.RefObject<HTMLElement> }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface PortalProps extends PrimitiveDivProps {
+  containerRef?: React.RefObject<HTMLElement>;
+}
 
 const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
   const { containerRef, style, ...portalProps } = props;
@@ -75,3 +75,4 @@ export {
   //
   Root,
 };
+export type { PortalProps };

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -3,18 +3,20 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { useStateMachine } from './useStateMachine';
 
-type PresenceProps = {
+interface PresenceProps {
   present: boolean;
   children: React.ReactElement | ((props: { present: boolean }) => React.ReactElement);
-};
+}
 
 const Presence: React.FC<PresenceProps> = (props) => {
   const { present, children } = props;
   const presence = usePresence(present);
 
-  const child = (typeof children === 'function'
-    ? children({ present: presence.isPresent })
-    : React.Children.only(children)) as React.ReactElement;
+  const child = (
+    typeof children === 'function'
+      ? children({ present: presence.isPresent })
+      : React.Children.only(children)
+  ) as React.ReactElement;
 
   const ref = useComposedRefs(presence.ref, (child as any).ref);
   const forceMount = typeof children === 'function';
@@ -126,3 +128,4 @@ function getAnimationName(styles?: CSSStyleDeclaration) {
 }
 
 export { Presence };
+export type { PresenceProps };

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -3,32 +3,32 @@ import { Slot } from '@radix-ui/react-slot';
 
 const NODES = ['a', 'button', 'div', 'h2', 'h3', 'p', 'img', 'span', 'svg'] as const;
 
-type MergeProps<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2;
-type Primitives = { [E in typeof NODES[number]]: PrimitiveForwardRefComponent<E> };
-
-type PrimitiveForwardRefComponent<E extends React.ElementType> = React.ForwardRefExoticComponent<
-  MergeProps<React.ComponentPropsWithRef<E>, PrimitiveProps>
->;
-
 // Temporary while we await merge of this fix:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55396
-type PropsWithoutRef<P> = P extends { ref?: any } ? Pick<P, Exclude<keyof P, 'ref'>> : P;
+// prettier-ignore
+type PropsWithoutRef<P> = P extends any ? ('ref' extends keyof P ? Pick<P, Exclude<keyof P, 'ref'>> : P) : P;
 type ComponentPropsWithoutRef<T extends React.ElementType> = PropsWithoutRef<
   React.ComponentProps<T>
 >;
+
+type Primitives = { [E in typeof NODES[number]]: PrimitiveForwardRefComponent<E> };
+type PrimitivePropsWithRef<E extends React.ElementType> = React.ComponentPropsWithRef<E> & {
+  asChild?: boolean;
+};
+
+interface PrimitiveForwardRefComponent<E extends React.ElementType>
+  extends React.ForwardRefExoticComponent<PrimitivePropsWithRef<E>> {}
 
 /* -------------------------------------------------------------------------------------------------
  * Primitive
  * -----------------------------------------------------------------------------------------------*/
 
-type PrimitiveProps = { asChild?: boolean };
-
 const Primitive = NODES.reduce(
   (primitive, node) => ({
     ...primitive,
-    [node]: React.forwardRef((props: PrimitiveProps, forwardedRef: any) => {
+    [node]: React.forwardRef((props: PrimitivePropsWithRef<typeof node>, forwardedRef: any) => {
       const { asChild, ...primitiveProps } = props;
-      const Comp = asChild ? Slot : node;
+      const Comp: any = asChild ? Slot : node;
       if ((props as any).as) console.error(AS_ERROR);
       return <Comp {...primitiveProps} ref={forwardedRef} />;
     }),
@@ -47,4 +47,4 @@ export {
   //
   Root,
 };
-export type { MergeProps, ComponentPropsWithoutRef };
+export type { ComponentPropsWithoutRef, PrimitivePropsWithRef };

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -38,7 +38,7 @@ const Primitive = NODES.reduce(
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChild\`. For details, see https://radix-ui.com/`;
+const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChild\`. For details, see https://radix-ui.com/docs/primitives/overview/styling#changing-the-rendered-element`;
 
 const Root = Primitive;
 

--- a/packages/react/primitive/src/extendPrimitive.test.tsx
+++ b/packages/react/primitive/src/extendPrimitive.test.tsx
@@ -11,10 +11,10 @@ import type * as Radix from '@radix-ui/react-primitive';
  * -----------------------------------------------------------------------------------------------*/
 
 type ButtonElement = React.ElementRef<typeof Primitive.button>;
-type ButtonProps = Radix.MergeProps<
-  React.ComponentProps<typeof Primitive.button>,
-  { isDisabled?: boolean }
->;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface ButtonProps extends PrimitiveButtonProps {
+  isDisabled?: boolean;
+}
 
 const Button = React.forwardRef<ButtonElement, ButtonProps>((props, forwardedRef) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react/primitive/src/extendPrimitive.tsx
+++ b/packages/react/primitive/src/extendPrimitive.tsx
@@ -9,7 +9,6 @@ function extendPrimitive<C extends React.ForwardRefExoticComponent<any>>(
     const propsWithDefaults = { ...config.defaultProps, ...props };
     return <Comp {...propsWithDefaults} ref={forwardedRef} />;
   });
-
   Extended.displayName = config.displayName || 'Extended' + Comp.displayName;
   return Extended as React.ForwardRefExoticComponent<React.ComponentProps<C>>;
 }

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -16,14 +16,12 @@ type ProgressContextValue = { value: number | null; max: number };
 const [ProgressProvider, useProgressContext] = createContext<ProgressContextValue>(PROGRESS_NAME);
 
 type ProgressElement = React.ElementRef<typeof Primitive.div>;
-type ProgressProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    value?: number | null | undefined;
-    max?: number;
-    getValueLabel?(value: number, max: number): string;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ProgressProps extends PrimitiveDivProps {
+  value?: number | null | undefined;
+  max?: number;
+  getValueLabel?(value: number, max: number): string;
+}
 
 const Progress = React.forwardRef<ProgressElement, ProgressProps>((props, forwardedRef) => {
   const {
@@ -84,7 +82,7 @@ Progress.propTypes = {
 const INDICATOR_NAME = 'ProgressIndicator';
 
 type ProgressIndicatorElement = React.ElementRef<typeof Primitive.div>;
-type ProgressIndicatorProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ProgressIndicatorProps extends PrimitiveDivProps {}
 
 const ProgressIndicator = React.forwardRef<ProgressIndicatorElement, ProgressIndicatorProps>(
   (props, forwardedRef) => {
@@ -167,3 +165,4 @@ export {
   //
   useProgressState,
 };
+export type { ProgressProps, ProgressIndicatorProps };

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -20,14 +20,12 @@ type RadioContextValue = { checked: boolean; disabled?: boolean };
 const [RadioProvider, useRadioContext] = createContext<RadioContextValue>(RADIO_NAME);
 
 type RadioElement = React.ElementRef<typeof Primitive.button>;
-type RadioProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.button>,
-  {
-    checked?: boolean;
-    required?: boolean;
-    onCheck?(): void;
-  }
->;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface RadioProps extends PrimitiveButtonProps {
+  checked?: boolean;
+  required?: boolean;
+  onCheck?(): void;
+}
 
 const Radio = React.forwardRef<RadioElement, RadioProps>((props, forwardedRef) => {
   const {
@@ -101,16 +99,14 @@ Radio.displayName = RADIO_NAME;
 const INDICATOR_NAME = 'RadioIndicator';
 
 type RadioIndicatorElement = React.ElementRef<typeof Primitive.span>;
-type RadioIndicatorProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+export interface RadioIndicatorProps extends PrimitiveSpanProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const RadioIndicator = React.forwardRef<RadioIndicatorElement, RadioIndicatorProps>(
   (props, forwardedRef) => {
@@ -133,11 +129,12 @@ RadioIndicator.displayName = INDICATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type BubbleInputProps = Omit<Radix.ComponentPropsWithoutRef<'input'>, 'checked'> & {
+type InputProps = Radix.ComponentPropsWithoutRef<'input'>;
+interface BubbleInputProps extends Omit<InputProps, 'checked'> {
   checked: boolean;
   control: HTMLElement | null;
   bubbles: boolean;
-};
+}
 
 const BubbleInput = (props: BubbleInputProps) => {
   const { control, checked, bubbles = true, ...inputProps } = props;
@@ -182,3 +179,4 @@ function getState(checked: boolean) {
 }
 
 export { Radio, RadioIndicator };
+export type { RadioProps };

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -25,21 +25,19 @@ type RadioGroupContextValue = {
 const [RadioGroupProvider, useRadioGroupContext] =
   createContext<RadioGroupContextValue>(RADIO_GROUP_NAME);
 
-type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
 type RadioGroupElement = React.ElementRef<typeof Primitive.div>;
-type RadioGroupProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    name?: RadioGroupContextValue['name'];
-    required?: Radix.ComponentPropsWithoutRef<typeof Radio>['required'];
-    dir?: RovingFocusGroupProps['dir'];
-    orientation?: RovingFocusGroupProps['orientation'];
-    loop?: RovingFocusGroupProps['loop'];
-    defaultValue?: string;
-    value?: RadioGroupContextValue['value'];
-    onValueChange?: RadioGroupContextValue['onValueChange'];
-  }
->;
+type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface RadioGroupProps extends PrimitiveDivProps {
+  name?: RadioGroupContextValue['name'];
+  required?: Radix.ComponentPropsWithoutRef<typeof Radio>['required'];
+  dir?: RovingFocusGroupProps['dir'];
+  orientation?: RovingFocusGroupProps['orientation'];
+  loop?: RovingFocusGroupProps['loop'];
+  defaultValue?: string;
+  value?: RadioGroupContextValue['value'];
+  onValueChange?: RadioGroupContextValue['onValueChange'];
+}
 
 const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>((props, forwardedRef) => {
   const {
@@ -86,10 +84,11 @@ RadioGroup.displayName = RADIO_GROUP_NAME;
 const ITEM_NAME = 'RadioGroupItem';
 
 type RadioGroupItemElement = React.ElementRef<typeof Radio>;
-type RadioGroupItemProps = Radix.MergeProps<
-  Omit<Radix.ComponentPropsWithoutRef<typeof Radio>, 'onCheck'>,
-  { value: string; name?: never }
->;
+type RadioProps = Radix.ComponentPropsWithoutRef<typeof Radio>;
+interface RadioGroupItemProps extends Omit<RadioProps, 'onCheck'> {
+  value: string;
+  name?: never;
+}
 
 const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
   (props, forwardedRef) => {
@@ -143,3 +142,4 @@ export {
   Item,
   Indicator,
 };
+export type { RadioGroupProps, RadioGroupItemProps };

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -85,9 +85,8 @@ const ITEM_NAME = 'RadioGroupItem';
 
 type RadioGroupItemElement = React.ElementRef<typeof Radio>;
 type RadioProps = Radix.ComponentPropsWithoutRef<typeof Radio>;
-interface RadioGroupItemProps extends Omit<RadioProps, 'onCheck'> {
+interface RadioGroupItemProps extends Omit<RadioProps, 'onCheck' | 'name'> {
   value: string;
-  name?: never;
 }
 
 const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -125,7 +125,11 @@ RadioGroupItem.displayName = ITEM_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const RadioGroupIndicator = extendPrimitive(RadioIndicator, { displayName: 'RadioGroupIndicator' });
+type RadioIndicatorProps = Radix.ComponentPropsWithoutRef<typeof RadioIndicator>;
+interface RadioGroupIndicatorProps extends RadioIndicatorProps {}
+const RadioGroupIndicator = extendPrimitive(RadioIndicator, {
+  displayName: 'RadioGroupIndicator',
+});
 
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -142,4 +146,4 @@ export {
   Item,
   Indicator,
 };
-export type { RadioGroupProps, RadioGroupItemProps };
+export type { RadioGroupProps, RadioGroupItemProps, RadioGroupIndicatorProps };

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -28,7 +28,7 @@ const GROUP_NAME = 'RovingFocusGroup';
 type Orientation = React.AriaAttributes['aria-orientation'];
 type Direction = 'ltr' | 'rtl';
 
-type RovingFocusGroupOptions = {
+interface RovingFocusGroupOptions {
   /**
    * The orientation of the group.
    * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
@@ -44,7 +44,7 @@ type RovingFocusGroupOptions = {
    * @defaultValue false
    */
   loop?: boolean;
-};
+}
 
 type RovingContextValue = RovingFocusGroupOptions & {
   currentTabStopId: string | null;
@@ -54,8 +54,8 @@ type RovingContextValue = RovingFocusGroupOptions & {
 
 const [RovingFocusProvider, useRovingFocusContext] = createContext<RovingContextValue>(GROUP_NAME);
 
-type RovingFocusGroupElement = React.ElementRef<typeof RovingFocusGroupImpl>;
-type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroupImpl>;
+type RovingFocusGroupElement = RovingFocusGroupImplElement;
+interface RovingFocusGroupProps extends RovingFocusGroupImplProps {}
 
 const RovingFocusGroup = React.forwardRef<RovingFocusGroupElement, RovingFocusGroupProps>(
   (props, forwardedRef) => (
@@ -72,15 +72,15 @@ RovingFocusGroup.displayName = GROUP_NAME;
 /* -----------------------------------------------------------------------------------------------*/
 
 type RovingFocusGroupImplElement = React.ElementRef<typeof Primitive.div>;
-type RovingFocusGroupImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  RovingFocusGroupOptions & {
-    currentTabStopId?: string | null;
-    defaultCurrentTabStopId?: string;
-    onCurrentTabStopIdChange?: (tabStopId: string | null) => void;
-    onEntryFocus?: (event: Event) => void;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface RovingFocusGroupImplProps
+  extends Omit<PrimitiveDivProps, 'dir'>,
+    RovingFocusGroupOptions {
+  currentTabStopId?: string | null;
+  defaultCurrentTabStopId?: string;
+  onCurrentTabStopIdChange?: (tabStopId: string | null) => void;
+  onEntryFocus?: (event: Event) => void;
+}
 
 const RovingFocusGroupImpl = React.forwardRef<
   RovingFocusGroupImplElement,
@@ -176,13 +176,11 @@ const RovingFocusGroupImpl = React.forwardRef<
 const ITEM_NAME = 'RovingFocusItem';
 
 type RovingFocusItemElement = React.ElementRef<typeof Primitive.span>;
-type RovingFocusItemProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  {
-    focusable?: boolean;
-    active?: boolean;
-  }
->;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface RovingFocusItemProps extends PrimitiveSpanProps {
+  focusable?: boolean;
+  active?: boolean;
+}
 
 const RovingFocusItem = React.forwardRef<RovingFocusItemElement, RovingFocusItemProps>(
   (props, forwardedRef) => {
@@ -298,3 +296,4 @@ export {
   Root,
   Item,
 };
+export type { RovingFocusGroupProps, RovingFocusItemProps };

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -56,14 +56,12 @@ const [ScrollAreaProvider, useScrollAreaContext] =
   createContext<ScrollAreaContextValue>(SCROLL_AREA_NAME);
 
 type ScrollAreaElement = React.ElementRef<typeof Primitive.div>;
-type ScrollAreaProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    type?: ScrollAreaContextValue['type'];
-    dir?: ScrollAreaContextValue['dir'];
-    scrollHideDelay?: number;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ScrollAreaProps extends PrimitiveDivProps {
+  type?: ScrollAreaContextValue['type'];
+  dir?: ScrollAreaContextValue['dir'];
+  scrollHideDelay?: number;
+}
 
 const ScrollArea = React.forwardRef<ScrollAreaElement, ScrollAreaProps>((props, forwardedRef) => {
   const { type = 'hover', scrollHideDelay = 600, ...scrollAreaProps } = props;
@@ -124,7 +122,7 @@ ScrollArea.displayName = SCROLL_AREA_NAME;
 const VIEWPORT_NAME = 'ScrollAreaViewport';
 
 type ScrollAreaViewportElement = React.ElementRef<typeof Primitive.div>;
-type ScrollAreaViewportProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ScrollAreaViewportProps extends PrimitiveDivProps {}
 
 const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAreaViewportProps>(
   (props, forwardedRef) => {
@@ -185,11 +183,10 @@ ScrollAreaViewport.displayName = VIEWPORT_NAME;
 
 const SCROLLBAR_NAME = 'ScrollAreaScrollbar';
 
-type ScrollAreaScrollbarElement = React.ElementRef<typeof ScrollAreaScrollbarVisible>;
-type ScrollAreaScrollbarProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarVisible>,
-  { forceMount?: true }
->;
+type ScrollAreaScrollbarElement = ScrollAreaScrollbarVisibleElement;
+interface ScrollAreaScrollbarProps extends ScrollAreaScrollbarVisibleProps {
+  forceMount?: true;
+}
 
 const ScrollAreaScrollbar = React.forwardRef<ScrollAreaScrollbarElement, ScrollAreaScrollbarProps>(
   (props, forwardedRef) => {
@@ -221,11 +218,10 @@ ScrollAreaScrollbar.displayName = SCROLLBAR_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type ScrollAreaScrollbarHoverElement = React.ElementRef<typeof ScrollAreaScrollbarAuto>;
-type ScrollAreaScrollbarHoverProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarAuto>,
-  { forceMount?: true }
->;
+type ScrollAreaScrollbarHoverElement = ScrollAreaScrollbarAutoElement;
+interface ScrollAreaScrollbarHoverProps extends ScrollAreaScrollbarAutoProps {
+  forceMount?: true;
+}
 
 const ScrollAreaScrollbarHover = React.forwardRef<
   ScrollAreaScrollbarHoverElement,
@@ -266,11 +262,10 @@ const ScrollAreaScrollbarHover = React.forwardRef<
   );
 });
 
-type ScrollAreaScrollbarScrollElement = React.ElementRef<typeof ScrollAreaScrollbarVisible>;
-type ScrollAreaScrollbarScrollProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarVisible>,
-  { forceMount?: true }
->;
+type ScrollAreaScrollbarScrollElement = ScrollAreaScrollbarVisibleElement;
+interface ScrollAreaScrollbarScrollProps extends ScrollAreaScrollbarVisibleProps {
+  forceMount?: true;
+}
 
 const ScrollAreaScrollbarScroll = React.forwardRef<
   ScrollAreaScrollbarScrollElement,
@@ -339,11 +334,10 @@ const ScrollAreaScrollbarScroll = React.forwardRef<
   );
 });
 
-type ScrollAreaScrollbarAutoElement = React.ElementRef<typeof ScrollAreaScrollbarVisible>;
-type ScrollAreaScrollbarAutoProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarVisible>,
-  { forceMount?: true }
->;
+type ScrollAreaScrollbarAutoElement = ScrollAreaScrollbarVisibleElement;
+interface ScrollAreaScrollbarAutoProps extends ScrollAreaScrollbarVisibleProps {
+  forceMount?: true;
+}
 
 const ScrollAreaScrollbarAuto = React.forwardRef<
   ScrollAreaScrollbarAutoElement,
@@ -377,17 +371,11 @@ const ScrollAreaScrollbarAuto = React.forwardRef<
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type ScrollAreaScrollbarVisibleElement = React.ElementRef<
-  typeof ScrollAreaScrollbarX | typeof ScrollAreaScrollbarY
->;
-type ScrollAreaScrollbarVisibleProps = Radix.MergeProps<
-  Omit<
-    | Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarX>
-    | Radix.ComponentPropsWithoutRef<typeof ScrollAreaScrollbarY>,
-    keyof ScrollAreaScrollbarAxisPrivateProps
-  >,
-  { orientation?: 'horizontal' | 'vertical' }
->;
+type ScrollAreaScrollbarVisibleElement = ScrollAreaScrollbarAxisElement;
+interface ScrollAreaScrollbarVisibleProps
+  extends Omit<ScrollAreaScrollbarAxisProps, keyof ScrollAreaScrollbarAxisPrivateProps> {
+  orientation?: 'horizontal' | 'vertical';
+}
 
 const ScrollAreaScrollbarVisible = React.forwardRef<
   ScrollAreaScrollbarVisibleElement,
@@ -482,11 +470,10 @@ type ScrollAreaScrollbarAxisPrivateProps = {
   onDragScroll(pointerPos: number): void;
 };
 
-type ScrollAreaScrollbarAxisElement = React.ElementRef<typeof ScrollAreaScrollbarImpl>;
-type ScrollAreaScrollbarAxisProps = Radix.MergeProps<
-  Omit<ScrollAreaScrollbarImplProps, keyof ScrollAreaScrollbarImplPrivateProps>,
-  ScrollAreaScrollbarAxisPrivateProps
->;
+type ScrollAreaScrollbarAxisElement = ScrollAreaScrollbarImplElement;
+interface ScrollAreaScrollbarAxisProps
+  extends Omit<ScrollAreaScrollbarImplProps, keyof ScrollAreaScrollbarImplPrivateProps>,
+    ScrollAreaScrollbarAxisPrivateProps {}
 
 const ScrollAreaScrollbarX = React.forwardRef<
   ScrollAreaScrollbarAxisElement,
@@ -626,10 +613,9 @@ type ScrollAreaScrollbarImplPrivateProps = {
   onDragScroll(pointerPos: { x: number; y: number }): void;
   onResize(): void;
 };
-type ScrollAreaScrollbarImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  ScrollAreaScrollbarImplPrivateProps
->;
+interface ScrollAreaScrollbarImplProps
+  extends PrimitiveDivProps,
+    ScrollAreaScrollbarImplPrivateProps {}
 
 const ScrollAreaScrollbarImpl = React.forwardRef<
   ScrollAreaScrollbarImplElement,
@@ -733,7 +719,7 @@ const ScrollAreaScrollbarImpl = React.forwardRef<
 const THUMB_NAME = 'ScrollbarThumb';
 
 type ScrollAreaThumbElement = React.ElementRef<typeof Primitive.div>;
-type ScrollAreaThumbProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ScrollAreaThumbProps extends PrimitiveDivProps {}
 
 const ScrollAreaThumb = React.forwardRef<ScrollAreaThumbElement, ScrollAreaThumbProps>(
   (props, forwardedRef) => {
@@ -806,8 +792,8 @@ ScrollAreaThumb.displayName = THUMB_NAME;
 
 const CORNER_NAME = 'ScrollAreaCorner';
 
-type ScrollAreaCornerElement = React.ElementRef<typeof ScrollAreaCornerImpl>;
-type ScrollAreaCornerProps = Radix.ComponentPropsWithoutRef<typeof ScrollAreaCornerImpl>;
+type ScrollAreaCornerElement = ScrollAreaCornerImplElement;
+interface ScrollAreaCornerProps extends ScrollAreaCornerImplProps {}
 
 const ScrollAreaCorner = React.forwardRef<ScrollAreaCornerElement, ScrollAreaCornerProps>(
   (props, forwardedRef) => {
@@ -823,7 +809,7 @@ ScrollAreaCorner.displayName = CORNER_NAME;
 /* -----------------------------------------------------------------------------------------------*/
 
 type ScrollAreaCornerImplElement = React.ElementRef<typeof Primitive.div>;
-type ScrollAreaCornerImplProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ScrollAreaCornerImplProps extends PrimitiveDivProps {}
 
 const ScrollAreaCornerImpl = React.forwardRef<
   ScrollAreaCornerImplElement,
@@ -996,4 +982,11 @@ export {
   Scrollbar,
   Thumb,
   Corner,
+};
+export type {
+  ScrollAreaProps,
+  ScrollAreaViewportProps,
+  ScrollAreaScrollbarProps,
+  ScrollAreaThumbProps,
+  ScrollAreaCornerProps,
 };

--- a/packages/react/separator/src/Separator.tsx
+++ b/packages/react/separator/src/Separator.tsx
@@ -13,20 +13,18 @@ const ORIENTATIONS = ['horizontal', 'vertical'] as const;
 
 type Orientation = typeof ORIENTATIONS[number];
 type SeparatorElement = React.ElementRef<typeof Primitive.div>;
-type SeparatorProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * Either `vertical` or `horizontal`. Defaults to `horizontal`.
-     */
-    orientation?: Orientation;
-    /**
-     * Whether or not the component is purely decorative. When true, accessibility-related attributes
-     * are updated so that that the rendered element is removed from the accessibility tree.
-     */
-    decorative?: boolean;
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface SeparatorProps extends PrimitiveDivProps {
+  /**
+   * Either `vertical` or `horizontal`. Defaults to `horizontal`.
+   */
+  orientation?: Orientation;
+  /**
+   * Whether or not the component is purely decorative. When true, accessibility-related attributes
+   * are updated so that that the rendered element is removed from the accessibility tree.
+   */
+  decorative?: boolean;
+}
 
 const Separator = React.forwardRef<SeparatorElement, SeparatorProps>((props, forwardedRef) => {
   const { decorative, orientation: orientationProp = DEFAULT_ORIENTATION, ...domProps } = props;
@@ -82,3 +80,4 @@ export {
   //
   Root,
 };
+export type { SeparatorProps };

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -39,32 +39,30 @@ type SliderContextValue = {
   max: number;
   values: number[];
   valueIndexToChangeRef: React.MutableRefObject<number>;
-  thumbs: Set<React.ElementRef<typeof SliderThumb>>;
+  thumbs: Set<SliderThumbElement>;
   orientation: SliderProps['orientation'];
 };
 
 const [SliderProvider, useSliderContext] = createContext<SliderContextValue>(SLIDER_NAME);
 
-type SliderElement = React.ElementRef<typeof SliderHorizontal | typeof SliderVertical>;
-type SliderProps = Radix.MergeProps<
-  Omit<
-    Radix.ComponentPropsWithoutRef<typeof SliderHorizontal | typeof SliderVertical>,
-    keyof SliderOrientationPrivateProps
-  >,
-  {
-    name?: string;
-    disabled?: boolean;
-    orientation?: React.AriaAttributes['aria-orientation'];
-    dir?: Direction;
-    min?: number;
-    max?: number;
-    step?: number;
-    minStepsBetweenThumbs?: number;
-    value?: number[];
-    defaultValue?: number[];
-    onValueChange?(value: number[]): void;
-  }
->;
+type SliderElement = SliderHorizontalElement | SliderVerticalElement;
+interface SliderProps
+  extends Omit<
+    SliderHorizontalProps | SliderVerticalProps,
+    keyof SliderOrientationPrivateProps | 'defaultValue'
+  > {
+  name?: string;
+  disabled?: boolean;
+  orientation?: React.AriaAttributes['aria-orientation'];
+  dir?: Direction;
+  min?: number;
+  max?: number;
+  step?: number;
+  minStepsBetweenThumbs?: number;
+  value?: number[];
+  defaultValue?: number[];
+  onValueChange?(value: number[]): void;
+}
 
 const Slider = React.forwardRef<SliderElement, SliderProps>((props, forwardedRef) => {
   const {
@@ -187,24 +185,27 @@ const SliderOrientationContext = React.createContext<{
 }>({} as any);
 
 type SliderOrientationPrivateProps = {
+  min: number;
+  max: number;
   onSlideStart?(value: number): void;
   onSlideMove?(value: number): void;
   onHomeKeyDown(event: React.KeyboardEvent): void;
   onEndKeyDown(event: React.KeyboardEvent): void;
   onStepKeyDown(step: { event: React.KeyboardEvent; direction: number }): void;
 };
-type SliderOrientationProps = Radix.MergeProps<
-  Omit<Radix.ComponentPropsWithoutRef<typeof SliderImpl>, keyof SliderImplPrivateProps>,
-  SliderOrientationPrivateProps & { min: number; max: number }
->;
+interface SliderOrientationProps
+  extends Omit<SliderImplProps, keyof SliderImplPrivateProps>,
+    SliderOrientationPrivateProps {}
 
-type SliderHorizontalElement = React.ElementRef<typeof SliderImpl>;
-type SliderHorizontalProps = SliderOrientationProps & { dir?: Direction };
+type SliderHorizontalElement = SliderImplElement;
+interface SliderHorizontalProps extends SliderOrientationProps {
+  dir?: Direction;
+}
 
 const SliderHorizontal = React.forwardRef<SliderHorizontalElement, SliderHorizontalProps>(
   (props, forwardedRef) => {
     const { min, max, dir, onSlideStart, onSlideMove, onStepKeyDown, ...sliderProps } = props;
-    const [slider, setSlider] = React.useState<React.ElementRef<typeof SliderImpl> | null>(null);
+    const [slider, setSlider] = React.useState<SliderImplElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setSlider(node));
     const rectRef = React.useRef<ClientRect>();
     const direction = useDirection(slider, dir);
@@ -263,13 +264,13 @@ const SliderHorizontal = React.forwardRef<SliderHorizontalElement, SliderHorizon
  * SliderVertical
  * -----------------------------------------------------------------------------------------------*/
 
-type SliderVerticalElement = React.ElementRef<typeof SliderImpl>;
-type SliderVerticalProps = SliderOrientationProps;
+type SliderVerticalElement = SliderImplElement;
+interface SliderVerticalProps extends SliderOrientationProps {}
 
 const SliderVertical = React.forwardRef<SliderVerticalElement, SliderVerticalProps>(
   (props, forwardedRef) => {
     const { min, max, onSlideStart, onSlideMove, onStepKeyDown, ...sliderProps } = props;
-    const sliderRef = React.useRef<React.ElementRef<typeof SliderImpl>>(null);
+    const sliderRef = React.useRef<SliderImplElement>(null);
     const ref = useComposedRefs(forwardedRef, sliderRef);
     const rectRef = React.useRef<ClientRect>();
 
@@ -322,6 +323,7 @@ const SliderVertical = React.forwardRef<SliderVerticalElement, SliderVerticalPro
  * -----------------------------------------------------------------------------------------------*/
 
 type SliderImplElement = React.ElementRef<typeof Primitive.span>;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
 type SliderImplPrivateProps = {
   onSlideStart(event: React.PointerEvent): void;
   onSlideMove(event: React.PointerEvent): void;
@@ -330,10 +332,7 @@ type SliderImplPrivateProps = {
   onEndKeyDown(event: React.KeyboardEvent): void;
   onStepKeyDown(event: React.KeyboardEvent): void;
 };
-type SliderImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  SliderImplPrivateProps
->;
+interface SliderImplProps extends PrimitiveDivProps, SliderImplPrivateProps {}
 
 const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>((props, forwardedRef) => {
   const {
@@ -397,7 +396,8 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>((props, 
 const TRACK_NAME = 'SliderTrack';
 
 type SliderTrackElement = React.ElementRef<typeof Primitive.span>;
-type SliderTrackProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface SliderTrackProps extends PrimitiveSpanProps {}
 
 const SliderTrack = React.forwardRef<SliderTrackElement, SliderTrackProps>(
   (props, forwardedRef) => {
@@ -422,7 +422,7 @@ SliderTrack.displayName = TRACK_NAME;
 const RANGE_NAME = 'SliderRange';
 
 type SliderRangeElement = React.ElementRef<typeof Primitive.span>;
-type SliderRangeProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface SliderRangeProps extends PrimitiveSpanProps {}
 
 const SliderRange = React.forwardRef<SliderRangeElement, SliderRangeProps>(
   (props, forwardedRef) => {
@@ -461,13 +461,13 @@ SliderRange.displayName = RANGE_NAME;
 
 const THUMB_NAME = 'SliderThumb';
 
-type SliderThumbElement = React.ElementRef<typeof SliderThumbImpl>;
-type SliderThumbProps = Omit<Radix.ComponentPropsWithoutRef<typeof SliderThumbImpl>, 'index'>;
+type SliderThumbElement = SliderThumbImplElement;
+interface SliderThumbProps extends Omit<SliderThumbImplProps, 'index'> {}
 
 const SliderThumb = React.forwardRef<SliderThumbElement, SliderThumbProps>(
   (props, forwardedRef) => {
     const { getItems } = useCollection();
-    const [thumb, setThumb] = React.useState<React.ElementRef<typeof SliderThumbImpl> | null>(null);
+    const [thumb, setThumb] = React.useState<SliderThumbImplElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setThumb(node));
     const index = React.useMemo(
       () => (thumb ? getItems().findIndex((item) => item.ref.current === thumb) : -1),
@@ -478,10 +478,9 @@ const SliderThumb = React.forwardRef<SliderThumbElement, SliderThumbProps>(
 );
 
 type SliderThumbImplElement = React.ElementRef<typeof Primitive.span>;
-type SliderThumbImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.span>,
-  { index: number }
->;
+interface SliderThumbImplProps extends PrimitiveSpanProps {
+  index: number;
+}
 
 const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImplProps>(
   (props, forwardedRef) => {
@@ -698,3 +697,4 @@ export {
   Range,
   Thumb,
 };
+export type { SliderProps, SliderTrackProps, SliderRangeProps, SliderThumbProps };

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -5,7 +5,9 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
  * Slot
  * -----------------------------------------------------------------------------------------------*/
 
-type SlotProps = { children?: React.ReactNode };
+interface SlotProps {
+  children?: React.ReactNode;
+}
 
 const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
@@ -42,7 +44,9 @@ Slot.displayName = 'Slot';
  * SlotClone
  * -----------------------------------------------------------------------------------------------*/
 
-type SlotCloneProps = { children: React.ReactNode };
+interface SlotCloneProps {
+  children: React.ReactNode;
+}
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
@@ -114,3 +118,4 @@ export {
   //
   Root,
 };
+export type { SlotProps };

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -16,20 +16,17 @@ import type * as Radix from '@radix-ui/react-primitive';
 
 const SWITCH_NAME = 'Switch';
 
-type SwitchElement = React.ElementRef<typeof Primitive.button>;
-type SwitchProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.button>,
-  {
-    checked?: boolean;
-    defaultChecked?: boolean;
-    required?: boolean;
-    onCheckedChange?(checked: boolean): void;
-  }
->;
-
 type SwitchContextValue = { checked: boolean; disabled?: boolean };
-
 const [SwitchProvider, useSwitchContext] = createContext<SwitchContextValue>(SWITCH_NAME);
+
+type SwitchElement = React.ElementRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface SwitchProps extends PrimitiveButtonProps {
+  checked?: boolean;
+  defaultChecked?: boolean;
+  required?: boolean;
+  onCheckedChange?(checked: boolean): void;
+}
 
 const Switch = React.forwardRef<SwitchElement, SwitchProps>((props, forwardedRef) => {
   const {
@@ -109,7 +106,8 @@ Switch.displayName = SWITCH_NAME;
 const THUMB_NAME = 'SwitchThumb';
 
 type SwitchThumbElement = React.ElementRef<typeof Primitive.span>;
-type SwitchThumbProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface SwitchThumbProps extends PrimitiveSpanProps {}
 
 const SwitchThumb = React.forwardRef<SwitchThumbElement, SwitchThumbProps>(
   (props, forwardedRef) => {
@@ -129,11 +127,12 @@ SwitchThumb.displayName = THUMB_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-type BubbleInputProps = Omit<Radix.ComponentPropsWithoutRef<'input'>, 'checked'> & {
+type InputProps = Radix.ComponentPropsWithoutRef<'input'>;
+interface BubbleInputProps extends Omit<InputProps, 'checked'> {
   checked: boolean;
   control: HTMLElement | null;
   bubbles: boolean;
-};
+}
 
 const BubbleInput = (props: BubbleInputProps) => {
   const { control, checked, bubbles = true, ...inputProps } = props;
@@ -187,3 +186,4 @@ export {
   Root,
   Thumb,
 };
+export type { SwitchProps, SwitchThumbProps };

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -9,8 +9,6 @@ import { useId } from '@radix-ui/react-id';
 
 import type * as Radix from '@radix-ui/react-primitive';
 
-type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
-
 /* -------------------------------------------------------------------------------------------------
  * Tabs
  * -----------------------------------------------------------------------------------------------*/
@@ -29,30 +27,29 @@ type TabsContextValue = {
 const [TabsProvider, useTabsContext] = createContext<TabsContextValue>(TABS_NAME);
 
 type TabsElement = React.ElementRef<typeof Primitive.div>;
-type TabsProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /** The value for the selected tab, if controlled */
-    value?: string;
-    /** The value of the tab to select by default, if uncontrolled */
-    defaultValue?: string;
-    /** A function called when a new tab is selected */
-    onValueChange?: (value: string) => void;
-    /**
-     * The orientation the tabs are layed out.
-     * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
-     * @defaultValue horizontal
-     */
-    orientation?: RovingFocusGroupProps['orientation'];
-    /**
-     * The direction of navigation between toolbar items.
-     * @defaultValue ltr
-     */
-    dir?: RovingFocusGroupProps['dir'];
-    /** Whether a tab is activated automatically or manually (default: automatic) */
-    activationMode?: 'automatic' | 'manual';
-  }
->;
+type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface TabsProps extends PrimitiveDivProps {
+  /** The value for the selected tab, if controlled */
+  value?: string;
+  /** The value of the tab to select by default, if uncontrolled */
+  defaultValue?: string;
+  /** A function called when a new tab is selected */
+  onValueChange?: (value: string) => void;
+  /**
+   * The orientation the tabs are layed out.
+   * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
+   * @defaultValue horizontal
+   */
+  orientation?: RovingFocusGroupProps['orientation'];
+  /**
+   * The direction of navigation between toolbar items.
+   * @defaultValue ltr
+   */
+  dir?: RovingFocusGroupProps['dir'];
+  /** Whether a tab is activated automatically or manually (default: automatic) */
+  activationMode?: 'automatic' | 'manual';
+}
 
 const Tabs = React.forwardRef<TabsElement, TabsProps>((props, forwardedRef) => {
   const {
@@ -94,10 +91,9 @@ Tabs.displayName = TABS_NAME;
 const TAB_LIST_NAME = 'TabsList';
 
 type TabsListElement = React.ElementRef<typeof Primitive.div>;
-type TabsListProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { loop?: RovingFocusGroupProps['loop'] }
->;
+interface TabsListProps extends PrimitiveDivProps {
+  loop?: RovingFocusGroupProps['loop'];
+}
 
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
   const { loop = true, ...listProps } = props;
@@ -118,13 +114,10 @@ TabsList.displayName = TAB_LIST_NAME;
 const TRIGGER_NAME = 'TabsTrigger';
 
 type TabsTriggerElement = React.ElementRef<typeof Primitive.div>;
-type TabsTriggerProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    value: string;
-    disabled?: boolean;
-  }
->;
+interface TabsTriggerProps extends PrimitiveDivProps {
+  value: string;
+  disabled?: boolean;
+}
 
 const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
   (props, forwardedRef) => {
@@ -181,10 +174,9 @@ TabsTrigger.displayName = TRIGGER_NAME;
 const CONTENT_NAME = 'TabsContent';
 
 type TabsContentElement = React.ElementRef<typeof Primitive.div>;
-type TabsContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  { value: string }
->;
+interface TabsContentProps extends PrimitiveDivProps {
+  value: string;
+}
 
 const TabsContent = React.forwardRef<TabsContentElement, TabsContentProps>(
   (props, forwardedRef) => {
@@ -237,3 +229,4 @@ export {
   Trigger,
   Content,
 };
+export type { TabsProps, TabsListProps, TabsTriggerProps, TabsContentProps };

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -13,24 +13,32 @@ import type * as Radix from '@radix-ui/react-primitive';
 
 const TOGGLE_GROUP_NAME = 'ToggleGroup';
 
-type ToggleGroupElement = React.ElementRef<typeof ToggleGroupSingle | typeof ToggleGroupMultiple>;
-type ToggleGroupProps =
-  | ({ type: 'single' } & Radix.ComponentPropsWithoutRef<typeof ToggleGroupSingle>)
-  | ({ type: 'multiple' } & Radix.ComponentPropsWithoutRef<typeof ToggleGroupMultiple>);
+type ToggleGroupElement = ToggleGroupSingleElement | ToggleGroupMultipleElement;
+interface ToggleGroupWithSingleProps extends ToggleGroupSingleProps {
+  type: 'single';
+}
+interface ToggleGroupWithMultipleProps extends ToggleGroupMultipleProps {
+  type: 'multiple';
+}
 
-const ToggleGroup = React.forwardRef<ToggleGroupElement, ToggleGroupProps>(
-  (props, forwardedRef) => {
-    if (props.type === 'single') {
-      return <ToggleGroupSingle {...props} ref={forwardedRef} />;
-    }
+const ToggleGroup = React.forwardRef<
+  ToggleGroupElement,
+  ToggleGroupWithSingleProps | ToggleGroupWithMultipleProps
+>((props, forwardedRef) => {
+  const { type, ...toggleGroupProps } = props;
 
-    if (props.type === 'multiple') {
-      return <ToggleGroupMultiple {...props} ref={forwardedRef} />;
-    }
-
-    throw new Error(`Missing prop \`type\` expected on \`${TOGGLE_GROUP_NAME}\``);
+  if (type === 'single') {
+    const singleProps = toggleGroupProps as ToggleGroupSingleProps;
+    return <ToggleGroupSingle {...singleProps} ref={forwardedRef} />;
   }
-);
+
+  if (type === 'multiple') {
+    const multipleProps = toggleGroupProps as ToggleGroupMultipleProps;
+    return <ToggleGroupMultiple {...multipleProps} ref={forwardedRef} />;
+  }
+
+  throw new Error(`Missing prop \`type\` expected on \`${TOGGLE_GROUP_NAME}\``);
+});
 
 ToggleGroup.displayName = TOGGLE_GROUP_NAME;
 
@@ -45,25 +53,22 @@ type ToggleGroupValueContextValue = {
 const [ToggleGroupValueProvider, useToggleGroupValueContext] =
   createContext<ToggleGroupValueContextValue>(TOGGLE_GROUP_NAME);
 
-type ToggleGroupSingleElement = React.ElementRef<typeof ToggleGroupImpl>;
-type ToggleGroupSingleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ToggleGroupImpl>,
-  {
-    /**
-     * The controlled stateful value of the item that is pressed.
-     */
-    value?: string;
-    /**
-     * The value of the item that is pressed when initially rendered. Use
-     * `defaultValue` if you do not need to control the state of a toggle group.
-     */
-    defaultValue?: string;
-    /**
-     * The callback that fires when the value of the toggle group changes.
-     */
-    onValueChange?(value: string): void;
-  }
->;
+type ToggleGroupSingleElement = ToggleGroupImplElement;
+interface ToggleGroupSingleProps extends ToggleGroupImplProps {
+  /**
+   * The controlled stateful value of the item that is pressed.
+   */
+  value?: string;
+  /**
+   * The value of the item that is pressed when initially rendered. Use
+   * `defaultValue` if you do not need to control the state of a toggle group.
+   */
+  defaultValue?: string;
+  /**
+   * The callback that fires when the value of the toggle group changes.
+   */
+  onValueChange?(value: string): void;
+}
 
 const ToggleGroupSingle = React.forwardRef<ToggleGroupSingleElement, ToggleGroupSingleProps>(
   (props, forwardedRef) => {
@@ -92,25 +97,22 @@ const ToggleGroupSingle = React.forwardRef<ToggleGroupSingleElement, ToggleGroup
   }
 );
 
-type ToggleGroupMultipleElement = React.ElementRef<typeof ToggleGroupImpl>;
-type ToggleGroupMultipleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof ToggleGroupImpl>,
-  {
-    /**
-     * The controlled stateful value of the items that are pressed.
-     */
-    value?: string[];
-    /**
-     * The value of the items that are pressed when initially rendered. Use
-     * `defaultValue` if you do not need to control the state of a toggle group.
-     */
-    defaultValue?: string[];
-    /**
-     * The callback that fires when the state of the toggle group changes.
-     */
-    onValueChange?(value: string[]): void;
-  }
->;
+type ToggleGroupMultipleElement = ToggleGroupImplElement;
+interface ToggleGroupMultipleProps extends ToggleGroupImplProps {
+  /**
+   * The controlled stateful value of the items that are pressed.
+   */
+  value?: string[];
+  /**
+   * The value of the items that are pressed when initially rendered. Use
+   * `defaultValue` if you do not need to control the state of a toggle group.
+   */
+  defaultValue?: string[];
+  /**
+   * The callback that fires when the state of the toggle group changes.
+   */
+  onValueChange?(value: string[]): void;
+}
 
 const ToggleGroupMultiple = React.forwardRef<ToggleGroupMultipleElement, ToggleGroupMultipleProps>(
   (props, forwardedRef) => {
@@ -160,24 +162,22 @@ const [ToggleGroupContext, useToggleGroupContext] =
 
 type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup>;
 type ToggleGroupImplElement = React.ElementRef<typeof Primitive.div>;
-type ToggleGroupImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    /**
-     * Whether the group is disabled from user interaction.
-     * @defaultValue false
-     */
-    disabled?: boolean;
-    /**
-     * Whether the group should maintain roving focus of its buttons.
-     * @defaultValue true
-     */
-    rovingFocus?: boolean;
-    loop?: RovingFocusGroupProps['loop'];
-    orientation?: RovingFocusGroupProps['orientation'];
-    dir?: RovingFocusGroupProps['dir'];
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ToggleGroupImplProps extends PrimitiveDivProps {
+  /**
+   * Whether the group is disabled from user interaction.
+   * @defaultValue false
+   */
+  disabled?: boolean;
+  /**
+   * Whether the group should maintain roving focus of its buttons.
+   * @defaultValue true
+   */
+  rovingFocus?: boolean;
+  loop?: RovingFocusGroupProps['loop'];
+  orientation?: RovingFocusGroupProps['orientation'];
+  dir?: RovingFocusGroupProps['dir'];
+}
 
 const ToggleGroupImpl = React.forwardRef<ToggleGroupImplElement, ToggleGroupImplProps>(
   (props, forwardedRef) => {
@@ -210,11 +210,8 @@ const ToggleGroupImpl = React.forwardRef<ToggleGroupImplElement, ToggleGroupImpl
 
 const ITEM_NAME = 'ToggleGroupItem';
 
-type ToggleGroupItemElement = React.ElementRef<typeof ToggleGroupItemImpl>;
-type ToggleGroupItemProps = Omit<
-  Radix.ComponentPropsWithoutRef<typeof ToggleGroupItemImpl>,
-  'pressed'
->;
+type ToggleGroupItemElement = ToggleGroupItemImplElement;
+interface ToggleGroupItemProps extends Omit<ToggleGroupItemImplProps, 'pressed'> {}
 
 const ToggleGroupItem = React.forwardRef<ToggleGroupItemElement, ToggleGroupItemProps>(
   (props, forwardedRef) => {
@@ -239,15 +236,13 @@ ToggleGroupItem.displayName = ITEM_NAME;
 /* -----------------------------------------------------------------------------------------------*/
 
 type ToggleGroupItemImplElement = React.ElementRef<typeof Toggle>;
-type ToggleGroupItemImplProps = Radix.MergeProps<
-  Omit<Radix.ComponentPropsWithoutRef<typeof Toggle>, 'defaultPressed' | 'onPressedChange'>,
-  {
-    /**
-     * A string value for the toggle group item. All items within a toggle group should use a unique value.
-     */
-    value: string;
-  }
->;
+type ToggleProps = Radix.ComponentPropsWithoutRef<typeof Toggle>;
+interface ToggleGroupItemImplProps extends Omit<ToggleProps, 'defaultPressed' | 'onPressedChange'> {
+  /**
+   * A string value for the toggle group item. All items within a toggle group should use a unique value.
+   */
+  value: string;
+}
 
 const ToggleGroupItemImpl = React.forwardRef<ToggleGroupItemImplElement, ToggleGroupItemImplProps>(
   (props, forwardedRef) => {
@@ -281,3 +276,4 @@ export {
   Root,
   Item,
 };
+export type { ToggleGroupWithSingleProps, ToggleGroupWithMultipleProps, ToggleGroupItemProps };

--- a/packages/react/toggle/src/Toggle.tsx
+++ b/packages/react/toggle/src/Toggle.tsx
@@ -12,25 +12,23 @@ import type * as Radix from '@radix-ui/react-primitive';
 const NAME = 'Toggle';
 
 type ToggleElement = React.ElementRef<typeof Primitive.button>;
-type ToggleProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.button>,
-  {
-    /**
-     * The controlled state of the toggle.
-     */
-    pressed?: boolean;
-    /**
-     * The state of the toggle when initially rendered. Use `defaultPressed`
-     * if you do not need to control the state of the toggle.
-     * @defaultValue false
-     */
-    defaultPressed?: boolean;
-    /**
-     * The callback that fires when the state of the toggle changes.
-     */
-    onPressedChange?(pressed: boolean): void;
-  }
->;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface ToggleProps extends PrimitiveButtonProps {
+  /**
+   * The controlled state of the toggle.
+   */
+  pressed?: boolean;
+  /**
+   * The state of the toggle when initially rendered. Use `defaultPressed`
+   * if you do not need to control the state of the toggle.
+   * @defaultValue false
+   */
+  defaultPressed?: boolean;
+  /**
+   * The callback that fires when the state of the toggle changes.
+   */
+  onPressedChange?(pressed: boolean): void;
+}
 
 const Toggle = React.forwardRef<ToggleElement, ToggleProps>((props, forwardedRef) => {
   const { pressed: pressedProp, defaultPressed = false, onPressedChange, ...buttonProps } = props;
@@ -69,3 +67,4 @@ export {
   //
   Root,
 };
+export type { ToggleProps };

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -19,14 +19,12 @@ type ToolbarContextValue = { orientation: RovingFocusGroupProps['orientation'] }
 const [ToolbarProvider, useToolbarContext] = createContext<ToolbarContextValue>(TOOLBAR_NAME);
 
 type ToolbarElement = React.ElementRef<typeof Primitive.div>;
-type ToolbarProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof Primitive.div>,
-  {
-    orientation?: RovingFocusGroupProps['orientation'];
-    loop?: RovingFocusGroupProps['loop'];
-    dir?: RovingFocusGroupProps['dir'];
-  }
->;
+type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
+interface ToolbarProps extends PrimitiveDivProps {
+  orientation?: RovingFocusGroupProps['orientation'];
+  loop?: RovingFocusGroupProps['loop'];
+  dir?: RovingFocusGroupProps['dir'];
+}
 
 const Toolbar = React.forwardRef<ToolbarElement, ToolbarProps>((props, forwardedRef) => {
   const { orientation = 'horizontal', dir = 'ltr', loop = true, ...toolbarProps } = props;
@@ -46,7 +44,8 @@ const Toolbar = React.forwardRef<ToolbarElement, ToolbarProps>((props, forwarded
 const SEPARATOR_NAME = 'ToolbarSeparator';
 
 type ToolbarSeparatorElement = React.ElementRef<typeof SeparatorPrimitive.Root>;
-type ToolbarSeparatorProps = Radix.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>;
+type SeparatorProps = Radix.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>;
+interface ToolbarSeparatorProps extends SeparatorProps {}
 
 const ToolbarSeparator = React.forwardRef<ToolbarSeparatorElement, ToolbarSeparatorProps>(
   (props, forwardedRef) => {
@@ -70,7 +69,8 @@ ToolbarSeparator.displayName = SEPARATOR_NAME;
 const BUTTON_NAME = 'ToolbarButton';
 
 type ToolbarButtonElement = React.ElementRef<typeof Primitive.button>;
-type ToolbarButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface ToolbarButtonProps extends PrimitiveButtonProps {}
 
 const ToolbarButton = React.forwardRef<ToolbarButtonElement, ToolbarButtonProps>(
   (props, forwardedRef) => (
@@ -89,9 +89,8 @@ ToolbarButton.displayName = BUTTON_NAME;
 const LINK_NAME = 'ToolbarLink';
 
 type ToolbarLinkElement = React.ElementRef<typeof Primitive.a>;
-type ToolbarLinkProps = Radix.ComponentPropsWithoutRef<typeof Primitive.a> & {
-  disabled?: boolean;
-};
+type PrimitiveLinkProps = Radix.ComponentPropsWithoutRef<typeof Primitive.a>;
+interface ToolbarLinkProps extends PrimitiveLinkProps {}
 
 const ToolbarLink = React.forwardRef<ToolbarLinkElement, ToolbarLinkProps>(
   (props, forwardedRef) => (
@@ -101,9 +100,7 @@ const ToolbarLink = React.forwardRef<ToolbarLinkElement, ToolbarLinkProps>(
         {...props}
         ref={forwardedRef}
         onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-          if (event.key === ' ') {
-            event.currentTarget.click();
-          }
+          if (event.key === ' ') event.currentTarget.click();
         })}
       />
     </RovingFocusItem>
@@ -119,7 +116,8 @@ ToolbarLink.displayName = LINK_NAME;
 const TOGGLE_GROUP_NAME = 'ToolbarToggleGroup';
 
 type ToolbarToggleGroupElement = React.ElementRef<typeof ToggleGroupPrimitive.Root>;
-type ToolbarToggleGroupProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>;
+type ToggleGroupProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>;
+type ToolbarToggleGroupProps = ToggleGroupProps;
 
 const ToolbarToggleGroup = React.forwardRef<ToolbarToggleGroupElement, ToolbarToggleGroupProps>(
   (props, forwardedRef) => {
@@ -144,7 +142,8 @@ ToolbarToggleGroup.displayName = TOGGLE_GROUP_NAME;
 const TOGGLE_ITEM_NAME = 'ToolbarToggleItem';
 
 type ToolbarToggleItemElement = React.ElementRef<typeof ToggleGroupPrimitive.Item>;
-type ToolbarToggleItemProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>;
+type ToggleGroupItemProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>;
+interface ToolbarToggleItemProps extends ToggleGroupItemProps {}
 
 const ToolbarToggleItem = React.forwardRef<ToolbarToggleItemElement, ToolbarToggleItemProps>(
   (props, forwardedRef) => (
@@ -179,4 +178,12 @@ export {
   Link,
   ToggleGroup,
   ToggleItem,
+};
+export type {
+  ToolbarProps,
+  ToolbarSeparatorProps,
+  ToolbarButtonProps,
+  ToolbarLinkProps,
+  ToolbarToggleGroupProps,
+  ToolbarToggleItemProps,
 };

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -117,6 +117,7 @@ const TOGGLE_GROUP_NAME = 'ToolbarToggleGroup';
 
 type ToolbarToggleGroupElement = React.ElementRef<typeof ToggleGroupPrimitive.Root>;
 type ToggleGroupProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>;
+// ToggleGroup props are a union of interfaces so we use a type alias because interfaces cannot extend unions.
 type ToolbarToggleGroupProps = ToggleGroupProps;
 
 const ToolbarToggleGroup = React.forwardRef<ToolbarToggleGroupElement, ToolbarToggleGroupProps>(

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -36,8 +36,8 @@ type TooltipContextValue = {
   contentId: string;
   open: boolean;
   stateAttribute: StateAttribute;
-  trigger: React.ElementRef<typeof TooltipTrigger> | null;
-  onTriggerChange(trigger: React.ElementRef<typeof TooltipTrigger> | null): void;
+  trigger: TooltipTriggerElement | null;
+  onTriggerChange(trigger: TooltipTriggerElement | null): void;
   onFocus(): void;
   onOpen(): void;
   onClose(): void;
@@ -45,7 +45,7 @@ type TooltipContextValue = {
 
 const [TooltipProvider, useTooltipContext] = createContext<TooltipContextValue>(TOOLTIP_NAME);
 
-type TooltipProps = {
+interface TooltipProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -61,7 +61,7 @@ type TooltipProps = {
    * (default: 300)
    */
   skipDelayDuration?: number;
-};
+}
 
 const Tooltip: React.FC<TooltipProps> = (props) => {
   const {
@@ -164,7 +164,8 @@ Tooltip.displayName = TOOLTIP_NAME;
 const TRIGGER_NAME = 'TooltipTrigger';
 
 type TooltipTriggerElement = React.ElementRef<typeof Primitive.button>;
-type TooltipTriggerProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface TooltipTriggerProps extends PrimitiveButtonProps {}
 
 const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerProps>(
   (props, forwardedRef) => {
@@ -202,17 +203,14 @@ TooltipTrigger.displayName = TRIGGER_NAME;
 
 const CONTENT_NAME = 'TooltipContent';
 
-type TooltipContentElement = React.ElementRef<typeof TooltipContentImpl>;
-type TooltipContentProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof TooltipContentImpl>,
-  {
-    /**
-     * Used to force mounting when more control is needed. Useful when
-     * controlling animation with React animation libraries.
-     */
-    forceMount?: true;
-  }
->;
+type TooltipContentElement = TooltipContentImplElement;
+interface TooltipContentProps extends TooltipContentImplProps {
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
+}
 
 const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentProps>(
   (props, forwardedRef) => {
@@ -227,21 +225,19 @@ const TooltipContent = React.forwardRef<TooltipContentElement, TooltipContentPro
 );
 
 type TooltipContentImplElement = React.ElementRef<typeof PopperPrimitive.Content>;
-type TooltipContentImplProps = Radix.MergeProps<
-  Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>,
-  {
-    /**
-     * A more descriptive label for accessibility purpose
-     */
-    'aria-label'?: string;
+type PopperContentProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>;
+interface TooltipContentImplProps extends PopperContentProps {
+  /**
+   * A more descriptive label for accessibility purpose
+   */
+  'aria-label'?: string;
 
-    /**
-     * Whether the Tooltip should render in a Portal
-     * (default: `true`)
-     */
-    portalled?: boolean;
-  }
->;
+  /**
+   * Whether the Tooltip should render in a Portal
+   * (default: `true`)
+   */
+  portalled?: boolean;
+}
 
 const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipContentImplProps>(
   (props, forwardedRef) => {
@@ -323,3 +319,4 @@ export {
   Content,
   Arrow,
 };
+export type { TooltipProps, TooltipTriggerProps, TooltipContentProps };

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -275,7 +275,11 @@ TooltipContent.displayName = CONTENT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const TooltipArrow = extendPrimitive(PopperPrimitive.Arrow, { displayName: 'TooltipArrow' });
+type PopperArrowProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
+interface TooltipArrowProps extends PopperArrowProps {}
+const TooltipArrow = extendPrimitive(PopperPrimitive.Arrow, {
+  displayName: 'TooltipArrow',
+});
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -319,4 +323,4 @@ export {
   Content,
   Arrow,
 };
-export type { TooltipProps, TooltipTriggerProps, TooltipContentProps };
+export type { TooltipProps, TooltipTriggerProps, TooltipContentProps, TooltipArrowProps };

--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -10,7 +10,8 @@ import type * as Radix from '@radix-ui/react-primitive';
 const NAME = 'VisuallyHidden';
 
 type VisuallyHiddenElement = React.ElementRef<typeof Primitive.span>;
-type VisuallyHiddenProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+type PrimitiveSpanProps = Radix.ComponentPropsWithoutRef<typeof Primitive.span>;
+interface VisuallyHiddenProps extends PrimitiveSpanProps {}
 
 const VisuallyHidden = React.forwardRef<VisuallyHiddenElement, VisuallyHiddenProps>(
   (props, forwardedRef) => {
@@ -48,3 +49,4 @@ export {
   //
   Root,
 };
+export type { VisuallyHiddenProps };


### PR DESCRIPTION
------------------

**Note**: PR will be easier to review with hidden whitespace changes.

------------------

- Reduces our type def file sizes by favouring interfaces for our prop types. Further reading: https://github.com/microsoft/TypeScript/issues/37151#issuecomment-681927567
- Uses `React.ElementRef<>` for external components only
- Uses `Radix.ComponentPropsWithRef<>` for external components only

_Those last two bullets weren't required to fix the inlining but I find it made the types easier to digest. Happy to change this though if others don't agree._

An additional benefit of using interfaces is that we no longer need the `MergeProps` utility because interfaces will moan when there are conflicts in an extended interface. Therefore, we can `Omit` specific conflicts manually inline only when needed. This [TS playground](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgPIggSXNeTkDeAUMqcjAPYUBcyAzmFKAOYDcRAvu0QPQ-IAVABbA6yaFApQxdCsgDuKANYgK8hSgwQAJsjByABqgC2wMAB50WHLEQQANMgDklCk4B8BoqEi38A+QpsXzwUCAAPSBBtMStg3DtCEjJXWhAAV2MAI2h2DiIiMABPAAcUKwFSlABeJLJyKloGJhA2Tm4+QRExbQoIOhAnMHEoSSh6OUVkYGMSgBtgBDM5ovFo5HSShTMhZAMMADdoAz0qhREEXdFz1amtbR09IRQDAFloZggABUkSuhP0mBgHMAHSFM4BCiVMrIWoVM4AMjqKUayAy2VynAKCAoIAYIzGABF0i1mABhXF0TIlIG42iQ6E1ZGkVLIACM7SAA
) shows the advantage over using `type`s.

