### PR TITLE
[Popover][Dialog] Expose `RemoveScroll` props

### DIFF
--- a/.yarn/versions/2ca8d8aa.yml
+++ b/.yarn/versions/2ca8d8aa.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -179,6 +179,34 @@ export const ForcedMount = () => (
   </Dialog>
 );
 
+export const ModalWithScrollbar = () => (
+  <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
+    <Dialog>
+      <DialogTrigger className={triggerClass}>open</DialogTrigger>
+      <DialogOverlay className={overlayClass} />
+      <DialogContent className={contentClass} removeScrollbar={false}>
+        <DialogTitle>Booking info</DialogTitle>
+        <DialogDescription>Please enter the info for your booking below.</DialogDescription>
+        <DialogClose className={closeClass}>close</DialogClose>
+      </DialogContent>
+    </Dialog>
+  </div>
+);
+
+export const AllowPinchZoom = () => (
+  <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
+    <Dialog>
+      <DialogTrigger className={triggerClass}>open</DialogTrigger>
+      <DialogOverlay className={overlayClass} />
+      <DialogContent className={contentClass} allowPinchZoom>
+        <DialogTitle>Booking info</DialogTitle>
+        <DialogDescription>Please enter the info for your booking below.</DialogDescription>
+        <DialogClose className={closeClass}>close</DialogClose>
+      </DialogContent>
+    </Dialog>
+  </div>
+);
+
 export const Chromatic = () => (
   <div
     style={{

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -178,12 +178,17 @@ DialogContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
+type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 type DialogContentTypeElement = DialogContentImplElement;
 interface DialogContentTypeProps
-  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {}
+  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {
+  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
+  removeScrollbar?: RemoveScrollProps['removeScrollBar'];
+}
 
 const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogContentTypeProps>(
   (props, forwardedRef) => {
+    const { allowPinchZoom, removeScrollbar = true, ...contentModalProps } = props;
     const context = useDialogContext(CONTENT_NAME);
     const contentRef = React.useRef<HTMLDivElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, contentRef);
@@ -196,9 +201,9 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
 
     return (
       <Portal>
-        <RemoveScroll>
+        <RemoveScroll allowPinchZoom={allowPinchZoom} removeScrollBar={removeScrollbar}>
           <DialogContentImpl
-            {...props}
+            {...contentModalProps}
             ref={composedRefs}
             // we make sure focus isn't trapped once `DialogContent` has been closed
             // (closed !== unmounted when animating out)

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -172,6 +172,7 @@ PopoverContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
+type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 type PopoverContentTypeElement = PopoverContentImplElement;
 interface PopoverContentTypeProps
   extends Omit<PopoverContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {
@@ -180,11 +181,18 @@ interface PopoverContentTypeProps
    * (default: `true`)
    */
   portalled?: boolean;
+  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
+  removeScrollbar?: RemoveScrollProps['removeScrollBar'];
 }
 
 const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverContentTypeProps>(
   (props, forwardedRef) => {
-    const { portalled = true, ...contentModalProps } = props;
+    const {
+      allowPinchZoom,
+      removeScrollbar = true,
+      portalled = true,
+      ...contentModalProps
+    } = props;
     const context = usePopoverContext(CONTENT_NAME);
     const contentRef = React.useRef<HTMLDivElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, contentRef);
@@ -200,7 +208,7 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
 
     return (
       <PortalWrapper>
-        <RemoveScroll>
+        <RemoveScroll allowPinchZoom={allowPinchZoom} removeScrollBar={removeScrollbar}>
           <PopoverContentImpl
             {...contentModalProps}
             ref={composedRefs}


### PR DESCRIPTION
PR for discussion since we had a request on Discord to allow pinch zoom functionality for `Dialog` when modal. They referenced an `allowPinchZoom` prop that ChakraUI expose from `RemoveScroll` so I've done the same here.