### PR TITLE
[Select] Fix SelectContent asChild prop

### DIFF
--- a/.yarn/versions/f27979d2.yml
+++ b/.yarn/versions/f27979d2.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives


### PR DESCRIPTION
Fixes #1244

The `asChild` would strip out the context provider because it was inside the `Primitive.div`. This moves it outside.

Easier to review with hidden whitespace changes.