### PR TITLE
[Presence] Get `animationName` consistently

### DIFF
--- a/.yarn/versions/b46af52c.yml
+++ b/.yarn/versions/b46af52c.yml
@@ -1,0 +1,18 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -28,6 +28,35 @@ export const WithMultipleOpenAndCloseAnimations = () => (
   <Animation className={multipleOpenAndCloseAnimationsClass} />
 );
 
+export const WithDeferredMountAnimation = () => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const timerRef = React.useRef(0);
+  const [open, setOpen] = React.useState(false);
+  const [animate, setAnimate] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) {
+      timerRef.current = window.setTimeout(() => {
+        setAnimate(true);
+      }, 150);
+    } else {
+      setAnimate(false);
+      window.clearTimeout(timerRef.current);
+    }
+  }, [open]);
+
+  return (
+    <>
+      <Toggles nodeRef={ref} open={open} onOpenChange={setOpen} />
+      <Presence present={open}>
+        <div className={animate ? mountAnimationClass : noAnimationClass} ref={ref}>
+          Content
+        </div>
+      </Presence>
+    </>
+  );
+};
+
 function Animation(props: React.ComponentProps<'div'>) {
   const ref = React.useRef<HTMLDivElement>(null);
   const [open, setOpen] = React.useState(false);
@@ -92,6 +121,10 @@ const slideUp = css.keyframes({
 const slideDown = css.keyframes({
   from: { transform: 'translateY(0)' },
   to: { transform: 'translateY(30px)' },
+});
+
+const noAnimationClass = css({
+  animation: 'none',
 });
 
 const mountAnimationClass = css({

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -36,9 +36,7 @@ export const WithDeferredMountAnimation = () => {
 
   React.useEffect(() => {
     if (open) {
-      timerRef.current = window.setTimeout(() => {
-        setAnimate(true);
-      }, 150);
+      timerRef.current = window.setTimeout(() => setAnimate(true), 150);
     } else {
       setAnimate(false);
       window.clearTimeout(timerRef.current);
@@ -47,9 +45,13 @@ export const WithDeferredMountAnimation = () => {
 
   return (
     <>
+      <p>
+        Deferred animation should unmount correctly when toggled. Content will flash briefly while
+        we wait for animation to be applied.
+      </p>
       <Toggles nodeRef={ref} open={open} onOpenChange={setOpen} />
       <Presence present={open}>
-        <div className={animate ? mountAnimationClass : noAnimationClass} ref={ref}>
+        <div className={animate ? mountAnimationClass : undefined} ref={ref}>
           Content
         </div>
       </Presence>
@@ -121,10 +123,6 @@ const slideUp = css.keyframes({
 const slideDown = css.keyframes({
   from: { transform: 'translateY(0)' },
   to: { transform: 'translateY(30px)' },
-});
-
-const noAnimationClass = css({
-  animation: 'none',
 });
 
 const mountAnimationClass = css({

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -103,9 +103,17 @@ function usePresence(present: boolean) {
           send('ANIMATION_END');
         }
       };
+      const handleAnimationStart = (event: AnimationEvent) => {
+        if (event.target === node) {
+          // if animation occurred, store its name as the previous animation.
+          prevAnimationNameRef.current = getAnimationName(stylesRef.current);
+        }
+      };
+      node.addEventListener('animationstart', handleAnimationStart);
       node.addEventListener('animationcancel', handleAnimationEnd);
       node.addEventListener('animationend', handleAnimationEnd);
       return () => {
+        node.removeEventListener('animationstart', handleAnimationStart);
         node.removeEventListener('animationcancel', handleAnimationEnd);
         node.removeEventListener('animationend', handleAnimationEnd);
       };


### PR DESCRIPTION
Fixes https://github.com/radix-ui/primitives/issues/849

The problem was caused by some state being stuck in `isAnimating` and suspending the unmount. It seems that the animation name getting retrieved from style in [the mount effect](https://github.com/radix-ui/primitives/blob/887228c4eab10aace9132b907e8693a027ae7027/packages/react/presence/src/Presence.tsx#L53) can sometimes return as `none` under certain conditions, that's why this doesn't show in the story. I was wondering if [this comment](https://github.com/radix-ui/primitives/pull/828#discussion_r691191786) was referring to this issue in the past?

Getting the name in the start event makes this behave consistently.


