### PR TITLE
[Accordion] Patch for TypeError on mismatched prop types when `type='multiple'` and `defaultValue='string'`

### DIFF
--- a/.yarn/versions/5ad189b9.yml
+++ b/.yarn/versions/5ad189b9.yml
@@ -1,0 +1,3 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  primitives: patch

--- a/packages/react/accordion/src/Accordion.test.tsx
+++ b/packages/react/accordion/src/Accordion.test.tsx
@@ -216,6 +216,32 @@ describe('given a multiple Accordion', () => {
   });
 });
 
+describe('given a multiple Accordion with mismatchProps', () => {
+  let handleValueChange: jest.Mock;
+  let rendered: RenderResult;
+
+  beforeEach(() => {
+    handleValueChange = jest.fn();
+    rendered = render(
+      // @ts-ignore-next-line
+      <AccordionTest type="multiple" onValueChange={handleValueChange} defaultValue={ITEMS[0]} />
+    );
+  });
+
+  describe('when clicking a trigger', () => {
+    let trigger: HTMLElement;
+
+    beforeEach(() => {
+      trigger = rendered.getByText(/Trigger One/);
+      fireEvent.click(trigger);
+    });
+
+    it('should gracefully handle mismatched defaultValue props', () => {
+      expect(rendered.container).toBeInTheDocument();
+    });
+  });
+});
+
 function AccordionTest(props: React.ComponentProps<typeof Accordion.Root>) {
   return (
     <Accordion.Root data-testid="container" {...props}>

--- a/packages/react/accordion/src/Accordion.test.tsx
+++ b/packages/react/accordion/src/Accordion.test.tsx
@@ -216,32 +216,6 @@ describe('given a multiple Accordion', () => {
   });
 });
 
-describe('given a multiple Accordion with mismatchProps', () => {
-  let handleValueChange: jest.Mock;
-  let rendered: RenderResult;
-
-  beforeEach(() => {
-    handleValueChange = jest.fn();
-    rendered = render(
-      // @ts-ignore-next-line
-      <AccordionTest type="multiple" onValueChange={handleValueChange} defaultValue={ITEMS[0]} />
-    );
-  });
-
-  describe('when clicking a trigger', () => {
-    let trigger: HTMLElement;
-
-    beforeEach(() => {
-      trigger = rendered.getByText(/Trigger One/);
-      fireEvent.click(trigger);
-    });
-
-    it('should gracefully handle mismatched defaultValue props', () => {
-      expect(rendered.container).toBeInTheDocument();
-    });
-  });
-});
-
 function AccordionTest(props: React.ComponentProps<typeof Accordion.Root>) {
   return (
     <Accordion.Root data-testid="container" {...props}>

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -42,7 +42,12 @@ const Accordion = React.forwardRef<AccordionElement, AccordionSingleProps | Acco
     }
 
     if (type === 'multiple') {
-      const multipleProps = accordionProps as AccordionImplMultipleProps;
+      const multipleProps = (
+        Array.isArray(accordionProps?.defaultValue)
+          ? accordionProps
+          : { ...accordionProps, defaultValue: [] }
+      ) as AccordionMultipleProps;
+
       return <AccordionImplMultiple {...multipleProps} ref={forwardedRef} />;
     }
 

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -42,11 +42,7 @@ const Accordion = React.forwardRef<AccordionElement, AccordionSingleProps | Acco
     }
 
     if (type === 'multiple') {
-      const multipleProps = (
-        Array.isArray(accordionProps?.defaultValue)
-          ? accordionProps
-          : { ...accordionProps, defaultValue: [] }
-      ) as AccordionMultipleProps;
+      const multipleProps = accordionProps as AccordionImplMultipleProps;
 
       return <AccordionImplMultiple {...multipleProps} ref={forwardedRef} />;
     }
@@ -56,6 +52,23 @@ const Accordion = React.forwardRef<AccordionElement, AccordionSingleProps | Acco
 );
 
 Accordion.displayName = ACCORDION_NAME;
+
+Accordion.propTypes = {
+  type(props) {
+    const value = props.value || props.defaultValue;
+    if (props.type === 'multiple' && typeof value === 'string') {
+      return new Error(
+        'Invalid prop `type` of value `multiple` supplied to `Accordion`. Expects `single` when `defaultValue` or `value` is type `string`.'
+      );
+    }
+    if (props.type === 'single' && Array.isArray(value)) {
+      return new Error(
+        'Invalid prop `type` of value `single` supplied to `Accordion`. Expects `multiple` when `defaultValue` or `value` is type `string[]`.'
+      );
+    }
+    return null;
+  },
+};
 
 /* -----------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Patch for #958 . Details in issue. Checks `defaultValue` for type to prevent TypeError
