### PR TITLE
Run Chromatic for external forks

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: 63f2bd83c33c
           exitOnceUploaded: true
           exitZeroOnChanges: true

--- a/.yarn/versions/7dc42e13.yml
+++ b/.yarn/versions/7dc42e13.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives


### PR DESCRIPTION
https://www.chromatic.com/docs/github-actions#run-chromatic-on-external-forks-of-open-source-projects

> **Run Chromatic on external forks of open source projects**
>
> You can enable PR checks for external forks by sharing your project-token where you configured the Chromatic command (often in package.json or in the workflow step).
>
> There are tradeoffs. Sharing project-token’s allows contributors and others to run Chromatic. They’ll be able to use your snapshots. They will not be able to get access to your account, settings, or accept baselines. It can be an acceptable tradeoff for open source projects which value community contributions.