### PR TITLE
[RovingFocusGroup][Toast][Tooltip] Avoid flushing dispatch when called in lifecycle

### DIFF
--- a/.yarn/versions/f0b57fd8.yml
+++ b/.yarn/versions/f0b57fd8.yml
@@ -1,9 +1,16 @@
 releases:
+  "@radix-ui/react-alert-dialog": patch
   "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
   "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
   "@radix-ui/react-radio-group": patch
   "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-select": patch
   "@radix-ui/react-tabs": patch
   "@radix-ui/react-toast": patch
   "@radix-ui/react-toggle-group": patch

--- a/.yarn/versions/f0b57fd8.yml
+++ b/.yarn/versions/f0b57fd8.yml
@@ -1,0 +1,14 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - "@radix-ui/react-primitive"

--- a/.yarn/versions/f0b57fd8.yml
+++ b/.yarn/versions/f0b57fd8.yml
@@ -11,4 +11,5 @@ releases:
   "@radix-ui/react-tooltip": patch
 
 declined:
+  - primitives
   - "@radix-ui/react-primitive"

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -211,11 +211,9 @@ function usePointerDownOutside(onPointerDownOutside?: (event: PointerDownOutside
     const handlePointerDown = (event: PointerEvent) => {
       if (event.target && !isPointerInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        handleAndDispatchDiscreteCustomEvent(
-          POINTER_DOWN_OUTSIDE,
-          handlePointerDownOutside,
-          eventDetail
-        );
+        handeAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handlePointerDownOutside, eventDetail, {
+          discrete: true,
+        });
       }
       isPointerInsideReactTreeRef.current = false;
     };
@@ -259,7 +257,9 @@ function useFocusOutside(onFocusOutside?: (event: FocusOutsideEvent) => void) {
     const handleFocus = (event: FocusEvent) => {
       if (event.target && !isFocusInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        handleAndDispatchDiscreteCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail);
+        handeAndDispatchCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail, {
+          discrete: false,
+        });
       }
     };
     document.addEventListener('focusin', handleFocus);
@@ -277,15 +277,21 @@ function dispatchUpdate() {
   document.dispatchEvent(event);
 }
 
-function handleAndDispatchDiscreteCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
+function handeAndDispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
   name: string,
   handler: ((event: E) => void) | undefined,
-  detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D> ? D : never)
+  detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D> ? D : never),
+  { discrete }: { discrete: boolean }
 ) {
   const target = detail.originalEvent.target;
   const event = new CustomEvent(name, { bubbles: false, cancelable: true, detail });
   if (handler) target.addEventListener(name, handler as EventListener, { once: true });
-  dispatchDiscreteCustomEvent(target, event);
+
+  if (discrete) {
+    dispatchDiscreteCustomEvent(target, event);
+  } else {
+    target.dispatchEvent(event);
+  }
 }
 
 const Root = DismissableLayer;

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -211,7 +211,7 @@ function usePointerDownOutside(onPointerDownOutside?: (event: PointerDownOutside
     const handlePointerDown = (event: PointerEvent) => {
       if (event.target && !isPointerInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        handeAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handlePointerDownOutside, eventDetail, {
+        handleAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handlePointerDownOutside, eventDetail, {
           discrete: true,
         });
       }
@@ -257,7 +257,7 @@ function useFocusOutside(onFocusOutside?: (event: FocusOutsideEvent) => void) {
     const handleFocus = (event: FocusEvent) => {
       if (event.target && !isFocusInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
-        handeAndDispatchCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail, {
+        handleAndDispatchCustomEvent(FOCUS_OUTSIDE, handleFocusOutside, eventDetail, {
           discrete: false,
         });
       }
@@ -277,7 +277,7 @@ function dispatchUpdate() {
   document.dispatchEvent(event);
 }
 
-function handeAndDispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
+function handleAndDispatchCustomEvent<E extends CustomEvent, OriginalEvent extends Event>(
   name: string,
   handler: ((event: E) => void) | undefined,
   detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D> ? D : never),

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -98,8 +98,9 @@ const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChi
  * dispatching a custom type within a `discrete` event 👍
  * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
  *
- * Note: care should be taken with the `focusout` event as it's possible for handlers to be called
- * implicitly during lifecycle, e.g. when focus is within the component as it is unmounted.
+ * Note: though React classifies `focus`, `focusin` and `focusout` events as `discrete`, it's  not recommended to use
+ * this utility with them. This is because it's possible for those handlers to be called implicitly during render
+ * e.g. when focus is within a component as it is unmounted, or when managing focus on mount.
  */
 
 function dispatchDiscreteCustomEvent<E extends CustomEvent>(target: E['target'], event: E) {

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -79,6 +79,8 @@ const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChi
  *  - continuous
  *  - default
  *
+ * https://github.com/facebook/react/blob/a8a4742f1c54493df00da648a3f9d26e3db9c8b5/packages/react-dom/src/events/ReactDOMEventListener.js#L294-L350
+ *
  * `discrete` is an  important distinction as updates within these events are applied immediately.
  * React however, is not able to infer the priority of custom event types due to how they are detected internally.
  * Because of this, it's possible for updates from custom events to be unexpectedly batched when

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -97,6 +97,9 @@ const AS_ERROR = `Warning: The \`as\` prop has been removed in favour of \`asChi
  *
  * dispatching a custom type within a `discrete` event 👍
  * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
+ *
+ * Note: care should be taken with the `focusout` event as it's possible for handlers to be called
+ * implicitly during lifecycle, e.g. when focus is within the component as it is unmounted.
  */
 
 function dispatchDiscreteCustomEvent<E extends CustomEvent>(target: E['target'], event: E) {

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -159,10 +159,6 @@ const RovingFocusGroupImpl = React.forwardRef<
 
           if (event.target === event.currentTarget && isKeyboardFocus && !isTabbingBackOut) {
             const entryFocusEvent = new CustomEvent(ENTRY_FOCUS, EVENT_OPTIONS);
-
-            // we avoid dispatching via `dispatchDiscreteCustomEvent` as it's possible
-            // for focus to be triggered during lifecycle, this is most common when
-            // focus is triggered by `FocusScope` and the `onMountAutoFocus` prop
             event.currentTarget.dispatchEvent(entryFocusEvent);
 
             if (!entryFocusEvent.defaultPrevented) {

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -4,7 +4,7 @@ import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
-import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
+import { Primitive } from '@radix-ui/react-primitive';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useDirection } from '@radix-ui/react-direction';
@@ -159,7 +159,11 @@ const RovingFocusGroupImpl = React.forwardRef<
 
           if (event.target === event.currentTarget && isKeyboardFocus && !isTabbingBackOut) {
             const entryFocusEvent = new CustomEvent(ENTRY_FOCUS, EVENT_OPTIONS);
-            dispatchDiscreteCustomEvent(event.currentTarget, entryFocusEvent);
+
+            // we avoid dispatching via `dispatchDiscreteCustomEvent` as it's possible
+            // for focus to be triggered during lifecycle, this is most common when
+            // focus is triggered by `FocusScope` and the `onMountAutoFocus` prop
+            event.currentTarget.dispatchEvent(entryFocusEvent);
 
             if (!entryFocusEvent.defaultPrevented) {
               const items = getItems().filter((item) => item.focusable);

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -161,7 +161,7 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
           context.isClosePausedRef.current = true;
         };
 
-        const handleResumeEvent = ({ discrete }: { discrete: boolean }) => {
+        const dispatchResumeEvent = ({ discrete }: { discrete: boolean }) => {
           const resumeEvent = new CustomEvent(VIEWPORT_RESUME);
 
           if (discrete) {
@@ -173,11 +173,11 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
           context.isClosePausedRef.current = false;
         };
 
-        const handleResume = () => handleResumeEvent({ discrete: true });
+        const handleResume = () => dispatchResumeEvent({ discrete: true });
         // `focusout` is a special case as it can be unexpectedly triggered
         // during lifecycle due to browser behaviour when nodes are removed,
         // As such, we avoid dispatching as `discrete` to prevent flushing during render.
-        const handleFocusOutResume = () => handleResumeEvent({ discrete: false });
+        const handleFocusOutResume = () => dispatchResumeEvent({ discrete: false });
 
         // Toasts are not in the viewport React tree so we need to bind DOM events
         wrapper.addEventListener('focusin', handlePause);

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -473,12 +473,12 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   const eventDetail = { originalEvent: event, delta };
                   if (hasSwipeMoveStarted) {
                     swipeDeltaRef.current = delta;
-                    handeAndDispatchCustomEvent(TOAST_SWIPE_MOVE, onSwipeMove, eventDetail, {
+                    handleAndDispatchCustomEvent(TOAST_SWIPE_MOVE, onSwipeMove, eventDetail, {
                       discrete: false,
                     });
                   } else if (isDeltaInDirection(delta, context.swipeDirection, moveStartBuffer)) {
                     swipeDeltaRef.current = delta;
-                    handeAndDispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail, {
+                    handleAndDispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail, {
                       discrete: false,
                     });
                     (event.target as HTMLElement).setPointerCapture(event.pointerId);
@@ -497,11 +497,11 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                     const toast = event.currentTarget;
                     const eventDetail = { originalEvent: event, delta };
                     if (isDeltaInDirection(delta, context.swipeDirection, context.swipeThreshold)) {
-                      handeAndDispatchCustomEvent(TOAST_SWIPE_END, onSwipeEnd, eventDetail, {
+                      handleAndDispatchCustomEvent(TOAST_SWIPE_END, onSwipeEnd, eventDetail, {
                         discrete: true,
                       });
                     } else {
-                      handeAndDispatchCustomEvent(TOAST_SWIPE_CANCEL, onSwipeCancel, eventDetail, {
+                      handleAndDispatchCustomEvent(TOAST_SWIPE_CANCEL, onSwipeCancel, eventDetail, {
                         discrete: true,
                       });
                     }
@@ -674,7 +674,7 @@ ToastClose.displayName = CLOSE_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-function handeAndDispatchCustomEvent<
+function handleAndDispatchCustomEvent<
   E extends CustomEvent,
   ReactEvent extends React.SyntheticEvent
 >(

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -8,7 +8,7 @@ import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
-import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
+import { Primitive } from '@radix-ui/react-primitive';
 import { Slottable } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
@@ -158,7 +158,10 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
       if (open) {
         // we dispatch here so `TooltipProvider` isn't required to
         // ensure other tooltips are aware of this one opening.
-        dispatchDiscreteCustomEvent(document, new CustomEvent(TOOLTIP_OPEN));
+        //
+        // as `onChange` is called within a lifecycle method we
+        // avoid dispatching via `dispatchDiscreteCustomEvent`.
+        document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN));
         onOpen();
       }
       onOpenChange?.(open);


### PR DESCRIPTION
Some wider changes in https://github.com/radix-ui/primitives/pull/1378 were a little overzealous as `flushSync` was unexpectedly being called during lifecycle in some cases.

In `Tooltip` this was clear because `onChange` is [called during lifecycle](https://github.com/radix-ui/primitives/blob/c92d43343f1233a94a41d12c5eb56a42b72dc98e/packages/react/use-controllable-state/src/useControllableState.tsx#L49), `RovingFocusGroup` and `Toast` were due to `focus` / `focusout` being called either during mount or during teardown.

Interesting to note the implicitness of the `focusout` case due to the browser removing the nodes and then firing the event.