### PR TITLE
[AlertDialog] Omit `onInteractOutside`

### DIFF
--- a/.yarn/versions/d22c18e8.yml
+++ b/.yarn/versions/d22c18e8.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -68,7 +68,8 @@ const [AlertDialogContentProvider, useAlertDialogContentContext] =
 
 type AlertDialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
 type DialogContentProps = Radix.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
-interface AlertDialogContentProps extends Omit<DialogContentProps, 'onPointerDownOutside'> {}
+interface AlertDialogContentProps
+  extends Omit<DialogContentProps, 'onPointerDownOutside' | 'onInteractOutside'> {}
 
 const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
   (props, forwardedRef) => {
@@ -94,6 +95,7 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
               cancelRef.current?.focus({ preventScroll: true });
             })}
             onPointerDownOutside={(event) => event.preventDefault()}
+            onInteractOutside={(event) => event.preventDefault()}
           >
             {/**
              * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`


### PR DESCRIPTION
I noticed that `onInteractOutside` was still valid in types and could be passed. This change brings it inline with what the docs communicate.