### PR TITLE
[DropdownMenu][ContextMenu] Make css variable name consistent on `Content`

### DIFF
--- a/.yarn/versions/c204ee30.yml
+++ b/.yarn/versions/c204ee30.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -467,7 +467,7 @@ const ContextMenuSubContent = React.forwardRef<
       style={{
         ...props.style,
         // re-namespace exposed content custom property
-        ['--radix-context-menu-sub-content-transform-origin' as any]:
+        ['--radix-context-menu-content-transform-origin' as any]:
           'var(--radix-popper-transform-origin)',
       }}
     />

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -462,7 +462,7 @@ const DropdownMenuSubContent = React.forwardRef<
       style={{
         ...props.style,
         // re-namespace exposed content custom property
-        ['--radix-dropdown-menu-sub-content-transform-origin' as any]:
+        ['--radix-dropdown-menu-content-transform-origin' as any]:
           'var(--radix-popper-transform-origin)',
       }}
     />


### PR DESCRIPTION
This was originally changed in https://github.com/radix-ui/primitives/pull/1394

In hindsight it's less ergonomic and inconsistent when used alongside `data-state` attributes etc.