### PR TITLE
[ToggleGroup] Fix `orientation` a11y

### DIFF
--- a/.yarn/versions/e0af1fb6.yml
+++ b/.yarn/versions/e0af1fb6.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -596,8 +596,9 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                 >
                   <PopperPrimitive.Content
                     role="menu"
-                    dir={context.dir}
+                    aria-orientation="vertical"
                     data-state={getOpenState(context.open)}
+                    dir={context.dir}
                     {...popperScope}
                     {...contentProps}
                     ref={composedRefs}

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -90,6 +90,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
         >
           <Primitive.div
             role="radiogroup"
+            aria-orientation={orientation}
             aria-labelledby={labelledBy}
             dir={dir}
             {...groupProps}

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -142,7 +142,6 @@ const RovingFocusGroupImpl = React.forwardRef<
     >
       <Primitive.div
         tabIndex={isTabbingBackOut ? -1 : 0}
-        aria-orientation={orientation}
         data-orientation={orientation}
         {...groupProps}
         ref={composedRefs}

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -120,7 +120,13 @@ const TabsList = React.forwardRef<TabsListElement, TabsListProps>(
         dir={context.dir}
         loop={loop}
       >
-        <Primitive.div role="tablist" dir={context.dir} {...listProps} ref={forwardedRef} />
+        <Primitive.div
+          role="tablist"
+          aria-orientation={context.orientation}
+          dir={context.dir}
+          {...listProps}
+          ref={forwardedRef}
+        />
       </RovingFocusGroup.Root>
     );
   }

--- a/packages/react/toggle-group/src/ToggleGroup.stories.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.stories.tsx
@@ -45,6 +45,28 @@ export const Single = () => {
   );
 };
 
+export const Vertical = () => {
+  return (
+    <ToggleGroup
+      type="single"
+      orientation="vertical"
+      className={rootClass}
+      aria-label="Options"
+      defaultValue="1"
+    >
+      <ToggleGroupItem value="1" className={itemClass}>
+        Option 1
+      </ToggleGroupItem>
+      <ToggleGroupItem value="2" className={itemClass}>
+        Option 2
+      </ToggleGroupItem>
+      <ToggleGroupItem value="3" className={itemClass}>
+        Option 3
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
 export const Multiple = () => {
   const [value, setValue] = React.useState<string[]>([]);
   return (
@@ -233,9 +255,12 @@ export const Chromatic = () => (
 Chromatic.parameters = { chromatic: { disable: false } };
 
 const rootClass = css({
-  display: 'flex',
+  display: 'inline-flex',
   gap: 5,
   padding: 5,
+  '&[data-orientation="vertical"]': {
+    flexDirection: 'column',
+  },
 });
 
 const itemClass = css({

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -57,7 +57,13 @@ const Toolbar = React.forwardRef<ToolbarElement, ToolbarProps>(
           dir={dir}
           loop={loop}
         >
-          <Primitive.div role="toolbar" dir={dir} {...toolbarProps} ref={forwardedRef} />
+          <Primitive.div
+            role="toolbar"
+            aria-orientation={orientation}
+            dir={dir}
+            {...toolbarProps}
+            ref={forwardedRef}
+          />
         </RovingFocusGroup.Root>
       </ToolbarProvider>
     );


### PR DESCRIPTION
Fixes #964

I've removed the `aria-orientation` from `RovingFocusGroup` and applied it in the relevant components instead.