### PR TITLE
[Dialog][AlertDialog] Add aria-describedby only when a description is provided

### DIFF
--- a/.yarn/versions/48dc3631.yml
+++ b/.yarn/versions/48dc3631.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -117,7 +117,7 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
     const cancelRef = React.useRef<AlertDialogCancelElement | null>(null);
 
     return (
-      <DialogPrimitive.LabelWarningProvider
+      <DialogPrimitive.WarningProvider
         contentName={CONTENT_NAME}
         titleName={TITLE_NAME}
         docsSlug="alert-dialog"
@@ -147,7 +147,7 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
             )}
           </DialogPrimitive.Content>
         </AlertDialogContentProvider>
-      </DialogPrimitive.LabelWarningProvider>
+      </DialogPrimitive.WarningProvider>
     );
   }
 );

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { axe } from 'jest-axe';
-import { RenderResult } from '@testing-library/react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, RenderResult, cleanup, screen } from '@testing-library/react';
 import * as Dialog from './Dialog';
 
 const OPEN_TEXT = 'Open';
 const CLOSE_TEXT = 'Close';
+const TITLE_TEXT = 'Title';
 
-const DialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
+const NoLabelDialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
   <Dialog.Root {...props}>
     <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
     <Dialog.Overlay />
@@ -16,6 +16,32 @@ const DialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
     </Dialog.Content>
   </Dialog.Root>
 );
+
+const UndefinedDescribedByDialog = (props: React.ComponentProps<typeof Dialog.Root>) => (
+  <Dialog.Root {...props}>
+    <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
+    <Dialog.Overlay />
+    <Dialog.Content aria-describedby={undefined}>
+      <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
+      <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
+    </Dialog.Content>
+  </Dialog.Root>
+);
+
+const DialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
+  <Dialog.Root {...props}>
+    <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
+    <Dialog.Overlay />
+    <Dialog.Content>
+      <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
+      <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
+    </Dialog.Content>
+  </Dialog.Root>
+);
+
+function renderAndClickDialogTrigger(Dialog: any) {
+  fireEvent.click(render(Dialog).getByText(OPEN_TEXT));
+}
 
 describe('given a default Dialog', () => {
   let rendered: RenderResult;
@@ -50,9 +76,28 @@ describe('given a default Dialog', () => {
       closeButton = rendered.getByText(CLOSE_TEXT);
     });
 
-    describe('when no valid label and description have been provided', () => {
+    describe('when no description has been provided', () => {
       it('should warn to the console', () => {
-        expect(consoleWarnMockFunction).toHaveBeenCalledTimes(2);
+        expect(consoleWarnMockFunction).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when no title has been provided', () => {
+      it('should throw an error', () =>
+        expect(() => {
+          renderAndClickDialogTrigger(<NoLabelDialogTest />);
+        }).toThrowError());
+    });
+
+    describe('when aria-describedby is set to undefined', () => {
+      beforeEach(() => {
+        cleanup();
+      });
+      it('should not warn to the console', () => {
+        consoleWarnMockFunction.mockClear();
+
+        renderAndClickDialogTrigger(<UndefinedDescribedByDialog />);
+        expect(consoleWarnMockFunction).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -21,14 +21,33 @@ describe('given a default Dialog', () => {
   let rendered: RenderResult;
   let trigger: HTMLElement;
   let closeButton: HTMLElement;
+  let consoleWarnMock: jest.SpyInstance;
+  let consoleWarnMockFunction: jest.Mock;
 
   beforeEach(() => {
+    // This surpresses React error boundary logs for testing intentionally
+    // thrown errors, like in some test cases in this suite. See discussion of
+    // this here: https://github.com/facebook/react/issues/11098
+    consoleWarnMockFunction = jest.fn();
+    consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(consoleWarnMockFunction);
+
     rendered = render(<DialogTest />);
     trigger = rendered.getByText(OPEN_TEXT);
   });
 
+  afterEach(() => {
+    consoleWarnMock.mockRestore();
+    consoleWarnMockFunction.mockClear();
+  });
+
   it('should have no accessibility violations in default state', async () => {
     expect(await axe(rendered.container)).toHaveNoViolations();
+  });
+
+  describe('when no description has been provided', () => {
+    it('should warn to the console', () => {
+      expect(consoleWarnMockFunction).toHaveBeenCalled();
+    });
   });
 
   describe('after clicking the trigger', () => {

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -44,16 +44,16 @@ describe('given a default Dialog', () => {
     expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
-  describe('when no description has been provided', () => {
-    it('should warn to the console', () => {
-      expect(consoleWarnMockFunction).toHaveBeenCalled();
-    });
-  });
-
   describe('after clicking the trigger', () => {
     beforeEach(() => {
       fireEvent.click(trigger);
       closeButton = rendered.getByText(CLOSE_TEXT);
+    });
+
+    describe('when no valid label and description have been provided', () => {
+      it('should warn to the console', () => {
+        expect(consoleWarnMockFunction).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('should open the content', () => {

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { axe } from 'jest-axe';
-import { render, fireEvent, RenderResult, cleanup, screen } from '@testing-library/react';
+import { render, fireEvent, RenderResult, cleanup } from '@testing-library/react';
 import * as Dialog from './Dialog';
 
 const OPEN_TEXT = 'Open';

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -515,7 +515,7 @@ const DESCRIPTION_WARNING_NAME = 'DialogDescriptionWarning';
 const DescriptionWarning: React.FC<WarningProps> = ({ contentRef }) => {
   const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
 
-  const MESSAGE = `Warning: Missing \`Description\` for {${descriptionWarningContext.contentName}}.`;
+  const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
 
   React.useEffect(() => {
     const describedById = contentRef.current?.getAttribute('aria-describedby');

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -231,6 +231,18 @@ const DialogContent = React.forwardRef<DialogContentElement, DialogContentProps>
   (props: ScopedProps<DialogContentProps>, forwardedRef) => {
     const { forceMount, ...contentProps } = props;
     const context = useDialogContext(CONTENT_NAME, props.__scopeDialog);
+
+    React.useEffect(() => {
+      if (process.env.NODE_ENV !== 'development') {
+        const description = document.getElementById(context.descriptionId);
+        if (!description) {
+          console.warn(
+            'Warning: Missing `Description` or `aria-describedby={undefined}` for `Dialog.Content`.'
+          );
+        }
+      }
+    }, [context.descriptionId]);
+
     return (
       <Presence present={forceMount || context.open}>
         {context.modal ? (

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -493,11 +493,9 @@ type WarningProps = {
 const TitleWarning: React.FC<WarningProps> = ({ contentRef }) => {
   const titleWarningContext = useWarningContext(TITLE_WARNING_NAME);
 
-  const MESSAGE = `\`${titleWarningContext.contentName}\` requires a label for the component to be accessible for screen reader users.
+  const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
 
-You can label the \`${titleWarningContext.contentName}\` by passing a \`${titleWarningContext.titleName}\` component as a child, which also benefits sighted users by adding visible context to the dialog. Note that if you still want to hide the \`${titleWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component.
-
-Alternatively, you can use your own component as a title by assigning it an \`id\` and passing the same value to the \`aria-labelledby\` prop in \`${titleWarningContext.contentName}\`. If the label is confusing or duplicative for sighted users, you can also pass a label directly by using the \`aria-label\` prop.
+If you want to hide the \`${titleWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component.
 
 For more information, see https://radix-ui.com/primitives/docs/components/${titleWarningContext.docsSlug}`;
 

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -395,7 +395,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
             onDismiss={() => context.onOpenChange(false)}
           />
         </FocusScope>
-        {['development', 'test'].includes(process.env.NODE_ENV!) && (
+        {process.env.NODE_ENV !== 'production' && (
           <>
             <TitleWarning contentRef={contentRef} />
             <DescriptionWarning contentRef={contentRef} />

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -408,7 +408,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
             onDismiss={() => context.onOpenChange(false)}
           />
         </FocusScope>
-        {process.env.NODE_ENV === 'test' && (
+        {process.env.NODE_ENV === 'development' && (
           <>
             <LabelWarning contentRef={contentRef} />
             <DescriptionWarning contentRef={contentRef} />

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -515,7 +515,7 @@ const LabelWarning: React.FC<LabelWarningProps> = ({ contentRef }) => {
 
   const MESSAGE = `\`${labelWarningContext.contentName}\` requires a label for the component to be accessible for screen reader users.
 
-You can label the \`${labelWarningContext.contentName}\` by passing a \`${labelWarningContext.titleName}\` component as a child, which also benefits sighted users by adding visible context to the dialog.
+You can label the \`${labelWarningContext.contentName}\` by passing a \`${labelWarningContext.titleName}\` component as a child, which also benefits sighted users by adding visible context to the dialog. Note that if you still want to hide the \`${labelWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component.
 
 Alternatively, you can use your own component as a title by assigning it an \`id\` and passing the same value to the \`aria-labelledby\` prop in \`${labelWarningContext.contentName}\`. If the label is confusing or duplicative for sighted users, you can also pass a label directly by using the \`aria-label\` prop.
 

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -533,10 +533,9 @@ const DescriptionWarning: React.FC<WarningProps> = ({ contentRef }) => {
   const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
 
   React.useEffect(() => {
-    const hasDescription = document.getElementById(
-      contentRef.current?.getAttribute('aria-describedby')!
-    );
-    if (!hasDescription) console.warn(MESSAGE);
+    const describedById = contentRef.current?.getAttribute('aria-describedby');
+    const hasDescription = document.getElementById(describedById);
+    if (describedById && !hasDescription) console.warn(MESSAGE);
   }, [MESSAGE, contentRef]);
 
   return null;


### PR DESCRIPTION
### Description

Fixes #1094

Right [now](https://github.com/radix-ui/primitives/blob/28c4fd981319992458757d860c26942fed703419/packages/react/dialog/src/Dialog.tsx#L82) the `dialog` component always generates a `descriptionId` even if no description component is registered.

This leads to [always](https://github.com/radix-ui/primitives/blob/28c4fd981319992458757d860c26942fed703419/packages/react/dialog/src/Dialog.tsx#L399) generate an `aria-describedby` even if no description has been added.

### TODO

- [x] Throw for missing label
- [x] Warn for missing description
- [x] Add test cases


### Notes for docs

- 🔥 `aria-label` will be ignored, use `Title` with `<VisuallyHidden asChild>`
- ✨  Use `aria-describedby={undefined}` to silence missing description warning