### PR TITLE
[Tooltip] Revert "Fix trigger when another tooltip overlays it"

### DIFF
--- a/.yarn/versions/244db929.yml
+++ b/.yarn/versions/244db929.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -538,33 +538,11 @@ export const Animated = () => {
   return (
     <TooltipProvider>
       <div style={{ padding: 100 }}>
-        <h1>Not covering triggers</h1>
-
         <SimpleTooltip className={animatedContentClass} label="Hello world 1">
           <TooltipTrigger style={{ marginRight: 10 }}>Hello 1</TooltipTrigger>
         </SimpleTooltip>
 
         <SimpleTooltip className={animatedContentClass} label="Hello world 2" side="top">
-          <TooltipTrigger>Hello 2</TooltipTrigger>
-        </SimpleTooltip>
-
-        <h1>Covering triggers</h1>
-
-        <SimpleTooltip
-          className={animatedContentClass}
-          side="right"
-          sideOffset={5}
-          label="Hello world 1"
-        >
-          <TooltipTrigger style={{ marginRight: 10 }}>Hello 1</TooltipTrigger>
-        </SimpleTooltip>
-
-        <SimpleTooltip
-          className={animatedContentClass}
-          side="left"
-          label="Hello world 2"
-          sideOffset={5}
-        >
           <TooltipTrigger>Hello 2</TooltipTrigger>
         </SimpleTooltip>
       </div>

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -235,7 +235,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           data-state={context.stateAttribute}
           {...triggerProps}
           ref={composedTriggerRef}
-          onMouseOver={composeEventHandlers(props.onMouseOver, context.onOpen)}
+          onMouseEnter={composeEventHandlers(props.onMouseEnter, context.onOpen)}
           onMouseLeave={composeEventHandlers(props.onMouseLeave, context.onClose)}
           onMouseDown={composeEventHandlers(props.onMouseDown, context.onClose)}
           onFocus={composeEventHandlers(props.onFocus, context.onFocus)}


### PR DESCRIPTION
Reverts [the original fix](https://github.com/radix-ui/primitives/pull/1018). We've realised that given the following "Hoverable" a11y criteria, the tooltips should remain open when the mouse moves over them. In which case, applying `pointer-events: none` would fail a11y.

https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus