### PR TITLE
Update Accordion.test.tsx

### DIFF
--- a/packages/react/accordion/src/Accordion.test.tsx
+++ b/packages/react/accordion/src/Accordion.test.tsx
@@ -80,11 +80,11 @@ describe('given a single Accordion', () => {
         fireEvent.click(trigger);
       });
 
-      it('should not close the content', () => {
-        expect(contentOne).toBeVisible();
+      it('should close the content', () => {
+        expect(contentOne).not.toBeVisible();
       });
 
-      it('should not call onValueChange', () => {
+      it('should call onValueChange', () => {
         expect(handleValueChange).toHaveBeenCalledTimes(1);
       });
     });


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

As seen in the described behaviour, clicking the trigger again hides the content

I don't know if this is a relevant PR, but just made sense to me when I was extending and testing the Accordion behaviour.

I haven't been able to install dependencies in my fork so I am not able to run the ci pipeline to check this.


<!-- Describe the change you are introducing -->
