### PR TITLE
[RadioGroup] Add `aria-required`

### DIFF
--- a/.yarn/versions/8ccec28f.yml
+++ b/.yarn/versions/8ccec28f.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-radio-group": patch
+
+declined:
+  - primitives

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -94,6 +94,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
         >
           <Primitive.div
             role="radiogroup"
+            aria-required={required}
             aria-orientation={orientation}
             aria-labelledby={labelledBy}
             dir={direction}


### PR DESCRIPTION
Continuation of #1415 which had issues with versions.

The attribute was moved to the radiogroup rather that each radio though as on the radio eslint was showing this:
https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/112261cbc84f5b7d74de9b427b529a10b41faece/docs/rules/role-supports-aria-props.md