### PR TITLE
[NavigationMenu] Consistent auto value

### DIFF
--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -355,7 +355,8 @@ interface NavigationMenuItemProps extends PrimitiveListItemProps {
 const NavigationMenuItem = React.forwardRef<NavigationMenuItemElement, NavigationMenuItemProps>(
   (props: ScopedProps<NavigationMenuItemProps>, forwardedRef) => {
     const { __scopeNavigationMenu, value: valueProp, ...itemProps } = props;
-    const value = valueProp || String(Math.random());
+    const autoValue = React.useMemo(() => String(Math.random()), []);
+    const value = valueProp || autoValue;
     const contentRef = React.useRef<NavigationMenuContentElement>(null);
     const triggerRef = React.useRef<NavigationMenuTriggerElement>(null);
     const focusProxyRef = React.useRef<FocusProxyElement>(null);


### PR DESCRIPTION
Previously if you were controlling you'd have to provide your own `value` to items as the `autoValue` was changing every render. Now consumers only need to provide a `value` on items if they need specific access, otherwise it'll continue to work using `autoValue`.