### PR TITLE
[Dialog][AlertDialog] Omit `asChild` from `Portal`

### DIFF
--- a/.yarn/versions/a90db96c.yml
+++ b/.yarn/versions/a90db96c.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -130,7 +130,7 @@ const PORTAL_NAME = 'DialogPortal';
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
 type DialogPortalElement = React.ElementRef<typeof UnstablePortal>;
-interface DialogPortalProps extends PortalProps {
+interface DialogPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
    * Used to force mounting when more control is needed. Useful when
@@ -141,13 +141,13 @@ interface DialogPortalProps extends PortalProps {
 
 const DialogPortal = React.forwardRef<DialogPortalElement, DialogPortalProps>(
   (props: ScopedProps<DialogPortalProps>, forwardedRef) => {
-    const { __scopeDialog, forceMount, children, asChild = true, ...portalProps } = props;
+    const { __scopeDialog, forceMount, children, ...portalProps } = props;
     const context = useDialogContext(PORTAL_NAME, __scopeDialog);
     return (
       <>
         {React.Children.map(children, (child) => (
           <Presence present={forceMount || context.open}>
-            <UnstablePortal {...portalProps} asChild={asChild} ref={forwardedRef}>
+            <UnstablePortal {...portalProps} asChild ref={forwardedRef}>
               {child}
             </UnstablePortal>
           </Presence>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -141,13 +141,13 @@ interface DialogPortalProps extends PortalProps {
 
 const DialogPortal = React.forwardRef<DialogPortalElement, DialogPortalProps>(
   (props: ScopedProps<DialogPortalProps>, forwardedRef) => {
-    const { __scopeDialog, forceMount, children, ...portalProps } = props;
+    const { __scopeDialog, forceMount, children, asChild = true, ...portalProps } = props;
     const context = useDialogContext(PORTAL_NAME, __scopeDialog);
     return (
       <>
         {React.Children.map(children, (child) => (
           <Presence present={forceMount || context.open}>
-            <UnstablePortal {...portalProps} asChild ref={forwardedRef}>
+            <UnstablePortal {...portalProps} asChild={asChild} ref={forwardedRef}>
               {child}
             </UnstablePortal>
           </Presence>


### PR DESCRIPTION
I noticed when documenting the release that the prop types for `Dialog.Portal` have the `asChild` prop but it doesn't do anything at the moment. Either we remove it from types or pass it along?

I've gone with passing it along for now in case people want the portal to render a `div`, then they can pass `asChild={false}`. I dunno if that's likely to be a valid use-case though so happy to remove it.