### PR TITLE
[Fix][Dialog] forceMount type for `Overlay` & `Content`

### DIFF
--- a/.yarn/versions/6427e47a.yml
+++ b/.yarn/versions/6427e47a.yml
@@ -1,3 +1,6 @@
 releases:
   "@radix-ui/react-alert-dialog": patch
   "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/6427e47a.yml
+++ b/.yarn/versions/6427e47a.yml
@@ -1,0 +1,3 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -171,7 +171,7 @@ interface DialogOverlayProps extends DialogOverlayImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.
    */
-  forceMount?: true;
+  forceMount?: boolean;
 }
 
 const DialogOverlay = React.forwardRef<DialogOverlayElement, DialogOverlayProps>(
@@ -224,7 +224,7 @@ interface DialogContentProps extends DialogContentTypeProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.
    */
-  forceMount?: true;
+  forceMount?: boolean;
 }
 
 const DialogContent = React.forwardRef<DialogContentElement, DialogContentProps>(


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

the `forceMount` prop on [`Dialog.Overlay`](https://www.radix-ui.com/docs/primitives/components/dialog#overlay) and [`Dialog.Content`](https://www.radix-ui.com/docs/primitives/components/dialog#content) both specify that the value should be `boolean` however the type signature has been declared as `true` therefore providing `false` creates a TS error. 

Maybe the initial idea was that `undefined` could be used instead, but if you pair it up with `onOpenChange` from `Dialog.Root` you're only provided `boolean` values.

### What

To solve this, I've replaced the `true` value with `false`.