### PR TITLE
[Dialog][AlertDialog] Fix pointer-events management

### DIFF
--- a/.yarn/versions/e5aea313.yml
+++ b/.yarn/versions/e5aea313.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -175,8 +175,6 @@ const DismissableLayerImpl = React.forwardRef<
   // on inheritence. This is because layers may be rendered in different portals where
   // inheritence wouldn't apply, so we need to set it explicity on its children too.
   const isBodyPointerEventsDisabled = totalLayerCountWithDisabledOutsidePointerEvents > 0;
-  const shouldReEnablePointerEvents =
-    isBodyPointerEventsDisabled && !containsChildLayerWithDisabledOutsidePointerEvents;
 
   return (
     <RunningLayerCountProvider runningCount={runningLayerCount}>
@@ -187,7 +185,11 @@ const DismissableLayerImpl = React.forwardRef<
           {...layerProps}
           ref={forwardedRef}
           style={{
-            pointerEvents: shouldReEnablePointerEvents ? 'auto' : undefined,
+            pointerEvents: isBodyPointerEventsDisabled
+              ? containsChildLayerWithDisabledOutsidePointerEvents
+                ? 'none'
+                : 'auto'
+              : undefined,
             ...layerProps.style,
           }}
           onPointerDownCapture={composeEventHandlers(


### PR DESCRIPTION
This is tricky one to describe but I'll give it a go 😅 

The original issue was reported [here](https://discord.com/channels/752614004387610674/803656530259738674/930096627895635989) as a `DropdownMenu` bug.

We recently added `pointer-events: 'auto'` to the `Dialog.Overlay` to allow scrollable overlays which broke some `pointer-events` assumptions in `DismissableLayer` (`Dialog.Content`) with the following composition:

```jsx
<Dialog.Root>
  <Dialog.Trigger>Open</Dialog.Trigger>
  <Dialog.Overlay>
    {/* inside overlay */}
    <Dialog.Content /> 
  </Dialog.Overlay>
</Dialog.Root>
``` 

A `DismissableLayer` would remove its `pointer-events: 'auto'` styles when it detected a child dismissable (e.g. dropdown) so that the child's siblings would inherit `pointer-events: 'none'` from the body. This was a bad assumption because anything inside the body could have `pointer-events: 'auto'` (e.g. `Dialog.Overlay`) making the dropdown siblings accept pointer events.

With Benoit's help to figure this all out, we've tweaked the `DismissableLayer` pointer event management to explicitly disable pointer events inside of it when a child dismissable is detected, instead of relying on inheritance from the body.