### PR TITLE
[Toolbar] Remove `toolbaritem` role

### DIFF
--- a/.yarn/versions/ca283b8d.yml
+++ b/.yarn/versions/ca283b8d.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -106,7 +106,7 @@ const ToolbarButton = React.forwardRef<ToolbarButtonElement, ToolbarButtonProps>
     const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeToolbar);
     return (
       <RovingFocusGroup.Item asChild {...rovingFocusGroupScope} focusable={!props.disabled}>
-        <Primitive.button role="toolbaritem" {...buttonProps} ref={forwardedRef} />
+        <Primitive.button {...buttonProps} ref={forwardedRef} />
       </RovingFocusGroup.Item>
     );
   }
@@ -131,7 +131,6 @@ const ToolbarLink = React.forwardRef<ToolbarLinkElement, ToolbarLinkProps>(
     return (
       <RovingFocusGroup.Item asChild {...rovingFocusGroupScope} focusable>
         <Primitive.a
-          role="toolbaritem"
           {...linkProps}
           ref={forwardedRef}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {


### PR DESCRIPTION
Fixes #949

There doesn't seem to be such a role in the WAI ARIA docs and their toolbar examples don't include this either. It looks suspiciously like a bad find+replace after copy/pasting the menu/menuitem pattern.

Does anyone know of a reason why this should be kept?