### PR TITLE
don't run pointerMove when menu is closing

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -645,6 +645,33 @@ export const WithTooltip = () => (
   </div>
 );
 
+export const Animated = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}>
+    <DropdownMenu>
+      <DropdownMenuTrigger className={triggerClass}>Open</DropdownMenuTrigger>
+      <DropdownMenuContent className={`${animatedContentClass} ${contentClass}`} sideOffset={5}>
+        <DropdownMenuItem className={itemClass} onSelect={() => console.log('undo')}>
+          Undo
+        </DropdownMenuItem>
+        <DropdownMenuItem className={itemClass} onSelect={() => console.log('redo')}>
+          Redo
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className={separatorClass} />
+        <DropdownMenuItem className={itemClass} disabled onSelect={() => console.log('cut')}>
+          Cut
+        </DropdownMenuItem>
+        <DropdownMenuItem className={itemClass} onSelect={() => console.log('copy')}>
+          Copy
+        </DropdownMenuItem>
+        <DropdownMenuItem className={itemClass} onSelect={() => console.log('paste')}>
+          Paste
+        </DropdownMenuItem>
+        <DropdownMenuArrow />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
 
@@ -1386,3 +1413,22 @@ const radioGroupAttrClass = css(styles);
 const radioItemAttrClass = css(styles);
 const separatorAttrClass = css(styles);
 const arrowAttrClass = css(styles);
+
+const animateIn = css.keyframes({
+  from: { transform: 'scale(0.95)', opacity: 0 },
+  to: { transform: 'scale(1)', opacity: 1 },
+});
+
+const animateOut = css.keyframes({
+  from: { transform: 'scale(1)', opacity: 1 },
+  to: { transform: 'scale(0.95)', opacity: 0 },
+});
+
+const animatedContentClass = css(contentClass, {
+  '&[data-state="open"]': {
+    animation: `${animateIn} 300ms ease`,
+  },
+  '&[data-state="closed"]': {
+    animation: `${animateOut} 300ms ease`,
+  },
+});

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -911,6 +911,7 @@ interface MenuItemImplProps extends PrimitiveDivProps {
 const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
   (props: ScopedProps<MenuItemImplProps>, forwardedRef) => {
     const { __scopeMenu, disabled = false, textValue, ...itemProps } = props;
+    const menuContext = useMenuContext(CONTENT_NAME, __scopeMenu);
     const contentContext = useMenuContentContext(ITEM_NAME, __scopeMenu);
     const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeMenu);
     const ref = React.useRef<HTMLDivElement>(null);
@@ -952,6 +953,10 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
             onPointerMove={composeEventHandlers(
               props.onPointerMove,
               whenMouse((event) => {
+                if (!menuContext.open) {
+                  return;
+                }
+
                 if (disabled) {
                   contentContext.onItemLeave(event);
                 } else {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Don't run pointerMove events while closing. If you have an animation these events will still fire and potentially steal focus away from where you actually want it.

Partially addresses #1266