### PR TITLE
[Accordion][Collapsible] Fix prevent mount animation

### DIFF
--- a/.yarn/versions/817fc7b7.yml
+++ b/.yarn/versions/817fc7b7.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-collapsible": patch
+
+declined:
+  - primitives


### PR DESCRIPTION
I realised while testing the release that the fix prevents the mount animation but then also prevents the close animation (for the item that is open on mount) the first time it is closed.