### PR TITLE
Try to avoid stealing focus unnecessarily when FocusScope unmounts

### DIFF
--- a/.yarn/versions/f49db6a2.yml
+++ b/.yarn/versions/f49db6a2.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -121,6 +121,10 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
       return () => {
         container.removeEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
 
+        if (document.activeElement !== document.body) {
+          return;
+        }
+
         // We hit a react bug (fixed in v17) with focusing in unmount.
         // We need to delay the focus a little to get around it for now.
         // See: https://github.com/facebook/react/issues/17894


### PR DESCRIPTION
### Description

I'm not super sure if this is the correct thing to do or if the solution is complete - I treat this PR as a conversation starter.

I was fixing an issue yesterday in our app that turned out to be about ContextMenu "stealing" our focus. We have a context menu with a "Rename" option and when that gets clicked we focus some input - the problem was that ContextMenu was focusing on another element, the one that was focused before the ContextMenu was opened, in an attempt to "restore focus".

In this scenario, this didn't make sense so I was able to workaround the issue on our side using `ev.preventDefault()` from within a handler for your custom event. I think that, in general, restoring focus when working with a context menu is rarely something that is intended to happen. Even if there is a specific trigger element for the context menu (in opposed to a situation when a context menu is acting like a "catch all" for a bigger container) then I think that what would be better is to move focus to that trigger element. There are probably cases when right-clicking on a trigger wont actually move focus to it so it might not be recorded as `previouslyFocusedElement`. I don't have any concrete examples for this at hand though (we could `preventDefault` the associated events to achieve this though).

So I got thinking that this could be fixed for the ContextMenu but I've figured out that perhaps a more generic solution could be applied in the FocusScope itself... so to the best of my understanding, the whole problem with focus restoration is that we need to move focus back to a triggering element, especially during keyboard navigations and that this usually happens when a focusable container (like menu, dialog, etc) where the focus currently is gets unmounted. The important bit is that when a focused element gets removed then the focus is being automatically moved to `document.body` by browsers. However, I can't find any scenario in which it would be desirable to "restore focus" when we have a better candidate for the active element, when the focus was already moved to another element - either programmatically, or even manually with a pointer device. At it seems to me that this is always the case when `document.activeElement !== document.body` but maybe I'm missing something.

This kind of a check (although more robust, to handle some other cases) is also already implemented in some other a11y-focused libraries, like Ariakit:
https://github.com/ariakit/ariakit/blob/29cdaad109485e3edf58d4763e850502c019cc3f/packages/ariakit/src/dialog/dialog.tsx#L291