### PR TITLE
[usePrevious] Persist return value between renders

### DIFF
--- a/.yarn/versions/ee709007.yml
+++ b/.yarn/versions/ee709007.yml
@@ -1,0 +1,10 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-previous": patch
+
+declined:
+  - primitives

--- a/packages/react/use-previous/src/usePrevious.tsx
+++ b/packages/react/use-previous/src/usePrevious.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
 function usePrevious<T>(value: T) {
-  // The ref object is a generic container whose current property is mutable ...
-  // ... and can hold any value, similar to an instance property on a class
   const ref = React.useRef({ value, previous: value });
 
   // We compare values before making an update to ensure that

--- a/packages/react/use-previous/src/usePrevious.tsx
+++ b/packages/react/use-previous/src/usePrevious.tsx
@@ -3,15 +3,18 @@ import * as React from 'react';
 function usePrevious<T>(value: T) {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
-  const ref = React.useRef<T>(value);
+  const ref = React.useRef({ value, previous: value });
 
-  // Store current value in ref
-  React.useEffect(() => {
-    ref.current = value;
-  }, [value]); // Only re-run if value changes
-
-  // Return previous value (happens before update in useEffect above)
-  return ref.current;
+  // We compare values before making an update to ensure that
+  // a change has been made. This ensures the previous value is
+  // persisted correctly between renders.
+  return React.useMemo(() => {
+    if (ref.current.value !== value) {
+      ref.current.previous = ref.current.value;
+      ref.current.value = value;
+    }
+    return ref.current.previous;
+  }, [value]);
 }
 
 export { usePrevious };


### PR DESCRIPTION
Based on our discussion on the expected behaviour of `usePrevious`. The [typical approach](https://usehooks.com/usePrevious/) actually returns the value from the previous **render**, our thinking however is that this is unintuitive and unexpected. Our expectation is that the value should represent the previous `value` that was **different** e.g. the previous value after it was changed, independent of any re-rendering that may occur.

You can see the difference below, notice how the previous value in the "common" demo only meets our expectation for a single render while "Adjusted" consistently meets it no matter how many renders occur.
 
https://codesandbox.io/s/summer-dream-7qymy?file=/src/App.js
