### PR TITLE
[Toast] Fix promise story

### DIFF
--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -344,6 +344,10 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
     });
 
     React.useEffect(() => {
+      closeTimerRemainingTimeRef.current = duration;
+    }, [duration]);
+
+    React.useEffect(() => {
       if (!context.isClosePaused && duration !== Infinity) {
         const closeTimerStartTime = new Date().getTime();
         const closeTimerRemainingTime = closeTimerRemainingTimeRef.current;


### PR DESCRIPTION
An update for `duration` prop was instantly closing the toast. This was happening because the `closeTimerRemainingTimeRef` was `Infinity` from the previous render closure so `setTimeout(handleClose, Infinity)` was instantly executing.

We do `closeTimerRemainingTimeRef  = React.useRef(duration)` when initially rendered but never updated this when the duration changed.