### PR TITLE
Remove package clean scripts

### DIFF
--- a/.yarn/versions/a91622a8.yml
+++ b/.yarn/versions/a91622a8.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+
+declined:
+  - primitives

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -13,7 +13,6 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "prepublish": "yarn clean",
     "version": "yarn version"
   },
   "dependencies": {

--- a/packages/react/toast/package.json
+++ b/packages/react/toast/package.json
@@ -13,7 +13,6 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "prepublish": "yarn clean",
     "version": "yarn version"
   },
   "dependencies": {


### PR DESCRIPTION
Doh 😅

This meant that the `dist` file was removed when publishing and we ended up with empty published packages. This must have been copy/pasted from an old architecture when we started these comps. Oops!