### PR TITLE
[Toast] Allow `children` in `Viewport` types for `asChild` composition

### DIFF
--- a/.yarn/versions/3abef429.yml
+++ b/.yarn/versions/3abef429.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toast": patch
+
+declined:
+  - primitives

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -112,7 +112,7 @@ const VIEWPORT_RESUME = 'toast.viewportResume';
 
 type ToastViewportElement = React.ElementRef<typeof Primitive.ol>;
 type PrimitiveOrderedListProps = Radix.ComponentPropsWithoutRef<typeof Primitive.ol>;
-interface ToastViewportProps extends Omit<PrimitiveOrderedListProps, 'children'> {
+interface ToastViewportProps extends PrimitiveOrderedListProps {
   /**
    * The keys to use as the keyboard shortcut that will move focus to the toast viewport.
    * @defaultValue ['F8']


### PR DESCRIPTION
Fixes #1284 