### PR TITLE
[Dialog][AlertDialog] Enable outer scrolling dialog pattern

### DIFF
--- a/.yarn/versions/a4d03789.yml
+++ b/.yarn/versions/a4d03789.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -27,7 +27,6 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -18,7 +18,7 @@ export const Styled = () => (
     <DialogTrigger className={triggerClass}>open</DialogTrigger>
     <DialogPortal>
       <DialogOverlay className={overlayClass} />
-      <DialogContent className={contentClass}>
+      <DialogContent className={contentDefaultClass}>
         <DialogTitle>Booking info</DialogTitle>
         <DialogDescription>Please enter the info for your booking below.</DialogDescription>
         <DialogClose className={closeClass}>close</DialogClose>
@@ -61,7 +61,7 @@ export const Controlled = () => {
       <DialogTrigger>{open ? 'close' : 'open'}</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentClass}>
+        <DialogContent className={contentDefaultClass}>
           <DialogTitle>Title</DialogTitle>
           <DialogClose>close</DialogClose>
         </DialogContent>
@@ -76,7 +76,7 @@ export const FocusTrap = () => (
       <DialogTrigger>open</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentClass}>
+        <DialogContent className={contentDefaultClass}>
           <DialogClose>close</DialogClose>
           <DialogTitle>Title</DialogTitle>
           <div>
@@ -108,7 +108,7 @@ export const CustomFocus = () => {
         <DialogPortal>
           <DialogOverlay className={overlayClass} />
           <DialogContent
-            className={contentClass}
+            className={contentDefaultClass}
             onOpenAutoFocus={(event) => {
               event.preventDefault();
               firstNameRef.current?.focus();
@@ -148,7 +148,10 @@ export const NoEscapeDismiss = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal>
       <DialogOverlay className={overlayClass} />
-      <DialogContent className={contentClass} onEscapeKeyDown={(event) => event.preventDefault()}>
+      <DialogContent
+        className={contentDefaultClass}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+      >
         <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
@@ -162,7 +165,7 @@ export const NoPointerDownOutsideDismiss = () => (
     <DialogPortal>
       <DialogOverlay className={overlayClass} />
       <DialogContent
-        className={contentClass}
+        className={contentDefaultClass}
         onPointerDownOutside={(event) => event.preventDefault()}
       >
         <DialogTitle>Title</DialogTitle>
@@ -180,7 +183,7 @@ export const WithPortalContainer = () => {
         <DialogTrigger>open</DialogTrigger>
         <DialogPortal container={portalContainer}>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={contentClass}>
+          <DialogContent className={contentDefaultClass}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose>close</DialogClose>
           </DialogContent>
@@ -209,7 +212,7 @@ export const ForcedMount = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal>
       <DialogOverlay className={overlayClass} forceMount />
-      <DialogContent className={contentClass} forceMount>
+      <DialogContent className={contentDefaultClass} forceMount>
         <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
@@ -219,11 +222,11 @@ export const ForcedMount = () => (
 
 export const AllowPinchZoom = () => (
   <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
-    <Dialog>
+    <Dialog allowPinchZoom>
       <DialogTrigger className={triggerClass}>open</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentClass} allowPinchZoom>
+        <DialogContent className={contentDefaultClass}>
           <DialogTitle>Booking info</DialogTitle>
           <DialogDescription>Please enter the info for your booking below.</DialogDescription>
           <DialogClose className={closeClass}>close</DialogClose>
@@ -231,6 +234,23 @@ export const AllowPinchZoom = () => (
       </DialogPortal>
     </Dialog>
   </div>
+);
+
+export const OuterScrollable = () => (
+  <Dialog>
+    <DialogTrigger className={triggerClass}>open</DialogTrigger>
+    <div style={{ backgroundColor: '#eee', width: 300, height: 1000 }} />
+    <DialogPortal>
+      <DialogOverlay className={scrollableOverlayClass}>
+        <DialogContent className={contentInScrollableOverlayClass}>
+          <DialogTitle>Booking info</DialogTitle>
+          <DialogDescription>Please enter the info for your booking below.</DialogDescription>
+          <div style={{ backgroundColor: '#eee', height: 500 }} />
+          <DialogClose className={closeClass}>close</DialogClose>
+        </DialogContent>
+      </DialogOverlay>
+    </DialogPortal>
+  </Dialog>
 );
 
 export const Chromatic = () => (
@@ -408,6 +428,13 @@ const overlayClass = css({
   backgroundColor: 'rgba(0,0,0,0.2)',
 });
 
+const scrollableOverlayClass = css(overlayClass, {
+  overflow: 'auto',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+});
+
 const RECOMMENDED_CSS__DIALOG__CONTENT: any = {
   // ensures good default position for content
   position: 'fixed',
@@ -415,11 +442,7 @@ const RECOMMENDED_CSS__DIALOG__CONTENT: any = {
   left: 0,
 };
 
-const contentClass = css({
-  ...RECOMMENDED_CSS__DIALOG__CONTENT,
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
+const contentStyles = css({
   minWidth: 300,
   minHeight: 150,
   padding: 50,
@@ -428,17 +451,26 @@ const contentClass = css({
   boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
 });
 
-const contentSheetClass = css({
+const contentDefaultClass = css(contentStyles, {
+  ...RECOMMENDED_CSS__DIALOG__CONTENT,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+});
+
+const contentInScrollableOverlayClass = css(contentStyles, {
+  marginTop: 50,
+  marginBottom: 50,
+});
+
+const contentSheetClass = css(contentStyles, {
   ...RECOMMENDED_CSS__DIALOG__CONTENT,
   left: undefined,
   right: 0,
   minWidth: 300,
   minHeight: '100vh',
-  padding: 50,
-  borderTopLeftRadius: 10,
-  borderBottomLeftRadius: 10,
-  backgroundColor: 'white',
-  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
+  borderTopRightRadius: 0,
+  borderBottomRightRadius: 0,
 });
 
 const closeClass = css({});
@@ -467,7 +499,7 @@ const animatedOverlayClass = css(overlayClass, {
   },
 });
 
-const animatedContentClass = css(contentClass, {
+const animatedContentClass = css(contentDefaultClass, {
   '&[data-state="open"]': {
     animation: `${fadeIn} ${scaleIn} 300ms ease-out`,
   },
@@ -476,7 +508,7 @@ const animatedContentClass = css(contentClass, {
   },
 });
 
-const chromaticContentClass = css(contentClass, {
+const chromaticContentClass = css(contentDefaultClass, {
   padding: 10,
   minWidth: 'auto',
   minHeight: 'auto',

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -9,7 +9,6 @@ import { FocusScope } from '@radix-ui/react-focus-scope';
 import { UnstablePortal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
@@ -177,7 +176,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
     const { __scopeDialog, ...overlayProps } = props;
     const context = useDialogContext(OVERLAY_NAME, __scopeDialog);
     return (
-      <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
+      <RemoveScroll forwardProps allowPinchZoom={context.allowPinchZoom}>
         <Primitive.div
           data-state={getState(context.open)}
           {...overlayProps}

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -35,15 +35,21 @@ type DialogContextValue = {
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
   modal: boolean;
+  allowPinchZoom: DialogProps['allowPinchZoom'];
 };
 
 const [DialogProvider, useDialogContext] = createDialogContext<DialogContextValue>(DIALOG_NAME);
 
+type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface DialogProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   modal?: boolean;
+  /**
+   * @see https://github.com/theKashey/react-remove-scroll#usage
+   */
+  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
   children?: React.ReactNode;
 }
 
@@ -55,6 +61,7 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
     defaultOpen,
     onOpenChange,
     modal = true,
+    allowPinchZoom,
   } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const [open = false, setOpen] = useControllableState({
@@ -74,6 +81,7 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
       onOpenChange={setOpen}
       onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
       modal={modal}
+      allowPinchZoom={allowPinchZoom}
     >
       {children}
     </DialogProvider>
@@ -169,7 +177,15 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
     const { __scopeDialog, ...overlayProps } = props;
     const context = useDialogContext(OVERLAY_NAME, __scopeDialog);
     return (
-      <Primitive.div data-state={getState(context.open)} {...overlayProps} ref={forwardedRef} />
+      <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
+        <Primitive.div
+          data-state={getState(context.open)}
+          {...overlayProps}
+          ref={forwardedRef}
+          // We re-enable pointerEvents on the Overlay to enable scrolling
+          style={{ pointerEvents: 'auto', ...overlayProps.style }}
+        />
+      </RemoveScroll>
     );
   }
 );
@@ -209,19 +225,12 @@ DialogContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 type DialogContentTypeElement = DialogContentImplElement;
 interface DialogContentTypeProps
-  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
-}
+  extends Omit<DialogContentImplProps, 'trapFocus' | 'disableOutsidePointerEvents'> {}
 
 const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogContentTypeProps>(
   (props: ScopedProps<DialogContentTypeProps>, forwardedRef) => {
-    const { allowPinchZoom, ...contentModalProps } = props;
     const context = useDialogContext(CONTENT_NAME, props.__scopeDialog);
     const contentRef = React.useRef<HTMLDivElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, contentRef);
@@ -233,34 +242,32 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
     }, []);
 
     return (
-      <RemoveScroll as={Slot} allowPinchZoom={allowPinchZoom}>
-        <DialogContentImpl
-          {...contentModalProps}
-          ref={composedRefs}
-          // we make sure focus isn't trapped once `DialogContent` has been closed
-          // (closed !== unmounted when animating out)
-          trapFocus={context.open}
-          disableOutsidePointerEvents
-          onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
-            event.preventDefault();
-            context.triggerRef.current?.focus();
-          })}
-          onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
-            const originalEvent = event.detail.originalEvent;
-            const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
-            const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+      <DialogContentImpl
+        {...props}
+        ref={composedRefs}
+        // we make sure focus isn't trapped once `DialogContent` has been closed
+        // (closed !== unmounted when animating out)
+        trapFocus={context.open}
+        disableOutsidePointerEvents
+        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          event.preventDefault();
+          context.triggerRef.current?.focus();
+        })}
+        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+          const originalEvent = event.detail.originalEvent;
+          const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
+          const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
 
-            // If the event is a right-click, we shouldn't close because
-            // it is effectively as if we right-clicked the `Overlay`.
-            if (isRightClick) event.preventDefault();
-          })}
-          // When focus is trapped, a `focusout` event may still happen.
-          // We make sure we don't trigger our `onDismiss` in such case.
-          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
-            event.preventDefault()
-          )}
-        />
-      </RemoveScroll>
+          // If the event is a right-click, we shouldn't close because
+          // it is effectively as if we right-clicked the `Overlay`.
+          if (isRightClick) event.preventDefault();
+        })}
+        // When focus is trapped, a `focusout` event may still happen.
+        // We make sure we don't trigger our `onDismiss` in such case.
+        onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+          event.preventDefault()
+        )}
+      />
     );
   }
 );

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -182,7 +182,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
           data-state={getState(context.open)}
           {...overlayProps}
           ref={forwardedRef}
-          // We re-enable pointerEvents on the Overlay to enable scrolling
+          // We re-enable pointer-events prevented by `Dialog.Content` to allow scrolling the overlay.
           style={{ pointerEvents: 'auto', ...overlayProps.style }}
         />
       </RemoveScroll>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,7 +3490,6 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
-    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0


### PR DESCRIPTION
Fixes #887

I'll explain the thoughts I had and what I did here:

## Problem
The main issue left with being able to create an outer scrolling dialog was that we have `RemoveScroll` in `DialogContent`, therefore making the overlay non-scrollable too.

## Thoughts and solution
- The overlay is only used when it's a modal dialog, which incidentally is when we want to remove scroll (sure enough, we were doing this in `DialogContentModal`)
- So I moved `RemoveScroll` inside `DialogOverlayImpl`.
- The only remaining issue was that we also disable outside pointer events from `DialogContentModal`, so that was still preventing scrolling the overlay, for that I specifically re-enable them on the overlay.
- It also required moving the `allowPinchZoom` prop as it was previously on `DialogContent`. I remember almost raising this in the previous PR review that I thought perhaps it should live at the root as it's kinda an implementation detail that it was on the "content". I guess this solidified that feeling, we could have moved the prop to the overlay but it would definitely feel odd there I think.

---

Notes for docs:
- Make sure the `allowPinchZoom` prop is documented on the right part (`Root`).