### PR TITLE
[Presence] Account for early node removal

### DIFF
--- a/.yarn/versions/fd1c3d71.yml
+++ b/.yarn/versions/fd1c3d71.yml
@@ -1,0 +1,18 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -118,7 +118,8 @@ function usePresence(present: boolean) {
         node.removeEventListener('animationend', handleAnimationEnd);
       };
     } else {
-      // Transition to the unmounted state if the node is removed prematurely
+      // Transition to the unmounted state if the node is removed prematurely.
+      // We avoid doing so during cleanup as the node may change but still exist.
       send('ANIMATION_END');
     }
   }, [node, send]);

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -117,6 +117,9 @@ function usePresence(present: boolean) {
         node.removeEventListener('animationcancel', handleAnimationEnd);
         node.removeEventListener('animationend', handleAnimationEnd);
       };
+    } else {
+      // Transition to the unmounted state if the node is removed prematurely
+      send('ANIMATION_END');
     }
   }, [node, send]);
 


### PR DESCRIPTION
I ran across this issue when using the render prop to pass `present` to a node outside of the `<Presence/>` tree. If the node has a long running animation and is removed early i.e. its parent unmounts, then `present` remains `true`. My expectation is that it would flip to `false` when the node is removed.

The `animationcancel` event does fire on node removal, but as we cleanup those handlers inside the effect they don't appear to run when the node is cleared.

https://codesandbox.io/s/youthful-feather-ifsvk?file=/src/App.js