### PR TITLE
[Tabs] Add animation support for content

### DIFF
--- a/.yarn/versions/9dea0877.yml
+++ b/.yarn/versions/9dea0877.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tabs": minor
+
+declined:
+  - primitives

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
-    "@radix-ui/react-use-controllable-state": "workspace:*"
+    "@radix-ui/react-use-controllable-state": "workspace:*",
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -18,9 +18,11 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-direction": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
+    "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -18,15 +18,13 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
-    "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-direction": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
-    "@radix-ui/react-use-controllable-state": "workspace:*",
-    "@radix-ui/react-use-layout-effect": "workspace:*"
+    "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/react/tabs/src/Tabs.stories.tsx
+++ b/packages/react/tabs/src/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DirectionProvider } from '@radix-ui/react-direction';
-import { css } from '../../../../stitches.config';
+import { css, keyframes } from '../../../../stitches.config';
 import * as Tabs from '@radix-ui/react-tabs';
 
 export default { title: 'Components/Tabs' };
@@ -61,6 +61,70 @@ export const Styled = () => (
         You'll never find me!
       </Tabs.Content>
       <Tabs.Content value="tab3" className={contentClass()}>
+        Ut nisi elementum metus semper mauris dui fames accumsan aenean, maecenas ac sociis dolor
+        quam tempus pretium.
+      </Tabs.Content>
+    </Tabs.Root>
+  </>
+);
+
+export const Animated = () => (
+  <>
+    <h1>Horizontal (automatic activation)</h1>
+    <Tabs.Root defaultValue="tab1" className={rootClass()}>
+      <Tabs.List aria-label="tabs example" className={listClass()}>
+        <Tabs.Trigger value="tab1" className={triggerClass()}>
+          Tab 1
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2" disabled className={triggerClass()}>
+          Tab 2
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab3" className={triggerClass()}>
+          Tab 3
+        </Tabs.Trigger>
+      </Tabs.List>
+
+      <Tabs.Content value="tab1" className={animatedContentClass()}>
+        Dis metus rhoncus sit convallis sollicitudin vel cum, hac purus tincidunt eros sem himenaeos
+        integer, faucibus varius nullam nostra bibendum consectetur mollis, gravida elementum
+        pellentesque volutpat dictum ipsum.
+      </Tabs.Content>
+      <Tabs.Content value="tab2" className={animatedContentClass()}>
+        You'll never find me!
+      </Tabs.Content>
+      <Tabs.Content value="tab3" className={animatedContentClass()}>
+        Ut nisi elementum metus semper mauris dui fames accumsan aenean, maecenas ac sociis dolor
+        quam tempus pretium.
+      </Tabs.Content>
+    </Tabs.Root>
+
+    <h1>Vertical (manual activation)</h1>
+    <Tabs.Root
+      defaultValue="tab1"
+      className={rootClass()}
+      orientation="vertical"
+      activationMode="manual"
+    >
+      <Tabs.List aria-label="tabs example" className={listClass()}>
+        <Tabs.Trigger value="tab1" className={triggerClass()}>
+          Tab 1
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2" disabled className={triggerClass()}>
+          Tab 2
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab3" className={triggerClass()}>
+          Tab 3
+        </Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="tab1" className={animatedContentClass()}>
+        Dis metus rhoncus sit convallis sollicitudin vel cum, hac purus tincidunt eros sem himenaeos
+        integer, faucibus varius nullam nostra bibendum consectetur mollis, gravida elementum
+        pellentesque volutpat dictum ipsum.
+      </Tabs.Content>
+      <Tabs.Content value="tab2" className={animatedContentClass()}>
+        You'll never find me!
+      </Tabs.Content>
+      <Tabs.Content value="tab3" className={animatedContentClass()}>
         Ut nisi elementum metus semper mauris dui fames accumsan aenean, maecenas ac sociis dolor
         quam tempus pretium.
       </Tabs.Content>
@@ -213,6 +277,38 @@ export const Chromatic = () => (
       </Tabs.Root>
     </DirectionProvider>
 
+    <h1>Animated</h1>
+    <p>Should not animate on initial mount</p>
+    <Tabs.Root value="tab1" className={rootClass()}>
+      <Tabs.List aria-label="tabs example" className={listClass()}>
+        <Tabs.Trigger value="tab1" className={triggerClass()}>
+          Tab 1
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2" disabled className={triggerClass()}>
+          Tab 2
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab3" className={triggerClass()}>
+          Tab 3
+        </Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content
+        value="tab1"
+        className={animatedContentClass()}
+        style={{ animationDuration: '3000ms' }}
+      >
+        Dis metus rhoncus sit convallis sollicitudin vel cum, hac purus tincidunt eros sem himenaeos
+        integer, faucibus varius nullam nostra bibendum consectetur mollis, gravida elementum
+        pellentesque volutpat dictum ipsum.
+      </Tabs.Content>
+      <Tabs.Content value="tab2" className={animatedContentClass()}>
+        You'll never find me!
+      </Tabs.Content>
+      <Tabs.Content value="tab3" className={animatedContentClass()}>
+        Ut nisi elementum metus semper mauris dui fames accumsan aenean, maecenas ac sociis dolor
+        quam tempus pretium.
+      </Tabs.Content>
+    </Tabs.Root>
+
     <h1>State attributes</h1>
     <Tabs.Root defaultValue="tab3" className={rootAttrClass()}>
       <Tabs.List aria-label="tabs example" className={listAttrClass()}>
@@ -245,6 +341,7 @@ Chromatic.parameters = { chromatic: { disable: false } };
 
 const RECOMMENDED_CSS__TABS__ROOT = {
   // ensures things are layed out correctly by default
+  border: '1px solid #eee',
   display: 'flex',
   '&[data-orientation="horizontal"]': {
     flexDirection: 'column',
@@ -308,19 +405,30 @@ const triggerClass = css({
 
 const RECOMMENDED_CSS__TABS__CONTENT = {
   flexGrow: 1,
+  padding: '1em',
+  fontWeight: '300',
+  fontSize: '0.85em',
+  lineHeight: '1.65',
 };
 
 const contentClass = css({
   ...RECOMMENDED_CSS__TABS__CONTENT,
 
-  padding: '1em',
-  border: '1px solid #eee',
-  fontWeight: '300',
-  fontSize: '0.85em',
-  lineHeight: '1.65',
-
   '&[data-orientation="horizontal"]': { borderTop: 'none' },
   '&[data-orientation="vertical"]': { borderLeft: 'none' },
+});
+
+const show = keyframes({
+  from: { opacity: 0, transform: 'translateY(10px)' },
+  to: { opacity: 1, transform: 'translateY(0px)' },
+});
+
+const animatedContentClass = css({
+  ...RECOMMENDED_CSS__TABS__CONTENT,
+
+  '&[data-state="active"]': {
+    animation: `${show} 400ms ease`,
+  },
 });
 
 const styles = {

--- a/packages/react/tabs/src/Tabs.stories.tsx
+++ b/packages/react/tabs/src/Tabs.stories.tsx
@@ -341,7 +341,6 @@ Chromatic.parameters = { chromatic: { disable: false } };
 
 const RECOMMENDED_CSS__TABS__ROOT = {
   // ensures things are layed out correctly by default
-  border: '1px solid #eee',
   display: 'flex',
   '&[data-orientation="horizontal"]': {
     flexDirection: 'column',
@@ -350,6 +349,7 @@ const RECOMMENDED_CSS__TABS__ROOT = {
 
 const rootClass = css({
   ...RECOMMENDED_CSS__TABS__ROOT,
+  border: '1px solid #eee',
   fontFamily:
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
   maxWidth: '20rem',

--- a/packages/react/tabs/src/Tabs.stories.tsx
+++ b/packages/react/tabs/src/Tabs.stories.tsx
@@ -405,15 +405,14 @@ const triggerClass = css({
 
 const RECOMMENDED_CSS__TABS__CONTENT = {
   flexGrow: 1,
-  padding: '1em',
-  fontWeight: '300',
-  fontSize: '0.85em',
-  lineHeight: '1.65',
 };
 
 const contentClass = css({
   ...RECOMMENDED_CSS__TABS__CONTENT,
-
+  padding: '1em',
+  fontWeight: '300',
+  fontSize: '0.85em',
+  lineHeight: '1.65',
   '&[data-orientation="horizontal"]': { borderTop: 'none' },
   '&[data-orientation="vertical"]': { borderLeft: 'none' },
 });
@@ -423,9 +422,7 @@ const show = keyframes({
   to: { opacity: 1, transform: 'translateY(0px)' },
 });
 
-const animatedContentClass = css({
-  ...RECOMMENDED_CSS__TABS__CONTENT,
-
+const animatedContentClass = css(contentClass, {
   '&[data-state="active"]': {
     animation: `${show} 400ms ease`,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,7 +3689,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
-    "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-direction": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
@@ -3697,7 +3696,6 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
-    "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,9 +3689,11 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-direction": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
+    "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,6 +3695,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0


### PR DESCRIPTION
closes https://github.com/radix-ui/primitives/issues/860

Very similar to our approach for [`Collapsible`](https://github.com/radix-ui/primitives/blob/415a3e1173c81829adcda88c0f02e57df3dedbab/packages/react/collapsible/src/Collapsible.tsx#L182-L185) with a couple of modifications (we don't need to measure in this case). I assume we have historic / a11y reasons for controlling render of `children` rather than on wrapping element, hence my use of the render prop in this instance.