### PR TITLE
[Collapsible][Accordion] Fix content animation of collapsible

### DIFF
--- a/.yarn/versions/9b75b880.yml
+++ b/.yarn/versions/9b75b880.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-collapsible": patch
+
+declined:
+  - primitives

--- a/packages/react/collapsible/src/Collapsible.stories.tsx
+++ b/packages/react/collapsible/src/Collapsible.stories.tsx
@@ -189,7 +189,7 @@ const animatedContentClass = css({
     animation: `${slideDown} 300ms ease-out`,
   },
   '&[data-state="closed"]': {
-    animation: `${slideUp} 300ms ease-in`,
+    animation: `${slideUp} 300ms ease-in forwards`,
   },
 });
 
@@ -199,7 +199,7 @@ const animatedWidthContentClass = css({
     animation: `${openRight} 300ms ease-out`,
   },
   '&[data-state="closed"]': {
-    animation: `${closeRight} 300ms ease-in`,
+    animation: `${closeRight} 300ms ease-in forwards`,
   },
 });
 

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -177,10 +177,12 @@ const CollapsibleContentImpl = React.forwardRef<
       originalStylesRef.current = originalStylesRef.current || {
         transitionDuration: node.style.transitionDuration,
         animationDuration: node.style.animationDuration,
+        animationFillMode: node.style.animationFillMode,
       };
       // block any animations/transitions so the element renders at its full dimensions
       node.style.transitionDuration = '0s';
       node.style.animationDuration = '0s';
+      node.style.animationFillMode = 'none';
 
       // get width and height from full dimensions
       const rect = node.getBoundingClientRect();
@@ -191,6 +193,7 @@ const CollapsibleContentImpl = React.forwardRef<
       if (!isMountAnimationPreventedRef.current) {
         node.style.transitionDuration = originalStylesRef.current.transitionDuration;
         node.style.animationDuration = originalStylesRef.current.animationDuration;
+        node.style.animationFillMode = originalStylesRef.current.animationFillMode;
       }
 
       setIsPresent(present);


### PR DESCRIPTION
Fixes https://github.com/radix-ui/primitives/issues/1074 by allowing to add an animation-fill-mode. 

When using the [Collapsible](https://github.com/radix-ui/primitives/tree/main/packages/react/collapsible) with React 18 Concurrent Mode, the close animation flickers. This is due to the fact, that it takes too long (not quite sure why) for the content to be hidden/unmounted. Since the [animation](https://www.radix-ui.com/docs/primitives/components/collapsible#animating-content-size) doesn't specify any fill-mode, the animation styles will only be applied during the execution of the animation. Therefore the content height is animated to 0 during the animation but jumps back to its original size afterwards, before beeing unmounted.  Adding `animation-fill-mode: forwards` fixes that issue (visually). 

### Notes for docs

- Update [Animation page](https://www.radix-ui.com/docs/primitives/overview/animation) to include `forwards`
- Update all component demos to include `forwards`
- Update all component docs examples to include `forwards`