### PR TITLE
[ContextMenu] Expose explicit `Sub` part

### DIFF
--- a/.yarn/versions/5305d6b7.yml
+++ b/.yarn/versions/5305d6b7.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -21,7 +21,8 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -79,7 +79,7 @@ export const Modality = () => {
                 <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
                   </ContextMenu.Item>
@@ -91,7 +91,7 @@ export const Modality = () => {
                     <ContextMenu.SubTrigger className={subTriggerClass()}>
                       Submenu →
                     </ContextMenu.SubTrigger>
-                    <ContextMenu.Content
+                    <ContextMenu.SubContent
                       className={contentClass()}
                       sideOffset={12}
                       alignOffset={-6}
@@ -109,14 +109,14 @@ export const Modality = () => {
                         Three
                       </ContextMenu.Item>
                       <ContextMenu.Arrow offset={14} />
-                    </ContextMenu.Content>
+                    </ContextMenu.SubContent>
                   </ContextMenu.Sub>
                   <ContextMenu.Separator className={separatorClass()} />
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                     Three
                   </ContextMenu.Item>
                   <ContextMenu.Arrow offset={14} />
-                </ContextMenu.Content>
+                </ContextMenu.SubContent>
               </ContextMenu.Sub>
               <ContextMenu.Separator className={separatorClass()} />
               <ContextMenu.Item
@@ -158,7 +158,7 @@ export const Modality = () => {
                 <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
                   </ContextMenu.Item>
@@ -170,7 +170,7 @@ export const Modality = () => {
                     <ContextMenu.SubTrigger className={subTriggerClass()}>
                       Submenu →
                     </ContextMenu.SubTrigger>
-                    <ContextMenu.Content
+                    <ContextMenu.SubContent
                       className={contentClass()}
                       sideOffset={12}
                       alignOffset={-6}
@@ -188,14 +188,14 @@ export const Modality = () => {
                         Three
                       </ContextMenu.Item>
                       <ContextMenu.Arrow offset={14} />
-                    </ContextMenu.Content>
+                    </ContextMenu.SubContent>
                   </ContextMenu.Sub>
                   <ContextMenu.Separator className={separatorClass()} />
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                     Three
                   </ContextMenu.Item>
                   <ContextMenu.Arrow offset={14} />
-                </ContextMenu.Content>
+                </ContextMenu.SubContent>
               </ContextMenu.Sub>
               <ContextMenu.Separator className={separatorClass()} />
               <ContextMenu.Item
@@ -265,7 +265,7 @@ export const Submenus = () => {
               <ContextMenu.SubTrigger className={subTriggerClass()}>
                 Bookmarks →
               </ContextMenu.SubTrigger>
-              <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
                   Inbox
                 </ContextMenu.Item>
@@ -277,7 +277,11 @@ export const Submenus = () => {
                   <ContextMenu.SubTrigger className={subTriggerClass()}>
                     Modulz →
                   </ContextMenu.SubTrigger>
-                  <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
                     <ContextMenu.Item
                       className={itemClass()}
                       onSelect={() => console.log('stitches')}
@@ -294,20 +298,20 @@ export const Submenus = () => {
                       Radix
                     </ContextMenu.Item>
                     <ContextMenu.Arrow offset={14} />
-                  </ContextMenu.Content>
+                  </ContextMenu.SubContent>
                 </ContextMenu.Sub>
                 <ContextMenu.Separator className={separatorClass()} />
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
                   Notion
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
-              </ContextMenu.Content>
+              </ContextMenu.SubContent>
             </ContextMenu.Sub>
             <ContextMenu.Sub>
               <ContextMenu.SubTrigger className={subTriggerClass()} disabled>
                 History →
               </ContextMenu.SubTrigger>
-              <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
                   Github
                 </ContextMenu.Item>
@@ -321,11 +325,11 @@ export const Submenus = () => {
                   Stack Overflow
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
-              </ContextMenu.Content>
+              </ContextMenu.SubContent>
             </ContextMenu.Sub>
             <ContextMenu.Sub>
               <ContextMenu.SubTrigger className={subTriggerClass()}>Tools →</ContextMenu.SubTrigger>
-              <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item
                   className={itemClass()}
                   onSelect={() => console.log('extensions')}
@@ -345,7 +349,7 @@ export const Submenus = () => {
                   Developer Tools
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
-              </ContextMenu.Content>
+              </ContextMenu.SubContent>
             </ContextMenu.Sub>
             <ContextMenu.Separator className={separatorClass()} />
             <ContextMenu.Item
@@ -599,7 +603,7 @@ export const Nested = () => (
               <ContextMenu.SubTrigger className={subTriggerClass()}>
                 Submenu →
               </ContextMenu.SubTrigger>
-              <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item
                   className={itemClass()}
                   onSelect={() => console.log('red sub action 1')}
@@ -613,7 +617,7 @@ export const Nested = () => (
                   Red sub action 2
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
-              </ContextMenu.Content>
+              </ContextMenu.SubContent>
             </ContextMenu.Sub>
           </ContextMenu.Content>
         </ContextMenu.Root>
@@ -630,7 +634,7 @@ export const Nested = () => (
         <ContextMenu.Separator className={separatorClass()} />
         <ContextMenu.Sub>
           <ContextMenu.SubTrigger className={subTriggerClass()}>Submenu →</ContextMenu.SubTrigger>
-          <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
+          <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
             <ContextMenu.Item
               className={itemClass()}
               onSelect={() => console.log('blue sub action 1')}
@@ -644,7 +648,7 @@ export const Nested = () => (
               Blue sub action 2
             </ContextMenu.Item>
             <ContextMenu.Arrow offset={14} />
-          </ContextMenu.Content>
+          </ContextMenu.SubContent>
         </ContextMenu.Sub>
       </ContextMenu.Content>
     </ContextMenu.Root>

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -75,10 +75,10 @@ export const Modality = () => {
                 Redo
               </ContextMenu.Item>
               <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Root>
-                <ContextMenu.TriggerItem className={subTriggerClass()}>
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
-                </ContextMenu.TriggerItem>
+                </ContextMenu.SubTrigger>
                 <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
@@ -87,10 +87,10 @@ export const Modality = () => {
                     Two
                   </ContextMenu.Item>
                   <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Root>
-                    <ContextMenu.TriggerItem className={subTriggerClass()}>
+                  <ContextMenu.Sub>
+                    <ContextMenu.SubTrigger className={subTriggerClass()}>
                       Submenu →
-                    </ContextMenu.TriggerItem>
+                    </ContextMenu.SubTrigger>
                     <ContextMenu.Content
                       className={contentClass()}
                       sideOffset={12}
@@ -110,14 +110,14 @@ export const Modality = () => {
                       </ContextMenu.Item>
                       <ContextMenu.Arrow offset={14} />
                     </ContextMenu.Content>
-                  </ContextMenu.Root>
+                  </ContextMenu.Sub>
                   <ContextMenu.Separator className={separatorClass()} />
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                     Three
                   </ContextMenu.Item>
                   <ContextMenu.Arrow offset={14} />
                 </ContextMenu.Content>
-              </ContextMenu.Root>
+              </ContextMenu.Sub>
               <ContextMenu.Separator className={separatorClass()} />
               <ContextMenu.Item
                 className={itemClass()}
@@ -154,10 +154,10 @@ export const Modality = () => {
                 Redo
               </ContextMenu.Item>
               <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Root>
-                <ContextMenu.TriggerItem className={subTriggerClass()}>
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
-                </ContextMenu.TriggerItem>
+                </ContextMenu.SubTrigger>
                 <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
                     One
@@ -166,10 +166,10 @@ export const Modality = () => {
                     Two
                   </ContextMenu.Item>
                   <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Root>
-                    <ContextMenu.TriggerItem className={subTriggerClass()}>
+                  <ContextMenu.Sub defaultOpen>
+                    <ContextMenu.SubTrigger className={subTriggerClass()}>
                       Submenu →
-                    </ContextMenu.TriggerItem>
+                    </ContextMenu.SubTrigger>
                     <ContextMenu.Content
                       className={contentClass()}
                       sideOffset={12}
@@ -189,14 +189,14 @@ export const Modality = () => {
                       </ContextMenu.Item>
                       <ContextMenu.Arrow offset={14} />
                     </ContextMenu.Content>
-                  </ContextMenu.Root>
+                  </ContextMenu.Sub>
                   <ContextMenu.Separator className={separatorClass()} />
                   <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
                     Three
                   </ContextMenu.Item>
                   <ContextMenu.Arrow offset={14} />
                 </ContextMenu.Content>
-              </ContextMenu.Root>
+              </ContextMenu.Sub>
               <ContextMenu.Separator className={separatorClass()} />
               <ContextMenu.Item
                 className={itemClass()}
@@ -261,10 +261,10 @@ export const Submenus = () => {
               New Window
             </ContextMenu.Item>
             <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Root>
-              <ContextMenu.TriggerItem className={subTriggerClass()}>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger className={subTriggerClass()}>
                 Bookmarks →
-              </ContextMenu.TriggerItem>
+              </ContextMenu.SubTrigger>
               <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
                   Inbox
@@ -273,10 +273,10 @@ export const Submenus = () => {
                   Calendar
                 </ContextMenu.Item>
                 <ContextMenu.Separator className={separatorClass()} />
-                <ContextMenu.Root>
-                  <ContextMenu.TriggerItem className={subTriggerClass()}>
+                <ContextMenu.Sub>
+                  <ContextMenu.SubTrigger className={subTriggerClass()}>
                     Modulz →
-                  </ContextMenu.TriggerItem>
+                  </ContextMenu.SubTrigger>
                   <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                     <ContextMenu.Item
                       className={itemClass()}
@@ -295,18 +295,18 @@ export const Submenus = () => {
                     </ContextMenu.Item>
                     <ContextMenu.Arrow offset={14} />
                   </ContextMenu.Content>
-                </ContextMenu.Root>
+                </ContextMenu.Sub>
                 <ContextMenu.Separator className={separatorClass()} />
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
                   Notion
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
               </ContextMenu.Content>
-            </ContextMenu.Root>
-            <ContextMenu.Root>
-              <ContextMenu.TriggerItem className={subTriggerClass()} disabled>
+            </ContextMenu.Sub>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger className={subTriggerClass()} disabled>
                 History →
-              </ContextMenu.TriggerItem>
+              </ContextMenu.SubTrigger>
               <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
                   Github
@@ -322,11 +322,9 @@ export const Submenus = () => {
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
               </ContextMenu.Content>
-            </ContextMenu.Root>
-            <ContextMenu.Root>
-              <ContextMenu.TriggerItem className={subTriggerClass()}>
-                Tools →
-              </ContextMenu.TriggerItem>
+            </ContextMenu.Sub>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger className={subTriggerClass()}>Tools →</ContextMenu.SubTrigger>
               <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item
                   className={itemClass()}
@@ -348,7 +346,7 @@ export const Submenus = () => {
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
               </ContextMenu.Content>
-            </ContextMenu.Root>
+            </ContextMenu.Sub>
             <ContextMenu.Separator className={separatorClass()} />
             <ContextMenu.Item
               className={itemClass()}
@@ -597,10 +595,10 @@ export const Nested = () => (
               Red action 2
             </ContextMenu.Item>
             <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Root>
-              <ContextMenu.TriggerItem className={subTriggerClass()}>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger className={subTriggerClass()}>
                 Submenu →
-              </ContextMenu.TriggerItem>
+              </ContextMenu.SubTrigger>
               <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
                 <ContextMenu.Item
                   className={itemClass()}
@@ -616,7 +614,7 @@ export const Nested = () => (
                 </ContextMenu.Item>
                 <ContextMenu.Arrow offset={14} />
               </ContextMenu.Content>
-            </ContextMenu.Root>
+            </ContextMenu.Sub>
           </ContextMenu.Content>
         </ContextMenu.Root>
       </ContextMenu.Trigger>
@@ -630,8 +628,8 @@ export const Nested = () => (
           Blue action 2
         </ContextMenu.Item>
         <ContextMenu.Separator className={separatorClass()} />
-        <ContextMenu.Root>
-          <ContextMenu.TriggerItem className={subTriggerClass()}>Submenu →</ContextMenu.TriggerItem>
+        <ContextMenu.Sub>
+          <ContextMenu.SubTrigger className={subTriggerClass()}>Submenu →</ContextMenu.SubTrigger>
           <ContextMenu.Content className={contentClass()} sideOffset={12} alignOffset={-6}>
             <ContextMenu.Item
               className={itemClass()}
@@ -647,7 +645,7 @@ export const Nested = () => (
             </ContextMenu.Item>
             <ContextMenu.Arrow offset={14} />
           </ContextMenu.Content>
-        </ContextMenu.Root>
+        </ContextMenu.Sub>
       </ContextMenu.Content>
     </ContextMenu.Root>
   </div>

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -444,8 +444,7 @@ ContextMenuSubTrigger.displayName = SUB_TRIGGER_NAME;
 const SUB_CONTENT_NAME = 'ContextMenuSubContent';
 
 type ContextMenuSubContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-interface ContextMenuSubContentProps
-  extends Omit<MenuContentProps, 'portalled' | 'side' | 'align'> {}
+interface ContextMenuSubContentProps extends MenuContentProps {}
 
 const ContextMenuSubContent = React.forwardRef<
   ContextMenuSubContentElement,

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -25,20 +25,14 @@ const [createContextMenuContext, createContextMenuScope] = createContextScope(CO
 ]);
 const useMenuScope = createMenuScope();
 
-type ContextMenuRootContextValue = {
-  isRootMenu: true;
+type ContextMenuContextValue = {
   open: boolean;
   onOpenChange(open: boolean): void;
   modal: boolean;
 };
 
-type ContextMenuSubContextValue = {
-  isRootMenu: false;
-};
-
-const [ContextMenuProvider, useContextMenuContext] = createContextMenuContext<
-  ContextMenuRootContextValue | ContextMenuSubContextValue
->(CONTEXT_MENU_NAME);
+const [ContextMenuProvider, useContextMenuContext] =
+  createContextMenuContext<ContextMenuContextValue>(CONTEXT_MENU_NAME);
 
 interface ContextMenuProps {
   children?: React.ReactNode;
@@ -64,7 +58,6 @@ const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuP
   return (
     <ContextMenuProvider
       scope={__scopeContextMenu}
-      isRootMenu={true}
       open={open}
       onOpenChange={handleOpenChange}
       modal={modal}
@@ -83,39 +76,6 @@ const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuP
 };
 
 ContextMenu.displayName = CONTEXT_MENU_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * ContextMenuSub
- * -----------------------------------------------------------------------------------------------*/
-
-const SUB_NAME = 'ContextMenuSub';
-
-interface ContextMenuSubProps {
-  children?: React.ReactNode;
-  open?: boolean;
-  defaultOpen?: boolean;
-  onOpenChange?(open: boolean): void;
-}
-
-const ContextMenuSub: React.FC<ContextMenuSubProps> = (props: ScopedProps<ContextMenuSubProps>) => {
-  const { __scopeContextMenu, children, onOpenChange, open: openProp, defaultOpen } = props;
-  const menuScope = useMenuScope(__scopeContextMenu);
-  const [open, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpen,
-    onChange: onOpenChange,
-  });
-
-  return (
-    <ContextMenuProvider scope={__scopeContextMenu} isRootMenu={false}>
-      <MenuPrimitive.Sub {...menuScope} open={open} onOpenChange={setOpen}>
-        {children}
-      </MenuPrimitive.Sub>
-    </ContextMenuProvider>
-  );
-};
-
-ContextMenuSub.displayName = SUB_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * ContextMenuTrigger
@@ -141,13 +101,14 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
       () => window.clearTimeout(longPressTimerRef.current),
       []
     );
-    const handleOpenPointUpdate = (event: React.MouseEvent | React.PointerEvent) => {
+    const handleOpen = (event: React.MouseEvent | React.PointerEvent) => {
       pointRef.current = { x: event.clientX, y: event.clientY };
+      context.onOpenChange(true);
     };
 
     React.useEffect(() => clearLongPress, [clearLongPress]);
 
-    return context.isRootMenu ? (
+    return (
       <>
         <MenuPrimitive.Anchor {...menuScope} virtualRef={virtualRef} />
         <Primitive.span
@@ -159,8 +120,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
             // clearing the long press here because some platforms already support
             // long press to trigger a `contextmenu` event
             clearLongPress();
-            handleOpenPointUpdate(event);
-            context.onOpenChange(true);
+            handleOpen(event);
             event.preventDefault();
           })}
           onPointerDown={composeEventHandlers(
@@ -169,8 +129,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
               // clear the long press here in case there's multiple touch points
               clearLongPress();
               longPressTimerRef.current = window.setTimeout(() => {
-                handleOpenPointUpdate(event);
-                context.onOpenChange(true);
+                handleOpen(event);
               }, 700);
             })
           )}
@@ -182,32 +141,11 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
           onPointerUp={composeEventHandlers(props.onPointerUp, whenTouchOrPen(clearLongPress))}
         />
       </>
-    ) : null;
+    );
   }
 );
 
 ContextMenuTrigger.displayName = TRIGGER_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * ContextMenuSubTrigger
- * -----------------------------------------------------------------------------------------------*/
-
-const SUB_TRIGGER_NAME = 'ContextMenuSubTrigger';
-
-type ContextMenuSubTriggerElement = React.ElementRef<typeof MenuPrimitive.SubTrigger>;
-type MenuSubTriggerProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.SubTrigger>;
-interface ContextMenuSubTriggerProps extends MenuSubTriggerProps {}
-
-const ContextMenuSubTrigger = React.forwardRef<
-  ContextMenuSubTriggerElement,
-  ContextMenuSubTriggerProps
->((props: ScopedProps<ContextMenuSubTriggerProps>, forwardedRef) => {
-  const { __scopeContextMenu, ...triggerItemProps } = props;
-  const menuScope = useMenuScope(__scopeContextMenu);
-  return <MenuPrimitive.SubTrigger {...menuScope} {...triggerItemProps} ref={forwardedRef} />;
-});
-
-ContextMenuSubTrigger.displayName = SUB_TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * ContextMenuContent
@@ -224,71 +162,43 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
     const { __scopeContextMenu, ...contentProps } = props;
     const context = useContextMenuContext(CONTENT_NAME, __scopeContextMenu);
     const menuScope = useMenuScope(__scopeContextMenu);
+    const hasInteractedOutsideRef = React.useRef(false);
 
-    const commonProps = {
-      ...contentProps,
-      style: {
-        ...props.style,
-        // re-namespace exposed content custom property
-        ['--radix-context-menu-content-transform-origin' as any]:
-          'var(--radix-popper-transform-origin)',
-      },
-    };
-
-    return context.isRootMenu ? (
-      <ContextMenuRootContent
-        __scopeContextMenu={__scopeContextMenu}
-        {...commonProps}
+    return (
+      <MenuPrimitive.Content
+        {...menuScope}
+        {...contentProps}
         ref={forwardedRef}
+        portalled
+        side="right"
+        sideOffset={2}
+        align="start"
+        onCloseAutoFocus={(event) => {
+          props.onCloseAutoFocus?.(event);
+
+          if (!event.defaultPrevented && hasInteractedOutsideRef.current) {
+            event.preventDefault();
+          }
+
+          hasInteractedOutsideRef.current = false;
+        }}
+        onInteractOutside={(event) => {
+          props.onInteractOutside?.(event);
+
+          if (!event.defaultPrevented && !context.modal) hasInteractedOutsideRef.current = true;
+        }}
+        style={{
+          ...props.style,
+          // re-namespace exposed content custom property
+          ['--radix-context-menu-content-transform-origin' as any]:
+            'var(--radix-popper-transform-origin)',
+        }}
       />
-    ) : (
-      <MenuPrimitive.Content {...menuScope} {...commonProps} ref={forwardedRef} />
     );
   }
 );
 
 ContextMenuContent.displayName = CONTENT_NAME;
-
-/* ---------------------------------------------------------------------------------------------- */
-
-type ContextMenuRootContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
-interface ContextMenuRootContentProps extends ScopedProps<MenuContentProps> {}
-
-const ContextMenuRootContent = React.forwardRef<
-  ContextMenuRootContentElement,
-  ContextMenuRootContentProps
->((props, forwardedRef) => {
-  const { __scopeContextMenu, ...contentProps } = props;
-  const context = useContextMenuContext(CONTENT_NAME, __scopeContextMenu);
-  const menuScope = useMenuScope(__scopeContextMenu);
-  const hasInteractedOutsideRef = React.useRef(false);
-
-  return context.isRootMenu ? (
-    <MenuPrimitive.Content
-      {...menuScope}
-      {...contentProps}
-      ref={forwardedRef}
-      portalled
-      side="right"
-      sideOffset={2}
-      align="start"
-      onCloseAutoFocus={(event) => {
-        props.onCloseAutoFocus?.(event);
-
-        if (!event.defaultPrevented && hasInteractedOutsideRef.current) {
-          event.preventDefault();
-        }
-
-        hasInteractedOutsideRef.current = false;
-      }}
-      onInteractOutside={(event) => {
-        props.onInteractOutside?.(event);
-
-        if (!event.defaultPrevented && !context.modal) hasInteractedOutsideRef.current = true;
-      }}
-    />
-  ) : null;
-});
 
 /* -------------------------------------------------------------------------------------------------
  * ContextMenuGroup
@@ -475,6 +385,92 @@ const ContextMenuArrow = React.forwardRef<ContextMenuArrowElement, ContextMenuAr
 
 ContextMenuArrow.displayName = ARROW_NAME;
 
+/* -------------------------------------------------------------------------------------------------
+ * ContextMenuSub
+ * -----------------------------------------------------------------------------------------------*/
+
+const SUB_NAME = 'ContextMenuSub';
+
+interface ContextMenuSubProps {
+  children?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?(open: boolean): void;
+}
+
+const ContextMenuSub: React.FC<ContextMenuSubProps> = (props: ScopedProps<ContextMenuSubProps>) => {
+  const { __scopeContextMenu, children, onOpenChange, open: openProp, defaultOpen } = props;
+  const menuScope = useMenuScope(__scopeContextMenu);
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
+
+  return (
+    <MenuPrimitive.Sub {...menuScope} open={open} onOpenChange={setOpen}>
+      {children}
+    </MenuPrimitive.Sub>
+  );
+};
+
+ContextMenuSub.displayName = SUB_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * ContextMenuSubTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const SUB_TRIGGER_NAME = 'ContextMenuSubTrigger';
+
+type ContextMenuSubTriggerElement = React.ElementRef<typeof MenuPrimitive.SubTrigger>;
+type MenuSubTriggerProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.SubTrigger>;
+interface ContextMenuSubTriggerProps extends MenuSubTriggerProps {}
+
+const ContextMenuSubTrigger = React.forwardRef<
+  ContextMenuSubTriggerElement,
+  ContextMenuSubTriggerProps
+>((props: ScopedProps<ContextMenuSubTriggerProps>, forwardedRef) => {
+  const { __scopeContextMenu, ...triggerItemProps } = props;
+  const menuScope = useMenuScope(__scopeContextMenu);
+  return <MenuPrimitive.SubTrigger {...menuScope} {...triggerItemProps} ref={forwardedRef} />;
+});
+
+ContextMenuSubTrigger.displayName = SUB_TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * ContextMenuSubContent
+ * -----------------------------------------------------------------------------------------------*/
+
+const SUB_CONTENT_NAME = 'ContextMenuSubContent';
+
+type ContextMenuSubContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
+interface ContextMenuSubContentProps
+  extends Omit<MenuContentProps, 'portalled' | 'side' | 'align'> {}
+
+const ContextMenuSubContent = React.forwardRef<
+  ContextMenuSubContentElement,
+  ContextMenuSubContentProps
+>((props: ScopedProps<ContextMenuSubContentProps>, forwardedRef) => {
+  const { __scopeContextMenu, ...subContentProps } = props;
+  const menuScope = useMenuScope(__scopeContextMenu);
+
+  return (
+    <MenuPrimitive.Content
+      {...menuScope}
+      {...subContentProps}
+      ref={forwardedRef}
+      style={{
+        ...props.style,
+        // re-namespace exposed content custom property
+        ['--radix-context-menu-sub-content-transform-origin' as any]:
+          'var(--radix-popper-transform-origin)',
+      }}
+    />
+  );
+});
+
+ContextMenuSubContent.displayName = SUB_CONTENT_NAME;
+
 /* -----------------------------------------------------------------------------------------------*/
 
 function whenTouchOrPen<E>(handler: React.PointerEventHandler<E>): React.PointerEventHandler<E> {
@@ -482,27 +478,26 @@ function whenTouchOrPen<E>(handler: React.PointerEventHandler<E>): React.Pointer
 }
 
 const Root = ContextMenu;
-const Sub = ContextMenuSub;
 const Trigger = ContextMenuTrigger;
 const Content = ContextMenuContent;
 const Group = ContextMenuGroup;
 const Label = ContextMenuLabel;
 const Item = ContextMenuItem;
-const SubTrigger = ContextMenuSubTrigger;
 const CheckboxItem = ContextMenuCheckboxItem;
 const RadioGroup = ContextMenuRadioGroup;
 const RadioItem = ContextMenuRadioItem;
 const ItemIndicator = ContextMenuItemIndicator;
 const Separator = ContextMenuSeparator;
 const Arrow = ContextMenuArrow;
+const Sub = ContextMenuSub;
+const SubTrigger = ContextMenuSubTrigger;
+const SubContent = ContextMenuSubContent;
 
 export {
   createContextMenuScope,
   //
   ContextMenu,
-  ContextMenuSub,
   ContextMenuTrigger,
-  ContextMenuSubTrigger,
   ContextMenuContent,
   ContextMenuGroup,
   ContextMenuLabel,
@@ -513,11 +508,12 @@ export {
   ContextMenuItemIndicator,
   ContextMenuSeparator,
   ContextMenuArrow,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
   //
   Root,
-  Sub,
   Trigger,
-  SubTrigger,
   Content,
   Group,
   Label,
@@ -528,11 +524,13 @@ export {
   ItemIndicator,
   Separator,
   Arrow,
+  Sub,
+  SubTrigger,
+  SubContent,
 };
 export type {
   ContextMenuProps,
   ContextMenuTriggerProps,
-  ContextMenuSubTriggerProps,
   ContextMenuContentProps,
   ContextMenuGroupProps,
   ContextMenuLabelProps,
@@ -543,4 +541,7 @@ export type {
   ContextMenuItemIndicatorProps,
   ContextMenuSeparatorProps,
   ContextMenuArrowProps,
+  ContextMenuSubProps,
+  ContextMenuSubTriggerProps,
+  ContextMenuSubContentProps,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3218,6 +3218,7 @@ __metadata:
     "@radix-ui/react-menu": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-controllable-state": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0


### PR DESCRIPTION
- Provides Sub part in place of implicit nesting to create sub menus
- Renames `TriggerItem` to `SubTrigger` to align with the additional part
- Provides props for `Sub` to be controlled

The controlled prop change is more of a consistency thing, controlling submenus hasn't actually been requested much afaik, but it makes sense to allow it here as it is in other prims.