### PR TITLE
[Popover] Disable looping if not `modal` or `portalled`

### DIFF
--- a/.yarn/versions/e76b55f5.yml
+++ b/.yarn/versions/e76b55f5.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -50,6 +50,20 @@ export const Modality = () => {
           />
         </div>
         <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
+          <h1>Non modal (not portalled)</h1>
+          <Popover>
+            <PopoverTrigger className={triggerClass}>open</PopoverTrigger>
+            <PopoverContent className={contentClass} sideOffset={5} portalled={false}>
+              <PopoverClose className={closeClass}>close</PopoverClose>
+              <PopoverArrow className={arrowClass} width={20} height={10} offset={10} />
+            </PopoverContent>
+          </Popover>
+          <textarea
+            style={{ width: 500, height: 100, marginTop: 10 }}
+            defaultValue="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat nobis at ipsa, nihil tempora debitis maxime dignissimos non amet."
+          />
+        </div>
+        <div style={{ display: 'inline-flex', alignItems: 'center', flexDirection: 'column' }}>
           <h1>Modal</h1>
           <Popover modal>
             <PopoverTrigger className={triggerClass}>open</PopoverTrigger>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -200,7 +200,7 @@ PopoverContent.displayName = CONTENT_NAME;
 type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 type PopoverContentTypeElement = PopoverContentImplElement;
 interface PopoverContentTypeProps
-  extends Omit<PopoverContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {
+  extends Omit<PopoverContentImplProps, 'disableOutsidePointerEvents'> {
   /**
    * @see https://github.com/theKashey/react-remove-scroll#usage
    */
@@ -347,19 +347,12 @@ type DismissableLayerProps = Radix.ComponentPropsWithoutRef<typeof DismissableLa
 type PopperContentProps = Radix.ComponentPropsWithoutRef<typeof PopperPrimitive.Content>;
 interface PopoverContentImplProps
   extends PopperContentProps,
-    Omit<DismissableLayerProps, 'onDismiss'> {
-  /**
-   * Whether focus should be trapped within the `Popover`
-   * (default: false)
-   */
-  trapFocus?: FocusScopeProps['trapped'];
-}
+    Omit<DismissableLayerProps, 'onDismiss'> {}
 
 const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverContentImplProps>(
   (props: ScopedProps<PopoverContentImplProps>, forwardedRef) => {
     const {
       __scopePopover,
-      trapFocus,
       disableOutsidePointerEvents,
       onEscapeKeyDown,
       onPointerDownOutside,


### PR DESCRIPTION
One step closer to solving https://github.com/radix-ui/primitives/issues/869

Easier to review with hidden whitespace changes.

I've just moved `FocusScope` from the `Impl` component up into the relevant modal/non-modal components and configured them independently there instead.

https://user-images.githubusercontent.com/175330/136603852-1aaca404-fb12-4aca-a154-56dd4f6bcfa8.mp4



