### PR TITLE
[DismissableLayer] Allow external nodes to be considered inside

### DIFF
--- a/.yarn/versions/4e063ba5.yml
+++ b/.yarn/versions/4e063ba5.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives


### PR DESCRIPTION
Needed for `Toast`. When a `DismissableLayer.Branch` is rendered, it will force any rendered `DismissableLayer.Root`s to consider the branch node inside the `DismissableLayer`.

In other words, pointer outside and focus outside etc. events will not fire when interacting with a branch.

