### PR TITLE
[AlertDialog][Toolbar] Fix asChild TS error

### DIFF
--- a/.yarn/versions/e56af611.yml
+++ b/.yarn/versions/e56af611.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dialog": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-slot": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -19,6 +19,7 @@
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
+    "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-separator": "workspace:*",
     "@radix-ui/react-toggle-group": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3330,6 +3330,7 @@ __metadata:
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-dialog": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ">=16.8"
@@ -3905,6 +3906,7 @@ __metadata:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-separator": "workspace:*"
     "@radix-ui/react-toggle-group": "workspace:*"


### PR DESCRIPTION
Originally reported on Discord. These two packages were missing the `@radix-ui/react-primitive` dependency.