### PR TITLE
[Dialog] Allow multiple Dialog triggers with focus restoration

### DIFF
--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -7,6 +7,8 @@ export default { title: 'Components/Dialog' };
 export const Styled = () => (
   <Dialog.Root>
     <Dialog.Trigger className={triggerClass()}>open</Dialog.Trigger>
+    <Dialog.Trigger className={triggerClass()}>open</Dialog.Trigger>
+    <Dialog.Trigger className={triggerClass()}>open</Dialog.Trigger>
     <Dialog.Portal>
       <Dialog.Overlay className={overlayClass()} />
       <Dialog.Content className={contentDefaultClass()}>


### PR DESCRIPTION
Before this change if multiple dialog triggers were used the one that focus would be restored to would be somewhat random, because it would be whichever set its ref last.

After this change we get the `HTMLButtonElement` in the `Trigger`s `onClick` handler and add it to the context, so that the focus can be restored to the correct trigger element.

I added two extra trigger elements in the `Dialog/Styled` story to test with. If this seems like a good approach I can add another story for this.