### PR TITLE
[DropdownMenu][Tooltip][Tabs] Use button with `onClick` for trigger

### DIFF
--- a/.yarn/versions/898c0ebd.yml
+++ b/.yarn/versions/898c0ebd.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -168,6 +168,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
+          onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(true))}
           onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
@@ -178,8 +179,8 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
               context.onOpenToggle();
             }
           })}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event: React.KeyboardEvent) => {
-            if (!disabled && [' ', 'Enter', 'ArrowDown'].includes(event.key)) {
+          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+            if (!disabled && event.key === 'ArrowDown') {
               event.preventDefault();
               context.onOpenChange(true);
             }

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -168,6 +168,8 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
+          // Handle anything that the browser considers a click for the element type if
+          // not using pointer e.g. Space keyup and Enter keydown
           onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(true))}
           onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)

--- a/packages/react/tabs/src/Tabs.stories.tsx
+++ b/packages/react/tabs/src/Tabs.stories.tsx
@@ -205,6 +205,7 @@ const listClass = css({
 });
 
 const RECOMMENDED_CSS__TABS__TRIGGER = {
+  all: 'unset' as any,
   flexShrink: 0,
 };
 

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -173,6 +173,8 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
           id={triggerId}
           {...triggerProps}
           ref={forwardedRef}
+          // Handle anything that the browser considers a click for the element type if
+          // not using pointer e.g. Space keyup and Enter keydown
           onClick={composeEventHandlers(props.onClick, handleTabChange)}
           onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -140,10 +140,10 @@ TabsList.displayName = TAB_LIST_NAME;
 
 const TRIGGER_NAME = 'TabsTrigger';
 
-type TabsTriggerElement = React.ElementRef<typeof Primitive.div>;
-interface TabsTriggerProps extends PrimitiveDivProps {
+type TabsTriggerElement = React.ElementRef<typeof Primitive.button>;
+type PrimitiveButtonProps = Radix.ComponentPropsWithoutRef<typeof Primitive.button>;
+interface TabsTriggerProps extends PrimitiveButtonProps {
   value: string;
-  disabled?: boolean;
 }
 
 const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
@@ -162,21 +162,18 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
         focusable={!disabled}
         active={isSelected}
       >
-        <Primitive.div
+        <Primitive.button
+          type="button"
           role="tab"
           aria-selected={isSelected}
           aria-controls={contentId}
-          aria-disabled={disabled || undefined}
           data-state={isSelected ? 'active' : 'inactive'}
           data-disabled={disabled ? '' : undefined}
+          disabled={disabled}
           id={triggerId}
           {...triggerProps}
           ref={forwardedRef}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-            if (!disabled && (event.key === ' ' || event.key === 'Enter')) {
-              handleTabChange();
-            }
-          })}
+          onClick={composeEventHandlers(props.onClick, handleTabChange)}
           onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -199,6 +199,8 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           onMouseDown={composeEventHandlers(props.onMouseDown, context.onClose)}
           onFocus={composeEventHandlers(props.onFocus, context.onFocus)}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
+          // Handle anything that the browser considers a click for the element type if
+          // not using pointer e.g. Space keyup and Enter keydown
           onClick={composeEventHandlers(props.onClick, context.onClose)}
         />
       </PopperPrimitive.Anchor>

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -199,11 +199,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           onMouseDown={composeEventHandlers(props.onMouseDown, context.onClose)}
           onFocus={composeEventHandlers(props.onFocus, context.onFocus)}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-              context.onClose();
-            }
-          })}
+          onClick={composeEventHandlers(props.onClick, context.onClose)}
         />
       </PopperPrimitive.Anchor>
     );


### PR DESCRIPTION
[This discussion](https://github.com/radix-ui/primitives/issues/980) reminded me of something that has been bothering me for some time so thought I'd propose this PR before I head off for the day to discuss whenever.


### Notes for docs

- Breaking change for tabs. Need to apply `all: unset` or similar to `Tabs.Trigger`.