### PR TITLE
[Select] Fix defaultValue not being recognised

### DIFF
--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -1,0 +1,49 @@
+describe('Select', () => {
+  describe('with in a form', () => {
+    beforeEach(() => {
+      cy.visitStory('select--within-form');
+    });
+
+    describe('with defaultValue', () => {
+      it('is present in form response', () => {
+        cy.get('pre').contains('fr').should('not.exist');
+        cy.get('input').type('Testing'); // 👈 Triggers form response to be printed to the DOM
+        cy.get('pre').contains('fr');
+      });
+
+      it('remains uncontrolled', () => {
+        cy.get('pre').contains('fr').should('not.exist');
+        cy.get('pre').contains('es').should('not.exist');
+        cy.get('input').type('Testing'); // 👈 Triggers form response to be printed to the DOM
+        cy.get('pre').contains('fr');
+        cy.get('select').select('es', { force: true });
+        cy.get('pre').contains('es');
+      });
+    });
+  });
+
+  describe('controlled', () => {
+    beforeEach(() => {
+      cy.visitStory('select--controlled');
+    });
+
+    describe('with initial value', () => {
+      it('is set as value', () => {
+        cy.findByText('🇬🇧').should('be.visible');
+        cy.findByText('🇪🇸').should('not.exist');
+        cy.findByText('🇫🇷').should('not.exist');
+      });
+
+      it('sets new value when selected', () => {
+        cy.get('[role="combobox"]').click();
+        cy.findByText('United Kingdom').should('be.visible');
+        cy.findByText('Spain').should('be.visible');
+        cy.findByText('France').should('be.visible');
+        cy.get('[role="option"]').contains('Spain').click();
+        cy.findByText('🇪🇸').should('be.visible');
+        cy.findByText('🇬🇧').should('not.exist');
+        cy.findByText('🇫🇷').should('not.exist');
+      });
+    });
+  });
+});

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -365,14 +365,14 @@ export const WithinForm = () => {
           </Select.Trigger>
           <Select.Content className={contentClass}>
             <Select.Viewport className={viewportClass}>
-              <Select.Item className={itemClass} value="fr">
-                <Select.ItemText>France</Select.ItemText>
+              <Select.Item className={itemClass} value="uk">
+                <Select.ItemText>United Kingdom</Select.ItemText>
                 <Select.ItemIndicator className={indicatorClass}>
                   <TickIcon />
                 </Select.ItemIndicator>
               </Select.Item>
-              <Select.Item className={itemClass} value="uk">
-                <Select.ItemText>United Kingdom</Select.ItemText>
+              <Select.Item className={itemClass} value="fr">
+                <Select.ItemText>France</Select.ItemText>
                 <Select.ItemIndicator className={indicatorClass}>
                   <TickIcon />
                 </Select.ItemIndicator>

--- a/packages/react/select/src/Select.test.tsx
+++ b/packages/react/select/src/Select.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import * as Select from './Select';
+
+describe('given a Select with defaultValue', () => {
+  it('should set defaultValue as selected option', () => {
+    const defaultValue = 'fr';
+    let result;
+
+    function handleSubmit(e: any) {
+      e.preventDefault();
+      result = e.target.elements.country.value;
+    }
+
+    render(
+      <form onSubmit={handleSubmit}>
+        <Select.Root name="country" autoComplete="country" defaultValue={defaultValue}>
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Item value="uk">
+                <Select.ItemText>United Kingdom</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="fr">
+                <Select.ItemText>France</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="es">
+                <Select.ItemText>Spain</Select.ItemText>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Root>
+        <button type="submit">Submit</button>
+      </form>
+    );
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(result).toBe(defaultValue);
+  });
+
+  it('should not be used when a value is passed', () => {
+    const defaultValue = 'fr';
+    const value = 'es';
+    let result;
+
+    function handleSubmit(e: any) {
+      e.preventDefault();
+      result = e.target.elements.country.value;
+    }
+
+    render(
+      <form onSubmit={handleSubmit}>
+        <Select.Root
+          name="country"
+          autoComplete="country"
+          value={value}
+          defaultValue={defaultValue}
+        >
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Item value="uk">
+                <Select.ItemText>United Kingdom</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="fr">
+                <Select.ItemText>France</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="es">
+                <Select.ItemText>Spain</Select.ItemText>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Root>
+        <button type="submit">Submit</button>
+      </form>
+    );
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(result).toBe('es');
+  });
+});

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1219,7 +1219,7 @@ const BubbleSelect = React.forwardRef<HTMLSelectElement, React.ComponentPropsWit
      */
     return (
       <VisuallyHidden asChild>
-        <select {...selectProps} ref={composedRefs} defaultValue={value} />
+        <select {...selectProps} ref={composedRefs} value={value} />
       </VisuallyHidden>
     );
   }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
I've been using Select a lot recently in forms and noticed `defaultValue` wasn't being reflected when the element's value was checked; e.g. in a form submission event with an uncontrolled Select. Instead the first option was defaulting as the value. 

Here is an issue covering the same thing https://github.com/radix-ui/primitives/issues/1223

<!-- Describe the change you are introducing -->
* Removed the `defaultValue` prop from the `<select />` inside `BubbleSelect` and just added `value={value}`
* Ensured this change fixed uncontrolled behaviour with unit and integration tests
* Ensured this change didn't break controlled behaviour with unit and integration tests
