### PR TITLE
[Select] Fix positioning issue when few items are present

### DIFF
--- a/.yarn/versions/57842fe3.yml
+++ b/.yarn/versions/57842fe3.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -454,7 +454,6 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         // Vertical positioning
         // -----------------------------------------------------------------------------------------
         const availableHeight = window.innerHeight - CONTENT_MARGIN * 2;
-        const minContentHeight = selectedItem.offsetHeight * 5;
         const itemsHeight = viewport.scrollHeight;
 
         const contentStyles = window.getComputedStyle(content);
@@ -463,6 +462,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         const contentBorderBottomWidth = parseInt(contentStyles.borderBottomWidth, 10);
         const contentPaddingBottom = parseInt(contentStyles.paddingBottom, 10);
         const fullContentHeight = contentBorderTopWidth + contentPaddingTop + itemsHeight + contentPaddingBottom + contentBorderBottomWidth; // prettier-ignore
+        const minContentHeight = Math.min(selectedItem.offsetHeight * 5, fullContentHeight);
 
         const topEdgeToTriggerMiddle = triggerRect.top + triggerRect.height / 2 - CONTENT_MARGIN;
         const triggerMiddleToBottomEdge = availableHeight - topEdgeToTriggerMiddle;


### PR DESCRIPTION
Closes #1350

We make sure our heuristic doesn't apply too eagerly when there are less items.

> **Note**: Whilst testing for this, I noticed a bunch of alignment stuff is broken :( probably due to the React 18 upgrade given nobody has reported yet… I'm gonna add a separate issue to track and will take a look.