### PR TITLE
[Dialog][AlertDialog] Share `forceMount` from Portal

### DIFF
--- a/.yarn/versions/0c1db6bc.yml
+++ b/.yarn/versions/0c1db6bc.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -210,15 +210,16 @@ export const Animated = () => (
 export const ForcedMount = () => (
   <Dialog>
     <DialogTrigger>open</DialogTrigger>
-    <DialogPortal>
-      <DialogOverlay className={overlayClass} forceMount />
-      <DialogContent className={contentDefaultClass} forceMount>
+    <DialogPortal forceMount>
+      <DialogOverlay className={overlayClass} />
+      <DialogContent className={contentDefaultClass}>
         <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
   </Dialog>
 );
+ForcedMount.parameters = { chromatic: { disable: false } };
 
 export const AllowPinchZoom = () => (
   <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -35,10 +35,10 @@ export const NonModal = () => (
         <DialogOverlay className={overlayClass} />
         <DialogContent
           className={contentSheetClass}
-          aria-describedby={undefined}
           onInteractOutside={(event) => event.preventDefault()}
         >
           <DialogTitle>Booking info</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
           <DialogClose className={closeClass}>close</DialogClose>
         </DialogContent>
       </DialogPortal>
@@ -62,8 +62,9 @@ export const Controlled = () => {
       <DialogTrigger>{open ? 'close' : 'open'}</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
+        <DialogContent className={contentDefaultClass}>
           <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
           <DialogClose>close</DialogClose>
         </DialogContent>
       </DialogPortal>
@@ -77,9 +78,10 @@ export const FocusTrap = () => (
       <DialogTrigger>open</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
+        <DialogContent className={contentDefaultClass}>
           <DialogClose>close</DialogClose>
           <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
           <div>
             <label htmlFor="firstName">First Name</label>
             <input type="text" id="firstName" placeholder="John" />
@@ -110,7 +112,6 @@ export const CustomFocus = () => {
           <DialogOverlay className={overlayClass} />
           <DialogContent
             className={contentDefaultClass}
-            aria-describedby={undefined}
             onOpenAutoFocus={(event) => {
               event.preventDefault();
               firstNameRef.current?.focus();
@@ -124,7 +125,10 @@ export const CustomFocus = () => {
 
             <div>
               <DialogTitle>Title</DialogTitle>
-              <p>The first name input will receive the focus after opening the dialog.</p>
+              <DialogDescription>
+                The first name input will receive the focus after opening the dialog.
+              </DialogDescription>
+
               <label htmlFor="firstName">First Name</label>
               <input type="text" id="firstName" placeholder="John" ref={firstNameRef} />
 
@@ -152,10 +156,12 @@ export const NoEscapeDismiss = () => (
       <DialogOverlay className={overlayClass} />
       <DialogContent
         className={contentDefaultClass}
-        aria-describedby={undefined}
         onEscapeKeyDown={(event) => event.preventDefault()}
       >
         <DialogTitle>Title</DialogTitle>
+        <DialogDescription>
+          The first name input will receive the focus after opening the dialog.
+        </DialogDescription>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
@@ -169,10 +175,10 @@ export const NoPointerDownOutsideDismiss = () => (
       <DialogOverlay className={overlayClass} />
       <DialogContent
         className={contentDefaultClass}
-        aria-describedby={undefined}
         onPointerDownOutside={(event) => event.preventDefault()}
       >
         <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Description</DialogDescription>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
@@ -187,8 +193,9 @@ export const WithPortalContainer = () => {
         <DialogTrigger>open</DialogTrigger>
         <DialogPortal container={portalContainer}>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
+          <DialogContent className={contentDefaultClass}>
             <DialogTitle>Title</DialogTitle>
+            <DialogDescription>Description</DialogDescription>
             <DialogClose>close</DialogClose>
           </DialogContent>
         </DialogPortal>
@@ -203,8 +210,9 @@ export const Animated = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal>
       <DialogOverlay className={animatedOverlayClass} />
-      <DialogContent className={animatedContentClass} aria-describedby={undefined}>
+      <DialogContent className={animatedContentClass}>
         <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Description</DialogDescription>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
@@ -216,8 +224,9 @@ export const ForcedMount = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal forceMount>
       <DialogOverlay className={overlayClass} />
-      <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
+      <DialogContent className={contentDefaultClass}>
         <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Description</DialogDescription>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
@@ -288,8 +297,9 @@ export const Chromatic = () => (
           <DialogTrigger className={triggerClass}>open</DialogTrigger>
           <DialogPortal>
             <DialogOverlay className={overlayClass} />
-            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+            <DialogContent className={chromaticContentClass}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -303,12 +313,9 @@ export const Chromatic = () => (
               className={overlayClass}
               style={{ left: 0, bottom: '50%', width: '25%' }}
             />
-            <DialogContent
-              className={chromaticContentClass}
-              style={{ top: '25%', left: '12%' }}
-              aria-describedby={undefined}
-            >
+            <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '12%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -321,8 +328,9 @@ export const Chromatic = () => (
         <Dialog>
           <DialogPortal>
             <DialogOverlay className={overlayClass} />
-            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+            <DialogContent className={chromaticContentClass}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -336,12 +344,9 @@ export const Chromatic = () => (
               className={overlayClass}
               style={{ left: '25%', bottom: '50%', width: '25%' }}
             />
-            <DialogContent
-              className={chromaticContentClass}
-              style={{ top: '25%', left: '37%' }}
-              aria-describedby={undefined}
-            >
+            <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '37%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -356,8 +361,9 @@ export const Chromatic = () => (
           <DialogTrigger className={triggerClass}>open</DialogTrigger>
           <DialogPortal>
             <DialogOverlay className={overlayClass} />
-            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+            <DialogContent className={chromaticContentClass}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -371,12 +377,9 @@ export const Chromatic = () => (
               className={overlayClass}
               style={{ left: '50%', bottom: '50%', width: '25%' }}
             />
-            <DialogContent
-              className={chromaticContentClass}
-              aria-describedby={undefined}
-              style={{ top: '25%', left: '62%' }}
-            >
+            <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '62%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -389,8 +392,9 @@ export const Chromatic = () => (
         <Dialog open={false}>
           <DialogPortal>
             <DialogOverlay className={overlayClass} />
-            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+            <DialogContent className={chromaticContentClass}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -404,12 +408,9 @@ export const Chromatic = () => (
               className={overlayClass}
               style={{ left: '75%', bottom: '50%', width: '25%' }}
             />
-            <DialogContent
-              className={chromaticContentClass}
-              aria-describedby={undefined}
-              style={{ top: '25%', left: '88%' }}
-            >
+            <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '88%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -437,12 +438,9 @@ export const Chromatic = () => (
                 backgroundColor: 'rgba(0, 0, 0, 0.3)',
               }}
             />
-            <DialogContent
-              className={chromaticContentClass}
-              aria-describedby={undefined}
-              style={{ left: '25%', top: '75%' }}
-            >
+            <DialogContent className={chromaticContentClass} style={{ left: '25%', top: '75%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -456,8 +454,9 @@ export const Chromatic = () => (
           <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
           <DialogPortal>
             <DialogOverlay className={overlayAttrClass} />
-            <DialogContent className={contentAttrClass} aria-describedby={undefined}>
+            <DialogContent className={contentAttrClass}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeAttrClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>
@@ -468,12 +467,9 @@ export const Chromatic = () => (
           <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
           <DialogPortal>
             <DialogOverlay className={overlayAttrClass} style={{ left: '50%', top: '50%' }} />
-            <DialogContent
-              className={contentAttrClass}
-              aria-describedby={undefined}
-              style={{ left: '75%', top: '75%' }}
-            >
+            <DialogContent className={contentAttrClass} style={{ left: '75%', top: '75%' }}>
               <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
               <DialogClose className={closeAttrClass}>close</DialogClose>
             </DialogContent>
           </DialogPortal>

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -223,7 +223,6 @@ export const ForcedMount = () => (
     </DialogPortal>
   </Dialog>
 );
-ForcedMount.parameters = { chromatic: { disable: false, delay: 1000 } };
 
 export const AllowPinchZoom = () => (
   <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
@@ -274,181 +273,214 @@ export const OuterScrollable = () => (
 );
 
 export const Chromatic = () => (
-  <div
-    style={{
-      display: 'grid',
-      gridTemplateColumns: 'repeat(4, 1fr)',
-      gridTemplateRows: 'repeat(2, 1fr)',
-      height: '100vh',
-    }}
-  >
-    <div>
-      <h1>Uncontrolled</h1>
-      <h2>Closed</h2>
-      <Dialog>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
+  <>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(4, 1fr)',
+        height: '50vh',
+      }}
+    >
+      <div>
+        <h1>Uncontrolled</h1>
+        <h2>Closed</h2>
+        <Dialog>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay className={overlayClass} />
+            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
 
-      <h2>Open</h2>
-      <Dialog defaultOpen>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay
-            className={overlayClass}
-            style={{ left: 0, bottom: '50%', width: '25%' }}
-          />
-          <DialogContent
-            className={chromaticContentClass}
-            style={{ top: '25%', left: '12%' }}
-            aria-describedby={undefined}
-          >
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
+        <h2>Open</h2>
+        <Dialog defaultOpen>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay
+              className={overlayClass}
+              style={{ left: 0, bottom: '50%', width: '25%' }}
+            />
+            <DialogContent
+              className={chromaticContentClass}
+              style={{ top: '25%', left: '12%' }}
+              aria-describedby={undefined}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </div>
+
+      <div>
+        <h1>Uncontrolled with reordered parts</h1>
+        <h2>Closed</h2>
+        <Dialog>
+          <DialogPortal>
+            <DialogOverlay className={overlayClass} />
+            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+        </Dialog>
+
+        <h2>Open</h2>
+        <Dialog defaultOpen>
+          <DialogPortal>
+            <DialogOverlay
+              className={overlayClass}
+              style={{ left: '25%', bottom: '50%', width: '25%' }}
+            />
+            <DialogContent
+              className={chromaticContentClass}
+              style={{ top: '25%', left: '37%' }}
+              aria-describedby={undefined}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+        </Dialog>
+      </div>
+
+      <div>
+        <h1>Controlled</h1>
+        <h2>Closed</h2>
+        <Dialog open={false}>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay className={overlayClass} />
+            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+
+        <h2>Open</h2>
+        <Dialog open>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay
+              className={overlayClass}
+              style={{ left: '50%', bottom: '50%', width: '25%' }}
+            />
+            <DialogContent
+              className={chromaticContentClass}
+              aria-describedby={undefined}
+              style={{ top: '25%', left: '62%' }}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </div>
+
+      <div>
+        <h1>Controlled with reordered parts</h1>
+        <h2>Closed</h2>
+        <Dialog open={false}>
+          <DialogPortal>
+            <DialogOverlay className={overlayClass} />
+            <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+        </Dialog>
+
+        <h2>Open</h2>
+        <Dialog open>
+          <DialogPortal>
+            <DialogOverlay
+              className={overlayClass}
+              style={{ left: '75%', bottom: '50%', width: '25%' }}
+            />
+            <DialogContent
+              className={chromaticContentClass}
+              aria-describedby={undefined}
+              style={{ top: '25%', left: '88%' }}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+        </Dialog>
+      </div>
     </div>
 
-    <div>
-      <h1>Uncontrolled with reordered parts</h1>
-      <h2>Closed</h2>
-      <Dialog>
-        <DialogPortal>
-          <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-      </Dialog>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, 1fr)',
+        height: '50vh',
+      }}
+    >
+      <div>
+        <h1>Forced Mount</h1>
+        <Dialog>
+          <DialogTrigger className={triggerClass}>open</DialogTrigger>
+          <DialogPortal forceMount>
+            <DialogOverlay
+              className={overlayClass}
+              style={{
+                top: '50%',
+                backgroundColor: 'rgba(0, 0, 0, 0.3)',
+              }}
+            />
+            <DialogContent
+              className={chromaticContentClass}
+              aria-describedby={undefined}
+              style={{ left: '25%', top: '75%' }}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </div>
 
-      <h2>Open</h2>
-      <Dialog defaultOpen>
-        <DialogPortal>
-          <DialogOverlay
-            className={overlayClass}
-            style={{ left: '25%', bottom: '50%', width: '25%' }}
-          />
-          <DialogContent
-            className={chromaticContentClass}
-            style={{ top: '25%', left: '37%' }}
-            aria-describedby={undefined}
-          >
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-      </Dialog>
+      <div>
+        <h1>State attributes</h1>
+        <h2>Closed</h2>
+        <Dialog>
+          <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay className={overlayAttrClass} />
+            <DialogContent className={contentAttrClass} aria-describedby={undefined}>
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeAttrClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+
+        <h2>Open</h2>
+        <Dialog defaultOpen>
+          <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay className={overlayAttrClass} style={{ left: '50%', top: '50%' }} />
+            <DialogContent
+              className={contentAttrClass}
+              aria-describedby={undefined}
+              style={{ left: '75%', top: '75%' }}
+            >
+              <DialogTitle>Title</DialogTitle>
+              <DialogClose className={closeAttrClass}>close</DialogClose>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </div>
     </div>
-
-    <div>
-      <h1>Controlled</h1>
-      <h2>Closed</h2>
-      <Dialog open={false}>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
-
-      <h2>Open</h2>
-      <Dialog open>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay
-            className={overlayClass}
-            style={{ left: '50%', bottom: '50%', width: '25%' }}
-          />
-          <DialogContent
-            className={chromaticContentClass}
-            aria-describedby={undefined}
-            style={{ top: '25%', left: '62%' }}
-          >
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
-    </div>
-
-    <div>
-      <h1>Controlled with reordered parts</h1>
-      <h2>Closed</h2>
-      <Dialog open={false}>
-        <DialogPortal>
-          <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-      </Dialog>
-
-      <h2>Open</h2>
-      <Dialog open>
-        <DialogPortal>
-          <DialogOverlay
-            className={overlayClass}
-            style={{ left: '75%', bottom: '50%', width: '25%' }}
-          />
-          <DialogContent
-            className={chromaticContentClass}
-            aria-describedby={undefined}
-            style={{ top: '25%', left: '88%' }}
-          >
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-        <DialogTrigger className={triggerClass}>open</DialogTrigger>
-      </Dialog>
-    </div>
-
-    <div>
-      <h1>State attributes</h1>
-      <h2>Closed</h2>
-      <Dialog>
-        <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay className={overlayAttrClass} />
-          <DialogContent className={contentAttrClass} aria-describedby={undefined}>
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeAttrClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
-
-      <h2>Open</h2>
-      <Dialog defaultOpen>
-        <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
-        <DialogPortal>
-          <DialogOverlay className={overlayAttrClass} style={{ top: '50%' }} />
-          <DialogContent
-            className={contentAttrClass}
-            aria-describedby={undefined}
-            style={{ top: '75%' }}
-          >
-            <DialogTitle>Title</DialogTitle>
-            <DialogClose className={closeAttrClass}>close</DialogClose>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
-    </div>
-  </div>
+  </>
 );
 Chromatic.parameters = { chromatic: { disable: false } };
 

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -426,7 +426,7 @@ export const Chromatic = () => (
       }}
     >
       <div>
-        <h1>Forced Mount</h1>
+        <h1>Forced mount</h1>
         <Dialog>
           <DialogTrigger className={triggerClass}>open</DialogTrigger>
           <DialogPortal forceMount>
@@ -487,7 +487,7 @@ Chromatic.parameters = { chromatic: { disable: false } };
 const triggerClass = css({});
 
 const RECOMMENDED_CSS__DIALOG__OVERLAY: any = {
-  // ensures overlay is positionned correctly
+  // ensures overlay is positioned correctly
   position: 'fixed',
   top: 0,
   right: 0,

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -35,6 +35,7 @@ export const NonModal = () => (
         <DialogOverlay className={overlayClass} />
         <DialogContent
           className={contentSheetClass}
+          aria-describedby={undefined}
           onInteractOutside={(event) => event.preventDefault()}
         >
           <DialogTitle>Booking info</DialogTitle>
@@ -61,7 +62,7 @@ export const Controlled = () => {
       <DialogTrigger>{open ? 'close' : 'open'}</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentDefaultClass}>
+        <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
           <DialogTitle>Title</DialogTitle>
           <DialogClose>close</DialogClose>
         </DialogContent>
@@ -76,7 +77,7 @@ export const FocusTrap = () => (
       <DialogTrigger>open</DialogTrigger>
       <DialogPortal>
         <DialogOverlay className={overlayClass} />
-        <DialogContent className={contentDefaultClass}>
+        <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
           <DialogClose>close</DialogClose>
           <DialogTitle>Title</DialogTitle>
           <div>
@@ -109,6 +110,7 @@ export const CustomFocus = () => {
           <DialogOverlay className={overlayClass} />
           <DialogContent
             className={contentDefaultClass}
+            aria-describedby={undefined}
             onOpenAutoFocus={(event) => {
               event.preventDefault();
               firstNameRef.current?.focus();
@@ -150,6 +152,7 @@ export const NoEscapeDismiss = () => (
       <DialogOverlay className={overlayClass} />
       <DialogContent
         className={contentDefaultClass}
+        aria-describedby={undefined}
         onEscapeKeyDown={(event) => event.preventDefault()}
       >
         <DialogTitle>Title</DialogTitle>
@@ -166,6 +169,7 @@ export const NoPointerDownOutsideDismiss = () => (
       <DialogOverlay className={overlayClass} />
       <DialogContent
         className={contentDefaultClass}
+        aria-describedby={undefined}
         onPointerDownOutside={(event) => event.preventDefault()}
       >
         <DialogTitle>Title</DialogTitle>
@@ -183,7 +187,7 @@ export const WithPortalContainer = () => {
         <DialogTrigger>open</DialogTrigger>
         <DialogPortal container={portalContainer}>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={contentDefaultClass}>
+          <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose>close</DialogClose>
           </DialogContent>
@@ -199,7 +203,7 @@ export const Animated = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal>
       <DialogOverlay className={animatedOverlayClass} />
-      <DialogContent className={animatedContentClass}>
+      <DialogContent className={animatedContentClass} aria-describedby={undefined}>
         <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
@@ -212,14 +216,14 @@ export const ForcedMount = () => (
     <DialogTrigger>open</DialogTrigger>
     <DialogPortal forceMount>
       <DialogOverlay className={overlayClass} />
-      <DialogContent className={contentDefaultClass}>
+      <DialogContent className={contentDefaultClass} aria-describedby={undefined}>
         <DialogTitle>Title</DialogTitle>
         <DialogClose>close</DialogClose>
       </DialogContent>
     </DialogPortal>
   </Dialog>
 );
-ForcedMount.parameters = { chromatic: { disable: false } };
+ForcedMount.parameters = { chromatic: { disable: false, delay: 1000 } };
 
 export const AllowPinchZoom = () => (
   <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
@@ -285,7 +289,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
         <DialogPortal>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass}>
+          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -300,7 +304,11 @@ export const Chromatic = () => (
             className={overlayClass}
             style={{ left: 0, bottom: '50%', width: '25%' }}
           />
-          <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '12%' }}>
+          <DialogContent
+            className={chromaticContentClass}
+            style={{ top: '25%', left: '12%' }}
+            aria-describedby={undefined}
+          >
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -314,7 +322,7 @@ export const Chromatic = () => (
       <Dialog>
         <DialogPortal>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass}>
+          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -329,7 +337,11 @@ export const Chromatic = () => (
             className={overlayClass}
             style={{ left: '25%', bottom: '50%', width: '25%' }}
           />
-          <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '37%' }}>
+          <DialogContent
+            className={chromaticContentClass}
+            style={{ top: '25%', left: '37%' }}
+            aria-describedby={undefined}
+          >
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -345,7 +357,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerClass}>open</DialogTrigger>
         <DialogPortal>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass}>
+          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -360,7 +372,11 @@ export const Chromatic = () => (
             className={overlayClass}
             style={{ left: '50%', bottom: '50%', width: '25%' }}
           />
-          <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '62%' }}>
+          <DialogContent
+            className={chromaticContentClass}
+            aria-describedby={undefined}
+            style={{ top: '25%', left: '62%' }}
+          >
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -374,7 +390,7 @@ export const Chromatic = () => (
       <Dialog open={false}>
         <DialogPortal>
           <DialogOverlay className={overlayClass} />
-          <DialogContent className={chromaticContentClass}>
+          <DialogContent className={chromaticContentClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -389,7 +405,11 @@ export const Chromatic = () => (
             className={overlayClass}
             style={{ left: '75%', bottom: '50%', width: '25%' }}
           />
-          <DialogContent className={chromaticContentClass} style={{ top: '25%', left: '88%' }}>
+          <DialogContent
+            className={chromaticContentClass}
+            aria-describedby={undefined}
+            style={{ top: '25%', left: '88%' }}
+          >
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeClass}>close</DialogClose>
           </DialogContent>
@@ -405,7 +425,7 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
         <DialogPortal>
           <DialogOverlay className={overlayAttrClass} />
-          <DialogContent className={contentAttrClass}>
+          <DialogContent className={contentAttrClass} aria-describedby={undefined}>
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeAttrClass}>close</DialogClose>
           </DialogContent>
@@ -417,7 +437,11 @@ export const Chromatic = () => (
         <DialogTrigger className={triggerAttrClass}>open</DialogTrigger>
         <DialogPortal>
           <DialogOverlay className={overlayAttrClass} style={{ top: '50%' }} />
-          <DialogContent className={contentAttrClass} style={{ top: '75%' }}>
+          <DialogContent
+            className={contentAttrClass}
+            aria-describedby={undefined}
+            style={{ top: '75%' }}
+          >
             <DialogTitle>Title</DialogTitle>
             <DialogClose className={closeAttrClass}>close</DialogClose>
           </DialogContent>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -404,8 +404,8 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
         </FocusScope>
         {process.env.NODE_ENV !== 'production' && (
           <>
-            <TitleWarning contentRef={contentRef} />
-            <DescriptionWarning contentRef={contentRef} />
+            <TitleWarning titleId={context.titleId} />
+            <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />
           </>
         )}
       </>
@@ -493,11 +493,9 @@ const [WarningProvider, useWarningContext] = createContext(TITLE_WARNING_NAME, {
   docsSlug: 'dialog',
 });
 
-type WarningProps = {
-  contentRef: React.RefObject<DialogContentElement>;
-};
+type TitleWarningProps = { titleId?: string };
 
-const TitleWarning: React.FC<WarningProps> = ({ contentRef }) => {
+const TitleWarning: React.FC<TitleWarningProps> = ({ titleId }) => {
   const titleWarningContext = useWarningContext(TITLE_WARNING_NAME);
 
   const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
@@ -507,30 +505,34 @@ If you want to hide the \`${titleWarningContext.titleName}\`, you can wrap it wi
 For more information, see https://radix-ui.com/primitives/docs/components/${titleWarningContext.docsSlug}`;
 
   React.useEffect(() => {
-    const hasLabel =
-      contentRef.current?.getAttribute('aria-label') ||
-      document.getElementById(contentRef.current?.getAttribute('aria-labelledby')!);
-
-    if (!hasLabel) throw new Error(MESSAGE);
-  }, [MESSAGE, contentRef]);
+    if (titleId) {
+      const hasTitle = document.getElementById(titleId);
+      if (!hasTitle) throw new Error(MESSAGE);
+    }
+  }, [MESSAGE, titleId]);
 
   return null;
 };
 
 const DESCRIPTION_WARNING_NAME = 'DialogDescriptionWarning';
 
-const DescriptionWarning: React.FC<WarningProps> = ({ contentRef }) => {
-  const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
+type DescriptionWarningProps = {
+  contentRef: React.RefObject<DialogContentElement>;
+  descriptionId?: string;
+};
 
+const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef, descriptionId }) => {
+  const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
   const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
 
   React.useEffect(() => {
     const describedById = contentRef.current?.getAttribute('aria-describedby');
-    if (describedById) {
-      const hasDescription = document.getElementById(describedById);
-      if (describedById && !hasDescription) console.warn(MESSAGE);
+    // if we have an id and the user hasn't set aria-describedby={undefined}
+    if (descriptionId && describedById) {
+      const hasDescription = document.getElementById(descriptionId);
+      if (!hasDescription) console.warn(MESSAGE);
     }
-  }, [MESSAGE, contentRef]);
+  }, [MESSAGE, contentRef, descriptionId]);
 
   return null;
 };


### PR DESCRIPTION
Closes #1061

Current implementation required `forceMount` to be added to all three parts which was unintuitive.

- Shares prop from portal
- Adds `ForceMount` story to Chromatic output to highlight breaking changes with `forceMount` in future

**Note: Not sure why it isn't force mounted in the Chromatic story lol, ack. I'll figure that out in a bit.**