### PR TITLE
[core/primitive] React 18 – Flush discrete `CustomEvent` dispatch calls

### DIFF
--- a/.yarn/versions/a360ff08.yml
+++ b/.yarn/versions/a360ff08.yml
@@ -40,4 +40,3 @@ releases:
 
 declined:
   - primitives
-  - "@radix-ui/primitive"

--- a/.yarn/versions/ce619930.yml
+++ b/.yarn/versions/ce619930.yml
@@ -1,24 +1,33 @@
 releases:
-  "@radix-ui/primitive": patch
+  "@radix-ui/react-accessible-icon": patch
   "@radix-ui/react-accordion": patch
   "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
   "@radix-ui/react-avatar": patch
   "@radix-ui/react-checkbox": patch
   "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dialog": patch
   "@radix-ui/react-dismissable-layer": patch
   "@radix-ui/react-dropdown-menu": patch
   "@radix-ui/react-focus-scope": patch
   "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
   "@radix-ui/react-menu": patch
   "@radix-ui/react-navigation-menu": patch
   "@radix-ui/react-popover": patch
   "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
   "@radix-ui/react-radio-group": patch
   "@radix-ui/react-roving-focus": patch
   "@radix-ui/react-scroll-area": patch
   "@radix-ui/react-select": patch
+  "@radix-ui/react-separator": patch
   "@radix-ui/react-slider": patch
   "@radix-ui/react-switch": patch
   "@radix-ui/react-tabs": patch
@@ -27,6 +36,8 @@ releases:
   "@radix-ui/react-toggle-group": patch
   "@radix-ui/react-toolbar": patch
   "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
 
 declined:
   - primitives
+  - "@radix-ui/primitive"

--- a/.yarn/versions/ce619930.yml
+++ b/.yarn/versions/ce619930.yml
@@ -1,0 +1,32 @@
+releases:
+  "@radix-ui/primitive": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/cypress/integration/ContextMenu.spec.ts
+++ b/cypress/integration/ContextMenu.spec.ts
@@ -6,7 +6,7 @@ describe('ContextMenu', () => {
     });
 
     describe('when using pointer', () => {
-      it.skip('should close open submenus and reopen the root menu when right clicking trigger', () => {
+      it('should close open submenus and reopen the root menu when right clicking trigger', () => {
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('be.visible');
         cy.findByText('Right Click Here').rightclick({ force: true });

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -15,6 +15,9 @@
     "clean": "rm -rf dist",
     "version": "yarn version"
   },
+  "peerDependencies": {
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -15,9 +15,6 @@
     "clean": "rm -rf dist",
     "version": "yarn version"
   },
-  "peerDependencies": {
-    "react-dom": "^16.8 || ^17.0 || ^18.0"
-  },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -6,7 +6,7 @@ function composeEventHandlers<E>(
   return function handleEvent(event: E) {
     originalEventHandler?.(event);
 
-    if (checkForDefaultPrevented === false || !(event as unknown as Event).defaultPrevented) {
+    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
       return ourEventHandler?.(event);
     }
   };

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,3 +1,9 @@
+import * as ReactDOM from 'react-dom';
+
+function dispatchDiscreteCustomEvent(target: Document | HTMLElement, event: CustomEvent) {
+  ReactDOM.flushSync(() => target.dispatchEvent(event));
+}
+
 function composeEventHandlers<E>(
   originalEventHandler?: (event: E) => void,
   ourEventHandler?: (event: E) => void,
@@ -6,10 +12,10 @@ function composeEventHandlers<E>(
   return function handleEvent(event: E) {
     originalEventHandler?.(event);
 
-    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
+    if (checkForDefaultPrevented === false || !(event as unknown as Event).defaultPrevented) {
       return ourEventHandler?.(event);
     }
   };
 }
 
-export { composeEventHandlers };
+export { composeEventHandlers, dispatchDiscreteCustomEvent };

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,5 +1,3 @@
-import * as ReactDOM from 'react-dom';
-
 function composeEventHandlers<E>(
   originalEventHandler?: (event: E) => void,
   ourEventHandler?: (event: E) => void,
@@ -14,37 +12,4 @@ function composeEventHandlers<E>(
   };
 }
 
-/**
- * Flush custom event dispatch
- * https://github.com/radix-ui/primitives/pull/1378
- *
- * React batches *all* event handlers since version 18, this introduces certain considerations when using custom event types.
- *
- * Internally, React prioritises events in the following order:
- *  - discrete
- *  - continous
- *  - default
- *
- * `discrete` is an  important distinction as updates within these events are applied immediately.
- * React however, is not able to infer the priority of custom event types due to how they are detected internally.
- * Because of this, it's possible for updates from custom events to be unexpectedly batched when
- * dispatched by another `discrete` event.
- *
- * In order to ensure that updates from custom events are applied predictably, we need to manually flush the batch.
- * This utility should be used when dispatching a custom event from within another `discrete` event, for example:
- *
- * dispatching a click event:
- * target.dispatchEvent(new Event(‘click’))
- *
- * dispatching a custom event type:
- * target.dispatchEvent(new CustomEvent(‘customType’))
- *
- * dispatching a custom event type from another `discrete` event
- * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
- */
-
-function dispatchDiscreteCustomEvent<E extends CustomEvent>(target: E['target'], event: E) {
-  if (target) ReactDOM.flushSync(() => target.dispatchEvent(event));
-}
-
-export { composeEventHandlers, dispatchDiscreteCustomEvent };
+export { composeEventHandlers };

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,9 +1,5 @@
 import * as ReactDOM from 'react-dom';
 
-function dispatchDiscreteCustomEvent(target: Document | HTMLElement, event: CustomEvent) {
-  ReactDOM.flushSync(() => target.dispatchEvent(event));
-}
-
 function composeEventHandlers<E>(
   originalEventHandler?: (event: E) => void,
   ourEventHandler?: (event: E) => void,
@@ -16,6 +12,39 @@ function composeEventHandlers<E>(
       return ourEventHandler?.(event);
     }
   };
+}
+
+/**
+ * Flush custom event dispatch
+ * https://github.com/radix-ui/primitives/pull/1378
+ *
+ * React batches *all* event handlers since version 18, this introduces certain considerations when using custom event types.
+ *
+ * Internally, React prioritises events in the following order:
+ *  - discrete
+ *  - continous
+ *  - default
+ *
+ * `discrete` is an  important distinction as updates within these events are applied immediately.
+ * React however, is not able to infer the priority of custom event types due to how they are detected internally.
+ * Because of this, it's possible for updates from custom events to be unexpectedly batched when
+ * dispatched by another `discrete` event.
+ *
+ * In order to ensure that updates from custom events are applied predictably, we need to manually flush the batch.
+ * This utility should be used when dispatching a custom event from within another `discrete` event, for example:
+ *
+ * dispatching a click event:
+ * target.dispatchEvent(new Event(‘click’))
+ *
+ * dispatching a custom event type:
+ * target.dispatchEvent(new CustomEvent(‘customType’))
+ *
+ * dispatching a custom event type from another `discrete` event
+ * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
+ */
+
+function dispatchDiscreteCustomEvent<E extends CustomEvent>(target: E['target'], event: E) {
+  if (target) ReactDOM.flushSync(() => target.dispatchEvent(event));
 }
 
 export { composeEventHandlers, dispatchDiscreteCustomEvent };

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -20,7 +20,8 @@
     "@radix-ui/react-visually-hidden": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -20,7 +20,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -20,7 +20,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-slot": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -28,7 +28,8 @@
     "react-remove-scroll": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -282,7 +282,7 @@ function handleAndDispatchDiscreteCustomEvent<E extends CustomEvent, OriginalEve
   handler: ((event: E) => void) | undefined,
   detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D> ? D : never)
 ) {
-  const target = detail.originalEvent.target as HTMLElement;
+  const target = detail.originalEvent.target;
   const event = new CustomEvent(name, { bubbles: false, cancelable: true, detail });
   if (handler) target.addEventListener(name, handler as EventListener, { once: true });
   dispatchDiscreteCustomEvent(target, event);

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
-import { Primitive } from '@radix-ui/react-primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useBodyPointerEvents } from '@radix-ui/react-use-body-pointer-events';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useBodyPointerEvents } from '@radix-ui/react-use-body-pointer-events';
@@ -211,7 +211,11 @@ function usePointerDownOutside(onPointerDownOutside?: (event: PointerDownOutside
     const handlePointerDown = (event: PointerEvent) => {
       if (event.target && !isPointerInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        dispatchCustomEvent(POINTER_DOWN_OUTSIDE, handlePointerDownOutside, eventDetail);
+        handleAndDispatchDiscreteCustomEvent(
+          POINTER_DOWN_OUTSIDE,
+          handlePointerDownOutside,
+          eventDetail
+        );
       }
       isPointerInsideReactTreeRef.current = false;
     };
@@ -255,7 +259,7 @@ function useFocusOutside(onFocusOutside?: (event: FocusOutsideEvent) => void) {
     const handleFocus = (event: FocusEvent) => {
       if (event.target && !isFocusInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        dispatchCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail);
+        handleAndDispatchDiscreteCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail);
       }
     };
     document.addEventListener('focusin', handleFocus);
@@ -269,11 +273,11 @@ function useFocusOutside(onFocusOutside?: (event: FocusOutsideEvent) => void) {
 }
 
 function dispatchUpdate() {
-  const event = new Event(CONTEXT_UPDATE);
+  const event = new CustomEvent(CONTEXT_UPDATE);
   document.dispatchEvent(event);
 }
 
-function dispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
+function handleAndDispatchDiscreteCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
   name: string,
   handler: ((event: E) => void) | undefined,
   detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D> ? D : never)
@@ -281,7 +285,7 @@ function dispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>
   const target = detail.originalEvent.target as HTMLElement;
   const event = new CustomEvent(name, { bubbles: false, cancelable: true, detail });
   if (handler) target.addEventListener(name, handler as EventListener, { once: true });
-  return !target.dispatchEvent(event);
+  dispatchDiscreteCustomEvent(target, event);
 }
 
 const Root = DismissableLayer;

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -22,7 +22,8 @@
     "@radix-ui/react-use-callback-ref": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -107,7 +107,7 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
       const hasFocusedCandidate = container.contains(previouslyFocusedElement);
 
       if (!hasFocusedCandidate) {
-        const mountEvent = new Event(AUTOFOCUS_ON_MOUNT, EVENT_OPTIONS);
+        const mountEvent = new CustomEvent(AUTOFOCUS_ON_MOUNT, EVENT_OPTIONS);
         container.addEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
         container.dispatchEvent(mountEvent);
         if (!mountEvent.defaultPrevented) {
@@ -125,7 +125,7 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
         // We need to delay the focus a little to get around it for now.
         // See: https://github.com/facebook/react/issues/17894
         setTimeout(() => {
-          const unmountEvent = new Event(AUTOFOCUS_ON_UNMOUNT, EVENT_OPTIONS);
+          const unmountEvent = new CustomEvent(AUTOFOCUS_ON_UNMOUNT, EVENT_OPTIONS);
           container.addEventListener(AUTOFOCUS_ON_UNMOUNT, onUnmountAutoFocus);
           container.dispatchEvent(unmountEvent);
           if (!unmountEvent.defaultPrevented) {

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -23,7 +23,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { Presence } from '@radix-ui/react-presence';
-import { Primitive } from '@radix-ui/react-primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -720,9 +720,9 @@ const MenuItem = React.forwardRef<MenuItemElement, MenuItemProps>(
     const handleSelect = () => {
       const menuItem = ref.current;
       if (!disabled && menuItem) {
-        const itemSelectEvent = new Event(ITEM_SELECT, { bubbles: true, cancelable: true });
+        const itemSelectEvent = new CustomEvent(ITEM_SELECT, { bubbles: true, cancelable: true });
         menuItem.addEventListener(ITEM_SELECT, (event) => onSelect?.(event), { once: true });
-        menuItem.dispatchEvent(itemSelectEvent);
+        dispatchDiscreteCustomEvent(menuItem, itemSelectEvent);
         if (itemSelectEvent.defaultPrevented) {
           isPointerDownRef.current = false;
         } else {

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { createContextScope } from '@radix-ui/react-context';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -509,17 +509,20 @@ const NavigationMenuLink = React.forwardRef<NavigationMenuLinkElement, Navigatio
           onClick={composeEventHandlers(
             props.onClick,
             (event) => {
-              const target = event.target;
-              const linkSelectEvent = new Event(LINK_SELECT, { bubbles: true, cancelable: true });
+              const target = event.target as HTMLElement;
+              const linkSelectEvent = new CustomEvent(LINK_SELECT, {
+                bubbles: true,
+                cancelable: true,
+              });
               target.addEventListener(LINK_SELECT, (event) => onSelect?.(event), { once: true });
-              target.dispatchEvent(linkSelectEvent);
+              dispatchDiscreteCustomEvent(target, linkSelectEvent);
 
               if (!linkSelectEvent.defaultPrevented) {
-                const rootContentDismissEvent = new Event(ROOT_CONTENT_DISMISS, {
+                const rootContentDismissEvent = new CustomEvent(ROOT_CONTENT_DISMISS, {
                   bubbles: true,
                   cancelable: true,
                 });
-                target.dispatchEvent(rootContentDismissEvent);
+                dispatchDiscreteCustomEvent(target, rootContentDismissEvent);
               }
             },
             { checkForDefaultPrevented: false }

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { createContextScope } from '@radix-ui/react-context';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
-import { Primitive } from '@radix-ui/react-primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useDirection } from '@radix-ui/react-direction';

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -27,7 +27,8 @@
     "@radix-ui/rect": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/primitive/package.json
+++ b/packages/react/primitive/package.json
@@ -23,7 +23,8 @@
     "@testing-library/react": "^10.4.8"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -85,15 +85,17 @@ const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChi
  * dispatched by another `discrete` event.
  *
  * In order to ensure that updates from custom events are applied predictably, we need to manually flush the batch.
- * This utility should be used when dispatching a custom event from within another `discrete` event, for example:
+ * This utility should be used when dispatching a custom event from within another `discrete` event, this utility
+ * is not nessesary when dispatching known event types, or if dispatching a custom type inside a non-discrete event.
+ * For example:
  *
- * dispatching a click event:
+ * dispatching a known click 👎
  * target.dispatchEvent(new Event(‘click’))
  *
- * dispatching a custom event type:
- * target.dispatchEvent(new CustomEvent(‘customType’))
+ * dispatching a custom type within a non-discrete event 👎
+ * onScroll={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
  *
- * dispatching a custom event type from another `discrete` event
+ * dispatching a custom type within a `discrete` event 👍
  * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
  */
 

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -93,7 +93,7 @@ const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChi
  * target.dispatchEvent(new Event(‘click’))
  *
  * dispatching a custom type within a non-discrete event 👎
- * onScroll={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
+ * onScroll={(event) => event.target.dispatchEvent(new CustomEvent(‘customType’))}
  *
  * dispatching a custom type within a `discrete` event 👍
  * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { Slot } from '@radix-ui/react-slot';
 
 const NODES = [
@@ -63,11 +64,52 @@ const Primitive = NODES.reduce(
 
 const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChild\`. For details, see https://radix-ui.com/docs/primitives/overview/styling#changing-the-rendered-element`;
 
+/* -------------------------------------------------------------------------------------------------
+ * Utils
+ * -----------------------------------------------------------------------------------------------*/
+
+/**
+ * Flush custom event dispatch
+ * https://github.com/radix-ui/primitives/pull/1378
+ *
+ * React batches *all* event handlers since version 18, this introduces certain considerations when using custom event types.
+ *
+ * Internally, React prioritises events in the following order:
+ *  - discrete
+ *  - continuous
+ *  - default
+ *
+ * `discrete` is an  important distinction as updates within these events are applied immediately.
+ * React however, is not able to infer the priority of custom event types due to how they are detected internally.
+ * Because of this, it's possible for updates from custom events to be unexpectedly batched when
+ * dispatched by another `discrete` event.
+ *
+ * In order to ensure that updates from custom events are applied predictably, we need to manually flush the batch.
+ * This utility should be used when dispatching a custom event from within another `discrete` event, for example:
+ *
+ * dispatching a click event:
+ * target.dispatchEvent(new Event(‘click’))
+ *
+ * dispatching a custom event type:
+ * target.dispatchEvent(new CustomEvent(‘customType’))
+ *
+ * dispatching a custom event type from another `discrete` event
+ * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
+ */
+
+function dispatchDiscreteCustomEvent<E extends CustomEvent>(target: E['target'], event: E) {
+  if (target) ReactDOM.flushSync(() => target.dispatchEvent(event));
+}
+
+/* -----------------------------------------------------------------------------------------------*/
+
 const Root = Primitive;
 
 export {
   Primitive,
   //
   Root,
+  //
+  dispatchDiscreteCustomEvent,
 };
 export type { ComponentPropsWithoutRef, PrimitivePropsWithRef };

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -21,7 +21,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -28,7 +28,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -158,8 +158,8 @@ const RovingFocusGroupImpl = React.forwardRef<
           const isKeyboardFocus = !isClickFocusRef.current;
 
           if (event.target === event.currentTarget && isKeyboardFocus && !isTabbingBackOut) {
-            const entryFocusEvent = new Event(ENTRY_FOCUS, EVENT_OPTIONS);
-            event.currentTarget.dispatchEvent(entryFocusEvent);
+            const entryFocusEvent = new CustomEvent(ENTRY_FOCUS, EVENT_OPTIONS);
+            dispatchDiscreteCustomEvent(event.currentTarget, entryFocusEvent);
 
             if (!entryFocusEvent.defaultPrevented) {
               const items = getItems().filter((item) => item.focusable);

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
-import { Primitive } from '@radix-ui/react-primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useDirection } from '@radix-ui/react-direction';

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -20,7 +20,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -34,7 +34,8 @@
     "form-serialize": "^0.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -27,7 +27,8 @@
     "@radix-ui/react-use-size": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -26,7 +26,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import * as DismissableLayer from '@radix-ui/react-dismissable-layer';
 import { UnstablePortal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
-import { Primitive } from '@radix-ui/react-primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import * as DismissableLayer from '@radix-ui/react-dismissable-layer';
@@ -156,13 +156,13 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
       const viewport = ref.current;
       if (wrapper && viewport) {
         const handlePause = () => {
-          const pauseEvent = new Event(VIEWPORT_PAUSE);
-          viewport.dispatchEvent(pauseEvent);
+          const pauseEvent = new CustomEvent(VIEWPORT_PAUSE);
+          dispatchDiscreteCustomEvent(viewport, pauseEvent);
           context.isClosePausedRef.current = true;
         };
         const handleResume = () => {
-          const resumeEvent = new Event(VIEWPORT_RESUME);
-          viewport.dispatchEvent(resumeEvent);
+          const resumeEvent = new CustomEvent(VIEWPORT_RESUME);
+          dispatchDiscreteCustomEvent(viewport, resumeEvent);
           context.isClosePausedRef.current = false;
         };
         // Toasts are not in the viewport React tree so we need to bind DOM events
@@ -471,10 +471,18 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   const eventDetail = { originalEvent: event, delta };
                   if (hasSwipeMoveStarted) {
                     swipeDeltaRef.current = delta;
-                    dispatchCustomEvent(TOAST_SWIPE_MOVE, onSwipeMove, eventDetail);
+                    handleAndDispatchDiscreteCustomEvent(
+                      TOAST_SWIPE_MOVE,
+                      onSwipeMove,
+                      eventDetail
+                    );
                   } else if (isDeltaInDirection(delta, context.swipeDirection, moveStartBuffer)) {
                     swipeDeltaRef.current = delta;
-                    dispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail);
+                    handleAndDispatchDiscreteCustomEvent(
+                      TOAST_SWIPE_START,
+                      onSwipeStart,
+                      eventDetail
+                    );
                     (event.target as HTMLElement).setPointerCapture(event.pointerId);
                   } else if (Math.abs(x) > moveStartBuffer || Math.abs(y) > moveStartBuffer) {
                     // User is swiping in wrong direction so we disable swipe gesture
@@ -491,9 +499,17 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                     const toast = event.currentTarget;
                     const eventDetail = { originalEvent: event, delta };
                     if (isDeltaInDirection(delta, context.swipeDirection, context.swipeThreshold)) {
-                      dispatchCustomEvent(TOAST_SWIPE_END, onSwipeEnd, eventDetail);
+                      handleAndDispatchDiscreteCustomEvent(
+                        TOAST_SWIPE_END,
+                        onSwipeEnd,
+                        eventDetail
+                      );
                     } else {
-                      dispatchCustomEvent(TOAST_SWIPE_CANCEL, onSwipeCancel, eventDetail);
+                      handleAndDispatchDiscreteCustomEvent(
+                        TOAST_SWIPE_CANCEL,
+                        onSwipeCancel,
+                        eventDetail
+                      );
                     }
                     // Prevent click event from triggering on items within the toast when
                     // pointer up is part of a swipe gesture
@@ -664,7 +680,10 @@ ToastClose.displayName = CLOSE_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-function dispatchCustomEvent<E extends CustomEvent, ReactEvent extends React.SyntheticEvent>(
+function handleAndDispatchDiscreteCustomEvent<
+  E extends CustomEvent,
+  ReactEvent extends React.SyntheticEvent
+>(
   name: string,
   handler: ((event: E) => void) | undefined,
   detail: { originalEvent: ReactEvent } & (E extends CustomEvent<infer D> ? D : never)
@@ -672,7 +691,7 @@ function dispatchCustomEvent<E extends CustomEvent, ReactEvent extends React.Syn
   const currentTarget = detail.originalEvent.currentTarget as HTMLElement;
   const event = new CustomEvent(name, { bubbles: true, cancelable: true, detail });
   if (handler) currentTarget.addEventListener(name, handler as EventListener, { once: true });
-  currentTarget.dispatchEvent(event);
+  dispatchDiscreteCustomEvent(currentTarget, event);
 }
 
 const isDeltaInDirection = (

--- a/packages/react/toggle-group/package.json
+++ b/packages/react/toggle-group/package.json
@@ -26,7 +26,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/toggle/package.json
+++ b/packages/react/toggle/package.json
@@ -22,7 +22,8 @@
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -26,7 +26,8 @@
     "@radix-ui/react-toggle-group": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -8,7 +8,7 @@ import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
-import { Primitive } from '@radix-ui/react-primitive';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { Slottable } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, dispatchDiscreteCustomEvent } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -158,7 +158,7 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
       if (open) {
         // we dispatch here so `TooltipProvider` isn't required to
         // ensure other tooltips are aware of this one opening.
-        document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN));
+        dispatchDiscreteCustomEvent(document, new CustomEvent(TOOLTIP_OPEN));
         onOpen();
       }
       onOpenChange?.(open);

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -20,7 +20,8 @@
     "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0"
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3040,8 +3040,6 @@ __metadata:
   resolution: "@radix-ui/primitive@workspace:packages/core/primitive"
   dependencies:
     "@babel/runtime": ^7.13.10
-  peerDependencies:
-    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3053,6 +3051,7 @@ __metadata:
     "@radix-ui/react-visually-hidden": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3114,6 +3113,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3125,6 +3125,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3193,6 +3194,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3369,6 +3371,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3504,6 +3507,7 @@ __metadata:
     "@testing-library/react": ^10.4.8
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3516,6 +3520,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3620,6 +3625,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3883,6 +3889,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3040,6 +3040,8 @@ __metadata:
   resolution: "@radix-ui/primitive@workspace:packages/core/primitive"
   dependencies:
     "@babel/runtime": ^7.13.10
+  peerDependencies:
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3137,6 +3139,7 @@ __metadata:
     "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3278,6 +3281,7 @@ __metadata:
     react-remove-scroll: ^2.4.0
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3319,6 +3323,7 @@ __metadata:
     "@radix-ui/react-use-callback-ref": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3460,6 +3465,7 @@ __metadata:
     "@radix-ui/rect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3551,6 +3557,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3636,6 +3643,7 @@ __metadata:
     form-serialize: ^0.7.2
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3665,6 +3673,7 @@ __metadata:
     "@radix-ui/react-use-size": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3682,6 +3691,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3721,6 +3731,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3734,6 +3745,7 @@ __metadata:
     "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 
@@ -3751,6 +3763,7 @@ __metadata:
     "@radix-ui/react-toggle-group": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes https://github.com/radix-ui/primitives/issues/1287
Supersedes https://github.com/radix-ui/primitives/pull/1292

Big thanks to @Andarist for providing great insight into a resolution. This change is mostly equivalent though with the additional goal of providing a clear heuristic for when this is necessary and applying the change to all applicable code.

### Context
One of the core changes in React 18 is the introduction of consistent batching across all event handlers, this differs from 17 where only certain events would be subject to batching. As a result, certain state updates are now batched where before they were not, creating issues like those seen in https://github.com/radix-ui/primitives/issues/1287

### Event priorities
React [assigns priorities](https://github.com/facebook/react/blob/a8a4742f1c54493df00da648a3f9d26e3db9c8b5/packages/react-dom/src/events/ReactDOMEventListener.js#L294-L350) to updates based on the type of user interaction (`discrete`, `continuous`, `default`), `discrete` is an important distinction as it allows updates from those handlers to be made immediately. As stated in https://github.com/radix-ui/primitives/pull/1292#issuecomment-1091983795 the way that React determines this priority is by usage of `window.event`.

Because custom event types are unable to be assessed in this way, they fall through to `default`. In most cases this wouldn’t be a problem, but in the case of `ContextMenu` our code structure is such that there is an implicit expectation for one update to commit before another. 

### Why this can be problematic
In the case of `ContextMenu`, the incorrect behaviour is caused by the unexpected batching of updates in `pointerdown` and `contextmenu`, while the execution order remains correct (`pointerdown` -> `contextmenu`), the resulting state change is batched in 18, resulting in no update  to `open`. As the [effect cleanup](https://github.com/radix-ui/primitives/blob/f2d50b0d310fbe2168333ceff95c7f43133fe7f0/packages/react/use-body-pointer-events/src/useBodyPointerEvents.tsx#L32-L57) is no longer cycled by moving through `false` -> `true` `pointer-events: none;` does not get removed and our handler in  `contextmenu` is blocked.

You can see and compare the behaviour in [this example](https://codesandbox.io/s/batching-simple-euprqh?file=/src/App.js).  

### A heuristic for consistency
Given our understanding of how React splits priorities for updates, and that the intention for immediate user interaction i.e. `discrete` events is to not defer, `dispatchDiscreteCustomEvent` should be used whenever a custom event type is dispatched from a `discrete` handler. This is the [recommendation](https://twitter.com/dan_abramov/status/1509543312427991046?s=20&t=Uzu2oiNruibt3QnSvK_Xvw) from the core team.

Internal p riorities for these types [can be found here](https://github.com/facebook/react/blob/a8a4742f1c54493df00da648a3f9d26e3db9c8b5/packages/react-dom/src/events/ReactDOMEventListener.js#L294-L350)

### Use of `Event` vs `CustomEvent`

I’ve changed every usage of the the `Event` constructor to be `CustomEvent` when a custom type is provided, this is a style change as either constructor is susceptible (it’s important to remember priority is inferred by the type passed, not which constructor used) the hope being that staying consistent will make deciding when to use `dispatchDiscreteCustomEvent` easier.

  e.g. 
```jsx
//   dispatching a click
  target.dispatchEvent(new Event(‘click’))
  
  //     dispatching a custom type
  target.dispatchEvent(new CustomEvent(‘customType’))
  
  //       dispatching a custom type within a discrete handler
  onPointerDown={(e) => dispatchDiscreteCustomEvent(e.target, new CustomEvent(‘customType’))}
```