### PR TITLE
[Select] When there's no `value` or `defaultValue`, align with first non-disabled item

### DIFF
--- a/.yarn/versions/64cb0ea5.yml
+++ b/.yarn/versions/64cb0ea5.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -150,6 +150,42 @@ export const Position = () => (
   </div>
 );
 
+export const NoDefault = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+    <Label>
+      Choose a number:
+      <Select.Root>
+        <Select.Trigger className={triggerClass()}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content className={contentClass()}>
+          <Select.Viewport className={viewportClass()}>
+            <Select.Item className={itemClass()} value="one" disabled>
+              <Select.ItemText>One</Select.ItemText>
+              <Select.ItemIndicator className={indicatorClass()}>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+            <Select.Item className={itemClass()} value="two">
+              <Select.ItemText>Two</Select.ItemText>
+              <Select.ItemIndicator className={indicatorClass()}>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+            <Select.Item className={itemClass()} value="three">
+              <Select.ItemText>Three</Select.ItemText>
+              <Select.ItemIndicator className={indicatorClass()}>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Root>
+    </Label>
+  </div>
+);
+
 export const Typeahead = () => (
   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '300vh' }}>
     <Label>

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -118,7 +118,7 @@ export const Position = () => (
   >
     <Label>
       Choose an item:
-      <Select.Root defaultValue="item-25">
+      <Select.Root>
         <Select.Trigger className={triggerClass()}>
           <Select.Value />
           <Select.Icon />
@@ -133,7 +133,7 @@ export const Position = () => (
                   key={value}
                   className={itemClass()}
                   value={value}
-                  disabled={i > 5 && i < 9}
+                  disabled={i >= 0 && i < 9}
                 >
                   <Select.ItemText>item {i + 1}</Select.ItemText>
                   <Select.ItemIndicator className={indicatorClass()}>
@@ -505,6 +505,37 @@ export const ChromaticBottomLastPaddedViewport = () => (
   <ChromaticStoryBottomLast paddedElement="viewport" />
 );
 ChromaticBottomLastPaddedViewport.parameters = { chromatic: { disable: false } };
+
+export const ChromaticNoDefault = () => (
+  <div
+    style={{
+      display: 'grid',
+      height: '100vh',
+      placeItems: 'center',
+    }}
+  >
+    <Select.Root open>
+      <Select.Trigger className={triggerClass()}>
+        <Select.Value />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Content className={contentClass()} style={{ opacity: 0.7 }}>
+        <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+        <Select.Viewport className={viewportClass()}>
+          {Array.from({ length: 10 }, (_, i) => (
+            <Select.Item key={i} className={itemClass()} value={String(i)} disabled={i < 5}>
+              <Select.ItemText>{String(i)}</Select.ItemText>
+              <Select.ItemIndicator className={indicatorClass()}>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+          ))}
+        </Select.Viewport>
+        <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+      </Select.Content>
+    </Select.Root>
+  </div>
+);
 
 type PaddedElement = 'content' | 'viewport';
 

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -118,7 +118,7 @@ export const Position = () => (
   >
     <Label>
       Choose an item:
-      <Select.Root>
+      <Select.Root defaultValue="item-25">
         <Select.Trigger className={triggerClass()}>
           <Select.Value />
           <Select.Icon />
@@ -133,7 +133,7 @@ export const Position = () => (
                   key={value}
                   className={itemClass()}
                   value={value}
-                  disabled={i >= 0 && i < 9}
+                  disabled={i > 5 && i < 9}
                 >
                   <Select.ItemText>item {i + 1}</Select.ItemText>
                   <Select.ItemIndicator className={indicatorClass()}>

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -150,7 +150,7 @@ export const Position = () => (
   </div>
 );
 
-export const NoDefault = () => (
+export const NoDefaultValue = () => (
   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
     <Label>
       Choose a number:
@@ -506,7 +506,7 @@ export const ChromaticBottomLastPaddedViewport = () => (
 );
 ChromaticBottomLastPaddedViewport.parameters = { chromatic: { disable: false } };
 
-export const ChromaticNoDefault = () => (
+export const ChromaticNoDefaultValue = () => (
   <div
     style={{
       display: 'grid',
@@ -536,6 +536,7 @@ export const ChromaticNoDefault = () => (
     </Select.Root>
   </div>
 );
+ChromaticNoDefaultValue.parameters = { chromatic: { disable: false } };
 
 type PaddedElement = 'content' | 'viewport';
 

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -631,11 +631,11 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
 
     const itemRefCallback = React.useCallback(
       (node: SelectItemElement | null, value: string, disabled: boolean) => {
-        const isFirstSeenValidItem = !firstValidItemFoundRef.current && !disabled;
+        const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
-        if (isSelectedItem || isFirstSeenValidItem) {
+        if (isSelectedItem || isFirstValidItem) {
           setSelectedItem(node);
-          if (isFirstSeenValidItem) firstValidItemFoundRef.current = true;
+          if (isFirstValidItem) firstValidItemFoundRef.current = true;
         }
       },
       [context.value]
@@ -643,9 +643,9 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const handleItemLeave = React.useCallback(() => content?.focus(), [content]);
     const itemTextRefCallback = React.useCallback(
       (node: SelectItemTextElement | null, value: string, disabled: boolean) => {
-        const isFirstSeenValidItem = !firstValidItemFoundRef.current && !disabled;
+        const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
-        if (isSelectedItem || isFirstSeenValidItem) {
+        if (isSelectedItem || isFirstValidItem) {
           setSelectedItemText(node);
         }
       },

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -53,7 +53,7 @@ type SelectContextValue = {
   valueNodeHasChildren: boolean;
   onValueNodeHasChildrenChange(hasChildren: boolean): void;
   contentId: string;
-  value: string | undefined;
+  value?: string;
   onValueChange(value: string): void;
   open: boolean;
   onOpenChange(open: boolean): void;

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -335,10 +335,14 @@ type SelectContentContextValue = {
   content?: SelectContentElement | null;
   viewport?: SelectViewportElement | null;
   onViewportChange?: (node: SelectViewportElement | null) => void;
-  onItemSeen?: (node: SelectItemElement | null, value: string, disabled: boolean) => void;
+  itemRefCallback?: (node: SelectItemElement | null, value: string, disabled: boolean) => void;
   selectedItem?: SelectItemElement | null;
   onItemLeave?: () => void;
-  onItemTextSeen?: (node: SelectItemTextElement | null, value: string, disabled: boolean) => void;
+  itemTextRefCallback?: (
+    node: SelectItemTextElement | null,
+    value: string,
+    disabled: boolean
+  ) => void;
   selectedItemText?: SelectItemTextElement | null;
   onScrollButtonChange?: (node: SelectScrollButtonImplElement | null) => void;
   isPositioned?: boolean;
@@ -625,7 +629,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
       }
     });
 
-    const handleItemSeen = React.useCallback(
+    const itemRefCallback = React.useCallback(
       (node: SelectItemElement | null, value: string, disabled: boolean) => {
         const isFirstSeenValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
@@ -637,7 +641,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
       [context.value]
     );
     const handleItemLeave = React.useCallback(() => content?.focus(), [content]);
-    const handleItemTextSeen = React.useCallback(
+    const itemTextRefCallback = React.useCallback(
       (node: SelectItemTextElement | null, value: string, disabled: boolean) => {
         const isFirstSeenValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
@@ -655,10 +659,10 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         content={content}
         viewport={viewport}
         onViewportChange={setViewport}
-        onItemSeen={handleItemSeen}
+        itemRefCallback={itemRefCallback}
         selectedItem={selectedItem}
         onItemLeave={handleItemLeave}
-        onItemTextSeen={handleItemTextSeen}
+        itemTextRefCallback={itemTextRefCallback}
         selectedItemText={selectedItemText}
         onScrollButtonChange={handleScrollButtonChange}
         isPositioned={isPositioned}
@@ -911,7 +915,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     const [textValue, setTextValue] = React.useState(textValueProp ?? '');
     const [isFocused, setIsFocused] = React.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, (node) =>
-      contentContext.onItemSeen?.(node, value, disabled)
+      contentContext.itemRefCallback?.(node, value, disabled)
     );
     const textId = useId();
 
@@ -1001,7 +1005,7 @@ const SelectItemText = React.forwardRef<SelectItemTextElement, SelectItemTextPro
     const itemContext = useSelectItemContext(ITEM_TEXT_NAME, __scopeSelect);
     const ref = React.useRef<SelectItemTextElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, itemContext.onItemTextChange, (node) =>
-      contentContext.onItemTextSeen?.(node, itemContext.value, itemContext.disabled)
+      contentContext.itemTextRefCallback?.(node, itemContext.value, itemContext.disabled)
     );
 
     return (

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -317,7 +317,6 @@ const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>
       <SelectContentImpl {...props} ref={forwardedRef} />
     ) : fragment ? (
       ReactDOM.createPortal(
-        // @ts-ignore: This is to avoid the "SelectViewport must be inside "SelectContent" error
         <SelectContentContextProvider scope={props.__scopeSelect}>
           <Collection.Slot scope={props.__scopeSelect}>
             <div>{props.children}</div>
@@ -332,19 +331,19 @@ const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>
 const CONTENT_MARGIN = 10;
 
 type SelectContentContextValue = {
-  contentWrapper: HTMLDivElement | null;
-  content: SelectContentElement | null;
-  viewport: SelectViewportElement | null;
-  onViewportChange(node: SelectViewportElement | null): void;
-  selectedItem: SelectItemElement | null;
-  onSelectedItemChange(node: SelectItemElement | null): void;
-  selectedItemText: SelectItemTextElement | null;
-  onSelectedItemTextChange(node: SelectItemTextElement | null): void;
-  onScrollButtonChange(node: SelectScrollButtonImplElement | null): void;
-  onItemLeave(): void;
-  isPositioned: boolean;
-  shouldExpandOnScrollRef: React.RefObject<boolean>;
-  searchRef: React.RefObject<string>;
+  contentWrapper?: HTMLDivElement | null;
+  content?: SelectContentElement | null;
+  viewport?: SelectViewportElement | null;
+  onViewportChange?: (node: SelectViewportElement | null) => void;
+  selectedItem?: SelectItemElement | null;
+  onSelectedItemChange?: (node: SelectItemElement | null) => void;
+  selectedItemText?: SelectItemTextElement | null;
+  onSelectedItemTextChange?: (node: SelectItemTextElement | null) => void;
+  onScrollButtonChange?: (node: SelectScrollButtonImplElement | null) => void;
+  onItemLeave?: () => void;
+  isPositioned?: boolean;
+  shouldExpandOnScrollRef?: React.RefObject<boolean>;
+  searchRef?: React.RefObject<string>;
 };
 
 const [SelectContentContextProvider, useSelectContentContext] =
@@ -553,7 +552,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     // trigger => selectedItem alignment off by the amount the viewport was pushed down.
     // We wait for this to happen and then re-run the positining logic one more time to account for it.
     const handleScrollButtonChange = React.useCallback(
-      (node: SelectScrollButtonImplElement) => {
+      (node: SelectScrollButtonImplElement | null) => {
         if (node && shouldRepositionRef.current === true) {
           position();
           focusSelectedItem();
@@ -771,7 +770,7 @@ const SelectViewport = React.forwardRef<SelectViewportElement, SelectViewportPro
             onScroll={composeEventHandlers(viewportProps.onScroll, (event) => {
               const viewport = event.currentTarget;
               const { contentWrapper, shouldExpandOnScrollRef } = contentContext;
-              if (shouldExpandOnScrollRef.current && contentWrapper) {
+              if (shouldExpandOnScrollRef?.current && contentWrapper) {
                 const scrolledBy = Math.abs(prevScrollTopRef.current - viewport.scrollTop);
                 if (scrolledBy > 0) {
                   const availableHeight = window.innerHeight - CONTENT_MARGIN * 2;
@@ -933,7 +932,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             onPointerUp={composeEventHandlers(itemProps.onPointerUp, handleSelect)}
             onPointerMove={composeEventHandlers(itemProps.onPointerMove, (event) => {
               if (disabled) {
-                contentContext.onItemLeave();
+                contentContext.onItemLeave?.();
               } else {
                 // even though safari doesn't support this option, it's acceptable
                 // as it only means it might scroll a few pixels when using the pointer.
@@ -942,11 +941,11 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             })}
             onPointerLeave={composeEventHandlers(itemProps.onPointerLeave, (event) => {
               if (event.currentTarget === document.activeElement) {
-                contentContext.onItemLeave();
+                contentContext.onItemLeave?.();
               }
             })}
             onKeyDown={composeEventHandlers(itemProps.onKeyDown, (event) => {
-              const isTypingAhead = contentContext.searchRef.current !== '';
+              const isTypingAhead = contentContext.searchRef?.current !== '';
               if (isTypingAhead && event.key === ' ') return;
               if (SELECTION_KEYS.includes(event.key)) handleSelect();
               // prevent page scroll if using the space key to select an item
@@ -1166,7 +1165,7 @@ const SelectScrollButtonImpl = React.forwardRef<
       ref={forwardedRef}
       style={{ flexShrink: 0, ...scrollIndicatorProps.style }}
       onPointerMove={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
-        contentContext.onItemLeave();
+        contentContext.onItemLeave?.();
         if (autoScrollTimerRef.current === null) {
           autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
         }

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -380,7 +380,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const [isPositioned, setIsPositioned] = React.useState(false);
     const shouldRepositionRef = React.useRef(true);
     const shouldExpandOnScrollRef = React.useRef(false);
-    const firstItemRef = React.useRef(false);
+    const firstValidItemFoundRef = React.useRef(false);
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
     React.useEffect(() => {
@@ -627,11 +627,11 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
 
     const handleItemSeen = React.useCallback(
       (node: SelectItemElement | null, value: string, disabled: boolean) => {
-        const isFirstSeenValidItem = !firstItemRef.current && !disabled;
+        const isFirstSeenValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
         if (isSelectedItem || isFirstSeenValidItem) {
           setSelectedItem(node);
-          if (isFirstSeenValidItem) firstItemRef.current = true;
+          if (isFirstSeenValidItem) firstValidItemFoundRef.current = true;
         }
       },
       [context.value]
@@ -640,7 +640,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const handleItemTextSeen = React.useCallback(
       (node: SelectItemTextElement | null, value: string) => {
         const isSelectedItemText = context.value !== undefined && context.value === value;
-        if (isSelectedItemText || !firstItemRef?.current) setSelectedItemText(node);
+        if (isSelectedItemText || !firstValidItemFoundRef?.current) setSelectedItemText(node);
       },
       [context.value]
     );


### PR DESCRIPTION
Fixes #1324 

I've managed to do even slightly better than we had tested. It will now align not with the first item, but the first non-disabled item. This gives a better experience if some of the first items are disabled.

I've added a chromatic story for it too.

> **Note**: Best to review individual commits