### PR TITLE
[Tooltip] Better "close on scroll" implementation

### DIFF
--- a/.yarn/versions/4c8bef63.yml
+++ b/.yarn/versions/4c8bef63.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -28,8 +28,6 @@
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
-    "@radix-ui/react-use-previous": "workspace:*",
-    "@radix-ui/react-use-rect": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -613,6 +613,43 @@ export const KeepOpenOnActivation = () => {
   );
 };
 
+export const WithinScrollable = () => (
+  <TooltipProvider>
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        height: 500,
+        width: 300,
+        border: '1px solid black',
+        overflow: 'auto',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 600 }}>
+        <Tooltip>
+          <TooltipTrigger className={triggerClass}>Hover or Focus me</TooltipTrigger>
+          <TooltipContent className={contentClass} sideOffset={5}>
+            Nicely done!
+            <TooltipArrow className={arrowClass} offset={10} />
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '150vh' }}
+    >
+      <Tooltip>
+        <TooltipTrigger className={triggerClass}>Hover or Focus me</TooltipTrigger>
+        <TooltipContent className={contentClass} sideOffset={5}>
+          Nicely done!
+          <TooltipArrow className={arrowClass} offset={10} />
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+);
+
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
 

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -11,8 +11,6 @@ import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slottable } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { usePrevious } from '@radix-ui/react-use-previous';
-import { useRect } from '@radix-ui/react-use-rect';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -342,15 +340,27 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
     const PortalWrapper = portalled ? Portal : React.Fragment;
     const { onClose } = context;
 
+    // Close this tooltip if another one opens
     React.useEffect(() => {
-      // Close this tooltip if another one opens
       document.addEventListener(TOOLTIP_OPEN, onClose);
       return () => document.removeEventListener(TOOLTIP_OPEN, onClose);
     }, [onClose]);
 
+    // Close the tooltip if the trigger is scrolled
+    const { trigger } = context;
+    React.useEffect(() => {
+      if (trigger) {
+        const handleScroll = (event: Event) => {
+          const target = event.target as HTMLElement;
+          if (target?.contains(trigger)) onClose();
+        };
+        window.addEventListener('scroll', handleScroll, { capture: true });
+        return () => window.removeEventListener('scroll', handleScroll, { capture: true });
+      }
+    }, [trigger, onClose]);
+
     return (
       <PortalWrapper>
-        <CheckTriggerMoved __scopeTooltip={__scopeTooltip} />
         <DismissableLayer
           asChild
           disableOutsidePointerEvents={false}
@@ -405,31 +415,6 @@ const TooltipArrow = React.forwardRef<TooltipArrowElement, TooltipArrowProps>(
 TooltipArrow.displayName = ARROW_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
-
-function CheckTriggerMoved(props: ScopedProps<{}>) {
-  const { __scopeTooltip } = props;
-  const context = useTooltipContext('CheckTriggerMoved', __scopeTooltip);
-
-  const triggerRect = useRect(context.trigger);
-  const triggerLeft = triggerRect?.left;
-  const previousTriggerLeft = usePrevious(triggerLeft);
-  const triggerTop = triggerRect?.top;
-  const previousTriggerTop = usePrevious(triggerTop);
-  const handleClose = context.onClose;
-
-  React.useEffect(() => {
-    // checking if the user has scrolled…
-    const hasTriggerMoved =
-      (previousTriggerLeft !== undefined && previousTriggerLeft !== triggerLeft) ||
-      (previousTriggerTop !== undefined && previousTriggerTop !== triggerTop);
-
-    if (hasTriggerMoved) {
-      handleClose();
-    }
-  }, [handleClose, previousTriggerLeft, previousTriggerTop, triggerLeft, triggerTop]);
-
-  return null;
-}
 
 const Provider = TooltipProvider;
 const Root = Tooltip;

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -347,17 +347,16 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
     }, [onClose]);
 
     // Close the tooltip if the trigger is scrolled
-    const { trigger } = context;
     React.useEffect(() => {
-      if (trigger) {
+      if (context.trigger) {
         const handleScroll = (event: Event) => {
           const target = event.target as HTMLElement;
-          if (target?.contains(trigger)) onClose();
+          if (target?.contains(context.trigger)) onClose();
         };
         window.addEventListener('scroll', handleScroll, { capture: true });
         return () => window.removeEventListener('scroll', handleScroll, { capture: true });
       }
-    }, [trigger, onClose]);
+    }, [context.trigger, onClose]);
 
     return (
       <PortalWrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,8 +4008,6 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
-    "@radix-ui/react-use-previous": "workspace:*"
-    "@radix-ui/react-use-rect": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0


### PR DESCRIPTION
Fixes #937

**Note:** We had discussed in the issue potentially implementing this at the `Popper` layer as it could be useful for other components that open and are attached to a trigger. However, it's not possible there because the notion of "open/closed" doesn't exist at that level but is implemented in each primitive.

For that reason, I implemented it only in `Tooltip` for now so it's easy to review, and we can create a separate issue to maybe abstract that in its own package and implement within others.