### PR TITLE
[NavigationMenu] Fix `Viewport` size calculation in Safari

### DIFF
--- a/.yarn/versions/cf522e27.yml
+++ b/.yarn/versions/cf522e27.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-navigation-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/navigation-menu/package.json
+++ b/packages/react/navigation-menu/package.json
@@ -30,7 +30,6 @@
     "@radix-ui/react-use-direction": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*",
     "@radix-ui/react-use-previous": "workspace:*",
-    "@radix-ui/react-use-size": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -925,7 +925,9 @@ const NavigationMenuViewportImpl = React.forwardRef<
 
   /**
    * Update viewport size to match the active content node.
-   * We prefer offset dimensions over `getBoundingClientRect` as the latter respects CSS transform. For example, if content animates in from `scale(0.5)` the dimensions would be anything from `0.5` to `1` of the intended size.
+   * We prefer offset dimensions over `getBoundingClientRect` as the latter respects CSS transform.
+   * For example, if content animates in from `scale(0.5)` the dimensions would be anything
+   * from `0.5` to `1` of the intended size.
    */
   const handleSizeChange = () => {
     if (content) setSize({ width: content.offsetWidth, height: content.offsetHeight });

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -915,7 +915,7 @@ const NavigationMenuViewportImpl = React.forwardRef<
     props.__scopeNavigationMenu
   );
   const [size, setSize] = React.useState<{ width: number; height: number } | null>(null);
-  const [contentNode, setContentNode] = React.useState<NavigationMenuContentElement | null>(null);
+  const [content, setContent] = React.useState<NavigationMenuContentElement | null>(null);
   const viewportWidth = size ? size?.width + 'px' : undefined;
   const viewportHeight = size ? size?.height + 'px' : undefined;
   const open = Boolean(context.value);
@@ -928,9 +928,9 @@ const NavigationMenuViewportImpl = React.forwardRef<
    * We prefer offsetWidth and height over `getBoundingClientRect` as the latter returns values after transform.
    */
   const handleSizeChange = () => {
-    if (contentNode) setSize({ width: contentNode.offsetWidth, height: contentNode.offsetHeight });
+    if (content) setSize({ width: content.offsetWidth, height: content.offsetHeight });
   };
-  useResizeObserver(contentNode, handleSizeChange);
+  useResizeObserver(content, handleSizeChange);
 
   return (
     <Primitive.div
@@ -959,7 +959,7 @@ const NavigationMenuViewportImpl = React.forwardRef<
               ref={composeRefs(ref, (node) => {
                 // We only want to update the stored node when another is available
                 // as we need to smoothly transition between them.
-                if (isActive && node) setContentNode(node);
+                if (isActive && node) setContent(node);
               })}
             />
           </Presence>

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -925,7 +925,7 @@ const NavigationMenuViewportImpl = React.forwardRef<
 
   /**
    * Update viewport size to match the active content node.
-   * We prefer offsetWidth and height over `getBoundingClientRect` as the latter returns values after transform.
+   * We prefer offset dimensions over `getBoundingClientRect` as the latter respects CSS transform. For example, if content animates in from `scale(0.5)` the dimensions would be anything from `0.5` to `1` of the intended size.
    */
   const handleSizeChange = () => {
     if (content) setSize({ width: content.offsetWidth, height: content.offsetHeight });

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -9,7 +9,6 @@ import { useDirection } from '@radix-ui/react-use-direction';
 import { Presence } from '@radix-ui/react-presence';
 import { useId } from '@radix-ui/react-id';
 import { createCollection } from '@radix-ui/react-collection';
-import { useSize } from '@radix-ui/react-use-size';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { usePrevious } from '@radix-ui/react-use-previous';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
@@ -915,16 +914,23 @@ const NavigationMenuViewportImpl = React.forwardRef<
     CONTENT_NAME,
     props.__scopeNavigationMenu
   );
-  const [activeContent, setActiveContent] = React.useState<NavigationMenuContentElement | null>(
-    null
-  );
-  const contentSize = useSize(activeContent);
-  const viewportWidth = contentSize ? contentSize?.width + 'px' : undefined;
-  const viewportHeight = contentSize ? contentSize?.height + 'px' : undefined;
+  const [size, setSize] = React.useState<{ width: number; height: number } | null>(null);
+  const [contentNode, setContentNode] = React.useState<NavigationMenuContentElement | null>(null);
+  const viewportWidth = size ? size?.width + 'px' : undefined;
+  const viewportHeight = size ? size?.height + 'px' : undefined;
   const open = Boolean(context.value);
   // We persist the last active content value as the viewport may be animating out
   // and we want the content to remain mounted for the lifecycle of the viewport.
   const activeContentValue = open ? context.value : context.previousValue;
+
+  /**
+   * Update viewport size to match the active content node.
+   * We prefer offsetWidth and height over `getBoundingClientRect` as the latter returns values after transform.
+   */
+  const handleSizeChange = () => {
+    if (contentNode) setSize({ width: contentNode.offsetWidth, height: contentNode.offsetHeight });
+  };
+  useResizeObserver(contentNode, handleSizeChange);
 
   return (
     <Primitive.div
@@ -953,7 +959,7 @@ const NavigationMenuViewportImpl = React.forwardRef<
               ref={composeRefs(ref, (node) => {
                 // We only want to update the stored node when another is available
                 // as we need to smoothly transition between them.
-                if (isActive && node) setActiveContent(node);
+                if (isActive && node) setContentNode(node);
               })}
             />
           </Presence>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,7 +3650,6 @@ __metadata:
     "@radix-ui/react-use-direction": "workspace:*"
     "@radix-ui/react-use-layout-effect": "workspace:*"
     "@radix-ui/react-use-previous": "workspace:*"
-    "@radix-ui/react-use-size": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
Safari was having problems applying the correct `Viewport` dimensions if using `scale/rotate` animations on open. This is because it was falling back to `getBoundingClientRect` inside `useSize` as it [doesn't support `borderBoxSize` yet](https://caniuse.com/mdn-api_resizeobserverentry_borderboxsize). `getBoundingClientRect` returns dimensions **after** transform, hence the issue.

Switching to trusty `offsetWidth/height` works as expected. I considered making this change at the `useSize` level but I think it warrants further testing across other consumers first.

Before:

https://user-images.githubusercontent.com/11708259/155436308-96e656a9-cb57-4877-8579-4f1bacdf307e.mp4

After:

https://user-images.githubusercontent.com/11708259/155436327-efd16efa-5b4b-4093-a015-8547d0696984.mp4


