### PR TITLE
[Tooltip] Expose `Portal` part

### DIFF
--- a/.yarn/versions/345d09c7.yml
+++ b/.yarn/versions/345d09c7.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives
+  - ssr-testing

--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -10,10 +10,12 @@ export const Styled = () => (
   <Tooltip.Provider>
     <Tooltip.Root>
       <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-      <Tooltip.Content className={contentClass()} sideOffset={5}>
-        Nicely done!
-        <Tooltip.Arrow className={arrowClass()} offset={10} />
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content className={contentClass()} sideOffset={5}>
+          Nicely done!
+          <Tooltip.Arrow className={arrowClass()} offset={10} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
   </Tooltip.Provider>
 );
@@ -26,10 +28,12 @@ export const Controlled = () => {
         <Tooltip.Trigger style={{ margin: 100 }}>
           I'm controlled, look I'm {open ? 'open' : 'closed'}
         </Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </Tooltip.Provider>
   );
@@ -40,17 +44,21 @@ export const WithoutProvider = () => (
     <p>These will always have an open delay because of the missing provider.</p>
     <Tooltip.Root>
       <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-      <Tooltip.Content className={contentClass()} sideOffset={5}>
-        Nicely done!
-        <Tooltip.Arrow className={arrowClass()} offset={10} />
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content className={contentClass()} sideOffset={5}>
+          Nicely done!
+          <Tooltip.Arrow className={arrowClass()} offset={10} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
     <Tooltip.Root>
       <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-      <Tooltip.Content className={contentClass()} sideOffset={5}>
-        Nicely done!
-        <Tooltip.Arrow className={arrowClass()} offset={10} />
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content className={contentClass()} sideOffset={5}>
+          Nicely done!
+          <Tooltip.Arrow className={arrowClass()} offset={10} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
   </>
 );
@@ -63,24 +71,30 @@ export const CustomDurations = () => (
     <div style={{ display: 'flex', gap: 50 }}>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </div>
 
@@ -89,24 +103,30 @@ export const CustomDurations = () => (
       <Tooltip.Provider delayDuration={0}>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </div>
@@ -116,24 +136,30 @@ export const CustomDurations = () => (
       <Tooltip.Provider delayDuration={2000}>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </div>
@@ -143,24 +169,30 @@ export const CustomDurations = () => (
     <div style={{ display: 'flex', gap: 50 }}>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </div>
 
@@ -169,24 +201,30 @@ export const CustomDurations = () => (
       <Tooltip.Provider skipDelayDuration={0}>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </div>
@@ -196,24 +234,30 @@ export const CustomDurations = () => (
       <Tooltip.Provider skipDelayDuration={5000}>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </div>
@@ -225,120 +269,138 @@ export const CustomContent = () => (
     <div style={{ display: 'flex', gap: 20, padding: 100 }}>
       <Tooltip.Root>
         <Tooltip.Trigger>Heading</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <h1>Some heading</h1>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <h1>Some heading</h1>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Paragraph</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <p>Some paragraph</p>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <p>Some paragraph</p>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>List</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <ul>
-            <li>One</li>
-            <li>Two</li>
-            <li>Three</li>
-          </ul>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+            </ul>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Article</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <article>
-            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Harum, quae qui. Magnam
-            delectus ex totam repellat amet distinctio unde, porro architecto voluptatibus nemo et
-            nisi, voluptatem eligendi earum autem fugit.
-          </article>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <article>
+              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Harum, quae qui. Magnam
+              delectus ex totam repellat amet distinctio unde, porro architecto voluptatibus nemo et
+              nisi, voluptatem eligendi earum autem fugit.
+            </article>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Figure</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <figure style={{ margin: 0 }}>
-            <img
-              src="https://pbs.twimg.com/profile_images/864164353771229187/Catw6Nmh_400x400.jpg"
-              alt=""
-              width={100}
-            />
-            <figcaption>Colm Tuite</figcaption>
-          </figure>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <figure style={{ margin: 0 }}>
+              <img
+                src="https://pbs.twimg.com/profile_images/864164353771229187/Catw6Nmh_400x400.jpg"
+                alt=""
+                width={100}
+              />
+              <figcaption>Colm Tuite</figcaption>
+            </figure>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Time</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          {/* @ts-ignore */}
-          <time datetime="2017-10-31T11:21:00+02:00">Tuesday, 31 October 2017</time>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            {/* @ts-ignore */}
+            <time datetime="2017-10-31T11:21:00+02:00">Tuesday, 31 October 2017</time>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Link</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          View in <a href="https://modulz.app">Modulz</a>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            View in <a href="https://modulz.app">Modulz</a>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Form</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <form>
-            <label htmlFor="fname">First name:</label>
-            <br />
-            <input type="text" id="fname" name="fname" />
-            <br />
-            <label htmlFor="lname">Last name:</label>
-            <br />
-            <input type="text" id="lname" name="lname" />
-          </form>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <form>
+              <label htmlFor="fname">First name:</label>
+              <br />
+              <input type="text" id="fname" name="fname" />
+              <br />
+              <label htmlFor="lname">Last name:</label>
+              <br />
+              <input type="text" id="lname" name="lname" />
+            </form>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <Tooltip.Root>
         <Tooltip.Trigger>Mini layout</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          <p
-            style={{
-              margin: 0,
-              textAlign: 'center',
-              fontFamily: 'apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif',
-              fontSize: 14,
-            }}
-          >
-            Start video call
-            <span style={{ display: 'block', color: '#999' }}>
-              press{' '}
-              <kbd
-                style={{
-                  fontFamily: 'apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif',
-                  fontWeight: 'bold',
-                  color: 'white',
-                }}
-                aria-label="c key"
-              >
-                c
-              </kbd>
-            </span>
-          </p>
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            <p
+              style={{
+                margin: 0,
+                textAlign: 'center',
+                fontFamily: 'apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif',
+                fontSize: 14,
+              }}
+            >
+              Start video call
+              <span style={{ display: 'block', color: '#999' }}>
+                press{' '}
+                <kbd
+                  style={{
+                    fontFamily: 'apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif',
+                    fontWeight: 'bold',
+                    color: 'white',
+                  }}
+                  aria-label="c key"
+                >
+                  c
+                </kbd>
+              </span>
+            </p>
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </div>
   </Tooltip.Provider>
@@ -584,12 +646,14 @@ export const SlottableContent = () => (
   <Tooltip.Provider>
     <Tooltip.Root>
       <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-      <Tooltip.Content asChild sideOffset={5}>
-        <div className={contentClass()}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </div>
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content asChild sideOffset={5}>
+          <div className={contentClass()}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </div>
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
   </Tooltip.Provider>
 );
@@ -604,10 +668,12 @@ export const WithinDialog = () => (
         <Dialog.Close>Close dialog</Dialog.Close>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Dialog.Content>
     </Dialog.Root>
@@ -627,16 +693,18 @@ export const KeepOpenOnActivation = () => {
         >
           Hover or Focus me
         </Tooltip.Trigger>
-        <Tooltip.Content
-          className={contentClass()}
-          sideOffset={5}
-          onPointerDownOutside={(event) => {
-            if (event.target === triggerRef.current) event.preventDefault();
-          }}
-        >
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className={contentClass()}
+            sideOffset={5}
+            onPointerDownOutside={(event) => {
+              if (event.target === triggerRef.current) event.preventDefault();
+            }}
+          >
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </Tooltip.Provider>
   );
@@ -658,10 +726,12 @@ export const WithinScrollable = () => (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 600 }}>
         <Tooltip.Root>
           <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-          <Tooltip.Content className={contentClass()} sideOffset={5}>
-            Nicely done!
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content className={contentClass()} sideOffset={5}>
+              Nicely done!
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </div>
     </div>
@@ -670,10 +740,12 @@ export const WithinScrollable = () => (
     >
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Nicely done!
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </div>
   </Tooltip.Provider>
@@ -689,27 +761,33 @@ export const Chromatic = () => (
       <h2>Closed</h2>
       <Tooltip.Root>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <h2>Open</h2>
       <Tooltip.Root defaultOpen>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
       <Tooltip.Root defaultOpen>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
       </Tooltip.Root>
 
@@ -717,27 +795,33 @@ export const Chromatic = () => (
       <h2>Closed</h2>
       <Tooltip.Root open={false}>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <h2>Open</h2>
       <Tooltip.Root open>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <h2 style={{ marginTop: 60 }}>Open with reordered parts</h2>
       <Tooltip.Root open>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
         <Tooltip.Trigger className={triggerClass()}>open</Tooltip.Trigger>
       </Tooltip.Root>
 
@@ -749,19 +833,21 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -774,24 +860,26 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow
-                  className={chromaticArrowClass()}
-                  width={20}
-                  height={10}
-                  offset={5}
-                />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow
+                    className={chromaticArrowClass()}
+                    width={20}
+                    height={10}
+                    offset={5}
+                  />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -802,24 +890,26 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow
-                  className={chromaticArrowClass()}
-                  width={20}
-                  height={10}
-                  offset={-10}
-                />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow
+                    className={chromaticArrowClass()}
+                    width={20}
+                    height={10}
+                    offset={-10}
+                  />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -832,20 +922,22 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                sideOffset={5}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  sideOffset={5}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -856,20 +948,22 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                sideOffset={-10}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  sideOffset={-10}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -882,20 +976,22 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                alignOffset={20}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  alignOffset={20}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -906,20 +1002,22 @@ export const Chromatic = () => (
           ALIGN_OPTIONS.map((align) => (
             <Tooltip.Root key={`${side}-${align}`} open>
               <Tooltip.Trigger className={chromaticTriggerClass()} />
-              <Tooltip.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                alignOffset={-10}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  alignOffset={-10}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           ))
         )}
@@ -949,14 +1047,16 @@ export const Chromatic = () => (
                     : { left: 10 })),
               }}
             />
-            <Tooltip.Content className={chromaticContentClass()} side={side} align={align}>
-              <p style={{ textAlign: 'center' }}>
-                {side}
-                <br />
-                {align}
-              </p>
-              <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
-            </Tooltip.Content>
+            <Tooltip.Portal>
+              <Tooltip.Content className={chromaticContentClass()} side={side} align={align}>
+                <p style={{ textAlign: 'center' }}>
+                  {side}
+                  <br />
+                  {align}
+                </p>
+                <Tooltip.Arrow className={chromaticArrowClass()} width={20} height={10} />
+              </Tooltip.Content>
+            </Tooltip.Portal>
           </Tooltip.Root>
         ))
       )}
@@ -966,21 +1066,25 @@ export const Chromatic = () => (
         <Tooltip.Trigger asChild>
           <button className={triggerClass()}>open</button>
         </Tooltip.Trigger>
-        <Tooltip.Content className={contentClass()} sideOffset={5}>
-          Some content
-          <Tooltip.Arrow className={arrowClass()} width={20} height={10} offset={10} />
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Some content
+            <Tooltip.Arrow className={arrowClass()} width={20} height={10} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
 
       <h1 style={{ marginTop: 100 }}>With slotted content</h1>
       <Tooltip.Root open>
         <Tooltip.Trigger className={triggerClass()}>Hover or Focus me</Tooltip.Trigger>
-        <Tooltip.Content asChild sideOffset={5}>
-          <div className={contentClass()}>
-            Some content
-            <Tooltip.Arrow className={arrowClass()} offset={10} />
-          </div>
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content asChild sideOffset={5}>
+            <div className={contentClass()}>
+              Some content
+              <Tooltip.Arrow className={arrowClass()} offset={10} />
+            </div>
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </div>
   </Tooltip.Provider>
@@ -998,10 +1102,17 @@ function SimpleTooltip({
   return (
     <Tooltip.Root open={open} onOpenChange={onOpenChange}>
       {children}
-      <Tooltip.Content className={contentClass()} sideOffset={5} aria-label={ariaLabel} {...props}>
-        {label}
-        <Tooltip.Arrow className={arrowClass()} offset={10} />
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          className={contentClass()}
+          sideOffset={5}
+          aria-label={ariaLabel}
+          {...props}
+        >
+          {label}
+          <Tooltip.Arrow className={arrowClass()} offset={10} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
   );
 }

--- a/ssr-testing/pages/tooltip.tsx
+++ b/ssr-testing/pages/tooltip.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipArrow } from '@radix-ui/react-tooltip';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 export default function TooltipPage() {
   return (
-    <Tooltip>
-      <TooltipTrigger>Hover or Focus me</TooltipTrigger>
-      <TooltipContent sideOffset={5}>
-        Nicely done!
-        <TooltipArrow offset={10} />
-      </TooltipContent>
-    </Tooltip>
+    <Tooltip.Root>
+      <Tooltip.Trigger>Hover or Focus me</Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content sideOffset={5}>
+          Nicely done!
+          <Tooltip.Arrow offset={10} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
   );
 }


### PR DESCRIPTION
Closes #1304

>**Warning**: This is based on #1306 branch because of the changes in `Popper`.
We will need to be merged in correct order, and run version check too.

> **Note**: Easier to review without whitespace

The implementation is the same as what's in `Popover`.

---

> **Warning**
> Breaking changes in docs:
> - new `Portal` part, with `forceMount` and `container` props, meaning default has changed (not portalled if not using new part)
> - lose `portalled` prop on `Content`
> - different default for `forceMount` on `Content`
> - manual z-index management
> - update demos/marketing comps