### PR TITLE
[NavigationMenu] Improve router link event composition

### DIFF
--- a/.yarn/versions/5e7f60d9.yml
+++ b/.yarn/versions/5e7f60d9.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-navigation-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -506,22 +506,24 @@ const NavigationMenuLink = React.forwardRef<NavigationMenuLinkElement, Navigatio
           aria-current={active ? 'page' : undefined}
           {...linkProps}
           ref={forwardedRef}
-          onClick={(event) => {
-            props.onClick?.(event);
+          onClick={composeEventHandlers(
+            props.onClick,
+            (event) => {
+              const target = event.target;
+              const linkSelectEvent = new Event(LINK_SELECT, { bubbles: true, cancelable: true });
+              target.addEventListener(LINK_SELECT, (event) => onSelect?.(event), { once: true });
+              target.dispatchEvent(linkSelectEvent);
 
-            const target = event.target;
-            const linkSelectEvent = new Event(LINK_SELECT, { bubbles: true, cancelable: true });
-            target.addEventListener(LINK_SELECT, (event) => onSelect?.(event), { once: true });
-            target.dispatchEvent(linkSelectEvent);
-
-            if (!linkSelectEvent.defaultPrevented) {
-              const rootContentDismissEvent = new Event(ROOT_CONTENT_DISMISS, {
-                bubbles: true,
-                cancelable: true,
-              });
-              target.dispatchEvent(rootContentDismissEvent);
-            }
-          }}
+              if (!linkSelectEvent.defaultPrevented) {
+                const rootContentDismissEvent = new Event(ROOT_CONTENT_DISMISS, {
+                  bubbles: true,
+                  cancelable: true,
+                });
+                target.dispatchEvent(rootContentDismissEvent);
+              }
+            },
+            { checkForDefaultPrevented: false }
+          )}
         />
       </FocusGroupItem>
     );

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -486,16 +486,18 @@ NavigationMenuTrigger.displayName = TRIGGER_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const LINK_NAME = 'NavigationMenuLink';
+const LINK_SELECT = 'navigationMenu.linkSelect';
 
 type NavigationMenuLinkElement = React.ElementRef<typeof Primitive.a>;
 type PrimitiveLinkProps = Radix.ComponentPropsWithoutRef<typeof Primitive.a>;
-interface NavigationMenuLinkProps extends PrimitiveLinkProps {
+interface NavigationMenuLinkProps extends Omit<PrimitiveLinkProps, 'onSelect'> {
   active?: boolean;
+  onSelect?: (event: Event) => void;
 }
 
 const NavigationMenuLink = React.forwardRef<NavigationMenuLinkElement, NavigationMenuLinkProps>(
   (props: ScopedProps<NavigationMenuLinkProps>, forwardedRef) => {
-    const { __scopeNavigationMenu, active, ...linkProps } = props;
+    const { __scopeNavigationMenu, active, onSelect, ...linkProps } = props;
 
     return (
       <FocusGroupItem asChild>
@@ -504,13 +506,22 @@ const NavigationMenuLink = React.forwardRef<NavigationMenuLinkElement, Navigatio
           aria-current={active ? 'page' : undefined}
           {...linkProps}
           ref={forwardedRef}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            const rootContentDismissEvent = new Event(ROOT_CONTENT_DISMISS, {
-              bubbles: true,
-              cancelable: true,
-            });
-            event.target.dispatchEvent(rootContentDismissEvent);
-          })}
+          onClick={(event) => {
+            props.onClick?.(event);
+
+            const target = event.target;
+            const linkSelectEvent = new Event(LINK_SELECT, { bubbles: true, cancelable: true });
+            target.addEventListener(LINK_SELECT, (event) => onSelect?.(event), { once: true });
+            target.dispatchEvent(linkSelectEvent);
+
+            if (!linkSelectEvent.defaultPrevented) {
+              const rootContentDismissEvent = new Event(ROOT_CONTENT_DISMISS, {
+                bubbles: true,
+                cancelable: true,
+              });
+              target.dispatchEvent(rootContentDismissEvent);
+            }
+          }}
         />
       </FocusGroupItem>
     );


### PR DESCRIPTION
See https://github.com/radix-ui/primitives/issues/1364#issuecomment-1116216373

- Adds an `onSelect` custom event so that we can maintain consistent "out of the box" close behaviour when composing with `next/link` (and others)
- Provides a mechanism to opt out of close on select without affecting default navigation behaviour (as they would if they simply `onClick={e => e.preventDefault()}`)