### PR TITLE
[Collapsible][Slot] Fix `React.Children.only` error

### DIFF
--- a/.yarn/versions/0a79b7b8.yml
+++ b/.yarn/versions/0a79b7b8.yml
@@ -1,0 +1,40 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/collapsible/src/Collapsible.stories.tsx
+++ b/packages/react/collapsible/src/Collapsible.stories.tsx
@@ -17,7 +17,7 @@ export const Controlled = () => {
     <Collapsible open={open} onOpenChange={setOpen} className={rootClass}>
       <CollapsibleTrigger className={triggerClass}>{open ? 'close' : 'open'}</CollapsibleTrigger>
       <CollapsibleContent className={contentClass} asChild>
-        <div>Content 1</div>
+        <article>Content 1</article>
       </CollapsibleContent>
     </Collapsible>
   );

--- a/packages/react/collapsible/src/Collapsible.stories.tsx
+++ b/packages/react/collapsible/src/Collapsible.stories.tsx
@@ -11,6 +11,18 @@ export const Styled = () => (
   </Collapsible>
 );
 
+export const Controlled = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className={rootClass}>
+      <CollapsibleTrigger className={triggerClass}>{open ? 'close' : 'open'}</CollapsibleTrigger>
+      <CollapsibleContent className={contentClass} asChild>
+        <div>Content 1</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
 export const Animated = () => {
   return (
     <Collapsible className={rootClass}>

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -32,7 +32,7 @@ interface CollapsibleProps extends PrimitiveDivProps {
   defaultOpen?: boolean;
   open?: boolean;
   disabled?: boolean;
-  onOpenChange?(open?: boolean): void;
+  onOpenChange?(open: boolean): void;
 }
 
 const Collapsible = React.forwardRef<CollapsibleElement, CollapsibleProps>(

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -98,7 +98,7 @@ const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTrig
           ref={forwardedRef}
           onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
           onPointerLeave={composeEventHandlers(props.onPointerLeave, excludeTouch(context.onClose))}
-        ></Primitive.a>
+        />
       </PopperPrimitive.Anchor>
     );
   }

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -59,6 +59,38 @@ export const Chromatic = () => (
       <SlotWithoutSlottable>{false}</SlotWithoutSlottable>
     </ErrorBoundary>
 
+    <h2>
+      False internal child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithFalseInternalChild>
+        <b data-slot-element>hello</b>
+      </SlotWithFalseInternalChild>
+    </ErrorBoundary>
+
+    <h2>
+      Null internal child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithNullInternalChild>
+        <b data-slot-element>hello</b>
+      </SlotWithNullInternalChild>
+    </ErrorBoundary>
+
+    <h2>
+      String consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithoutSlottable>test</SlotWithoutSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      Number consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithoutSlottable>{1}</SlotWithoutSlottable>
+    </ErrorBoundary>
+
     <h1>With Slottable</h1>
 
     <h2>
@@ -88,6 +120,20 @@ export const Chromatic = () => (
     </ErrorBoundary>
 
     <h2>
+      String consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithSlottable>test</SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      Number consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithSlottable>{1}</SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
       Empty consumer child - <span aria-hidden>✅</span>
     </h2>
     <ErrorBoundary>
@@ -99,24 +145,6 @@ export const Chromatic = () => (
     </h2>
     <ErrorBoundary>
       <SlotWithSlottable>{false}</SlotWithSlottable>
-    </ErrorBoundary>
-
-    <h2>
-      False internal child - <span aria-hidden>✅</span>
-    </h2>
-    <ErrorBoundary>
-      <SlotWithFalseInternalChild>
-        <b data-slot-element>hello</b>
-      </SlotWithFalseInternalChild>
-    </ErrorBoundary>
-
-    <h2>
-      Null internal child - <span aria-hidden>✅</span>
-    </h2>
-    <ErrorBoundary>
-      <SlotWithNullInternalChild>
-        <b data-slot-element>hello</b>
-      </SlotWithNullInternalChild>
     </ErrorBoundary>
   </>
 );
@@ -151,13 +179,9 @@ const SlotWithSlottable = ({ children, ...props }: any) => (
 );
 
 const SlotWithFalseInternalChild = ({ children, ...props }: any) => (
-  <Slot {...props}>
-    <Slottable>{false && children}</Slottable>
-  </Slot>
+  <Slot {...props}>{false && children}</Slot>
 );
 
 const SlotWithNullInternalChild = ({ children, ...props }: any) => (
-  <Slot {...props}>
-    <Slottable>{false ? children : null}</Slottable>
-  </Slot>
+  <Slot {...props}>{false ? children : null}</Slot>
 );

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -17,56 +17,106 @@ export const WithSlottable = () => (
 
 export const Chromatic = () => (
   <>
-    <h1>
-      One consumer child without internal slottable - <span aria-hidden>✅</span>
-    </h1>
+    <h1>Without Slottable</h1>
+
+    <h2>
+      One consumer child - <span aria-hidden>✅</span>
+    </h2>
     <ErrorBoundary>
       <SlotWithoutSlottable>
         <b data-slot-element>hello</b>
       </SlotWithoutSlottable>
     </ErrorBoundary>
 
-    <h1>
-      One consumer child with internal slottable - <span aria-hidden>✅</span>
-    </h1>
+    <h2>
+      Multiple consumer child - <span aria-hidden>🔴</span>
+    </h2>
     <ErrorBoundary>
-      <SlotWithSlottable>
+      <SlotWithoutSlottable>
         <b data-slot-element>hello</b>
-      </SlotWithSlottable>
+        <b data-slot-element>hello</b>
+      </SlotWithoutSlottable>
     </ErrorBoundary>
 
-    <h1>
-      No consumer child without internal slottable - <span aria-hidden>🔴</span>
-    </h1>
+    <h2>
+      Null consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithoutSlottable>{null}</SlotWithoutSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      Empty consumer child - <span aria-hidden>✅</span>
+    </h2>
     <ErrorBoundary>
       <SlotWithoutSlottable></SlotWithoutSlottable>
     </ErrorBoundary>
 
-    <h1>
-      No consumer child with internal slottable - <span aria-hidden>🔴</span>
-    </h1>
+    <h2>
+      False consumer child - <span aria-hidden>✅</span>
+    </h2>
     <ErrorBoundary>
-      <SlotWithSlottable></SlotWithSlottable>
+      <SlotWithoutSlottable>{false}</SlotWithoutSlottable>
     </ErrorBoundary>
 
-    <h1>
-      Multiple consumer children without internal slottable - <span aria-hidden>🔴</span>
-    </h1>
+    <h1>With Slottable</h1>
+
+    <h2>
+      One consumer child - <span aria-hidden>✅</span>
+    </h2>
     <ErrorBoundary>
-      <SlotWithoutSlottable>
+      <SlotWithSlottable>
         <b data-slot-element>hello</b>
-        <b data-slot-element>hello</b>
-      </SlotWithoutSlottable>
+      </SlotWithSlottable>
     </ErrorBoundary>
 
-    <h1>
-      Multiple consumer children with internal slottable - <span aria-hidden>🔴</span>
-    </h1>
+    <h2>
+      Multiple consumer child - <span aria-hidden>🔴</span>
+    </h2>
     <ErrorBoundary>
       <SlotWithSlottable>
         <b data-slot-element>hello</b>
         <b data-slot-element>hello</b>
       </SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      Null consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithSlottable>{null}</SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      Empty consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithSlottable></SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      False consumer child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithSlottable>{false}</SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h2>
+      False internal child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithFalseInternalChild>
+        <b data-slot-element>hello</b>
+      </SlotWithFalseInternalChild>
+    </ErrorBoundary>
+
+    <h2>
+      Null internal child - <span aria-hidden>✅</span>
+    </h2>
+    <ErrorBoundary>
+      <SlotWithNullInternalChild>
+        <b data-slot-element>hello</b>
+      </SlotWithNullInternalChild>
     </ErrorBoundary>
   </>
 );
@@ -97,5 +147,17 @@ const SlotWithSlottable = ({ children, ...props }: any) => (
   <Slot {...props}>
     <Slottable>{children}</Slottable>
     <span>world</span>
+  </Slot>
+);
+
+const SlotWithFalseInternalChild = ({ children, ...props }: any) => (
+  <Slot {...props}>
+    <Slottable>{false && children}</Slottable>
+  </Slot>
+);
+
+const SlotWithNullInternalChild = ({ children, ...props }: any) => (
+  <Slot {...props}>
+    <Slottable>{false ? children : null}</Slottable>
   </Slot>
 );

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -4,38 +4,98 @@ import { Slot, Slottable } from './Slot';
 export default { title: 'Components/Slot' };
 
 export const WithoutSlottable = () => (
-  <AsCompWithoutSlottable as={Slot}>
+  <SlotWithoutSlottable>
     <b data-slot-element>hello</b>
-  </AsCompWithoutSlottable>
+  </SlotWithoutSlottable>
 );
 
 export const WithSlottable = () => (
-  <AsCompWithSlottable as={Slot}>
+  <SlotWithSlottable>
     <b data-slot-element>hello</b>
-  </AsCompWithSlottable>
+  </SlotWithSlottable>
 );
 
 export const Chromatic = () => (
   <>
-    <h1>Without slottable</h1>
-    <AsCompWithoutSlottable as={Slot}>
-      <b data-slot-element>hello</b>
-    </AsCompWithoutSlottable>
+    <h1>
+      One consumer child without internal slottable - <span aria-hidden>✅</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithoutSlottable>
+        <b data-slot-element>hello</b>
+      </SlotWithoutSlottable>
+    </ErrorBoundary>
 
-    <h1>With slottable</h1>
-    <AsCompWithSlottable as={Slot}>
-      <b data-slot-element>hello</b>
-    </AsCompWithSlottable>
+    <h1>
+      One consumer child with internal slottable - <span aria-hidden>✅</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithSlottable>
+        <b data-slot-element>hello</b>
+      </SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h1>
+      No consumer child without internal slottable - <span aria-hidden>🔴</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithoutSlottable></SlotWithoutSlottable>
+    </ErrorBoundary>
+
+    <h1>
+      No consumer child with internal slottable - <span aria-hidden>🔴</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithSlottable></SlotWithSlottable>
+    </ErrorBoundary>
+
+    <h1>
+      Multiple consumer children without internal slottable - <span aria-hidden>🔴</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithoutSlottable>
+        <b data-slot-element>hello</b>
+        <b data-slot-element>hello</b>
+      </SlotWithoutSlottable>
+    </ErrorBoundary>
+
+    <h1>
+      Multiple consumer children with internal slottable - <span aria-hidden>🔴</span>
+    </h1>
+    <ErrorBoundary>
+      <SlotWithSlottable>
+        <b data-slot-element>hello</b>
+        <b data-slot-element>hello</b>
+      </SlotWithSlottable>
+    </ErrorBoundary>
   </>
 );
 Chromatic.parameters = { chromatic: { disable: false } };
 
-type AsCompProps = React.ComponentProps<'div'> & { as: React.ElementType };
+/* ---------------------------------------------------------------------------------------------- */
 
-const AsCompWithoutSlottable = ({ as: Comp = 'div', ...props }: AsCompProps) => <Comp {...props} />;
-const AsCompWithSlottable = ({ as: Comp = 'div', children, ...props }: AsCompProps) => (
-  <Comp {...props}>
+class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div style={{ background: 'red', color: 'white', padding: 10 }}>Error</div>;
+    }
+    return this.props.children;
+  }
+}
+
+const SlotWithoutSlottable = (props: any) => <Slot {...props} />;
+const SlotWithSlottable = ({ children, ...props }: any) => (
+  <Slot {...props}>
     <Slottable>{children}</Slottable>
     <span>world</span>
-  </Comp>
+  </Slot>
 );

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -50,9 +50,8 @@ interface SlotCloneProps {
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
-  const child = React.Children.only(children);
-
-  return React.isValidElement(child)
+  const child = React.isValidElement(children) && React.Children.only(children);
+  return child
     ? React.cloneElement(child, {
         ...mergeProps(slotProps, child.props),
         ref: composeRefs(forwardedRef, (child as any).ref),
@@ -67,7 +66,7 @@ SlotClone.displayName = 'SlotClone';
  * -----------------------------------------------------------------------------------------------*/
 
 const Slottable = ({ children }: { children: React.ReactNode }) => {
-  return children as React.ReactElement;
+  return <>{children}</>;
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -11,23 +11,15 @@ interface SlotProps {
 
 const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
-  const childLength = React.Children.count(children);
+  const childArray = React.Children.toArray(children);
 
-  if (childLength === 1) {
-    return (
-      <SlotClone {...slotProps} ref={forwardedRef}>
-        {children}
-      </SlotClone>
-    );
-  }
-
-  if (React.Children.toArray(children).some(isSlottable)) {
+  if (childArray.some(isSlottable)) {
     return (
       <>
-        {React.Children.map(children, (child) => {
+        {childArray.map((child) => {
           return isSlottable(child) ? (
             <SlotClone {...slotProps} ref={forwardedRef}>
-              <Slot>{child.props.children}</Slot>
+              {child.props.children}
             </SlotClone>
           ) : (
             child
@@ -37,7 +29,11 @@ const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
     );
   }
 
-  return <>{React.Children.only(children)}</>;
+  return (
+    <SlotClone {...slotProps} ref={forwardedRef}>
+      {children}
+    </SlotClone>
+  );
 });
 
 Slot.displayName = 'Slot';
@@ -52,12 +48,15 @@ interface SlotCloneProps {
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
-  return React.isValidElement(children)
-    ? React.cloneElement(children, {
-        ...mergeProps(slotProps, children.props),
-        ref: composeRefs(forwardedRef, (children as any).ref),
-      })
-    : null;
+
+  if (React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...mergeProps(slotProps, children.props),
+      ref: composeRefs(forwardedRef, (children as any).ref),
+    });
+  }
+
+  return React.Children.count(children) > 1 ? React.Children.only(null) : null;
 });
 
 SlotClone.displayName = 'SlotClone';

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -13,25 +13,31 @@ const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
   const { children, ...slotProps } = props;
   const childLength = React.Children.count(children);
 
-  return childLength === 1 ? (
-    <SlotClone {...slotProps} ref={forwardedRef}>
-      {children}
-    </SlotClone>
-  ) : React.Children.toArray(children).some(isSlottable) ? (
-    <>
-      {React.Children.map(children, (child) => {
-        return isSlottable(child) ? (
-          <SlotClone {...slotProps} ref={forwardedRef}>
-            {child.props.children}
-          </SlotClone>
-        ) : (
-          child
-        );
-      })}
-    </>
-  ) : (
-    <>{React.Children.only(children)}</>
-  );
+  if (childLength === 1) {
+    return (
+      <SlotClone {...slotProps} ref={forwardedRef}>
+        {children}
+      </SlotClone>
+    );
+  }
+
+  if (React.Children.toArray(children).some(isSlottable)) {
+    return (
+      <>
+        {React.Children.map(children, (child) => {
+          return isSlottable(child) ? (
+            <SlotClone {...slotProps} ref={forwardedRef}>
+              <Slot>{child.props.children}</Slot>
+            </SlotClone>
+          ) : (
+            child
+          );
+        })}
+      </>
+    );
+  }
+
+  return <>{React.Children.only(children)}</>;
 });
 
 Slot.displayName = 'Slot';


### PR DESCRIPTION
Originally reported here https://discord.com/channels/752614004387610674/803656530259738674/886570819134816317

Sandbox showing issue: https://codesandbox.io/s/kind-violet-v0b1b?file=/src/App.tsx

Sometimes the `Slot` children might be a `false` boolean if someone does `isSomething && <Whatever />` and that would cause `React.Children.only` to throw its error because it expects a React Element.

In the case of `CollapsibleContent` it was doing `isOpen && children`.