### PR TITLE
[All] Fix `React.useId` check bundler issues

### DIFF
--- a/.yarn/versions/f53fead8.yml
+++ b/.yarn/versions/f53fead8.yml
@@ -1,0 +1,22 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-id": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/id/src/id.tsx
+++ b/packages/react/id/src/id.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
-const useReactId = (React as any).useId || (() => undefined);
+// We `toString()` to prevent bundlers from trying to `import { useId } from 'react';`
+const useReactId = (React as any)['useId'.toString()] || (() => undefined);
 let count = 0;
 
 function useId(deterministicId?: string): string {


### PR DESCRIPTION
Fixes #1023

It seems some bundlers will try to be clever and convert `import * as React` to `import { useId } from 'react'` which would throw `'useId' does not exist` errors.

This PR adds a workaround to prevent them from trying to do this.