### PR TITLE
[Tabs] Prevent accidental focus activation via right-click

### DIFF
--- a/.yarn/versions/704c1b17.yml
+++ b/.yarn/versions/704c1b17.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tabs": patch
+
+declined:
+  - primitives

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -179,6 +179,9 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {
               context.onValueChange(value);
+            } else {
+              // prevent focus to avoid accidental activation
+              event.preventDefault();
             }
           })}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {


### PR DESCRIPTION
Fixes #1113

The proposed change to solve the linked issue here is to prevent focus from happening if it's not a left click.