### PR TITLE
[DropdownMenu] Fix non-modal dropdown pointer-events

### DIFF
--- a/.yarn/versions/f78dbf9e.yml
+++ b/.yarn/versions/f78dbf9e.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -175,15 +175,15 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
               // prevent trigger focusing when opening
               // this allows the content to be given focus without competition
               if (!context.open) event.preventDefault();
-              // trigger always opens, and content click outside closes. since trigger is
-              // considered outside content, clicking trigger when open will close the content.
-              context.onOpenChange(true);
+              context.onOpenToggle();
             }
           })}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-            if (!disabled && ['ArrowDown', 'Enter', ' '].includes(event.key)) {
+            if (disabled) return;
+            if (['Enter', ' '].includes(event.key)) context.onOpenToggle();
+            if (event.key === 'ArrowDown') {
               context.onOpenChange(true);
-              // Prevent keypresses from scrolling window
+              // prevent arrow keypress from scrolling window
               event.preventDefault();
             }
           })}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -181,11 +181,9 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
             if (['Enter', ' '].includes(event.key)) context.onOpenToggle();
-            if (event.key === 'ArrowDown') {
-              context.onOpenChange(true);
-              // prevent arrow keypress from scrolling window
-              event.preventDefault();
-            }
+            if (event.key === 'ArrowDown') context.onOpenChange(true);
+            // prevent keypresses from scrolling window
+            if ([' ', 'ArrowDown'].includes(event.key)) event.preventDefault();
           })}
         />
       </MenuPrimitive.Anchor>

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -22,7 +22,6 @@
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
-    "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -181,11 +181,8 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
               context.onValueChange(value);
             }
           })}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            // Handle anything that the browser considers a click for the element type if
-            // not using pointer e.g. Space keyup and Enter keydown
-            const isPointerClick = event.detail > 0;
-            if (!isPointerClick) context.onValueChange(value);
+          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+            if ([' ', 'Enter'].includes(event.key)) context.onValueChange(value);
           })}
           onFocus={composeEventHandlers(props.onFocus, () => {
             // handle "automatic" activation if necessary

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
-import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
@@ -55,7 +54,7 @@ interface TabsProps extends PrimitiveDivProps {
    * @defaultValue ltr
    */
   dir?: RovingFocusGroupProps['dir'];
-  /** 
+  /**
    * Whether a tab is activated automatically or manually.
    * @defaultValue automatic
    * */
@@ -157,7 +156,6 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
     const triggerId = makeTriggerId(context.baseId, value);
     const contentId = makeContentId(context.baseId, value);
     const isSelected = value === context.value;
-    const handleTabChange = useCallbackRef(() => context.onValueChange(value));
     return (
       <RovingFocusGroup.Item
         asChild
@@ -176,22 +174,25 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
           id={triggerId}
           {...triggerProps}
           ref={forwardedRef}
-          // Handle anything that the browser considers a click for the element type if
-          // not using pointer e.g. Space keyup and Enter keydown
-          onClick={composeEventHandlers(props.onClick, handleTabChange)}
           onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {
-              handleTabChange();
+              context.onValueChange(value);
             }
+          })}
+          onClick={composeEventHandlers(props.onClick, (event) => {
+            // Handle anything that the browser considers a click for the element type if
+            // not using pointer e.g. Space keyup and Enter keydown
+            const isPointerClick = event.detail > 0;
+            if (!isPointerClick) context.onValueChange(value);
           })}
           onFocus={composeEventHandlers(props.onFocus, () => {
             // handle "automatic" activation if necessary
             // ie. activate tab following focus
             const isAutomaticActivation = context.activationMode !== 'manual';
             if (!isSelected && !disabled && isAutomaticActivation) {
-              handleTabChange();
+              context.onValueChange(value);
             }
           })}
         />

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -260,10 +260,10 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           })}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
           onClick={composeEventHandlers(props.onClick, (event) => {
-            // Handle anything that the browser considers a click for the element type if
-            // not using pointer e.g. Space keyup and Enter keydown
-            const isPointerClick = event.detail > 0;
-            if (!isPointerClick) context.onClose();
+            // keyboard click will occur under different conditions for different node
+            // types so we use `onClick` instead of `onKeyDown` to respect that
+            const isKeyboardClick = event.detail === 0;
+            if (isKeyboardClick) context.onClose();
           })}
         />
       </PopperPrimitive.Anchor>

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -259,9 +259,12 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             if (!isMouseDownRef.current) context.onOpen();
           })}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
-          // Handle anything that the browser considers a click for the element type if
-          // not using pointer e.g. Space keyup and Enter keydown
-          onClick={composeEventHandlers(props.onClick, context.onClose)}
+          onClick={composeEventHandlers(props.onClick, (event) => {
+            // Handle anything that the browser considers a click for the element type if
+            // not using pointer e.g. Space keyup and Enter keydown
+            const isPointerClick = event.detail > 0;
+            if (!isPointerClick) context.onClose();
+          })}
         />
       </PopperPrimitive.Anchor>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3865,7 +3865,6 @@ __metadata:
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
-    "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
Fixes #1059

Also: 

- While fixing, I noticed that non-modal dropdowns don't focus the trigger when closing via trigger click so fixed that too
- Updated the other components where the `onClick` logic was added to ensure this only fires when it's not a mouse click (since these components already have `onMouseDown` or `onPointerDown` handlers for that).
