### PR TITLE
[Toast] Pointer capture on swipe only

### DIFF
--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -400,7 +400,6 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                 })}
                 onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
                   if (!pointerStartRef.current) return;
-                  (event.target as HTMLElement).setPointerCapture(event.pointerId);
                   const x = event.clientX - pointerStartRef.current.x;
                   const y = event.clientY - pointerStartRef.current.y;
                   const hasSwipeMoveStarted = Boolean(swipeDeltaRef.current);
@@ -419,6 +418,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   } else if (isDeltaInDirection(delta, context.swipeDirection, moveStartBuffer)) {
                     swipeDeltaRef.current = delta;
                     dispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail);
+                    (event.target as HTMLElement).setPointerCapture(event.pointerId);
                   } else if (Math.abs(x) > moveStartBuffer || Math.abs(y) > moveStartBuffer) {
                     // User is swiping in wrong direction so we disable swipe gesture
                     // for the current pointer down interaction


### PR DESCRIPTION
I noticed that pointer down on `Action` and moving mouse away to release (cancel your action) would still click the action because I had set pointer capture regardless of swipe direction.

This ensures pointer is only captured when swiping in the specified `swipeDirection`.