### PR TITLE
Wrap custom events dispatching with `flushSync`

### DIFF
--- a/.yarn/versions/2b845d44.yml
+++ b/.yarn/versions/2b845d44.yml
@@ -1,0 +1,14 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+  primitives: decline

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -28,7 +28,8 @@
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { flushSync } from 'react-dom';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -281,7 +282,7 @@ function dispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>
   const target = detail.originalEvent.target as HTMLElement;
   const event = new CustomEvent(name, { bubbles: false, cancelable: true, detail });
   if (handler) target.addEventListener(name, handler as EventListener, { once: true });
-  return !target.dispatchEvent(event);
+  return flushSync(() => !target.dispatchEvent(event));
 }
 
 const Root = DismissableLayer;

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { flushSync } from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -282,7 +282,7 @@ function dispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>
   const target = detail.originalEvent.target as HTMLElement;
   const event = new CustomEvent(name, { bubbles: false, cancelable: true, detail });
   if (handler) target.addEventListener(name, handler as EventListener, { once: true });
-  return flushSync(() => !target.dispatchEvent(event));
+  return ReactDOM.flushSync(() => !target.dispatchEvent(event));
 }
 
 const Root = DismissableLayer;

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -663,7 +663,7 @@ function dispatchCustomEvent<E extends CustomEvent, ReactEvent extends React.Syn
   const currentTarget = detail.originalEvent.currentTarget as HTMLElement;
   const event = new CustomEvent(name, { bubbles: true, cancelable: true, detail });
   if (handler) currentTarget.addEventListener(name, handler as EventListener, { once: true });
-  currentTarget.dispatchEvent(event);
+  ReactDOM.flushSync(() => currentTarget.dispatchEvent(event));
 }
 
 const isDeltaInDirection = (

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -157,13 +158,15 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
     prop: openProp,
     defaultProp: defaultOpen,
     onChange: (open) => {
-      if (open) {
-        // we dispatch here so `TooltipProvider` isn't required to
-        // ensure other tooltips are aware of this one opening.
-        document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN));
-        onOpen();
-      }
-      onOpenChange?.(open);
+      ReactDOM.flushSync(() => {
+        if (open) {
+          // we dispatch here so `TooltipProvider` isn't required to
+          // ensure other tooltips are aware of this one opening.
+          document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN));
+          onOpen();
+        }
+        onOpenChange?.(open);
+      });
     },
   });
   const stateAttribute = React.useMemo(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,6 +3515,7 @@ __metadata:
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0
+    react-dom: ^16.8 || ^17.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
fixes https://github.com/radix-ui/primitives/issues/1287

Ok, so this is what I got from a quick debugging session:
1. it's because in React 18 the `contextmenuchange` isn't dispatched at all in this case and thus you can't prevent it and fire a custom logic for it
2. this in turn is caused by the fact that you set `pointer-events: none` on the body, [here](https://github.com/radix-ui/primitives/blob/250ed1cd6a6b62bc353e1a8e448046a2f3c2ba20/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx#L23)
3. you need to set this to handle some requirements and that is fine, the problem is that in this scenario [`resetPointerEvents`](https://github.com/radix-ui/primitives/blob/250ed1cd6a6b62bc353e1a8e448046a2f3c2ba20/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx#L53) is not called "soon enough" to unblock the mentioned `contextmenuchange` event
4. In React 17 it actually happens "soon enough" so the whole thing works

I've attached `onOpenChange` to the `ContextMenu.Root` and just logged the received value together with some other stuff.

This is the order of the things happening under the hood:
React 17: `resetPointerEvents()` -> `onOpenChange(false)`
React 18: `onOpenChange(false)` -> `resetPointerEvents()`

As we can see... this somewhat matches the info that I've gathered when debugging. The order is flipped and this leads to a special sort of race condition.

Based on my intuition I've just deduced that this might behave slightly differently in terms of "flushing" the updates as there were some changes to that in React 18. I was looking for a rogue `setState`, to wrap it with `flushSync` but then I've realized that during debugging I've seen some `CustomEvent` stuff and since React is using `window.event` to determine the update priority... it made sense to just wrap **all** of those custom events with `flushSync`. You might want to be more granular, but I think that it's safer to just merge this and then reexamine if some of your custom events should actually not be wrapped with this.