### PR TITLE
update chromatic github workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: 63f2bd83c33c
+          projectToken:  ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
           exitZeroOnChanges: true


### PR DESCRIPTION
Morning, 

maybe I checked out your design-system tooling over the weekend, and maybe I copy&pasted your chromatic github-workflow, and maybe I just published my Storybook into your Chromatic-Account 😳😂 

Could you please remove this two builds 🙏 
- https://www.chromatic.com/build?appId=601857eb614bae0021c9b9dd&number=1626
- https://www.chromatic.com/build?appId=601857eb614bae0021c9b9dd&number=1627

### Description

This PR replaces the chromatic-token by a github-secret in the chromatic workflow. You have to add the Github-Action Secret `CHROMATIC_PROJECT_TOKEN` for this repo: https://github.com/radix-ui/primitives/settings/secrets/actions/new


 I learnt a lot studying your setup! Thanks for this excellent repo!
