### PR TITLE
remove style outline:none from menu primitive

### DIFF
--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -604,7 +604,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                     {...popperScope}
                     {...contentProps}
                     ref={composedRefs}
-                    style={{ outline: 'none', ...contentProps.style }}
+                    style={{ ...contentProps.style }}
                     onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
                       // submenu key events bubble through portals. We only care about keys in this menu.
                       const target = event.target as HTMLElement;


### PR DESCRIPTION
### Description

<!-- Describe the change you are introducing -->

Removes `outline: none` from menu primitive style.

Using this library with tailwindcss, and noticing I can't override the outline style unless I use the important property since menu primitive ships with `outline: none`.

```jsx
    <ContextMenu.Content className="outline outline-1 outline-sky-500">
```

shows up as

```html
<div 
  role="menu"
  aria-orientation="vertical"
  data-state="open" dir="ltr"
  class="outline outline-1 outline-sky-500" 
  tabindex="-1" 
  data-orientation="vertical" 
  style="outline: none;--radix-context-menu-content-transform-origin:var(--radix-popper-transform-origin);pointer-events: auto;" 
  data-side="right" 
  data-align="start"
>
```

with style taking precedence over class.

Tailwind workaround right now is

```jsx
    <ContextMenu.Content className="!outline !outline-1 !outline-sky-500">
```