### PR TITLE
[Checkbox][RadioGroup] Prevent enter key activation

### DIFF
--- a/.yarn/versions/4e4a8b76.yml
+++ b/.yarn/versions/4e4a8b76.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -81,6 +81,10 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
           value={value}
           {...checkboxProps}
           ref={composedRefs}
+          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+            // According to WAI ARIA, Checkboxes don't activate on enter keypress
+            if (event.key === 'Enter') event.preventDefault();
+          })}
           onClick={composeEventHandlers(props.onClick, (event) => {
             setChecked((prevChecked) => (isIndeterminate(prevChecked) ? true : !prevChecked));
             if (isFormControl) {

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -160,6 +160,10 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
           name={context.name}
           ref={composedRefs}
           onCheck={() => context.onValueChange(itemProps.value)}
+          onKeyDown={composeEventHandlers((event) => {
+            // According to WAI ARIA, radio groups don't activate items on enter keypress
+            if (event.key === 'Enter') event.preventDefault();
+          })}
           onFocus={composeEventHandlers(itemProps.onFocus, () => {
             /**
              * Our `RovingFocusGroup` will focus the radio when navigating with arrow keys


### PR DESCRIPTION
Fixes #1103

According the the WAI ARIA spec:

- [Checkboxes](https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-5) don't activate on enter keypress
- [Radio groups](https://www.w3.org/TR/wai-aria-practices-1.2/#for-radio-groups-not-contained-in-a-toolbar) don't activate on enter keypress when not in a toolbar
  - We have a separate `ToolbarToggleGroup` component for toolbars which activates on enter keypress

I also checked WAI ARIA info on `Switch` and switch is fine to activate on enter keypress.