### PR TITLE
[Menu][Select] Add `data-highlighted` attribute

### DIFF
--- a/.yarn/versions/272fbd8c.yml
+++ b/.yarn/versions/272fbd8c.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -442,9 +442,9 @@ const labelClass = css({
 
 const itemClass = css({
   ...itemStyles,
+  outline: 'none',
 
-  '&:focus': {
-    outline: 'none',
+  '&[data-active]': {
     backgroundColor: '$black',
     color: 'white',
   },
@@ -455,7 +455,7 @@ const itemClass = css({
 });
 
 const subTriggerClass = css(itemClass, {
-  '&:not(:focus)[data-state="open"]': {
+  '&:not([data-active])[data-state="open"]': {
     backgroundColor: '$gray100',
     color: '$black',
   },

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -444,7 +444,7 @@ const itemClass = css({
   ...itemStyles,
   outline: 'none',
 
-  '&[data-active]': {
+  '&[data-highlighted]': {
     backgroundColor: '$black',
     color: 'white',
   },
@@ -455,7 +455,7 @@ const itemClass = css({
 });
 
 const subTriggerClass = css(itemClass, {
-  '&:not([data-active])[data-state="open"]': {
+  '&:not([data-highlighted])[data-state="open"]': {
     backgroundColor: '$gray100',
     color: '$black',
   },

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -933,7 +933,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
         <RovingFocusGroup.Item asChild {...rovingFocusGroupScope} focusable={!disabled}>
           <Primitive.div
             role="menuitem"
-            data-active={isFocused ? '' : undefined}
+            data-highlighted={isFocused ? '' : undefined}
             aria-disabled={disabled || undefined}
             data-disabled={disabled ? '' : undefined}
             {...itemProps}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -913,6 +913,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
     const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeMenu);
     const ref = React.useRef<HTMLDivElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref);
+    const [isFocused, setIsFocused] = React.useState(false);
 
     // get the item's `.textContent` as default strategy for typeahead `textValue`
     const [textContent, setTextContent] = React.useState('');
@@ -932,6 +933,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
         <RovingFocusGroup.Item asChild {...rovingFocusGroupScope} focusable={!disabled}>
           <Primitive.div
             role="menuitem"
+            data-active={isFocused ? '' : undefined}
             aria-disabled={disabled || undefined}
             data-disabled={disabled ? '' : undefined}
             {...itemProps}
@@ -965,6 +967,8 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
               props.onPointerLeave,
               whenMouse((event) => contentContext.onItemLeave(event))
             )}
+            onFocus={composeEventHandlers(props.onFocus, () => setIsFocused(true))}
+            onBlur={composeEventHandlers(props.onBlur, () => setIsFocused(false))}
           />
         </RovingFocusGroup.Item>
       </Collection.ItemSlot>

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -756,9 +756,9 @@ const labelClass = css({
 const itemClass = css({
   ...itemStyles,
   position: 'relative',
+  outline: 'none',
 
-  '&:focus': {
-    outline: 'none',
+  '&[data-active]': {
     backgroundColor: '$black',
     color: 'white',
   },

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -758,7 +758,7 @@ const itemClass = css({
   position: 'relative',
   outline: 'none',
 
-  '&[data-active]': {
+  '&[data-highlighted]': {
     backgroundColor: '$black',
     color: 'white',
   },

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -946,7 +946,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
           <Primitive.div
             role="option"
             aria-labelledby={textId}
-            data-active={isFocused ? '' : undefined}
+            data-highlighted={isFocused ? '' : undefined}
             // `isFocused` caveat fixes stuttering in VoiceOver
             aria-selected={isSelected && isFocused}
             data-state={isSelected ? 'checked' : 'unchecked'}

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -946,9 +946,10 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
           <Primitive.div
             role="option"
             aria-labelledby={textId}
+            data-active={isFocused ? '' : undefined}
             // `isFocused` caveat fixes stuttering in VoiceOver
             aria-selected={isSelected && isFocused}
-            data-state={isSelected ? 'active' : 'inactive'}
+            data-state={isSelected ? 'checked' : 'unchecked'}
             aria-disabled={disabled || undefined}
             data-disabled={disabled ? '' : undefined}
             tabIndex={disabled ? undefined : -1}


### PR DESCRIPTION
Closes #1289

> Note: I also renamed `data-state="active|inactive"` to `data-state="checked|unchecked"` in `Select` to avoid confusion and bring inline with menus.