### PR TITLE
[DropdownMenu][ContextMenu] Expose new `Portal` part

### DIFF
--- a/.yarn/versions/1bf02bd7.yml
+++ b/.yarn/versions/1bf02bd7.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives
+  - ssr-testing

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -28,24 +28,26 @@ export const Styled = () => {
         >
           Right click here
         </ContextMenu.Trigger>
-        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </ContextMenu.Item>
-          <ContextMenu.Separator className={separatorClass()} />
-          <ContextMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </ContextMenu.Item>
-        </ContextMenu.Content>
+        <ContextMenu.Portal>
+          <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </ContextMenu.Item>
+            <ContextMenu.Separator className={separatorClass()} />
+            <ContextMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
       </ContextMenu.Root>
     </div>
   );
@@ -67,72 +69,84 @@ export const Modality = () => {
               className={triggerClass()}
               style={{ background: open1 ? 'lightblue' : undefined }}
             />
-            <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                Undo
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                Redo
-              </ContextMenu.Item>
-              <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Sub>
-                <ContextMenu.SubTrigger className={subTriggerClass()}>
-                  Submenu →
-                </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </ContextMenu.Item>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </ContextMenu.Item>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Sub>
-                    <ContextMenu.SubTrigger className={subTriggerClass()}>
-                      Submenu →
-                    </ContextMenu.SubTrigger>
-                    <ContextMenu.SubContent
-                      className={contentClass()}
-                      sideOffset={12}
-                      alignOffset={-6}
-                    >
-                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                        One
-                      </ContextMenu.Item>
-                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                        Two
-                      </ContextMenu.Item>
-                      <ContextMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('three')}
+            <ContextMenu.Portal>
+              <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                  Undo
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                  Redo
+                </ContextMenu.Item>
+                <ContextMenu.Separator className={separatorClass()} />
+                <ContextMenu.Sub>
+                  <ContextMenu.SubTrigger className={subTriggerClass()}>
+                    Submenu →
+                  </ContextMenu.SubTrigger>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                      One
+                    </ContextMenu.Item>
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                      Two
+                    </ContextMenu.Item>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Sub>
+                      <ContextMenu.SubTrigger className={subTriggerClass()}>
+                        Submenu →
+                      </ContextMenu.SubTrigger>
+                      <ContextMenu.SubContent
+                        className={contentClass()}
+                        sideOffset={12}
+                        alignOffset={-6}
                       >
-                        Three
-                      </ContextMenu.Item>
-                      <ContextMenu.Arrow offset={14} />
-                    </ContextMenu.SubContent>
-                  </ContextMenu.Sub>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
-              </ContextMenu.Sub>
-              <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Item
-                className={itemClass()}
-                disabled
-                onSelect={() => console.log('cut')}
-              >
-                Cut
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-                Copy
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-                Paste
-              </ContextMenu.Item>
-            </ContextMenu.Content>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('one')}
+                        >
+                          One
+                        </ContextMenu.Item>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('two')}
+                        >
+                          Two
+                        </ContextMenu.Item>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('three')}
+                        >
+                          Three
+                        </ContextMenu.Item>
+                        <ContextMenu.Arrow offset={14} />
+                      </ContextMenu.SubContent>
+                    </ContextMenu.Sub>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+                      Three
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Sub>
+                <ContextMenu.Separator className={separatorClass()} />
+                <ContextMenu.Item
+                  className={itemClass()}
+                  disabled
+                  onSelect={() => console.log('cut')}
+                >
+                  Cut
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+                  Copy
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+                  Paste
+                </ContextMenu.Item>
+              </ContextMenu.Content>
+            </ContextMenu.Portal>
           </ContextMenu.Root>
           <textarea
             style={{ width: 500, height: 100, marginTop: 10 }}
@@ -146,72 +160,84 @@ export const Modality = () => {
               className={triggerClass()}
               style={{ background: open2 ? 'lightblue' : undefined }}
             />
-            <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                Undo
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                Redo
-              </ContextMenu.Item>
-              <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Sub>
-                <ContextMenu.SubTrigger className={subTriggerClass()}>
-                  Submenu →
-                </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </ContextMenu.Item>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </ContextMenu.Item>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Sub defaultOpen>
-                    <ContextMenu.SubTrigger className={subTriggerClass()}>
-                      Submenu →
-                    </ContextMenu.SubTrigger>
-                    <ContextMenu.SubContent
-                      className={contentClass()}
-                      sideOffset={12}
-                      alignOffset={-6}
-                    >
-                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                        One
-                      </ContextMenu.Item>
-                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                        Two
-                      </ContextMenu.Item>
-                      <ContextMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('three')}
+            <ContextMenu.Portal>
+              <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                  Undo
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                  Redo
+                </ContextMenu.Item>
+                <ContextMenu.Separator className={separatorClass()} />
+                <ContextMenu.Sub>
+                  <ContextMenu.SubTrigger className={subTriggerClass()}>
+                    Submenu →
+                  </ContextMenu.SubTrigger>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                      One
+                    </ContextMenu.Item>
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                      Two
+                    </ContextMenu.Item>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Sub defaultOpen>
+                      <ContextMenu.SubTrigger className={subTriggerClass()}>
+                        Submenu →
+                      </ContextMenu.SubTrigger>
+                      <ContextMenu.SubContent
+                        className={contentClass()}
+                        sideOffset={12}
+                        alignOffset={-6}
                       >
-                        Three
-                      </ContextMenu.Item>
-                      <ContextMenu.Arrow offset={14} />
-                    </ContextMenu.SubContent>
-                  </ContextMenu.Sub>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
-              </ContextMenu.Sub>
-              <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.Item
-                className={itemClass()}
-                disabled
-                onSelect={() => console.log('cut')}
-              >
-                Cut
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-                Copy
-              </ContextMenu.Item>
-              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-                Paste
-              </ContextMenu.Item>
-            </ContextMenu.Content>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('one')}
+                        >
+                          One
+                        </ContextMenu.Item>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('two')}
+                        >
+                          Two
+                        </ContextMenu.Item>
+                        <ContextMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('three')}
+                        >
+                          Three
+                        </ContextMenu.Item>
+                        <ContextMenu.Arrow offset={14} />
+                      </ContextMenu.SubContent>
+                    </ContextMenu.Sub>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+                      Three
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Sub>
+                <ContextMenu.Separator className={separatorClass()} />
+                <ContextMenu.Item
+                  className={itemClass()}
+                  disabled
+                  onSelect={() => console.log('cut')}
+                >
+                  Cut
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+                  Copy
+                </ContextMenu.Item>
+                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+                  Paste
+                </ContextMenu.Item>
+              </ContextMenu.Content>
+            </ContextMenu.Portal>
           </ContextMenu.Root>
           <textarea
             style={{ width: 500, height: 100, marginTop: 10 }}
@@ -253,119 +279,129 @@ export const Submenus = () => {
           >
             Right Click Here
           </ContextMenu.Trigger>
-          <ContextMenu.Content className={contentClass()}>
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('new-tab')}>
-              New Tab
-            </ContextMenu.Item>
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('new-window')}>
-              New Window
-            </ContextMenu.Item>
-            <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Sub>
-              <ContextMenu.SubTrigger className={subTriggerClass()}>
-                Bookmarks →
-              </ContextMenu.SubTrigger>
-              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
-                  Inbox
-                </ContextMenu.Item>
-                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('calendar')}>
-                  Calendar
-                </ContextMenu.Item>
-                <ContextMenu.Separator className={separatorClass()} />
-                <ContextMenu.Sub>
-                  <ContextMenu.SubTrigger className={subTriggerClass()}>
-                    WorkOS →
-                  </ContextMenu.SubTrigger>
-                  <ContextMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
+          <ContextMenu.Portal>
+            <ContextMenu.Content className={contentClass()}>
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('new-tab')}>
+                New Tab
+              </ContextMenu.Item>
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('new-window')}>
+                New Window
+              </ContextMenu.Item>
+              <ContextMenu.Separator className={separatorClass()} />
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()}>
+                  Bookmarks →
+                </ContextMenu.SubTrigger>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
+                    Inbox
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('calendar')}
                   >
-                    <ContextMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('stitches')}
+                    Calendar
+                  </ContextMenu.Item>
+                  <ContextMenu.Separator className={separatorClass()} />
+                  <ContextMenu.Sub>
+                    <ContextMenu.SubTrigger className={subTriggerClass()}>
+                      Modulz →
+                    </ContextMenu.SubTrigger>
+                    <ContextMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
                     >
-                      Stitches
-                    </ContextMenu.Item>
-                    <ContextMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('composer')}
-                    >
-                      Composer
-                    </ContextMenu.Item>
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('radix')}>
-                      Radix
-                    </ContextMenu.Item>
-                    <ContextMenu.Arrow offset={14} />
-                  </ContextMenu.SubContent>
-                </ContextMenu.Sub>
-                <ContextMenu.Separator className={separatorClass()} />
-                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
-                  Notion
-                </ContextMenu.Item>
-                <ContextMenu.Arrow offset={14} />
-              </ContextMenu.SubContent>
-            </ContextMenu.Sub>
-            <ContextMenu.Sub>
-              <ContextMenu.SubTrigger className={subTriggerClass()} disabled>
-                History →
-              </ContextMenu.SubTrigger>
-              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
-                  Github
-                </ContextMenu.Item>
-                <ContextMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
-                  Google
-                </ContextMenu.Item>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('stack-overflow')}
-                >
-                  Stack Overflow
-                </ContextMenu.Item>
-                <ContextMenu.Arrow offset={14} />
-              </ContextMenu.SubContent>
-            </ContextMenu.Sub>
-            <ContextMenu.Sub>
-              <ContextMenu.SubTrigger className={subTriggerClass()}>Tools →</ContextMenu.SubTrigger>
-              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('extensions')}
-                >
-                  Extensions
-                </ContextMenu.Item>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('task-manager')}
-                >
-                  Task Manager
-                </ContextMenu.Item>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('developer-tools')}
-                >
-                  Developer Tools
-                </ContextMenu.Item>
-                <ContextMenu.Arrow offset={14} />
-              </ContextMenu.SubContent>
-            </ContextMenu.Sub>
-            <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Item
-              className={itemClass()}
-              disabled
-              onSelect={() => console.log('print')}
-            >
-              Print…
-            </ContextMenu.Item>
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('cast')}>
-              Cast…
-            </ContextMenu.Item>
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('find')}>
-              Find…
-            </ContextMenu.Item>
-          </ContextMenu.Content>
+                      <ContextMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('stitches')}
+                      >
+                        Stitches
+                      </ContextMenu.Item>
+                      <ContextMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('composer')}
+                      >
+                        Composer
+                      </ContextMenu.Item>
+                      <ContextMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('radix')}
+                      >
+                        Radix
+                      </ContextMenu.Item>
+                      <ContextMenu.Arrow offset={14} />
+                    </ContextMenu.SubContent>
+                  </ContextMenu.Sub>
+                  <ContextMenu.Separator className={separatorClass()} />
+                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
+                    Notion
+                  </ContextMenu.Item>
+                  <ContextMenu.Arrow offset={14} />
+                </ContextMenu.SubContent>
+              </ContextMenu.Sub>
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()} disabled>
+                  History →
+                </ContextMenu.SubTrigger>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
+                    Github
+                  </ContextMenu.Item>
+                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
+                    Google
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('stack-overflow')}
+                  >
+                    Stack Overflow
+                  </ContextMenu.Item>
+                  <ContextMenu.Arrow offset={14} />
+                </ContextMenu.SubContent>
+              </ContextMenu.Sub>
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()}>
+                  Tools →
+                </ContextMenu.SubTrigger>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('extensions')}
+                  >
+                    Extensions
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('task-manager')}
+                  >
+                    Task Manager
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('developer-tools')}
+                  >
+                    Developer Tools
+                  </ContextMenu.Item>
+                  <ContextMenu.Arrow offset={14} />
+                </ContextMenu.SubContent>
+              </ContextMenu.Sub>
+              <ContextMenu.Separator className={separatorClass()} />
+              <ContextMenu.Item
+                className={itemClass()}
+                disabled
+                onSelect={() => console.log('print')}
+              >
+                Print…
+              </ContextMenu.Item>
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('cast')}>
+                Cast…
+              </ContextMenu.Item>
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('find')}>
+                Find…
+              </ContextMenu.Item>
+            </ContextMenu.Content>
+          </ContextMenu.Portal>
         </ContextMenu.Root>
       </div>
     </div>
@@ -376,30 +412,32 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu.Root>
       <ContextMenu.Trigger className={triggerClass()}>Right click here</ContextMenu.Trigger>
-      <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-        {foodGroups.map((foodGroup, index) => (
-          <ContextMenu.Group key={index}>
-            {foodGroup.label && (
-              <ContextMenu.Label className={labelClass()} key={foodGroup.label}>
-                {foodGroup.label}
-              </ContextMenu.Label>
-            )}
-            {foodGroup.foods.map((food) => (
-              <ContextMenu.Item
-                key={food.value}
-                className={itemClass()}
-                disabled={food.disabled}
-                onSelect={() => console.log(food.label)}
-              >
-                {food.label}
-              </ContextMenu.Item>
-            ))}
-            {index < foodGroups.length - 1 && (
-              <ContextMenu.Separator className={separatorClass()} />
-            )}
-          </ContextMenu.Group>
-        ))}
-      </ContextMenu.Content>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+          {foodGroups.map((foodGroup, index) => (
+            <ContextMenu.Group key={index}>
+              {foodGroup.label && (
+                <ContextMenu.Label className={labelClass()} key={foodGroup.label}>
+                  {foodGroup.label}
+                </ContextMenu.Label>
+              )}
+              {foodGroup.foods.map((food) => (
+                <ContextMenu.Item
+                  key={food.value}
+                  className={itemClass()}
+                  disabled={food.disabled}
+                  onSelect={() => console.log(food.label)}
+                >
+                  {food.label}
+                </ContextMenu.Item>
+              ))}
+              {index < foodGroups.length - 1 && (
+                <ContextMenu.Separator className={separatorClass()} />
+              )}
+            </ContextMenu.Group>
+          ))}
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
     </ContextMenu.Root>
   </div>
 );
@@ -416,32 +454,34 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu.Root>
         <ContextMenu.Trigger className={triggerClass()}>Right click here</ContextMenu.Trigger>
-        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
-            Show fonts
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
-            Bigger
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </ContextMenu.Item>
-          <ContextMenu.Separator className={separatorClass()} />
-          {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
-            <ContextMenu.CheckboxItem
-              key={label}
-              className={itemClass()}
-              checked={checked}
-              onCheckedChange={setChecked}
-              disabled={disabled}
-            >
-              {label}
-              <ContextMenu.ItemIndicator>
-                <TickIcon />
-              </ContextMenu.ItemIndicator>
-            </ContextMenu.CheckboxItem>
-          ))}
-        </ContextMenu.Content>
+        <ContextMenu.Portal>
+          <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
+              Show fonts
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
+              Bigger
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </ContextMenu.Item>
+            <ContextMenu.Separator className={separatorClass()} />
+            {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
+              <ContextMenu.CheckboxItem
+                key={label}
+                className={itemClass()}
+                checked={checked}
+                onCheckedChange={setChecked}
+                disabled={disabled}
+              >
+                {label}
+                <ContextMenu.ItemIndicator>
+                  <TickIcon />
+                </ContextMenu.ItemIndicator>
+              </ContextMenu.CheckboxItem>
+            ))}
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
       </ContextMenu.Root>
     </div>
   );
@@ -455,28 +495,30 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <ContextMenu.Root>
         <ContextMenu.Trigger className={triggerClass()}>Right click here</ContextMenu.Trigger>
-        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('minimize')}>
-            Minimize window
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('zoom')}>
-            Zoom
-          </ContextMenu.Item>
-          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </ContextMenu.Item>
-          <ContextMenu.Separator className={separatorClass()} />
-          <ContextMenu.RadioGroup value={file} onValueChange={setFile}>
-            {files.map((file) => (
-              <ContextMenu.RadioItem key={file} className={itemClass()} value={file}>
-                {file}
-                <ContextMenu.ItemIndicator>
-                  <TickIcon />
-                </ContextMenu.ItemIndicator>
-              </ContextMenu.RadioItem>
-            ))}
-          </ContextMenu.RadioGroup>
-        </ContextMenu.Content>
+        <ContextMenu.Portal>
+          <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('minimize')}>
+              Minimize window
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('zoom')}>
+              Zoom
+            </ContextMenu.Item>
+            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </ContextMenu.Item>
+            <ContextMenu.Separator className={separatorClass()} />
+            <ContextMenu.RadioGroup value={file} onValueChange={setFile}>
+              {files.map((file) => (
+                <ContextMenu.RadioItem key={file} className={itemClass()} value={file}>
+                  {file}
+                  <ContextMenu.ItemIndicator>
+                    <TickIcon />
+                  </ContextMenu.ItemIndicator>
+                </ContextMenu.RadioItem>
+              ))}
+            </ContextMenu.RadioGroup>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
       </ContextMenu.Root>
       <p>Selected file: {file}</p>
     </div>
@@ -487,20 +529,22 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <ContextMenu.Root>
       <ContextMenu.Trigger className={triggerClass()}>Right click here</ContextMenu.Trigger>
-      <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-        <ContextMenu.Item className={itemClass()} onSelect={() => window.alert('action 1')}>
-          I will close
-        </ContextMenu.Item>
-        <ContextMenu.Item
-          className={itemClass()}
-          onSelect={(event) => {
-            event.preventDefault();
-            window.alert('action 1');
-          }}
-        >
-          I won't close
-        </ContextMenu.Item>
-      </ContextMenu.Content>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+          <ContextMenu.Item className={itemClass()} onSelect={() => window.alert('action 1')}>
+            I will close
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            className={itemClass()}
+            onSelect={(event) => {
+              event.preventDefault();
+              window.alert('action 1');
+            }}
+          >
+            I won't close
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
     </ContextMenu.Root>
   </div>
 );
@@ -517,41 +561,45 @@ export const Multiple = () => {
         const customColor = customColors[i];
         return (
           <ContextMenu.Root key={i}>
-            <ContextMenu.Content className={animatedContentClass()} alignOffset={-5}>
-              <ContextMenu.Label className={labelClass()}>Color</ContextMenu.Label>
-              <ContextMenu.RadioGroup
-                value={customColor}
-                onValueChange={(color) => setCustomColors((colors) => ({ ...colors, [i]: color }))}
-              >
-                <ContextMenu.RadioItem className={itemClass()} value="royalblue">
-                  Blue
+            <ContextMenu.Portal>
+              <ContextMenu.Content className={animatedContentClass()} alignOffset={-5}>
+                <ContextMenu.Label className={labelClass()}>Color</ContextMenu.Label>
+                <ContextMenu.RadioGroup
+                  value={customColor}
+                  onValueChange={(color) =>
+                    setCustomColors((colors) => ({ ...colors, [i]: color }))
+                  }
+                >
+                  <ContextMenu.RadioItem className={itemClass()} value="royalblue">
+                    Blue
+                    <ContextMenu.ItemIndicator>
+                      <TickIcon />
+                    </ContextMenu.ItemIndicator>
+                  </ContextMenu.RadioItem>
+                  <ContextMenu.RadioItem className={itemClass()} value="tomato">
+                    Red
+                    <ContextMenu.ItemIndicator>
+                      <TickIcon />
+                    </ContextMenu.ItemIndicator>
+                  </ContextMenu.RadioItem>
+                </ContextMenu.RadioGroup>
+                <ContextMenu.Separator className={separatorClass()} />
+                <ContextMenu.CheckboxItem
+                  className={itemClass()}
+                  checked={fadedIndexes.includes(i)}
+                  onCheckedChange={(faded) =>
+                    setFadedIndexes((indexes) =>
+                      faded ? [...indexes, i] : indexes.filter((index) => index !== i)
+                    )
+                  }
+                >
+                  Fade
                   <ContextMenu.ItemIndicator>
                     <TickIcon />
                   </ContextMenu.ItemIndicator>
-                </ContextMenu.RadioItem>
-                <ContextMenu.RadioItem className={itemClass()} value="tomato">
-                  Red
-                  <ContextMenu.ItemIndicator>
-                    <TickIcon />
-                  </ContextMenu.ItemIndicator>
-                </ContextMenu.RadioItem>
-              </ContextMenu.RadioGroup>
-              <ContextMenu.Separator className={separatorClass()} />
-              <ContextMenu.CheckboxItem
-                className={itemClass()}
-                checked={fadedIndexes.includes(i)}
-                onCheckedChange={(faded) =>
-                  setFadedIndexes((indexes) =>
-                    faded ? [...indexes, i] : indexes.filter((index) => index !== i)
-                  )
-                }
-              >
-                Fade
-                <ContextMenu.ItemIndicator>
-                  <TickIcon />
-                </ContextMenu.ItemIndicator>
-              </ContextMenu.CheckboxItem>
-            </ContextMenu.Content>
+                </ContextMenu.CheckboxItem>
+              </ContextMenu.Content>
+            </ContextMenu.Portal>
             <ContextMenu.Trigger>
               <div
                 style={{
@@ -589,68 +637,72 @@ export const Nested = () => (
       >
         <ContextMenu.Root>
           <ContextMenu.Trigger className={triggerClass()} style={{ backgroundColor: 'tomato' }} />{' '}
-          <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-            <ContextMenu.Label className={labelClass()}>Red box menu</ContextMenu.Label>
-            <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('red action1')}>
-              Red action 1
-            </ContextMenu.Item>
-            <ContextMenu.Item className={itemClass()} onSelect={() => console.log('red action2')}>
-              Red action 2
-            </ContextMenu.Item>
-            <ContextMenu.Separator className={separatorClass()} />
-            <ContextMenu.Sub>
-              <ContextMenu.SubTrigger className={subTriggerClass()}>
-                Submenu →
-              </ContextMenu.SubTrigger>
-              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('red sub action 1')}
-                >
-                  Red sub action 1
-                </ContextMenu.Item>
-                <ContextMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('red sub action 2')}
-                >
-                  Red sub action 2
-                </ContextMenu.Item>
-                <ContextMenu.Arrow offset={14} />
-              </ContextMenu.SubContent>
-            </ContextMenu.Sub>
-          </ContextMenu.Content>
+          <ContextMenu.Portal>
+            <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+              <ContextMenu.Label className={labelClass()}>Red box menu</ContextMenu.Label>
+              <ContextMenu.Separator className={separatorClass()} />
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('red action1')}>
+                Red action 1
+              </ContextMenu.Item>
+              <ContextMenu.Item className={itemClass()} onSelect={() => console.log('red action2')}>
+                Red action 2
+              </ContextMenu.Item>
+              <ContextMenu.Separator className={separatorClass()} />
+              <ContextMenu.Sub>
+                <ContextMenu.SubTrigger className={subTriggerClass()}>
+                  Submenu →
+                </ContextMenu.SubTrigger>
+                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('red sub action 1')}
+                  >
+                    Red sub action 1
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('red sub action 2')}
+                  >
+                    Red sub action 2
+                  </ContextMenu.Item>
+                  <ContextMenu.Arrow offset={14} />
+                </ContextMenu.SubContent>
+              </ContextMenu.Sub>
+            </ContextMenu.Content>
+          </ContextMenu.Portal>
         </ContextMenu.Root>
       </ContextMenu.Trigger>
-      <ContextMenu.Content className={contentClass()} alignOffset={-5}>
-        <ContextMenu.Label className={labelClass()}>Blue box menu</ContextMenu.Label>
-        <ContextMenu.Separator className={separatorClass()} />
-        <ContextMenu.Item className={itemClass()} onSelect={() => console.log('blue action1')}>
-          Blue action 1
-        </ContextMenu.Item>
-        <ContextMenu.Item className={itemClass()} onSelect={() => console.log('blue action2')}>
-          Blue action 2
-        </ContextMenu.Item>
-        <ContextMenu.Separator className={separatorClass()} />
-        <ContextMenu.Sub>
-          <ContextMenu.SubTrigger className={subTriggerClass()}>Submenu →</ContextMenu.SubTrigger>
-          <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-            <ContextMenu.Item
-              className={itemClass()}
-              onSelect={() => console.log('blue sub action 1')}
-            >
-              Blue sub action 1
-            </ContextMenu.Item>
-            <ContextMenu.Item
-              className={itemClass()}
-              onSelect={() => console.log('blue sub action 2')}
-            >
-              Blue sub action 2
-            </ContextMenu.Item>
-            <ContextMenu.Arrow offset={14} />
-          </ContextMenu.SubContent>
-        </ContextMenu.Sub>
-      </ContextMenu.Content>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className={contentClass()} alignOffset={-5}>
+          <ContextMenu.Label className={labelClass()}>Blue box menu</ContextMenu.Label>
+          <ContextMenu.Separator className={separatorClass()} />
+          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('blue action1')}>
+            Blue action 1
+          </ContextMenu.Item>
+          <ContextMenu.Item className={itemClass()} onSelect={() => console.log('blue action2')}>
+            Blue action 2
+          </ContextMenu.Item>
+          <ContextMenu.Separator className={separatorClass()} />
+          <ContextMenu.Sub>
+            <ContextMenu.SubTrigger className={subTriggerClass()}>Submenu →</ContextMenu.SubTrigger>
+            <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+              <ContextMenu.Item
+                className={itemClass()}
+                onSelect={() => console.log('blue sub action 1')}
+              >
+                Blue sub action 1
+              </ContextMenu.Item>
+              <ContextMenu.Item
+                className={itemClass()}
+                onSelect={() => console.log('blue sub action 2')}
+              >
+                Blue sub action 2
+              </ContextMenu.Item>
+              <ContextMenu.Arrow offset={14} />
+            </ContextMenu.SubContent>
+          </ContextMenu.Sub>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
     </ContextMenu.Root>
   </div>
 );

--- a/packages/react/context-menu/src/ContextMenu.stories.tsx
+++ b/packages/react/context-menu/src/ContextMenu.stories.tsx
@@ -82,54 +82,61 @@ export const Modality = () => {
                   <ContextMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
                   </ContextMenu.SubTrigger>
-                  <ContextMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
-                  >
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                      One
-                    </ContextMenu.Item>
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                      Two
-                    </ContextMenu.Item>
-                    <ContextMenu.Separator className={separatorClass()} />
-                    <ContextMenu.Sub>
-                      <ContextMenu.SubTrigger className={subTriggerClass()}>
-                        Submenu →
-                      </ContextMenu.SubTrigger>
-                      <ContextMenu.SubContent
-                        className={contentClass()}
-                        sideOffset={12}
-                        alignOffset={-6}
+                  <ContextMenu.Portal>
+                    <ContextMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
+                    >
+                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                        One
+                      </ContextMenu.Item>
+                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                        Two
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator className={separatorClass()} />
+                      <ContextMenu.Sub>
+                        <ContextMenu.SubTrigger className={subTriggerClass()}>
+                          Submenu →
+                        </ContextMenu.SubTrigger>
+                        <ContextMenu.Portal>
+                          <ContextMenu.SubContent
+                            className={contentClass()}
+                            sideOffset={12}
+                            alignOffset={-6}
+                          >
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('one')}
+                            >
+                              One
+                            </ContextMenu.Item>
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('two')}
+                            >
+                              Two
+                            </ContextMenu.Item>
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('three')}
+                            >
+                              Three
+                            </ContextMenu.Item>
+                            <ContextMenu.Arrow offset={14} />
+                          </ContextMenu.SubContent>
+                        </ContextMenu.Portal>
+                      </ContextMenu.Sub>
+                      <ContextMenu.Separator className={separatorClass()} />
+                      <ContextMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('three')}
                       >
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('one')}
-                        >
-                          One
-                        </ContextMenu.Item>
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('two')}
-                        >
-                          Two
-                        </ContextMenu.Item>
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('three')}
-                        >
-                          Three
-                        </ContextMenu.Item>
-                        <ContextMenu.Arrow offset={14} />
-                      </ContextMenu.SubContent>
-                    </ContextMenu.Sub>
-                    <ContextMenu.Separator className={separatorClass()} />
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                      Three
-                    </ContextMenu.Item>
-                    <ContextMenu.Arrow offset={14} />
-                  </ContextMenu.SubContent>
+                        Three
+                      </ContextMenu.Item>
+                      <ContextMenu.Arrow offset={14} />
+                    </ContextMenu.SubContent>
+                  </ContextMenu.Portal>
                 </ContextMenu.Sub>
                 <ContextMenu.Separator className={separatorClass()} />
                 <ContextMenu.Item
@@ -173,54 +180,61 @@ export const Modality = () => {
                   <ContextMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
                   </ContextMenu.SubTrigger>
-                  <ContextMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
-                  >
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                      One
-                    </ContextMenu.Item>
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                      Two
-                    </ContextMenu.Item>
-                    <ContextMenu.Separator className={separatorClass()} />
-                    <ContextMenu.Sub defaultOpen>
-                      <ContextMenu.SubTrigger className={subTriggerClass()}>
-                        Submenu →
-                      </ContextMenu.SubTrigger>
-                      <ContextMenu.SubContent
-                        className={contentClass()}
-                        sideOffset={12}
-                        alignOffset={-6}
+                  <ContextMenu.Portal>
+                    <ContextMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
+                    >
+                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                        One
+                      </ContextMenu.Item>
+                      <ContextMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                        Two
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator className={separatorClass()} />
+                      <ContextMenu.Sub defaultOpen>
+                        <ContextMenu.SubTrigger className={subTriggerClass()}>
+                          Submenu →
+                        </ContextMenu.SubTrigger>
+                        <ContextMenu.Portal>
+                          <ContextMenu.SubContent
+                            className={contentClass()}
+                            sideOffset={12}
+                            alignOffset={-6}
+                          >
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('one')}
+                            >
+                              One
+                            </ContextMenu.Item>
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('two')}
+                            >
+                              Two
+                            </ContextMenu.Item>
+                            <ContextMenu.Item
+                              className={itemClass()}
+                              onSelect={() => console.log('three')}
+                            >
+                              Three
+                            </ContextMenu.Item>
+                            <ContextMenu.Arrow offset={14} />
+                          </ContextMenu.SubContent>
+                        </ContextMenu.Portal>
+                      </ContextMenu.Sub>
+                      <ContextMenu.Separator className={separatorClass()} />
+                      <ContextMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('three')}
                       >
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('one')}
-                        >
-                          One
-                        </ContextMenu.Item>
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('two')}
-                        >
-                          Two
-                        </ContextMenu.Item>
-                        <ContextMenu.Item
-                          className={itemClass()}
-                          onSelect={() => console.log('three')}
-                        >
-                          Three
-                        </ContextMenu.Item>
-                        <ContextMenu.Arrow offset={14} />
-                      </ContextMenu.SubContent>
-                    </ContextMenu.Sub>
-                    <ContextMenu.Separator className={separatorClass()} />
-                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                      Three
-                    </ContextMenu.Item>
-                    <ContextMenu.Arrow offset={14} />
-                  </ContextMenu.SubContent>
+                        Three
+                      </ContextMenu.Item>
+                      <ContextMenu.Arrow offset={14} />
+                    </ContextMenu.SubContent>
+                  </ContextMenu.Portal>
                 </ContextMenu.Sub>
                 <ContextMenu.Separator className={separatorClass()} />
                 <ContextMenu.Item
@@ -292,99 +306,128 @@ export const Submenus = () => {
                 <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Bookmarks →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
-                    Inbox
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('calendar')}
+                <ContextMenu.Portal>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Calendar
-                  </ContextMenu.Item>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Sub>
-                    <ContextMenu.SubTrigger className={subTriggerClass()}>
-                      Modulz →
-                    </ContextMenu.SubTrigger>
-                    <ContextMenu.SubContent
-                      className={contentClass()}
-                      sideOffset={12}
-                      alignOffset={-6}
+                    <ContextMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
+                      Inbox
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('calendar')}
                     >
-                      <ContextMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('stitches')}
-                      >
-                        Stitches
-                      </ContextMenu.Item>
-                      <ContextMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('composer')}
-                      >
-                        Composer
-                      </ContextMenu.Item>
-                      <ContextMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('radix')}
-                      >
-                        Radix
-                      </ContextMenu.Item>
-                      <ContextMenu.Arrow offset={14} />
-                    </ContextMenu.SubContent>
-                  </ContextMenu.Sub>
-                  <ContextMenu.Separator className={separatorClass()} />
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
-                    Notion
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
+                      Calendar
+                    </ContextMenu.Item>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Sub>
+                      <ContextMenu.SubTrigger className={subTriggerClass()}>
+                        WorkOS →
+                      </ContextMenu.SubTrigger>
+                      <ContextMenu.Portal>
+                        <ContextMenu.SubContent
+                          className={contentClass()}
+                          sideOffset={12}
+                          alignOffset={-6}
+                        >
+                          <ContextMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('stitches')}
+                          >
+                            Stitches
+                          </ContextMenu.Item>
+                          <ContextMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('composer')}
+                          >
+                            Composer
+                          </ContextMenu.Item>
+                          <ContextMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('radix')}
+                          >
+                            Radix
+                          </ContextMenu.Item>
+                          <ContextMenu.Arrow offset={14} />
+                        </ContextMenu.SubContent>
+                      </ContextMenu.Portal>
+                    </ContextMenu.Sub>
+                    <ContextMenu.Separator className={separatorClass()} />
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('notion')}
+                    >
+                      Notion
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Portal>
               </ContextMenu.Sub>
               <ContextMenu.Sub>
                 <ContextMenu.SubTrigger className={subTriggerClass()} disabled>
                   History →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
-                    Github
-                  </ContextMenu.Item>
-                  <ContextMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
-                    Google
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('stack-overflow')}
+                <ContextMenu.Portal>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Stack Overflow
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('github')}
+                    >
+                      Github
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('google')}
+                    >
+                      Google
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('stack-overflow')}
+                    >
+                      Stack Overflow
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Portal>
               </ContextMenu.Sub>
               <ContextMenu.Sub>
                 <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Tools →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('extensions')}
+                <ContextMenu.Portal>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Extensions
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('task-manager')}
-                  >
-                    Task Manager
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('developer-tools')}
-                  >
-                    Developer Tools
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('extensions')}
+                    >
+                      Extensions
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('task-manager')}
+                    >
+                      Task Manager
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('developer-tools')}
+                    >
+                      Developer Tools
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Portal>
               </ContextMenu.Sub>
               <ContextMenu.Separator className={separatorClass()} />
               <ContextMenu.Item
@@ -652,21 +695,27 @@ export const Nested = () => (
                 <ContextMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </ContextMenu.SubTrigger>
-                <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('red sub action 1')}
+                <ContextMenu.Portal>
+                  <ContextMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Red sub action 1
-                  </ContextMenu.Item>
-                  <ContextMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('red sub action 2')}
-                  >
-                    Red sub action 2
-                  </ContextMenu.Item>
-                  <ContextMenu.Arrow offset={14} />
-                </ContextMenu.SubContent>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('red sub action 1')}
+                    >
+                      Red sub action 1
+                    </ContextMenu.Item>
+                    <ContextMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('red sub action 2')}
+                    >
+                      Red sub action 2
+                    </ContextMenu.Item>
+                    <ContextMenu.Arrow offset={14} />
+                  </ContextMenu.SubContent>
+                </ContextMenu.Portal>
               </ContextMenu.Sub>
             </ContextMenu.Content>
           </ContextMenu.Portal>
@@ -685,21 +734,23 @@ export const Nested = () => (
           <ContextMenu.Separator className={separatorClass()} />
           <ContextMenu.Sub>
             <ContextMenu.SubTrigger className={subTriggerClass()}>Submenu →</ContextMenu.SubTrigger>
-            <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-              <ContextMenu.Item
-                className={itemClass()}
-                onSelect={() => console.log('blue sub action 1')}
-              >
-                Blue sub action 1
-              </ContextMenu.Item>
-              <ContextMenu.Item
-                className={itemClass()}
-                onSelect={() => console.log('blue sub action 2')}
-              >
-                Blue sub action 2
-              </ContextMenu.Item>
-              <ContextMenu.Arrow offset={14} />
-            </ContextMenu.SubContent>
+            <ContextMenu.Portal>
+              <ContextMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
+                <ContextMenu.Item
+                  className={itemClass()}
+                  onSelect={() => console.log('blue sub action 1')}
+                >
+                  Blue sub action 1
+                </ContextMenu.Item>
+                <ContextMenu.Item
+                  className={itemClass()}
+                  onSelect={() => console.log('blue sub action 2')}
+                >
+                  Blue sub action 2
+                </ContextMenu.Item>
+                <ContextMenu.Arrow offset={14} />
+              </ContextMenu.SubContent>
+            </ContextMenu.Portal>
           </ContextMenu.Sub>
         </ContextMenu.Content>
       </ContextMenu.Portal>

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -152,6 +152,25 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
 ContextMenuTrigger.displayName = TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
+ * ContextMenuPortal
+ * -----------------------------------------------------------------------------------------------*/
+
+const PORTAL_NAME = 'ContextMenuPortal';
+
+type MenuPortalProps = React.ComponentPropsWithoutRef<typeof MenuPrimitive.Portal>;
+interface ContextMenuPortalProps extends MenuPortalProps {}
+
+const ContextMenuPortal: React.FC<ContextMenuPortalProps> = (
+  props: ScopedProps<ContextMenuPortalProps>
+) => {
+  const { __scopeContextMenu, ...portalProps } = props;
+  const menuScope = useMenuScope(__scopeContextMenu);
+  return <MenuPrimitive.Portal {...menuScope} {...portalProps} />;
+};
+
+ContextMenuPortal.displayName = PORTAL_NAME;
+
+/* -------------------------------------------------------------------------------------------------
  * ContextMenuContent
  * -----------------------------------------------------------------------------------------------*/
 
@@ -159,8 +178,7 @@ const CONTENT_NAME = 'ContextMenuContent';
 
 type ContextMenuContentElement = React.ElementRef<typeof MenuPrimitive.Content>;
 type MenuContentProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Content>;
-interface ContextMenuContentProps
-  extends Omit<MenuContentProps, 'portalled' | 'side' | 'sideOffset' | 'align'> {}
+interface ContextMenuContentProps extends Omit<MenuContentProps, 'side' | 'sideOffset' | 'align'> {}
 
 const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMenuContentProps>(
   (props: ScopedProps<ContextMenuContentProps>, forwardedRef) => {
@@ -174,7 +192,6 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
         {...menuScope}
         {...contentProps}
         ref={forwardedRef}
-        portalled
         side="right"
         sideOffset={2}
         align="start"
@@ -484,6 +501,7 @@ function whenTouchOrPen<E>(handler: React.PointerEventHandler<E>): React.Pointer
 
 const Root = ContextMenu;
 const Trigger = ContextMenuTrigger;
+const Portal = ContextMenuPortal;
 const Content = ContextMenuContent;
 const Group = ContextMenuGroup;
 const Label = ContextMenuLabel;
@@ -503,6 +521,7 @@ export {
   //
   ContextMenu,
   ContextMenuTrigger,
+  ContextMenuPortal,
   ContextMenuContent,
   ContextMenuGroup,
   ContextMenuLabel,
@@ -519,6 +538,7 @@ export {
   //
   Root,
   Trigger,
+  Portal,
   Content,
   Group,
   Label,
@@ -536,6 +556,7 @@ export {
 export type {
   ContextMenuProps,
   ContextMenuTriggerProps,
+  ContextMenuPortalProps,
   ContextMenuContentProps,
   ContextMenuGroupProps,
   ContextMenuLabelProps,

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -15,25 +15,27 @@ export const Styled = () => (
   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}>
     <DropdownMenu.Root>
       <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-      <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-          Undo
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-          Redo
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator className={separatorClass()} />
-        <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-          Cut
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-          Copy
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-          Paste
-        </DropdownMenu.Item>
-        <DropdownMenu.Arrow />
-      </DropdownMenu.Content>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className={separatorClass()} />
+          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenu.Item>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
     </DropdownMenu.Root>
   </div>
 );
@@ -48,51 +50,56 @@ export const Modality = () => {
           <h1>Modal (default)</h1>
           <DropdownMenu.Root>
             <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-            <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                Undo
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                Redo
-              </DropdownMenu.Item>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Sub>
-                <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                  Submenu →
-                </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                  Undo
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                  Redo
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator className={separatorClass()} />
+                <DropdownMenu.Sub>
+                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                    Submenu →
+                  </DropdownMenu.SubTrigger>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                      One
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                      Two
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('three')}
+                    >
+                      Three
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Sub>
+                <DropdownMenu.Separator className={separatorClass()} />
+                <DropdownMenu.Item
+                  className={itemClass()}
+                  disabled
+                  onSelect={() => console.log('cut')}
                 >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
-              </DropdownMenu.Sub>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Item
-                className={itemClass()}
-                disabled
-                onSelect={() => console.log('cut')}
-              >
-                Cut
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-                Copy
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-                Paste
-              </DropdownMenu.Item>
-              <DropdownMenu.Arrow />
-            </DropdownMenu.Content>
+                  Cut
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+                  Copy
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+                  Paste
+                </DropdownMenu.Item>
+                <DropdownMenu.Arrow />
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
           </DropdownMenu.Root>
           <textarea
             style={{ width: 500, height: 100, marginTop: 10 }}
@@ -103,51 +110,56 @@ export const Modality = () => {
           <h1>Non modal</h1>
           <DropdownMenu.Root modal={false}>
             <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-            <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                Undo
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                Redo
-              </DropdownMenu.Item>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Sub>
-                <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                  Submenu →
-                </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                  Undo
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                  Redo
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator className={separatorClass()} />
+                <DropdownMenu.Sub>
+                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                    Submenu →
+                  </DropdownMenu.SubTrigger>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                  >
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                      One
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                      Two
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('three')}
+                    >
+                      Three
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Sub>
+                <DropdownMenu.Separator className={separatorClass()} />
+                <DropdownMenu.Item
+                  className={itemClass()}
+                  disabled
+                  onSelect={() => console.log('cut')}
                 >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
-              </DropdownMenu.Sub>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Item
-                className={itemClass()}
-                disabled
-                onSelect={() => console.log('cut')}
-              >
-                Cut
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-                Copy
-              </DropdownMenu.Item>
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-                Paste
-              </DropdownMenu.Item>
-              <DropdownMenu.Arrow />
-            </DropdownMenu.Content>
+                  Cut
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+                  Copy
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+                  Paste
+                </DropdownMenu.Item>
+                <DropdownMenu.Arrow />
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
           </DropdownMenu.Root>
           <textarea
             style={{ width: 500, height: 100, marginTop: 10 }}
@@ -176,125 +188,142 @@ export const Submenus = () => {
         </label>
         <DropdownMenu.Root dir={rtl ? 'rtl' : 'ltr'}>
           <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('new-tab')}>
-              New Tab
-            </DropdownMenu.Item>
-            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('new-window')}>
-              New Window
-            </DropdownMenu.Item>
-            <DropdownMenu.Separator className={separatorClass()} />
-            <DropdownMenu.Sub>
-              <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                Bookmarks →
-              </DropdownMenu.SubTrigger>
-              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
-                  Inbox
-                </DropdownMenu.Item>
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('calendar')}>
-                  Calendar
-                </DropdownMenu.Item>
-                <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Sub>
-                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                    WorkOS →
-                  </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('new-tab')}>
+                New Tab
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('new-window')}>
+                New Window
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator className={separatorClass()} />
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                  Bookmarks →
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
+                >
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
+                    Inbox
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('calendar')}
                   >
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('stitches')}
+                    Calendar
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Sub>
+                    <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                      Modulz →
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
                     >
-                      Stitches
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('composer')}
-                    >
-                      Composer
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('radix')}
-                    >
-                      Radix
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.SubContent>
-                </DropdownMenu.Sub>
-                <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
-                  Notion
-                </DropdownMenu.Item>
-                <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Sub>
-            <DropdownMenu.Sub>
-              <DropdownMenu.SubTrigger className={subTriggerClass()} disabled>
-                History →
-              </DropdownMenu.SubTrigger>
-              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
-                  Github
-                </DropdownMenu.Item>
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
-                  Google
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('stack-overflow')}
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('stitches')}
+                      >
+                        Stitches
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('composer')}
+                      >
+                        Composer
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('radix')}
+                      >
+                        Radix
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Arrow offset={14} />
+                    </DropdownMenu.SubContent>
+                  </DropdownMenu.Sub>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
+                    Notion
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow offset={14} />
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className={subTriggerClass()} disabled>
+                  History →
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
                 >
-                  Stack Overflow
-                </DropdownMenu.Item>
-                <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Sub>
-            <DropdownMenu.Sub>
-              <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                Tools →
-              </DropdownMenu.SubTrigger>
-              <DropdownMenu.SubContent className={contentClass()} sideOffset={12} alignOffset={-6}>
-                <DropdownMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('extensions')}
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
+                    Github
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
+                    Google
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('stack-overflow')}
+                  >
+                    Stack Overflow
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow offset={14} />
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                  Tools →
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
                 >
-                  Extensions
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('task-manager')}
-                >
-                  Task Manager
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className={itemClass()}
-                  onSelect={() => console.log('developer-tools')}
-                >
-                  Developer Tools
-                </DropdownMenu.Item>
-                <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Sub>
-            <DropdownMenu.Separator className={separatorClass()} />
-            <DropdownMenu.Item
-              className={itemClass()}
-              disabled
-              onSelect={() => console.log('print')}
-            >
-              Print…
-            </DropdownMenu.Item>
-            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('cast')}>
-              Cast…
-            </DropdownMenu.Item>
-            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('find')}>
-              Find…
-            </DropdownMenu.Item>
-            <DropdownMenu.Arrow />
-          </DropdownMenu.Content>
+                  <DropdownMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('extensions')}
+                  >
+                    Extensions
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('task-manager')}
+                  >
+                    Task Manager
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={itemClass()}
+                    onSelect={() => console.log('developer-tools')}
+                  >
+                    Developer Tools
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow offset={14} />
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Separator className={separatorClass()} />
+              <DropdownMenu.Item
+                className={itemClass()}
+                disabled
+                onSelect={() => console.log('print')}
+              >
+                Print…
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('cast')}>
+                Cast…
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('find')}>
+                Find…
+              </DropdownMenu.Item>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
         </DropdownMenu.Root>
       </div>
     </div>
@@ -305,31 +334,33 @@ export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <DropdownMenu.Root>
       <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-      <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-        {foodGroups.map((foodGroup, index) => (
-          <DropdownMenu.Group key={index}>
-            {foodGroup.label && (
-              <DropdownMenu.Label className={labelClass()} key={foodGroup.label}>
-                {foodGroup.label}
-              </DropdownMenu.Label>
-            )}
-            {foodGroup.foods.map((food) => (
-              <DropdownMenu.Item
-                key={food.value}
-                className={itemClass()}
-                disabled={food.disabled}
-                onSelect={() => console.log(food.label)}
-              >
-                {food.label}
-              </DropdownMenu.Item>
-            ))}
-            {index < foodGroups.length - 1 && (
-              <DropdownMenu.Separator className={separatorClass()} />
-            )}
-          </DropdownMenu.Group>
-        ))}
-        <DropdownMenu.Arrow />
-      </DropdownMenu.Content>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+          {foodGroups.map((foodGroup, index) => (
+            <DropdownMenu.Group key={index}>
+              {foodGroup.label && (
+                <DropdownMenu.Label className={labelClass()} key={foodGroup.label}>
+                  {foodGroup.label}
+                </DropdownMenu.Label>
+              )}
+              {foodGroup.foods.map((food) => (
+                <DropdownMenu.Item
+                  key={food.value}
+                  className={itemClass()}
+                  disabled={food.disabled}
+                  onSelect={() => console.log(food.label)}
+                >
+                  {food.label}
+                </DropdownMenu.Item>
+              ))}
+              {index < foodGroups.length - 1 && (
+                <DropdownMenu.Separator className={separatorClass()} />
+              )}
+            </DropdownMenu.Group>
+          ))}
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
     </DropdownMenu.Root>
   </div>
 );
@@ -347,41 +378,51 @@ export const NestedComposition = () => {
     >
       <DropdownMenu.Root>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-          <Dialog.Root>
-            <Dialog.Trigger className={itemClass()} asChild>
-              <DropdownMenu.Item onSelect={(event) => event.preventDefault()}>
-                Open dialog
-              </DropdownMenu.Item>
-            </Dialog.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+            <Dialog.Root>
+              <Dialog.Trigger className={itemClass()} asChild>
+                <DropdownMenu.Item onSelect={(event) => event.preventDefault()}>
+                  Open dialog
+                </DropdownMenu.Item>
+              </Dialog.Trigger>
 
-            <Dialog.Portal>
-              <Dialog.Content className={dialogClass()} style={{ zIndex: 2147483647 }}>
-                <Dialog.Title>Nested dropdown</Dialog.Title>
-                <DropdownMenu.Root>
-                  <DropdownMenu.Trigger
-                    className={triggerClass()}
-                    style={{ width: '100%', marginBottom: 20 }}
-                  >
-                    Open
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                      Undo
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                      Redo
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Arrow />
-                  </DropdownMenu.Content>
-                </DropdownMenu.Root>
-                <Dialog.Close>Close</Dialog.Close>
-              </Dialog.Content>
-            </Dialog.Portal>
-          </Dialog.Root>
-          <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+              <Dialog.Portal>
+                <Dialog.Content className={dialogClass()} style={{ zIndex: 2147483647 }}>
+                  <Dialog.Title>Nested dropdown</Dialog.Title>
+                  <DropdownMenu.Root>
+                    <DropdownMenu.Trigger
+                      className={triggerClass()}
+                      style={{ width: '100%', marginBottom: 20 }}
+                    >
+                      Open
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+                        <DropdownMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('undo')}
+                        >
+                          Undo
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('redo')}
+                        >
+                          Redo
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Arrow />
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Root>
+                  <Dialog.Close>Close</Dialog.Close>
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+            <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
     </div>
   );
@@ -422,13 +463,15 @@ export const SingleItemAsDialogTrigger = () => {
             Open
           </DropdownMenu.Trigger>
 
-          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-            <Dialog.Trigger className={itemClass()} asChild>
-              <DropdownMenu.Item>Delete</DropdownMenu.Item>
-            </Dialog.Trigger>
-            <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
-            <DropdownMenu.Arrow />
-          </DropdownMenu.Content>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+              <Dialog.Trigger className={itemClass()} asChild>
+                <DropdownMenu.Item>Delete</DropdownMenu.Item>
+              </Dialog.Trigger>
+              <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
         </DropdownMenu.Root>
 
         <Dialog.Content className={dialogClass()} onCloseAutoFocus={handleModalDialogClose}>
@@ -444,22 +487,24 @@ export const SingleItemAsDialogTrigger = () => {
             Open
           </DropdownMenu.Trigger>
 
-          <DropdownMenu.Content
-            className={contentClass()}
-            sideOffset={5}
-            onCloseAutoFocus={(event) => {
-              // prevent focusing dropdown trigger when it closes from a dialog trigger
-              if (isDialogOpenRef.current) event.preventDefault();
-            }}
-          >
-            <Dialog.Trigger className={itemClass()} asChild>
-              <DropdownMenu.Item onSelect={() => (isDialogOpenRef.current = true)}>
-                Delete
-              </DropdownMenu.Item>
-            </Dialog.Trigger>
-            <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
-            <DropdownMenu.Arrow />
-          </DropdownMenu.Content>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className={contentClass()}
+              sideOffset={5}
+              onCloseAutoFocus={(event) => {
+                // prevent focusing dropdown trigger when it closes from a dialog trigger
+                if (isDialogOpenRef.current) event.preventDefault();
+              }}
+            >
+              <Dialog.Trigger className={itemClass()} asChild>
+                <DropdownMenu.Item onSelect={() => (isDialogOpenRef.current = true)}>
+                  Delete
+                </DropdownMenu.Item>
+              </Dialog.Trigger>
+              <DropdownMenu.Item className={itemClass()}>Test</DropdownMenu.Item>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
         </DropdownMenu.Root>
 
         <Dialog.Content className={dialogClass()} onCloseAutoFocus={handleNonModalDialogClose}>
@@ -503,17 +548,19 @@ export const MultipleItemsAsDialogTriggers = () => {
             Open
           </DropdownMenu.Trigger>
 
-          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-            <Dialog.Trigger asChild className={itemClass()}>
-              <DropdownMenu.Item onSelect={() => setSwitchAccountsOpen(true)}>
-                Switch Accounts
-              </DropdownMenu.Item>
-            </Dialog.Trigger>
-            <Dialog.Trigger asChild className={itemClass()}>
-              <DropdownMenu.Item onSelect={() => setDeleteOpen(true)}>Delete</DropdownMenu.Item>
-            </Dialog.Trigger>
-            <DropdownMenu.Arrow />
-          </DropdownMenu.Content>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+              <Dialog.Trigger asChild className={itemClass()}>
+                <DropdownMenu.Item onSelect={() => setSwitchAccountsOpen(true)}>
+                  Switch Accounts
+                </DropdownMenu.Item>
+              </Dialog.Trigger>
+              <Dialog.Trigger asChild className={itemClass()}>
+                <DropdownMenu.Item onSelect={() => setDeleteOpen(true)}>Delete</DropdownMenu.Item>
+              </Dialog.Trigger>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
         </DropdownMenu.Root>
 
         <Dialog.Content
@@ -545,24 +592,26 @@ export const MultipleItemsAsDialogTriggers = () => {
             Open
           </DropdownMenu.Trigger>
 
-          <DropdownMenu.Content
-            className={contentClass()}
-            sideOffset={5}
-            onCloseAutoFocus={(event) => {
-              // prevent focusing dropdown trigger when it closes from a dialog trigger
-              if (deleteOpen2 || switchAccountsOpen2) event.preventDefault();
-            }}
-          >
-            <Dialog.Trigger asChild className={itemClass()}>
-              <DropdownMenu.Item onSelect={() => setSwitchAccountsOpen2(true)}>
-                Switch Accounts
-              </DropdownMenu.Item>
-            </Dialog.Trigger>
-            <Dialog.Trigger asChild className={itemClass()}>
-              <DropdownMenu.Item onSelect={() => setDeleteOpen2(true)}>Delete</DropdownMenu.Item>
-            </Dialog.Trigger>
-            <DropdownMenu.Arrow />
-          </DropdownMenu.Content>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className={contentClass()}
+              sideOffset={5}
+              onCloseAutoFocus={(event) => {
+                // prevent focusing dropdown trigger when it closes from a dialog trigger
+                if (deleteOpen2 || switchAccountsOpen2) event.preventDefault();
+              }}
+            >
+              <Dialog.Trigger asChild className={itemClass()}>
+                <DropdownMenu.Item onSelect={() => setSwitchAccountsOpen2(true)}>
+                  Switch Accounts
+                </DropdownMenu.Item>
+              </Dialog.Trigger>
+              <Dialog.Trigger asChild className={itemClass()}>
+                <DropdownMenu.Item onSelect={() => setDeleteOpen2(true)}>Delete</DropdownMenu.Item>
+              </Dialog.Trigger>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
         </DropdownMenu.Root>
 
         <Dialog.Content
@@ -594,33 +643,35 @@ export const CheckboxItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
-            Show fonts
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
-            Bigger
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
-            <DropdownMenu.CheckboxItem
-              key={label}
-              className={itemClass()}
-              checked={checked}
-              onCheckedChange={setChecked}
-              disabled={disabled}
-            >
-              {label}
-              <DropdownMenu.ItemIndicator>
-                <TickIcon />
-              </DropdownMenu.ItemIndicator>
-            </DropdownMenu.CheckboxItem>
-          ))}
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
+              Show fonts
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
+              Bigger
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
+              <DropdownMenu.CheckboxItem
+                key={label}
+                className={itemClass()}
+                checked={checked}
+                onCheckedChange={setChecked}
+                disabled={disabled}
+              >
+                {label}
+                <DropdownMenu.ItemIndicator>
+                  <TickIcon />
+                </DropdownMenu.ItemIndicator>
+              </DropdownMenu.CheckboxItem>
+            ))}
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
     </div>
   );
@@ -634,29 +685,31 @@ export const RadioItems = () => {
     <div style={{ textAlign: 'center', padding: 50 }}>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('minimize')}>
-            Minimize window
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('zoom')}>
-            Zoom
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.RadioGroup value={file} onValueChange={setFile}>
-            {files.map((file) => (
-              <DropdownMenu.RadioItem key={file} className={itemClass()} value={file}>
-                {file}
-                <DropdownMenu.ItemIndicator>
-                  <TickIcon />
-                </DropdownMenu.ItemIndicator>
-              </DropdownMenu.RadioItem>
-            ))}
-          </DropdownMenu.RadioGroup>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('minimize')}>
+              Minimize window
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('zoom')}>
+              Zoom
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.RadioGroup value={file} onValueChange={setFile}>
+              {files.map((file) => (
+                <DropdownMenu.RadioItem key={file} className={itemClass()} value={file}>
+                  {file}
+                  <DropdownMenu.ItemIndicator>
+                    <TickIcon />
+                  </DropdownMenu.ItemIndicator>
+                </DropdownMenu.RadioItem>
+              ))}
+            </DropdownMenu.RadioGroup>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
       <p>Selected file: {file}</p>
     </div>
@@ -667,21 +720,23 @@ export const PreventClosing = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <DropdownMenu.Root>
       <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-      <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => window.alert('action 1')}>
-          I will close
-        </DropdownMenu.Item>
-        <DropdownMenu.Item
-          className={itemClass()}
-          onSelect={(event) => {
-            event.preventDefault();
-            window.alert('action 1');
-          }}
-        >
-          I won't close
-        </DropdownMenu.Item>
-        <DropdownMenu.Arrow />
-      </DropdownMenu.Content>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => window.alert('action 1')}>
+            I will close
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            className={itemClass()}
+            onSelect={(event) => {
+              event.preventDefault();
+              window.alert('action 1');
+            }}
+          >
+            I won't close
+          </DropdownMenu.Item>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
     </DropdownMenu.Root>
   </div>
 );
@@ -695,25 +750,27 @@ export const WithTooltip = () => (
         </Tooltip.Trigger>
         <Tooltip.Content>Tooltip content</Tooltip.Content>
       </Tooltip.Root>
-      <DropdownMenu.Content className={contentClass()} sideOffset={5}>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-          Undo
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-          Redo
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator className={separatorClass()} />
-        <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-          Cut
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-          Copy
-        </DropdownMenu.Item>
-        <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-          Paste
-        </DropdownMenu.Item>
-        <DropdownMenu.Arrow />
-      </DropdownMenu.Content>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={contentClass()} sideOffset={5}>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+            Undo
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className={separatorClass()} />
+          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenu.Item>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
     </DropdownMenu.Root>
   </div>
 );
@@ -737,82 +794,88 @@ export const Chromatic = () => {
       <h2>Closed</h2>
       <DropdownMenu.Root modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h2>Open</h2>
       <DropdownMenu.Root defaultOpen modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content
-          className={contentClass()}
-          sideOffset={5}
-          avoidCollisions={false}
-          onFocusOutside={(event) => event.preventDefault()}
-        >
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            className={contentClass()}
+            sideOffset={5}
+            avoidCollisions={false}
+            onFocusOutside={(event) => event.preventDefault()}
+          >
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
       <DropdownMenu.Root defaultOpen modal={false}>
-        <DropdownMenu.Content
-          className={contentClass()}
-          sideOffset={5}
-          avoidCollisions={false}
-          onFocusOutside={(event) => event.preventDefault()}
-        >
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            className={contentClass()}
+            sideOffset={5}
+            avoidCollisions={false}
+            onFocusOutside={(event) => event.preventDefault()}
+          >
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
       </DropdownMenu.Root>
 
@@ -820,151 +883,85 @@ export const Chromatic = () => {
       <h2>Closed</h2>
       <DropdownMenu.Root open={false} modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h2>Open</h2>
       <DropdownMenu.Root open modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h2 style={{ marginTop: 180 }}>Open with reordered parts</h2>
       <DropdownMenu.Root open modal={false}>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
+              Cut
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+              Copy
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+              Paste
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
       </DropdownMenu.Root>
 
       <h1 style={{ marginTop: 200 }}>Submenus</h1>
       <h2>Open</h2>
       <DropdownMenu.Root open modal={false}>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-            Undo
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-            Redo
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Sub open>
-            <DropdownMenu.SubTrigger className={subTriggerClass()}>
-              Submenu →
-            </DropdownMenu.SubTrigger>
-            <DropdownMenu.SubContent
-              className={contentClass()}
-              sideOffset={12}
-              alignOffset={-6}
-              avoidCollisions={false}
-            >
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                One
-              </DropdownMenu.Item>
-
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                Two
-              </DropdownMenu.Item>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Sub open>
-                <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                  Submenu →
-                </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
-                  avoidCollisions={false}
-                >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
-              </DropdownMenu.Sub>
-              <DropdownMenu.Separator className={separatorClass()} />
-              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                Three
-              </DropdownMenu.Item>
-              <DropdownMenu.Arrow offset={14} />
-            </DropdownMenu.SubContent>
-          </DropdownMenu.Sub>
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
-            Cut
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
-            Copy
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
-            Paste
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
-        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-      </DropdownMenu.Root>
-
-      <h2 style={{ marginTop: 275 }}>RTL</h2>
-      <div dir="rtl">
-        <DropdownMenu.Root open dir="rtl" modal={false}>
+        <DropdownMenu.Portal>
           <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
             <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
               Undo
@@ -1035,6 +1032,95 @@ export const Chromatic = () => {
             </DropdownMenu.Item>
             <DropdownMenu.Arrow />
           </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
+      </DropdownMenu.Root>
+
+      <h2 style={{ marginTop: 275 }}>RTL</h2>
+      <div dir="rtl">
+        <DropdownMenu.Root open dir="rtl" modal={false}>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                Undo
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                Redo
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator className={separatorClass()} />
+              <DropdownMenu.Sub open>
+                <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                  Submenu →
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
+                  avoidCollisions={false}
+                >
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenu.Item>
+
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Sub open>
+                    <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                      Submenu →
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
+                      avoidCollisions={false}
+                    >
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('one')}
+                      >
+                        One
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('two')}
+                      >
+                        Two
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('three')}
+                      >
+                        Three
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Arrow offset={14} />
+                    </DropdownMenu.SubContent>
+                  </DropdownMenu.Sub>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow offset={14} />
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Separator className={separatorClass()} />
+              <DropdownMenu.Item
+                className={itemClass()}
+                disabled
+                onSelect={() => console.log('cut')}
+              >
+                Cut
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('copy')}>
+                Copy
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('paste')}>
+                Paste
+              </DropdownMenu.Item>
+              <DropdownMenu.Arrow />
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
           <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
         </DropdownMenu.Root>
       </div>
@@ -1047,19 +1133,21 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1072,24 +1160,26 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow
-                  className={chromaticArrowClass()}
-                  width={20}
-                  height={10}
-                  offset={5}
-                />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow
+                    className={chromaticArrowClass()}
+                    width={20}
+                    height={10}
+                    offset={5}
+                  />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1100,24 +1190,26 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow
-                  className={chromaticArrowClass()}
-                  width={20}
-                  height={10}
-                  offset={-10}
-                />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow
+                    className={chromaticArrowClass()}
+                    width={20}
+                    height={10}
+                    offset={-10}
+                  />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1130,20 +1222,22 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                sideOffset={5}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  sideOffset={5}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1154,20 +1248,22 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                sideOffset={-10}
-                align={align}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  sideOffset={-10}
+                  align={align}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1180,20 +1276,22 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                alignOffset={20}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  alignOffset={20}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1204,20 +1302,22 @@ export const Chromatic = () => {
           ALIGN_OPTIONS.map((align) => (
             <DropdownMenu.Root key={`${side}-${align}`} open modal={false}>
               <DropdownMenu.Trigger className={chromaticTriggerClass()} />
-              <DropdownMenu.Content
-                className={chromaticContentClass()}
-                side={side}
-                align={align}
-                alignOffset={-10}
-                avoidCollisions={false}
-              >
-                <p style={{ textAlign: 'center' }}>
-                  {side}
-                  <br />
-                  {align}
-                </p>
-                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={chromaticContentClass()}
+                  side={side}
+                  align={align}
+                  alignOffset={-10}
+                  avoidCollisions={false}
+                >
+                  <p style={{ textAlign: 'center' }}>
+                    {side}
+                    <br />
+                    {align}
+                  </p>
+                  <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ))
         )}
@@ -1247,14 +1347,16 @@ export const Chromatic = () => {
                     : { left: 10 })),
               }}
             />
-            <DropdownMenu.Content className={chromaticContentClass()} side={side} align={align}>
-              <p style={{ textAlign: 'center' }}>
-                {side}
-                <br />
-                {align}
-              </p>
-              <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
-            </DropdownMenu.Content>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className={chromaticContentClass()} side={side} align={align}>
+                <p style={{ textAlign: 'center' }}>
+                  {side}
+                  <br />
+                  {align}
+                </p>
+                <DropdownMenu.Arrow className={chromaticArrowClass()} width={20} height={10} />
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
           </DropdownMenu.Root>
         ))
       )}
@@ -1262,86 +1364,86 @@ export const Chromatic = () => {
       <h1>With labels</h1>
       <DropdownMenu.Root open modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          {foodGroups.map((foodGroup, index) => (
-            <DropdownMenu.Group key={index}>
-              {foodGroup.label && (
-                <DropdownMenu.Label className={labelClass()} key={foodGroup.label}>
-                  {foodGroup.label}
-                </DropdownMenu.Label>
-              )}
-              {foodGroup.foods.map((food) => (
-                <DropdownMenu.Item
-                  key={food.value}
-                  className={itemClass()}
-                  disabled={food.disabled}
-                  onSelect={() => console.log(food.label)}
-                >
-                  {food.label}
-                </DropdownMenu.Item>
-              ))}
-              {index < foodGroups.length - 1 && (
-                <DropdownMenu.Separator className={separatorClass()} />
-              )}
-            </DropdownMenu.Group>
-          ))}
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            {foodGroups.map((foodGroup, index) => (
+              <DropdownMenu.Group key={index}>
+                {foodGroup.label && (
+                  <DropdownMenu.Label className={labelClass()} key={foodGroup.label}>
+                    {foodGroup.label}
+                  </DropdownMenu.Label>
+                )}
+                {foodGroup.foods.map((food) => (
+                  <DropdownMenu.Item
+                    key={food.value}
+                    className={itemClass()}
+                    disabled={food.disabled}
+                    onSelect={() => console.log(food.label)}
+                  >
+                    {food.label}
+                  </DropdownMenu.Item>
+                ))}
+                {index < foodGroups.length - 1 && (
+                  <DropdownMenu.Separator className={separatorClass()} />
+                )}
+              </DropdownMenu.Group>
+            ))}
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h1 style={{ marginTop: 600 }}>With checkbox and radio items</h1>
       <DropdownMenu.Root open modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
-            Show fonts
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
-            Bigger
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorClass()} />
-          {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
-            <DropdownMenu.CheckboxItem
-              key={label}
-              className={itemClass()}
-              checked={checked}
-              onCheckedChange={setChecked}
-              disabled={disabled}
-            >
-              {label}
-              <DropdownMenu.ItemIndicator>
-                <TickIcon />
-              </DropdownMenu.ItemIndicator>
-            </DropdownMenu.CheckboxItem>
-          ))}
-          <DropdownMenu.Separator className={separatorClass()} />
-          <DropdownMenu.RadioGroup value={file} onValueChange={setFile}>
-            {files.map((file) => (
-              <DropdownMenu.RadioItem key={file} className={itemClass()} value={file}>
-                {file}
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('show')}>
+              Show fonts
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('bigger')}>
+              Bigger
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorClass()} />
+            {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
+              <DropdownMenu.CheckboxItem
+                key={label}
+                className={itemClass()}
+                checked={checked}
+                onCheckedChange={setChecked}
+                disabled={disabled}
+              >
+                {label}
                 <DropdownMenu.ItemIndicator>
                   <TickIcon />
                 </DropdownMenu.ItemIndicator>
-              </DropdownMenu.RadioItem>
+              </DropdownMenu.CheckboxItem>
             ))}
-          </DropdownMenu.RadioGroup>
-          <DropdownMenu.Arrow />
-        </DropdownMenu.Content>
+            <DropdownMenu.Separator className={separatorClass()} />
+            <DropdownMenu.RadioGroup value={file} onValueChange={setFile}>
+              {files.map((file) => (
+                <DropdownMenu.RadioItem key={file} className={itemClass()} value={file}>
+                  {file}
+                  <DropdownMenu.ItemIndicator>
+                    <TickIcon />
+                  </DropdownMenu.ItemIndicator>
+                </DropdownMenu.RadioItem>
+              ))}
+            </DropdownMenu.RadioGroup>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h1 style={{ marginTop: 500 }}>Nested composition</h1>
 
       <DropdownMenu.Root open modal={false}>
         <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content
-          className={contentClass()}
-          sideOffset={5}
-          avoidCollisions={false}
-          portalled={false}
-        >
+
+        <DropdownMenu.Content className={contentClass()} sideOffset={5} avoidCollisions={false}>
           <Dialog.Root open modal={false}>
             <Dialog.Trigger className={itemClass()} asChild>
               <DropdownMenu.Item onSelect={(event) => event.preventDefault()}>
@@ -1365,19 +1467,21 @@ export const Chromatic = () => {
                 <DropdownMenu.Trigger className={triggerClass()} style={{ width: '100%' }}>
                   Open
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Content
-                  className={contentClass()}
-                  sideOffset={5}
-                  avoidCollisions={false}
-                >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
-                    Undo
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
-                    Redo
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow />
-                </DropdownMenu.Content>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content
+                    className={contentClass()}
+                    sideOffset={5}
+                    avoidCollisions={false}
+                  >
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+                      Undo
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+                      Redo
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow />
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
               </DropdownMenu.Root>
             </Dialog.Content>
           </Dialog.Root>
@@ -1390,58 +1494,66 @@ export const Chromatic = () => {
       <h2>Closed</h2>
       <DropdownMenu.Root open={false} modal={false}>
         <DropdownMenu.Trigger className={triggerAttrClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content
-          className={contentAttrClass()}
-          sideOffset={5}
-          avoidCollisions={false}
-        />
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            className={contentAttrClass()}
+            sideOffset={5}
+            avoidCollisions={false}
+          />
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
       <h2>Open</h2>
       <DropdownMenu.Root open modal={false}>
         <DropdownMenu.Trigger className={triggerAttrClass()}>Open</DropdownMenu.Trigger>
-        <DropdownMenu.Content className={contentAttrClass()} sideOffset={5} avoidCollisions={false}>
-          <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('show')}>
-            Show fonts
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('bigger')}>
-            Bigger
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('smaller')}>
-            Smaller
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className={separatorAttrClass()} />
-          {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
-            <DropdownMenu.CheckboxItem
-              key={label}
-              className={checkboxItemAttrClass()}
-              checked={checked}
-              onCheckedChange={setChecked}
-              disabled={disabled}
-            >
-              {label}
-              <DropdownMenu.ItemIndicator className={itemIndicatorAttrClass()}>
-                <TickIcon />
-              </DropdownMenu.ItemIndicator>
-            </DropdownMenu.CheckboxItem>
-          ))}
-          <DropdownMenu.Separator className={separatorAttrClass()} />
-          <DropdownMenu.RadioGroup
-            className={radioGroupAttrClass()}
-            value={file}
-            onValueChange={setFile}
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            className={contentAttrClass()}
+            sideOffset={5}
+            avoidCollisions={false}
           >
-            {files.map((file) => (
-              <DropdownMenu.RadioItem key={file} className={radioItemAttrClass()} value={file}>
-                {file}
+            <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('show')}>
+              Show fonts
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('bigger')}>
+              Bigger
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemAttrClass()} onSelect={() => console.log('smaller')}>
+              Smaller
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator className={separatorAttrClass()} />
+            {checkboxItems.map(({ label, state: [checked, setChecked], disabled }) => (
+              <DropdownMenu.CheckboxItem
+                key={label}
+                className={checkboxItemAttrClass()}
+                checked={checked}
+                onCheckedChange={setChecked}
+                disabled={disabled}
+              >
+                {label}
                 <DropdownMenu.ItemIndicator className={itemIndicatorAttrClass()}>
                   <TickIcon />
                 </DropdownMenu.ItemIndicator>
-              </DropdownMenu.RadioItem>
+              </DropdownMenu.CheckboxItem>
             ))}
-          </DropdownMenu.RadioGroup>
-          <DropdownMenu.Arrow className={arrowAttrClass()} />
-        </DropdownMenu.Content>
+            <DropdownMenu.Separator className={separatorAttrClass()} />
+            <DropdownMenu.RadioGroup
+              className={radioGroupAttrClass()}
+              value={file}
+              onValueChange={setFile}
+            >
+              {files.map((file) => (
+                <DropdownMenu.RadioItem key={file} className={radioItemAttrClass()} value={file}>
+                  {file}
+                  <DropdownMenu.ItemIndicator className={itemIndicatorAttrClass()}>
+                    <TickIcon />
+                  </DropdownMenu.ItemIndicator>
+                </DropdownMenu.RadioItem>
+              ))}
+            </DropdownMenu.RadioGroup>
+            <DropdownMenu.Arrow className={arrowAttrClass()} />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu.Root>
     </div>
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -63,25 +63,33 @@ export const Modality = () => {
                   <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
-                  >
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                      One
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                      Two
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('three')}
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
                     >
-                      Three
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.SubContent>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('one')}
+                      >
+                        One
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('two')}
+                      >
+                        Two
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('three')}
+                      >
+                        Three
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Arrow offset={14} />
+                    </DropdownMenu.SubContent>
+                  </DropdownMenu.Portal>
                 </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item
@@ -123,25 +131,33 @@ export const Modality = () => {
                   <DropdownMenu.SubTrigger className={subTriggerClass()}>
                     Submenu →
                   </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
-                  >
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                      One
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                      Two
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('three')}
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.SubContent
+                      className={contentClass()}
+                      sideOffset={12}
+                      alignOffset={-6}
                     >
-                      Three
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.SubContent>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('one')}
+                      >
+                        One
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('two')}
+                      >
+                        Two
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={itemClass()}
+                        onSelect={() => console.log('three')}
+                      >
+                        Three
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Arrow offset={14} />
+                    </DropdownMenu.SubContent>
+                  </DropdownMenu.Portal>
                 </DropdownMenu.Sub>
                 <DropdownMenu.Separator className={separatorClass()} />
                 <DropdownMenu.Item
@@ -201,111 +217,131 @@ export const Submenus = () => {
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Bookmarks →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
-                >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('index')}>
-                    Inbox
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('calendar')}
+                <DropdownMenu.Portal>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Calendar
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Separator className={separatorClass()} />
-                  <DropdownMenu.Sub>
-                    <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                      Modulz →
-                    </DropdownMenu.SubTrigger>
-                    <DropdownMenu.SubContent
-                      className={contentClass()}
-                      sideOffset={12}
-                      alignOffset={-6}
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('index')}
                     >
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('stitches')}
-                      >
-                        Stitches
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('composer')}
-                      >
-                        Composer
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('radix')}
-                      >
-                        Radix
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Arrow offset={14} />
-                    </DropdownMenu.SubContent>
-                  </DropdownMenu.Sub>
-                  <DropdownMenu.Separator className={separatorClass()} />
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('notion')}>
-                    Notion
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
+                      Inbox
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('calendar')}
+                    >
+                      Calendar
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator className={separatorClass()} />
+                    <DropdownMenu.Sub>
+                      <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                        WorkOS →
+                      </DropdownMenu.SubTrigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.SubContent
+                          className={contentClass()}
+                          sideOffset={12}
+                          alignOffset={-6}
+                        >
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('stitches')}
+                          >
+                            Stitches
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('composer')}
+                          >
+                            Composer
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('radix')}
+                          >
+                            Radix
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Arrow offset={14} />
+                        </DropdownMenu.SubContent>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu.Sub>
+                    <DropdownMenu.Separator className={separatorClass()} />
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('notion')}
+                    >
+                      Notion
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Portal>
               </DropdownMenu.Sub>
               <DropdownMenu.Sub>
                 <DropdownMenu.SubTrigger className={subTriggerClass()} disabled>
                   History →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
-                >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('github')}>
-                    Github
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('google')}>
-                    Google
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('stack-overflow')}
+                <DropdownMenu.Portal>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Stack Overflow
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('github')}
+                    >
+                      Github
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('google')}
+                    >
+                      Google
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('stack-overflow')}
+                    >
+                      Stack Overflow
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Portal>
               </DropdownMenu.Sub>
               <DropdownMenu.Sub>
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Tools →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
-                >
-                  <DropdownMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('extensions')}
+                <DropdownMenu.Portal>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
                   >
-                    Extensions
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('task-manager')}
-                  >
-                    Task Manager
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    className={itemClass()}
-                    onSelect={() => console.log('developer-tools')}
-                  >
-                    Developer Tools
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('extensions')}
+                    >
+                      Extensions
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('task-manager')}
+                    >
+                      Task Manager
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('developer-tools')}
+                    >
+                      Developer Tools
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Portal>
               </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item
@@ -974,51 +1010,61 @@ export const Chromatic = () => {
               <DropdownMenu.SubTrigger className={subTriggerClass()}>
                 Submenu →
               </DropdownMenu.SubTrigger>
-              <DropdownMenu.SubContent
-                className={contentClass()}
-                sideOffset={12}
-                alignOffset={-6}
-                avoidCollisions={false}
-              >
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                  One
-                </DropdownMenu.Item>
+              <DropdownMenu.Portal>
+                <DropdownMenu.SubContent
+                  className={contentClass()}
+                  sideOffset={12}
+                  alignOffset={-6}
+                  avoidCollisions={false}
+                >
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                    One
+                  </DropdownMenu.Item>
 
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                  Two
-                </DropdownMenu.Item>
-                <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Sub open>
-                  <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                    Submenu →
-                  </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent
-                    className={contentClass()}
-                    sideOffset={12}
-                    alignOffset={-6}
-                    avoidCollisions={false}
-                  >
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                      One
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                      Two
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={itemClass()}
-                      onSelect={() => console.log('three')}
-                    >
-                      Three
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Arrow offset={14} />
-                  </DropdownMenu.SubContent>
-                </DropdownMenu.Sub>
-                <DropdownMenu.Separator className={separatorClass()} />
-                <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                  Three
-                </DropdownMenu.Item>
-                <DropdownMenu.Arrow offset={14} />
-              </DropdownMenu.SubContent>
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                    Two
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Sub open>
+                    <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                      Submenu →
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.SubContent
+                        className={contentClass()}
+                        sideOffset={12}
+                        alignOffset={-6}
+                        avoidCollisions={false}
+                      >
+                        <DropdownMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('one')}
+                        >
+                          One
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('two')}
+                        >
+                          Two
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          className={itemClass()}
+                          onSelect={() => console.log('three')}
+                        >
+                          Three
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Arrow offset={14} />
+                      </DropdownMenu.SubContent>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Sub>
+                  <DropdownMenu.Separator className={separatorClass()} />
+                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+                    Three
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Arrow offset={14} />
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Portal>
             </DropdownMenu.Sub>
             <DropdownMenu.Separator className={separatorClass()} />
             <DropdownMenu.Item className={itemClass()} disabled onSelect={() => console.log('cut')}>
@@ -1052,57 +1098,64 @@ export const Chromatic = () => {
                 <DropdownMenu.SubTrigger className={subTriggerClass()}>
                   Submenu →
                 </DropdownMenu.SubTrigger>
-                <DropdownMenu.SubContent
-                  className={contentClass()}
-                  sideOffset={12}
-                  alignOffset={-6}
-                  avoidCollisions={false}
-                >
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
-                    One
-                  </DropdownMenu.Item>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.SubContent
+                    className={contentClass()}
+                    sideOffset={12}
+                    alignOffset={-6}
+                    avoidCollisions={false}
+                  >
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+                      One
+                    </DropdownMenu.Item>
 
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
-                    Two
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Separator className={separatorClass()} />
-                  <DropdownMenu.Sub open>
-                    <DropdownMenu.SubTrigger className={subTriggerClass()}>
-                      Submenu →
-                    </DropdownMenu.SubTrigger>
-                    <DropdownMenu.SubContent
-                      className={contentClass()}
-                      sideOffset={12}
-                      alignOffset={-6}
-                      avoidCollisions={false}
+                    <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+                      Two
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator className={separatorClass()} />
+                    <DropdownMenu.Sub open>
+                      <DropdownMenu.SubTrigger className={subTriggerClass()}>
+                        Submenu →
+                      </DropdownMenu.SubTrigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.SubContent
+                          className={contentClass()}
+                          sideOffset={12}
+                          alignOffset={-6}
+                          avoidCollisions={false}
+                        >
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('one')}
+                          >
+                            One
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('two')}
+                          >
+                            Two
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            className={itemClass()}
+                            onSelect={() => console.log('three')}
+                          >
+                            Three
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Arrow offset={14} />
+                        </DropdownMenu.SubContent>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu.Sub>
+                    <DropdownMenu.Separator className={separatorClass()} />
+                    <DropdownMenu.Item
+                      className={itemClass()}
+                      onSelect={() => console.log('three')}
                     >
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('one')}
-                      >
-                        One
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('two')}
-                      >
-                        Two
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item
-                        className={itemClass()}
-                        onSelect={() => console.log('three')}
-                      >
-                        Three
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Arrow offset={14} />
-                    </DropdownMenu.SubContent>
-                  </DropdownMenu.Sub>
-                  <DropdownMenu.Separator className={separatorClass()} />
-                  <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
-                    Three
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Arrow offset={14} />
-                </DropdownMenu.SubContent>
+                      Three
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Arrow offset={14} />
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Portal>
               </DropdownMenu.Sub>
               <DropdownMenu.Separator className={separatorClass()} />
               <DropdownMenu.Item

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -153,6 +153,25 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
 DropdownMenuTrigger.displayName = TRIGGER_NAME;
 
 /* -------------------------------------------------------------------------------------------------
+ * DropdownMenuPortal
+ * -----------------------------------------------------------------------------------------------*/
+
+const PORTAL_NAME = 'DropdownMenuPortal';
+
+type MenuPortalProps = React.ComponentPropsWithoutRef<typeof MenuPrimitive.Portal>;
+interface DropdownMenuPortalProps extends MenuPortalProps {}
+
+const DropdownMenuPortal: React.FC<DropdownMenuPortalProps> = (
+  props: ScopedProps<DropdownMenuPortalProps>
+) => {
+  const { __scopeDropdownMenu, ...portalProps } = props;
+  const menuScope = useMenuScope(__scopeDropdownMenu);
+  return <MenuPrimitive.Portal {...menuScope} {...portalProps} />;
+};
+
+DropdownMenuPortal.displayName = PORTAL_NAME;
+
+/* -------------------------------------------------------------------------------------------------
  * DropdownMenuContent
  * -----------------------------------------------------------------------------------------------*/
 
@@ -164,7 +183,7 @@ interface DropdownMenuContentProps extends MenuContentProps {}
 
 const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, DropdownMenuContentProps>(
   (props: ScopedProps<DropdownMenuContentProps>, forwardedRef) => {
-    const { __scopeDropdownMenu, portalled = true, ...contentProps } = props;
+    const { __scopeDropdownMenu, ...contentProps } = props;
     const context = useDropdownMenuContext(CONTENT_NAME, __scopeDropdownMenu);
     const menuScope = useMenuScope(__scopeDropdownMenu);
     const hasInteractedOutsideRef = React.useRef(false);
@@ -176,7 +195,6 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
         {...menuScope}
         {...contentProps}
         ref={forwardedRef}
-        portalled={portalled}
         onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
           if (!hasInteractedOutsideRef.current) context.triggerRef.current?.focus();
           hasInteractedOutsideRef.current = false;
@@ -475,6 +493,7 @@ DropdownMenuSubContent.displayName = SUB_CONTENT_NAME;
 
 const Root = DropdownMenu;
 const Trigger = DropdownMenuTrigger;
+const Portal = DropdownMenuPortal;
 const Content = DropdownMenuContent;
 const Group = DropdownMenuGroup;
 const Label = DropdownMenuLabel;
@@ -494,6 +513,7 @@ export {
   //
   DropdownMenu,
   DropdownMenuTrigger,
+  DropdownMenuPortal,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuLabel,
@@ -510,6 +530,7 @@ export {
   //
   Root,
   Trigger,
+  Portal,
   Content,
   Group,
   Label,
@@ -527,6 +548,7 @@ export {
 export type {
   DropdownMenuProps,
   DropdownMenuTriggerProps,
+  DropdownMenuPortalProps,
   DropdownMenuContentProps,
   DropdownMenuGroupProps,
   DropdownMenuLabelProps,

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -353,11 +353,7 @@ export const Animated = () => {
 
 type MenuProps = Omit<
   React.ComponentProps<typeof Menu.Root> & React.ComponentProps<typeof Menu.Content>,
-  | 'portalled'
-  | 'trapFocus'
-  | 'onCloseAutoFocus'
-  | 'disableOutsidePointerEvents'
-  | 'disableOutsideScroll'
+  'trapFocus' | 'onCloseAutoFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'
 >;
 
 const MenuWithAnchor: React.FC<MenuProps> = (props) => {
@@ -366,15 +362,16 @@ const MenuWithAnchor: React.FC<MenuProps> = (props) => {
     <Menu.Root open={open} onOpenChange={() => {}} modal={false}>
       {/* inline-block allows anchor to move when rtl changes on document */}
       <Menu.Anchor style={{ display: 'inline-block' }} />
-      <Menu.Content
-        className={contentClass()}
-        portalled
-        onCloseAutoFocus={(event) => event.preventDefault()}
-        align="start"
-        {...contentProps}
-      >
-        {children}
-      </Menu.Content>
+      <Menu.Portal>
+        <Menu.Content
+          className={contentClass()}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          align="start"
+          {...contentProps}
+        >
+          {children}
+        </Menu.Content>
+      </Menu.Portal>
     </Menu.Root>
   );
 };
@@ -396,12 +393,14 @@ const Submenu: React.FC<MenuProps & { animated: boolean; disabled?: boolean; hea
       <Menu.SubTrigger className={subTriggerClass()} disabled={disabled}>
         {heading} →
       </Menu.SubTrigger>
-      <Menu.SubContent
-        className={animated ? animatedContentClass() : contentClass()}
-        {...contentProps}
-      >
-        {children}
-      </Menu.SubContent>
+      <Menu.Portal>
+        <Menu.SubContent
+          className={animated ? animatedContentClass() : contentClass()}
+          {...contentProps}
+        >
+          {children}
+        </Menu.SubContent>
+      </Menu.Portal>
     </Menu.Sub>
   );
 };

--- a/ssr-testing/pages/dialog.tsx
+++ b/ssr-testing/pages/dialog.tsx
@@ -4,6 +4,7 @@ import {
   DialogTitle,
   DialogDescription,
   DialogTrigger,
+  DialogPortal,
   DialogOverlay,
   DialogContent,
   DialogClose,
@@ -13,12 +14,14 @@ export default function DialogPage() {
   return (
     <Dialog>
       <DialogTrigger>open</DialogTrigger>
-      <DialogOverlay />
-      <DialogContent>
-        <DialogTitle>Title</DialogTitle>
-        <DialogDescription>Description</DialogDescription>
-        <DialogClose>close</DialogClose>
-      </DialogContent>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
+          <DialogClose>close</DialogClose>
+        </DialogContent>
+      </DialogPortal>
     </Dialog>
   );
 }

--- a/ssr-testing/pages/dropdown-menu.tsx
+++ b/ssr-testing/pages/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
+  DropdownMenuPortal,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -12,17 +13,19 @@ export default function DropdownMenuPage() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>Open</DropdownMenuTrigger>
-      <DropdownMenuContent sideOffset={5}>
-        <DropdownMenuItem onSelect={() => console.log('undo')}>Undo</DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => console.log('redo')}>Redo</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem disabled onSelect={() => console.log('cut')}>
-          Cut
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => console.log('copy')}>Copy</DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => console.log('paste')}>Paste</DropdownMenuItem>
-        <DropdownMenuArrow />
-      </DropdownMenuContent>
+      <DropdownMenuPortal>
+        <DropdownMenuContent sideOffset={5}>
+          <DropdownMenuItem onSelect={() => console.log('undo')}>Undo</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => console.log('redo')}>Redo</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem disabled onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => console.log('copy')}>Copy</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => console.log('paste')}>Paste</DropdownMenuItem>
+          <DropdownMenuArrow />
+        </DropdownMenuContent>
+      </DropdownMenuPortal>
     </DropdownMenu>
   );
 }

--- a/ssr-testing/pages/hover-card.tsx
+++ b/ssr-testing/pages/hover-card.tsx
@@ -5,7 +5,6 @@ export default function HoverCardPage() {
   return (
     <HoverCard.Root>
       <HoverCard.Trigger>Hover me</HoverCard.Trigger>
-
       <HoverCard.Portal>
         <HoverCard.Content>
           <HoverCard.Arrow width={20} height={10} />


### PR DESCRIPTION
Closes #1302
Closes #1303

>**Warning**: This is based on #1306 branch because of the changes in `Popper`.
We will need to be merged in correct order, and run version check too.

> **Note**: Easier to review without whitespace

The implementation is mostly the same as what's in `Popover`, although this one has an extra level of extension through `Menu`.

**The work is done, BUT I haven't had much time to test different situations when you use the portal or not. I suspect we need to pay a bit more attention to this one, because it used to not always expose `portalled` before. Sometimes it was hardcoded (like for sub-menus), etc**

---

> **Warning**
> Breaking changes in docs:
> - new `Portal` part, with `forceMount` and `container` props, meaning default has changed (not portalled if not using new part)
> - lose `portalled` prop on `Content` (was present in some cases, not all)
> - different default for `forceMount` on `Content`
> - update demos/marketing comps