### PR TITLE
[Slot] Improvements

### DIFF
--- a/.yarn/versions/3c930410.yml
+++ b/.yarn/versions/3c930410.yml
@@ -1,0 +1,40 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-slot": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -15,6 +15,44 @@ export const WithSlottable = () => (
   </SlotWithSlottable>
 );
 
+export const WithComposedEvents = () => (
+  <>
+    <h1>Should log both</h1>
+    <SlotWithPreventableEvent>
+      <button onClick={() => console.log('button click')}>Slot event not prevented</button>
+    </SlotWithPreventableEvent>
+
+    <h1>Should log "button click"</h1>
+    <SlotWithPreventableEvent>
+      <button
+        onClick={(event) => {
+          console.log('button click');
+          event.preventDefault();
+        }}
+      >
+        Slot event prevented
+      </button>
+    </SlotWithPreventableEvent>
+
+    <h1>Should log both</h1>
+    <SlotWithoutPreventableEvent>
+      <button onClick={() => console.log('button click')}>Slot event not prevented</button>
+    </SlotWithoutPreventableEvent>
+
+    <h1>Should log both</h1>
+    <SlotWithoutPreventableEvent>
+      <button
+        onClick={(event) => {
+          console.log('button click');
+          event.preventDefault();
+        }}
+      >
+        Slot event prevented
+      </button>
+    </SlotWithoutPreventableEvent>
+  </>
+);
+
 export const Chromatic = () => (
   <>
     <h1>Without Slottable</h1>
@@ -170,7 +208,12 @@ class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
   }
 }
 
-const SlotWithoutSlottable = (props: any) => <Slot {...props} />;
+/* Also verifying that props and ref types don't error */
+const SlotWithoutSlottable = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<'div'>
+>((props, forwardedRef) => <Slot {...props} className="test" ref={forwardedRef} />);
+
 const SlotWithSlottable = ({ children, ...props }: any) => (
   <Slot {...props}>
     <Slottable>{children}</Slottable>
@@ -184,4 +227,26 @@ const SlotWithFalseInternalChild = ({ children, ...props }: any) => (
 
 const SlotWithNullInternalChild = ({ children, ...props }: any) => (
   <Slot {...props}>{false ? children : null}</Slot>
+);
+
+const SlotWithPreventableEvent = (props: any) => (
+  <Slot
+    {...props}
+    onClick={(event) => {
+      props.onClick?.(event);
+      if (!event.defaultPrevented) {
+        console.log(event.target);
+      }
+    }}
+  />
+);
+
+const SlotWithoutPreventableEvent = (props: any) => (
+  <Slot
+    {...props}
+    onClick={(event) => {
+      props.onClick?.(event);
+      console.log(event.target);
+    }}
+  />
 );

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -5,7 +5,7 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
  * Slot
  * -----------------------------------------------------------------------------------------------*/
 
-interface SlotProps {
+interface SlotProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
 }
 
@@ -88,7 +88,10 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
     const isHandler = /^on[A-Z]/.test(propName);
     // if it's a handler, modify the override by composing the base handler
     if (isHandler) {
-      overrideProps[propName] = composeHandlers(childPropValue, slotPropValue);
+      overrideProps[propName] = (...args: unknown[]) => {
+        childPropValue?.(...args);
+        slotPropValue?.(...args);
+      };
     }
     // if it's `style`, we merge them
     else if (propName === 'style') {
@@ -99,18 +102,6 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
   }
 
   return { ...slotProps, ...overrideProps };
-}
-
-type EventHandler = (...args: unknown[]) => unknown;
-
-function composeHandlers(childHandler?: EventHandler, slotHandler?: EventHandler) {
-  return function handleEvent(...args) {
-    childHandler?.(...args);
-    const isDefaultPreventedEvent = args[0] instanceof Event && args[0].defaultPrevented;
-    if (!isDefaultPreventedEvent) {
-      slotHandler?.(...args);
-    }
-  } as EventHandler;
 }
 
 const Root = Slot;


### PR DESCRIPTION
Pedro noticed that `<Slot className="foo" />` was [giving TS errors](https://codesandbox.io/s/nostalgic-kapitsa-fspsx?file=/src/App.tsx). 

This fixes that but also removes the `event.defaultPrevented` checks we do in `Slot` when composing events. I noticed this when debugging something from Discord #help yday and thought I'd tackle it at the same time since I don't think the `Slot` should determine whether events can be prevented or not. That should be up to the components that are being composed together. I've added a story to show that events can still be prevented correctly.

