### PR TITLE
[Toolbar] Replace inconsistent type alias prop type

### DIFF
--- a/.yarn/versions/2ab89854.yml
+++ b/.yarn/versions/2ab89854.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/src/Accordion.stories.tsx
+++ b/packages/react/accordion/src/Accordion.stories.tsx
@@ -7,7 +7,6 @@ import {
   AccordionHeader,
   AccordionTrigger,
   AccordionContent,
-  AccordionSingleProps,
 } from './Accordion';
 
 export default { title: 'Components/Accordion' };
@@ -677,7 +676,3 @@ const contentAttrClass = css({
   display: 'block',
   ...styles,
 });
-
-export function Accordion2(props: AccordionSingleProps) {
-  return <Accordion {...props} type="single" collapsible />;
-}

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -13,28 +13,28 @@ import type * as Radix from '@radix-ui/react-primitive';
 
 const TOGGLE_GROUP_NAME = 'ToggleGroup';
 
-type ToggleGroupElement = ToggleGroupSingleElement | ToggleGroupMultipleElement;
-interface ToggleGroupWithSingleProps extends ToggleGroupSingleProps {
+type ToggleGroupElement = ToggleGroupImplSingleElement | ToggleGroupImplMultipleElement;
+interface ToggleGroupSingleProps extends ToggleGroupImplSingleProps {
   type: 'single';
 }
-interface ToggleGroupWithMultipleProps extends ToggleGroupMultipleProps {
+interface ToggleGroupMultipleProps extends ToggleGroupImplMultipleProps {
   type: 'multiple';
 }
 
 const ToggleGroup = React.forwardRef<
   ToggleGroupElement,
-  ToggleGroupWithSingleProps | ToggleGroupWithMultipleProps
+  ToggleGroupSingleProps | ToggleGroupMultipleProps
 >((props, forwardedRef) => {
   const { type, ...toggleGroupProps } = props;
 
   if (type === 'single') {
-    const singleProps = toggleGroupProps as ToggleGroupSingleProps;
-    return <ToggleGroupSingle {...singleProps} ref={forwardedRef} />;
+    const singleProps = toggleGroupProps as ToggleGroupImplSingleProps;
+    return <ToggleGroupImplSingle {...singleProps} ref={forwardedRef} />;
   }
 
   if (type === 'multiple') {
-    const multipleProps = toggleGroupProps as ToggleGroupMultipleProps;
-    return <ToggleGroupMultiple {...multipleProps} ref={forwardedRef} />;
+    const multipleProps = toggleGroupProps as ToggleGroupImplMultipleProps;
+    return <ToggleGroupImplMultiple {...multipleProps} ref={forwardedRef} />;
   }
 
   throw new Error(`Missing prop \`type\` expected on \`${TOGGLE_GROUP_NAME}\``);
@@ -53,8 +53,8 @@ type ToggleGroupValueContextValue = {
 const [ToggleGroupValueProvider, useToggleGroupValueContext] =
   createContext<ToggleGroupValueContextValue>(TOGGLE_GROUP_NAME);
 
-type ToggleGroupSingleElement = ToggleGroupImplElement;
-interface ToggleGroupSingleProps extends ToggleGroupImplProps {
+type ToggleGroupImplSingleElement = ToggleGroupImplElement;
+interface ToggleGroupImplSingleProps extends ToggleGroupImplProps {
   /**
    * The controlled stateful value of the item that is pressed.
    */
@@ -70,35 +70,36 @@ interface ToggleGroupSingleProps extends ToggleGroupImplProps {
   onValueChange?(value: string): void;
 }
 
-const ToggleGroupSingle = React.forwardRef<ToggleGroupSingleElement, ToggleGroupSingleProps>(
-  (props, forwardedRef) => {
-    const {
-      value: valueProp,
-      defaultValue,
-      onValueChange = () => {},
-      ...toggleGroupSingleProps
-    } = props;
+const ToggleGroupImplSingle = React.forwardRef<
+  ToggleGroupImplSingleElement,
+  ToggleGroupImplSingleProps
+>((props, forwardedRef) => {
+  const {
+    value: valueProp,
+    defaultValue,
+    onValueChange = () => {},
+    ...toggleGroupSingleProps
+  } = props;
 
-    const [value, setValue] = useControllableState({
-      prop: valueProp,
-      defaultProp: defaultValue,
-      onChange: onValueChange,
-    });
+  const [value, setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue,
+    onChange: onValueChange,
+  });
 
-    return (
-      <ToggleGroupValueProvider
-        value={value ? [value] : []}
-        onItemActivate={setValue}
-        onItemDeactivate={React.useCallback(() => setValue(''), [setValue])}
-      >
-        <ToggleGroupImpl {...toggleGroupSingleProps} ref={forwardedRef} />
-      </ToggleGroupValueProvider>
-    );
-  }
-);
+  return (
+    <ToggleGroupValueProvider
+      value={value ? [value] : []}
+      onItemActivate={setValue}
+      onItemDeactivate={React.useCallback(() => setValue(''), [setValue])}
+    >
+      <ToggleGroupImpl {...toggleGroupSingleProps} ref={forwardedRef} />
+    </ToggleGroupValueProvider>
+  );
+});
 
-type ToggleGroupMultipleElement = ToggleGroupImplElement;
-interface ToggleGroupMultipleProps extends ToggleGroupImplProps {
+type ToggleGroupImplMultipleElement = ToggleGroupImplElement;
+interface ToggleGroupImplMultipleProps extends ToggleGroupImplProps {
   /**
    * The controlled stateful value of the items that are pressed.
    */
@@ -114,42 +115,43 @@ interface ToggleGroupMultipleProps extends ToggleGroupImplProps {
   onValueChange?(value: string[]): void;
 }
 
-const ToggleGroupMultiple = React.forwardRef<ToggleGroupMultipleElement, ToggleGroupMultipleProps>(
-  (props, forwardedRef) => {
-    const {
-      value: valueProp,
-      defaultValue,
-      onValueChange = () => {},
-      ...toggleGroupMultipleProps
-    } = props;
+const ToggleGroupImplMultiple = React.forwardRef<
+  ToggleGroupImplMultipleElement,
+  ToggleGroupImplMultipleProps
+>((props, forwardedRef) => {
+  const {
+    value: valueProp,
+    defaultValue,
+    onValueChange = () => {},
+    ...toggleGroupMultipleProps
+  } = props;
 
-    const [value = [], setValue] = useControllableState({
-      prop: valueProp,
-      defaultProp: defaultValue,
-      onChange: onValueChange,
-    });
+  const [value = [], setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue,
+    onChange: onValueChange,
+  });
 
-    const handleButtonActivate = React.useCallback(
-      (itemValue) => setValue((prevValue = []) => [...prevValue, itemValue]),
-      [setValue]
-    );
+  const handleButtonActivate = React.useCallback(
+    (itemValue) => setValue((prevValue = []) => [...prevValue, itemValue]),
+    [setValue]
+  );
 
-    const handleButtonDeactivate = React.useCallback(
-      (itemValue) => setValue((prevValue = []) => prevValue.filter((value) => value !== itemValue)),
-      [setValue]
-    );
+  const handleButtonDeactivate = React.useCallback(
+    (itemValue) => setValue((prevValue = []) => prevValue.filter((value) => value !== itemValue)),
+    [setValue]
+  );
 
-    return (
-      <ToggleGroupValueProvider
-        value={value}
-        onItemActivate={handleButtonActivate}
-        onItemDeactivate={handleButtonDeactivate}
-      >
-        <ToggleGroupImpl {...toggleGroupMultipleProps} ref={forwardedRef} />
-      </ToggleGroupValueProvider>
-    );
-  }
-);
+  return (
+    <ToggleGroupValueProvider
+      value={value}
+      onItemActivate={handleButtonActivate}
+      onItemDeactivate={handleButtonDeactivate}
+    >
+      <ToggleGroupImpl {...toggleGroupMultipleProps} ref={forwardedRef} />
+    </ToggleGroupValueProvider>
+  );
+});
 
 ToggleGroup.displayName = TOGGLE_GROUP_NAME;
 
@@ -276,4 +278,4 @@ export {
   Root,
   Item,
 };
-export type { ToggleGroupWithSingleProps, ToggleGroupWithMultipleProps, ToggleGroupItemProps };
+export type { ToggleGroupSingleProps, ToggleGroupMultipleProps, ToggleGroupItemProps };

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -117,22 +117,23 @@ const TOGGLE_GROUP_NAME = 'ToolbarToggleGroup';
 
 type ToolbarToggleGroupElement = React.ElementRef<typeof ToggleGroupPrimitive.Root>;
 type ToggleGroupProps = Radix.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>;
-// ToggleGroup props are a union of interfaces so we use a type alias because interfaces cannot extend unions.
-type ToolbarToggleGroupProps = ToggleGroupProps;
+interface ToolbarToggleGroupSingleProps extends Extract<ToggleGroupProps, { type: 'single' }> {}
+interface ToolbarToggleGroupMultipleProps extends Extract<ToggleGroupProps, { type: 'multiple' }> {}
 
-const ToolbarToggleGroup = React.forwardRef<ToolbarToggleGroupElement, ToolbarToggleGroupProps>(
-  (props, forwardedRef) => {
-    const context = useToolbarContext(TOGGLE_GROUP_NAME);
-    return (
-      <ToggleGroupPrimitive.Root
-        data-orientation={context.orientation}
-        {...props}
-        ref={forwardedRef}
-        rovingFocus={false}
-      />
-    );
-  }
-);
+const ToolbarToggleGroup = React.forwardRef<
+  ToolbarToggleGroupElement,
+  ToolbarToggleGroupSingleProps | ToolbarToggleGroupMultipleProps
+>((props, forwardedRef) => {
+  const context = useToolbarContext(TOGGLE_GROUP_NAME);
+  return (
+    <ToggleGroupPrimitive.Root
+      data-orientation={context.orientation}
+      {...props}
+      ref={forwardedRef}
+      rovingFocus={false}
+    />
+  );
+});
 
 ToolbarToggleGroup.displayName = TOGGLE_GROUP_NAME;
 
@@ -185,6 +186,7 @@ export type {
   ToolbarSeparatorProps,
   ToolbarButtonProps,
   ToolbarLinkProps,
-  ToolbarToggleGroupProps,
+  ToolbarToggleGroupSingleProps,
+  ToolbarToggleGroupMultipleProps,
   ToolbarToggleItemProps,
 };


### PR DESCRIPTION
Realised we could avoid this when I was reviewing [Benoit's recent PR](https://github.com/radix-ui/primitives/pull/842#issuecomment-913781362).

It also bugged me that we had the `With` naming so I rejigged some of the naming conventions for the implementation components.