### PR TITLE
[Tooltip] if skipDelayDuration is 0 don't ever skip delay

### DIFF
--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -85,7 +85,10 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
       delayDuration={delayDuration}
       onOpen={React.useCallback(() => {
         window.clearTimeout(skipDelayTimerRef.current);
-        setIsOpenDelayed(false);
+
+        if (skipDelayDuration !== 0) {
+          setIsOpenDelayed(false);
+        }
       }, [])}
       onClose={React.useCallback(() => {
         window.clearTimeout(skipDelayTimerRef.current);


### PR DESCRIPTION
### Description

Before this change the `TooltipProvider` would skip the open delay even though we set `skipDelayDuration` to 0.

Before (with 1000ms `delayDuration`):

https://user-images.githubusercontent.com/1192452/150194900-d807f8b1-830f-42f9-a412-a1a37e9d46eb.mp4

After:

https://user-images.githubusercontent.com/1192452/150195130-5d60aaa5-1f66-43b4-a640-9a2864bd3bdd.mp4

