### PR TITLE
[DismissableLayer] Don't exit fullscreen when esc-ing out of a layer

### DIFF
--- a/.yarn/versions/aa7247ea.yml
+++ b/.yarn/versions/aa7247ea.yml
@@ -1,0 +1,16 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -104,7 +104,10 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
       const isHighestLayer = index === context.layers.size - 1;
       if (!isHighestLayer) return;
       onEscapeKeyDown?.(event);
-      if (!event.defaultPrevented) onDismiss?.();
+      if (!event.defaultPrevented && onDismiss) {
+        event.preventDefault();
+        onDismiss();
+      }
     });
 
     React.useEffect(() => {


### PR DESCRIPTION
### Description

Basically just call `preventDefault`! I’m not sure about the semantics of `onDismiss` being undefined, but I _think_ if it’s undefined, we shouldn’t be preventing the default—I’m open to input on that.

Fixes radix-ui/primitives#1420
