### PR TITLE
[Primitive] Improve debugging

### DIFF
--- a/.yarn/versions/5a76db20.yml
+++ b/.yarn/versions/5a76db20.yml
@@ -1,0 +1,42 @@
+releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+
+declined:
+  - primitives

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -38,27 +38,27 @@ interface PrimitiveForwardRefComponent<E extends React.ElementType>
  * Primitive
  * -----------------------------------------------------------------------------------------------*/
 
-const Primitive = NODES.reduce(
-  (primitive, node) => ({
-    ...primitive,
-    [node]: React.forwardRef((props: PrimitivePropsWithRef<typeof node>, forwardedRef: any) => {
-      const { asChild, ...primitiveProps } = props;
-      const Comp: any = asChild ? Slot : node;
+const Primitive = NODES.reduce((primitive, node) => {
+  const Node = React.forwardRef((props: PrimitivePropsWithRef<typeof node>, forwardedRef: any) => {
+    const { asChild, ...primitiveProps } = props;
+    const Comp: any = asChild ? Slot : node;
 
-      React.useEffect(() => {
-        (window as any)[Symbol.for('radix-ui')] = true;
-      }, []);
+    React.useEffect(() => {
+      (window as any)[Symbol.for('radix-ui')] = true;
+    }, []);
 
-      // DEPRECATED
-      if (process.env.NODE_ENV === 'development' && (props as any).as) {
-        console.warn(AS_ERROR);
-      }
+    // DEPRECATED
+    if (process.env.NODE_ENV === 'development' && (props as any).as) {
+      console.warn(AS_ERROR);
+    }
 
-      return <Comp {...primitiveProps} ref={forwardedRef} />;
-    }),
-  }),
-  {} as Primitives
-);
+    return <Comp {...primitiveProps} ref={forwardedRef} />;
+  });
+
+  Node.displayName = `Primitive.${node}`;
+
+  return { ...primitive, [node]: Node };
+}, {} as Primitives);
 
 /* -----------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
> **Note**: easier to review without whitespace

I was debugging some stuff in `Select` in react developer tools and noticed a lot of `Anonymous` components in the tree.
It was mostly all of the `Primitive.x` nodes, so I've added a display name to them to reflect it, makes it much more obvious what you're looking at.

I've noticed a few other mismatch related to display names that I might try to look at separately but this was the biggest one.