### PR TITLE
[Presence] Prevent premature unmount

### DIFF
--- a/.yarn/versions/215c2811.yml
+++ b/.yarn/versions/215c2811.yml
@@ -1,0 +1,18 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -59,6 +59,27 @@ export const WithDeferredMountAnimation = () => {
   );
 };
 
+export const WithOpenAndCloseAnimationViaEffect = () => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const [stateAttribute, setStateAttribute] = React.useState('closed');
+
+  React.useEffect(() => {
+    setStateAttribute(open ? 'open' : 'closed');
+  }, [open]);
+
+  return (
+    <>
+      <Toggles nodeRef={ref} open={open} onOpenChange={setOpen} />
+      <Presence present={open}>
+        <div data-state={stateAttribute} className={openAndCloseAnimationClass} ref={ref}>
+          Content
+        </div>
+      </Presence>
+    </>
+  );
+};
+
 function Animation(props: React.ComponentProps<'div'>) {
   const ref = React.useRef<HTMLDivElement>(null);
   const [open, setOpen] = React.useState(false);


### PR DESCRIPTION
Raising for discussion.

`Presence` has trouble getting the latest animation value if they are updated via state inside an effect, it will retrieve a stale `animationName` when `present` changes and fall through to the `UNMOUNT`.

Here is an example, you can see the unmount animation doesn't occur:
https://codesandbox.io/s/exciting-rgb-j04y0

This change pushes the animation retrieval logic to next tick so that the most recent animation value can be checked.
