### PR TITLE
[Storybook] Fix Collection stories

### DIFF
--- a/packages/react/collection/src/Collection.stories.tsx
+++ b/packages/react/collection/src/Collection.stories.tsx
@@ -157,7 +157,7 @@ const MemoItem = React.memo(Item);
 const MemoItems = React.memo(WrappedItems);
 
 function LogItems({ name = 'items' }: { name?: string }) {
-  const getItems = useCollection({});
+  const getItems = useCollection(undefined);
   React.useEffect(() => console.log(name, getItems()));
   return null;
 }


### PR DESCRIPTION
Whilst checking every story when working on #1048 I noticed all of the `Collection` stories were broken.
Probably have been broken since we use the scoping of contexts, the scope wasn't matching in `useCollection` usage.