### PR TITLE
[Tooltip] Remove `type="button"`

### DIFF
--- a/.yarn/versions/83127137.yml
+++ b/.yarn/versions/83127137.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -189,7 +189,6 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
     return (
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
-          type="button"
           aria-describedby={context.open ? context.contentId : undefined}
           data-state={context.stateAttribute}
           {...triggerProps}

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -189,6 +189,8 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
     return (
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
+          // We purposefully avoid adding `type=button` here because tooltip triggers are also
+          // commonly anchors and the anchor `type` attribute signifies MIME type.
           aria-describedby={context.open ? context.contentId : undefined}
           data-state={context.stateAttribute}
           {...triggerProps}


### PR DESCRIPTION
Closes #1010 
Closes #993

I haven't done this for our other components that add `type="button"` since  I don't believe we have had reports regarding those yet. Not sure what thoughts are here though?
