### PR TITLE
[Dialog][AlertDialog] Fix `Dialog` unmount animation

### DIFF
--- a/.yarn/versions/c31614bf.yml
+++ b/.yarn/versions/c31614bf.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "^2.4.0"

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -72,14 +72,19 @@ Portal.displayName = PORTAL_NAME;
 
 const UNSTABLE_PORTAL_NAME = 'Portal';
 
-interface UnstablePortalProps {
+type UnstablePortalElement = React.ElementRef<typeof Primitive.div>;
+interface UnstablePortalProps extends PrimitiveDivProps {
   container?: HTMLElement | null;
 }
 
-const UnstablePortal: React.FC<UnstablePortalProps> = (props) => {
-  const { container = globalThis?.document?.body, children } = props;
-  return container ? ReactDOM.createPortal(<>{children}</>, container) : null;
-};
+const UnstablePortal = React.forwardRef<UnstablePortalElement, UnstablePortalProps>(
+  (props, forwardedRef) => {
+    const { container = globalThis?.document?.body, ...portalProps } = props;
+    return container
+      ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
+      : null;
+  }
+);
 
 Portal.displayName = UNSTABLE_PORTAL_NAME;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,6 +3490,7 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: ^2.4.0


### PR DESCRIPTION
When I added the new `Dialog.Portal` part, I forgot to portal from inside `Presence` which meant its `context.open` check would rip the dialog parts out before `Presence` could suspend.

~The `Dialog.Portal` just renders a provider instead now so we can read that inside the relevant parts and wrap them in a portal when necessary.~ I map over the `children` and wrap them in `Presence` and `UnstablePortal` instead.

### Notes for docs

- ✨ &nbsp; New `forceMount` prop on `Dialog.Portal`.