### PR TITLE
[Presence] React 18 – Fix animation frame sync flicker 

### DIFF
--- a/.yarn/versions/8edec830.yml
+++ b/.yarn/versions/8edec830.yml
@@ -1,0 +1,20 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -27,7 +27,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -28,7 +28,8 @@
     "@radix-ui/react-use-size": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -27,7 +27,8 @@
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/collapsible/src/Collapsible.stories.tsx
+++ b/packages/react/collapsible/src/Collapsible.stories.tsx
@@ -191,7 +191,7 @@ const animatedContentClass = css({
     animation: `${slideDown} 300ms ease-out`,
   },
   '&[data-state="closed"]': {
-    animation: `${slideUp} 300ms ease-in forwards`,
+    animation: `${slideUp} 300ms ease-in`,
   },
 });
 
@@ -201,7 +201,7 @@ const animatedWidthContentClass = css({
     animation: `${openRight} 300ms ease-out`,
   },
   '&[data-state="closed"]': {
-    animation: `${closeRight} 300ms ease-in forwards`,
+    animation: `${closeRight} 300ms ease-in`,
   },
 });
 

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -21,7 +21,8 @@
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -155,6 +155,6 @@ const multipleOpenAndCloseAnimationsClass = css({
     animation: `${fadeIn} 3s cubic-bezier(0.22, 1, 0.36, 1), ${slideUp} 1s cubic-bezier(0.22, 1, 0.36, 1)`,
   },
   '&[data-state="closed"]': {
-    animation: `${fadeOut} 3s cubic-bezier(0.22, 1, 0.36, 1), ${slideDown} 1s cubic-bezier(0.22, 1, 0.36, 1) forwards`,
+    animation: `${fadeOut} 3s cubic-bezier(0.22, 1, 0.36, 1), ${slideDown} 1s cubic-bezier(0.22, 1, 0.36, 1)`,
   },
 });

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { useStateMachine } from './useStateMachine';
@@ -100,7 +101,7 @@ function usePresence(present: boolean) {
         const currentAnimationName = getAnimationName(stylesRef.current);
         const isCurrentAnimation = currentAnimationName.includes(event.animationName);
         if (event.target === node && isCurrentAnimation) {
-          send('ANIMATION_END');
+          ReactDOM.flushSync(() => send('ANIMATION_END'));
         }
       };
       const handleAnimationStart = (event: AnimationEvent) => {

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -101,6 +101,9 @@ function usePresence(present: boolean) {
         const currentAnimationName = getAnimationName(stylesRef.current);
         const isCurrentAnimation = currentAnimationName.includes(event.animationName);
         if (event.target === node && isCurrentAnimation) {
+          // With React 18 concurrency this update is applied
+          // a frame after the animation ends, creating a flash of visible content.
+          // By manually flushing we ensure they sync within a frame, removing the flash.
           ReactDOM.flushSync(() => send('ANIMATION_END'));
         }
       };

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -30,7 +30,8 @@
     "@radix-ui/react-use-size": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -31,7 +31,8 @@
     "@types/resize-observer-browser": "^0.1.4"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3475,6 +3475,7 @@ __metadata:
     "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,6 +3062,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3148,6 +3149,7 @@ __metadata:
     "@radix-ui/react-use-size": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3166,6 +3168,7 @@ __metadata:
     "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3521,6 +3524,7 @@ __metadata:
     "@radix-ui/react-use-size": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3560,6 +3564,7 @@ __metadata:
     "@types/resize-observer-browser": ^0.1.4
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
closes https://github.com/radix-ui/primitives/issues/1074
related https://github.com/radix-ui/primitives/pull/1292 https://github.com/radix-ui/primitives/pull/1125

The introduction of batched updates across all handlers in 18 concurrent mode introduces a frame sync issue where the state transition (`unmount`) is communicated a frame after animation has completed.

Currently we are recommending `animation-fill-mode: forwards` to cover this gap. While it does work, it [creates other problems](https://github.com/radix-ui/primitives/discussions/1311).

I'm still getting my head around the internal mechanics of react scheduling so feedback here would be very welcome, but as it stands I feel that this change is a superior option vs the css we are recommending.

⚠️  Note for docs: Remove `forwards` recommendation from demos if accepted?

Before:

https://user-images.githubusercontent.com/11708259/165278293-c86c3658-f133-4b05-a11a-f7f24ff5ca2b.mp4

After:

https://user-images.githubusercontent.com/11708259/165278317-0b396a47-615b-4d65-9110-8f28cddbf70a.mp4

