### PR TITLE
[useSize] Avoid `undefined` when switching nodes

### DIFF
--- a/.yarn/versions/573f03d4.yml
+++ b/.yarn/versions/573f03d4.yml
@@ -1,0 +1,16 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-size": patch
+
+declined:
+  - primitives

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -41,10 +41,10 @@ function useSize(element: HTMLElement | SVGElement | null) {
 
       resizeObserver.observe(element, { box: 'border-box' });
 
-      return () => {
-        resizeObserver.unobserve(element);
-      };
+      return () => resizeObserver.unobserve(element);
     } else {
+      // We only want to reset to `undefined` when the element becomes `null`,
+      // not if it changes to another element.
       setSize(undefined);
     }
   }, [element]);

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -42,11 +42,11 @@ function useSize(element: HTMLElement | SVGElement | null) {
       resizeObserver.observe(element, { box: 'border-box' });
 
       return () => {
-        setSize(undefined);
         resizeObserver.unobserve(element);
       };
+    } else {
+      setSize(undefined);
     }
-    return;
   }, [element]);
 
   return size;


### PR DESCRIPTION
Raising for discussion. Setting `undefined` in the cleanup means we can't smoothly transition between values when switching nodes.

Contrived example:
https://codesandbox.io/s/charming-glitter-2fx1q?file=/src/App.js

