### PR TITLE
[Toast] Close focused toast on escape keypress

### DIFF
--- a/packages/react/toast/src/Toast.stories.tsx
+++ b/packages/react/toast/src/Toast.stories.tsx
@@ -478,7 +478,7 @@ const viewportClass = css({
 });
 
 const rootClass = css({
-  all: 'unset',
+  listStyle: 'none',
   width: 230,
   borderRadius: 4,
   border: '1px solid black',


### PR DESCRIPTION
Escape keypress will close the most recent toast unless a toast is focused, in which case, it will close the focused one.

https://user-images.githubusercontent.com/175330/155144594-fa47582a-71b1-4322-836e-fc9a55131691.mp4

