### PR TITLE
[DropdownMenu] Expose explicit `Sub` part

### DIFF
--- a/.yarn/versions/29c9cc74.yml
+++ b/.yarn/versions/29c9cc74.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -56,10 +56,10 @@ export const Modality = () => {
                 Redo
               </DropdownMenu.Item>
               <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Root>
-                <DropdownMenu.TriggerItem className={subTriggerClass()}>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
-                </DropdownMenu.TriggerItem>
+                </DropdownMenu.SubTrigger>
                 <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
@@ -72,7 +72,7 @@ export const Modality = () => {
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
                 </DropdownMenu.Content>
-              </DropdownMenu.Root>
+              </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item
                 className={itemClass()}
@@ -107,10 +107,10 @@ export const Modality = () => {
                 Redo
               </DropdownMenu.Item>
               <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Root>
-                <DropdownMenu.TriggerItem className={subTriggerClass()}>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
-                </DropdownMenu.TriggerItem>
+                </DropdownMenu.SubTrigger>
                 <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
@@ -123,7 +123,7 @@ export const Modality = () => {
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
                 </DropdownMenu.Content>
-              </DropdownMenu.Root>
+              </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item
                 className={itemClass()}
@@ -176,10 +176,10 @@ export const Submenus = () => {
               New Window
             </DropdownMenu.Item>
             <DropdownMenu.Separator className={separatorClass()} />
-            <DropdownMenu.Root>
-              <DropdownMenu.TriggerItem className={subTriggerClass()}>
+            <DropdownMenu.Sub>
+              <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Bookmarks →
-              </DropdownMenu.TriggerItem>
+              </DropdownMenu.SubTrigger>
               <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
                   Inbox
@@ -188,10 +188,10 @@ export const Submenus = () => {
                   Calendar
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Root>
-                  <DropdownMenu.TriggerItem className={subTriggerClass()}>
+                <DropdownMenu.Sub>
+                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Modulz →
-                  </DropdownMenu.TriggerItem>
+                  </DropdownMenu.SubTrigger>
                   <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                     <DropdownMenu.Item
                       className={itemClass()}
@@ -213,18 +213,18 @@ export const Submenus = () => {
                     </DropdownMenu.Item>
                     <DropdownMenu.Arrow offset={14} />
                   </DropdownMenu.Content>
-                </DropdownMenu.Root>
+                </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
                   Notion
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
               </DropdownMenu.Content>
-            </DropdownMenu.Root>
-            <DropdownMenu.Root>
-              <DropdownMenu.TriggerItem className={subTriggerClass()} disabled>
+            </DropdownMenu.Sub>
+            <DropdownMenu.Sub>
+              <DropdownMenu.SubTrigger className={subTriggerClass()} disabled>
                 History →
-              </DropdownMenu.TriggerItem>
+              </DropdownMenu.SubTrigger>
               <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
                   Github
@@ -240,11 +240,11 @@ export const Submenus = () => {
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
               </DropdownMenu.Content>
-            </DropdownMenu.Root>
-            <DropdownMenu.Root>
-              <DropdownMenu.TriggerItem className={subTriggerClass()}>
+            </DropdownMenu.Sub>
+            <DropdownMenu.Sub>
+              <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Tools →
-              </DropdownMenu.TriggerItem>
+              </DropdownMenu.SubTrigger>
               <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item
                   className={itemClass()}
@@ -266,7 +266,7 @@ export const Submenus = () => {
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
               </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            </DropdownMenu.Sub>
             <DropdownMenu.Separator className={separatorClass()} />
             <DropdownMenu.Item
               className={itemClass()}
@@ -321,6 +321,59 @@ export const WithLabels = () => (
     </DropdownMenu.Root>
   </div>
 );
+
+export const NestedComposition = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+      }}
+    >
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+          <Dialog.Root>
+            <Dialog.Trigger className={itemClass()} asChild>
+              <DropdownMenu.Item onSelect={(event) => event.preventDefault()}>
+                Open dialog
+              </DropdownMenu.Item>
+            </Dialog.Trigger>
+
+            <Dialog.Portal>
+              <Dialog.Content className={dialogClass()} style={{ zIndex: 2147483647 }}>
+                <Dialog.Title>Nested dropdown</Dialog.Title>
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger
+                    className={triggerClass()}
+                    style={{ width: '100%', marginBottom: 20 }}
+                  >
+                    Open
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                      Undo
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                      Redo
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow />
+                  </DropdownMenu.Content>
+                </DropdownMenu.Root>
+                <Dialog.Close>Close</Dialog.Close>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+          <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
+  );
+};
 
 export const SingleItemAsDialogTrigger = () => {
   const dropdownTriggerRef = React.useRef<React.ElementRef<typeof DropdownMenu.Trigger>>(null);
@@ -835,10 +888,10 @@ export const Chromatic = () => {
             Redo
           </DropdownMenu.Item>
           <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Root open>
-            <DropdownMenu.TriggerItem className={subTriggerClass()}>
+          <DropdownMenu.Sub open>
+            <DropdownMenu.SubTrigger className={subTriggerClass()}>
               Submenu →
-            </DropdownMenu.TriggerItem>
+            </DropdownMenu.SubTrigger>
             <DropdownMenu.Content
               className={contentClass()}
               sideOffset={12}
@@ -853,10 +906,10 @@ export const Chromatic = () => {
                 Two
               </DropdownMenu.Item>
               <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Root open>
-                <DropdownMenu.TriggerItem className={subTriggerClass()}>
+              <DropdownMenu.Sub open>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
-                </DropdownMenu.TriggerItem>
+                </DropdownMenu.SubTrigger>
                 <DropdownMenu.Content
                   className={contentClass()}
                   sideOffset={12}
@@ -874,14 +927,14 @@ export const Chromatic = () => {
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
                 </DropdownMenu.Content>
-              </DropdownMenu.Root>
+              </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                 Three
               </DropdownMenu.Item>
               <DropdownMenu.Arrow offset={14} />
             </DropdownMenu.Content>
-          </DropdownMenu.Root>
+          </DropdownMenu.Sub>
           <DropdownMenu.Separator className={separatorClass()} />
           <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
             Cut
@@ -908,10 +961,10 @@ export const Chromatic = () => {
               Redo
             </DropdownMenu.Item>
             <DropdownMenu.Separator className={separatorClass()} />
-            <DropdownMenu.Root open>
-              <DropdownMenu.TriggerItem className={subTriggerClass()}>
+            <DropdownMenu.Sub open>
+              <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Submenu →
-              </DropdownMenu.TriggerItem>
+              </DropdownMenu.SubTrigger>
               <DropdownMenu.Content
                 className={contentClass()}
                 sideOffset={12}
@@ -926,10 +979,10 @@ export const Chromatic = () => {
                   Two
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Root open>
-                  <DropdownMenu.TriggerItem className={subTriggerClass()}>
+                <DropdownMenu.Sub open>
+                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
-                  </DropdownMenu.TriggerItem>
+                  </DropdownMenu.SubTrigger>
                   <DropdownMenu.Content
                     className={contentClass()}
                     sideOffset={12}
@@ -950,14 +1003,14 @@ export const Chromatic = () => {
                     </DropdownMenu.Item>
                     <DropdownMenu.Arrow offset={14} />
                   </DropdownMenu.Content>
-                </DropdownMenu.Root>
+                </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                   Three
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
               </DropdownMenu.Content>
-            </DropdownMenu.Root>
+            </DropdownMenu.Sub>
             <DropdownMenu.Separator className={separatorClass()} />
             <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
               Cut
@@ -1263,6 +1316,60 @@ export const Chromatic = () => {
               </DropdownMenu.RadioItem>
             ))}
           </DropdownMenu.RadioGroup>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <h1 style={{ marginTop: 500 }}>Nested composition</h1>
+
+      <DropdownMenu.Root open modal={false}>
+        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Content
+          className={contentClass()}
+          sideOffset={5}
+          avoidCollisions={false}
+          portalled={false}
+        >
+          <Dialog.Root open modal={false}>
+            <Dialog.Trigger className={itemClass()} asChild>
+              <DropdownMenu.Item onSelect={(event) => event.preventDefault()}>
+                Open dialog
+              </DropdownMenu.Item>
+            </Dialog.Trigger>
+
+            <Dialog.Content
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 150,
+                width: 300,
+                padding: 20,
+                backgroundColor: 'whitesmoke',
+                border: '1px solid black',
+              }}
+            >
+              <Dialog.Title style={{ marginTop: 0 }}>Dropdown in nested dialog</Dialog.Title>
+              <DropdownMenu.Root open modal={false}>
+                <DropdownMenu.Trigger className={triggerClass()} style={{ width: '100%' }}>
+                  Open
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content
+                  className={contentClass()}
+                  sideOffset={5}
+                  avoidCollisions={false}
+                >
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                    Undo
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                    Redo
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow />
+                </DropdownMenu.Content>
+              </DropdownMenu.Root>
+            </Dialog.Content>
+          </Dialog.Root>
+          <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
           <DropdownMenu.Arrow />
         </DropdownMenu.Content>
       </DropdownMenu.Root>

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -60,7 +60,11 @@ export const Modality = () => {
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
+                >
                   <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
                   </DropdownMenu.Item>
@@ -71,7 +75,7 @@ export const Modality = () => {
                     Three
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.Content>
+                </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item
@@ -111,7 +115,11 @@ export const Modality = () => {
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
+                >
                   <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
                   </DropdownMenu.Item>
@@ -122,7 +130,7 @@ export const Modality = () => {
                     Three
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.Content>
+                </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item
@@ -180,7 +188,7 @@ export const Submenus = () => {
               <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Bookmarks →
               </DropdownMenu.SubTrigger>
-              <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
                   Inbox
                 </DropdownMenu.Item>
@@ -192,7 +200,11 @@ export const Submenus = () => {
                   <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Modulz →
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
                     <DropdownMenu.Item
                       className={itemClass()}
                       onSelect={() => console.log('stitches')}
@@ -212,20 +224,20 @@ export const Submenus = () => {
                       Radix
                     </DropdownMenu.Item>
                     <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.Content>
+                  </DropdownMenu.SubContent>
                 </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
                   Notion
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.Content>
+              </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
             <DropdownMenu.Sub>
               <DropdownMenu.SubTrigger className={subTriggerClass()} disabled>
                 History →
               </DropdownMenu.SubTrigger>
-              <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
                   Github
                 </DropdownMenu.Item>
@@ -239,13 +251,13 @@ export const Submenus = () => {
                   Stack Overflow
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.Content>
+              </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
             <DropdownMenu.Sub>
               <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Tools →
               </DropdownMenu.SubTrigger>
-              <DropdownMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <DropdownMenu.Item
                   className={itemClass()}
                   onSelect={() => console.log('extensions')}
@@ -265,7 +277,7 @@ export const Submenus = () => {
                   Developer Tools
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.Content>
+              </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
             <DropdownMenu.Separator className={separatorClass()} />
             <DropdownMenu.Item
@@ -892,7 +904,7 @@ export const Chromatic = () => {
             <DropdownMenu.SubTrigger className={subTriggerClass()}>
               Submenu →
             </DropdownMenu.SubTrigger>
-            <DropdownMenu.Content
+            <DropdownMenu.SubContent
               className={contentClass()}
               sideOffset={12}
               alignOffset={-6}
@@ -910,7 +922,7 @@ export const Chromatic = () => {
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.Content
+                <DropdownMenu.SubContent
                   className={contentClass()}
                   sideOffset={12}
                   alignOffset={-6}
@@ -926,14 +938,14 @@ export const Chromatic = () => {
                     Three
                   </DropdownMenu.Item>
                   <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.Content>
+                </DropdownMenu.SubContent>
               </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                 Three
               </DropdownMenu.Item>
               <DropdownMenu.Arrow offset={14} />
-            </DropdownMenu.Content>
+            </DropdownMenu.SubContent>
           </DropdownMenu.Sub>
           <DropdownMenu.Separator className={separatorClass()} />
           <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
@@ -965,7 +977,7 @@ export const Chromatic = () => {
               <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Submenu →
               </DropdownMenu.SubTrigger>
-              <DropdownMenu.Content
+              <DropdownMenu.SubContent
                 className={contentClass()}
                 sideOffset={12}
                 alignOffset={-6}
@@ -983,7 +995,7 @@ export const Chromatic = () => {
                   <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.Content
+                  <DropdownMenu.SubContent
                     className={contentClass()}
                     sideOffset={12}
                     alignOffset={-6}
@@ -1002,14 +1014,14 @@ export const Chromatic = () => {
                       Three
                     </DropdownMenu.Item>
                     <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.Content>
+                  </DropdownMenu.SubContent>
                 </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                   Three
                 </DropdownMenu.Item>
                 <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.Content>
+              </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
             <DropdownMenu.Separator className={separatorClass()} />
             <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>


### PR DESCRIPTION
- Provides `Sub` part in place of implicit nesting to create sub menus
- Renames `TriggerItem` to `SubTrigger` to align with the additional part

I looked into this again briefly https://github.com/radix-ui/primitives/issues/1016#issuecomment-989842648 but the static typing limitations (having two different element and prop types for one part) remains the same.