### PR TITLE
Popper core: Expose translateX and translateY as variables

### DIFF
--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -311,6 +311,8 @@ function getPlacementStylesForPoint(point: Point): CSS.Properties {
     minWidth: 'max-content',
     willChange: 'transform',
     transform: `translate3d(${x}px, ${y}px, 0)`,
+    '--radix-popper-translate-x': `${x}px`,
+    '--radix-popper-translate-y': `${y}px`,
   };
 }
 


### PR DESCRIPTION
### Description

Hi, Modulz team! First, thanks for this excellent library.

I'm currently working on a project that I need to control the popover a bit more than this package needs. I made this proposed change on `index.module.js` and I'm using `patch-package` to keep them over builds etc, but I thought that I could submit it to upstream and maybe get it merged.

This change just exposes internal `translateX` and `translateY` that can then be used down the tree.
