### PR TITLE
[Checkbox][RadioGroup][Switch] Hide bubble input from SRs

### DIFF
--- a/.yarn/versions/a2d4b456.yml
+++ b/.yarn/versions/a2d4b456.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-switch": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -175,6 +175,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="checkbox"
+      aria-hidden
       defaultChecked={isIndeterminate(checked) ? false : checked}
       {...inputProps}
       tabIndex={-1}

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -158,6 +158,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="radio"
+      aria-hidden
       defaultChecked={checked}
       {...inputProps}
       tabIndex={-1}

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -156,6 +156,7 @@ const BubbleInput = (props: BubbleInputProps) => {
   return (
     <input
       type="checkbox"
+      aria-hidden
       defaultChecked={checked}
       {...inputProps}
       tabIndex={-1}


### PR DESCRIPTION
It looks like when I removed the `display: none` stuff from these, I forgot to hide them from SRs. Noticed while testing this https://github.com/radix-ui/website/pull/240

Without this change, using the virtual cursor allows you to select the hidden input so it reads like there are two controls for SR users. Oops!