### PR TITLE
[Label] Consistent label ordering for screen readers

### DIFF
--- a/.yarn/versions/e62b671c.yml
+++ b/.yarn/versions/e62b671c.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-switch": patch
+
+declined:
+  - primitives

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -37,7 +37,7 @@ const Label = React.forwardRef<LabelElement, LabelProps>((props, forwardedRef) =
       const label = ref.current;
       if (label && element) {
         const getAriaLabel = () => element.getAttribute('aria-labelledby');
-        const ariaLabelledBy = [getAriaLabel(), id].filter(Boolean).join(' ');
+        const ariaLabelledBy = [id, getAriaLabel()].filter(Boolean).join(' ');
         element.setAttribute('aria-labelledby', ariaLabelledBy);
         controlRef.current = element;
         return () => {


### PR DESCRIPTION
This is coming off the back of when I worked on labelling with `Select` and realised that depending on wrapping vs. `htmlFor` strategy, the labelling order would potentially differ.
Incidentally, it also probably make more sense to announce the label first (if there are 2 like in the case of select).