### PR TITLE
[Menu][Popover][Select] Minimise number of extra divs

### DIFF
--- a/.yarn/versions/19f95876.yml
+++ b/.yarn/versions/19f95876.yml
@@ -1,0 +1,9 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -7,6 +7,7 @@ import { Portal } from '@radix-ui/react-portal';
 import { FocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+import { Slot } from '@radix-ui/react-slot';
 
 type DismissableLayerProps = React.ComponentProps<typeof DismissableLayer>;
 type FocusScopeProps = React.ComponentProps<typeof FocusScope>;
@@ -502,7 +503,7 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
             />
           </Portal>
           <Portal>
-            <RemoveScroll>
+            <RemoveScroll as={Slot}>
               <DismissableLayer
                 asChild
                 disableOutsidePointerEvents

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-roving-focus": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "2.5.4"

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
-import { RemoveScroll } from 'react-remove-scroll';
-import { hideOthers } from 'aria-hidden';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
+import { useDirection } from '@radix-ui/react-direction';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { FocusScope } from '@radix-ui/react-focus-scope';
-import { Presence } from '@radix-ui/react-presence';
-import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
+import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
 import { UnstablePortal } from '@radix-ui/react-portal';
+import { Presence } from '@radix-ui/react-presence';
+import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
-import { useDirection } from '@radix-ui/react-direction';
+import { Slot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
-import { useFocusGuards } from '@radix-ui/react-focus-guards';
-import { useId } from '@radix-ui/react-id';
+import { hideOthers } from 'aria-hidden';
+import { RemoveScroll } from 'react-remove-scroll';
 
 import type * as Radix from '@radix-ui/react-primitive';
 import type { Scope } from '@radix-ui/react-context';
@@ -398,7 +399,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
 
     const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
     const scrollLockWrapperProps = disableOutsideScroll
-      ? { allowPinchZoom: rootContext.allowPinchZoom }
+      ? { as: Slot, allowPinchZoom: rootContext.allowPinchZoom }
       : undefined;
 
     const handleTypeaheadSearch = (key: string) => {
@@ -440,35 +441,35 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
     }, []);
 
     return (
-      <ScrollLockWrapper {...scrollLockWrapperProps}>
-        <MenuContentProvider
-          scope={__scopeMenu}
-          searchRef={searchRef}
-          onItemEnter={React.useCallback(
-            (event) => {
-              if (isPointerMovingToSubmenu(event)) event.preventDefault();
-            },
-            [isPointerMovingToSubmenu]
-          )}
-          onItemLeave={React.useCallback(
-            (event) => {
-              if (isPointerMovingToSubmenu(event)) return;
-              contentRef.current?.focus();
-              setCurrentItemId(null);
-            },
-            [isPointerMovingToSubmenu]
-          )}
-          onTriggerLeave={React.useCallback(
-            (event) => {
-              if (isPointerMovingToSubmenu(event)) event.preventDefault();
-            },
-            [isPointerMovingToSubmenu]
-          )}
-          pointerGraceTimerRef={pointerGraceTimerRef}
-          onPointerGraceIntentChange={React.useCallback((intent) => {
-            pointerGraceIntentRef.current = intent;
-          }, [])}
-        >
+      <MenuContentProvider
+        scope={__scopeMenu}
+        searchRef={searchRef}
+        onItemEnter={React.useCallback(
+          (event) => {
+            if (isPointerMovingToSubmenu(event)) event.preventDefault();
+          },
+          [isPointerMovingToSubmenu]
+        )}
+        onItemLeave={React.useCallback(
+          (event) => {
+            if (isPointerMovingToSubmenu(event)) return;
+            contentRef.current?.focus();
+            setCurrentItemId(null);
+          },
+          [isPointerMovingToSubmenu]
+        )}
+        onTriggerLeave={React.useCallback(
+          (event) => {
+            if (isPointerMovingToSubmenu(event)) event.preventDefault();
+          },
+          [isPointerMovingToSubmenu]
+        )}
+        pointerGraceTimerRef={pointerGraceTimerRef}
+        onPointerGraceIntentChange={React.useCallback((intent) => {
+          pointerGraceIntentRef.current = intent;
+        }, [])}
+      >
+        <ScrollLockWrapper {...scrollLockWrapperProps}>
           <FocusScope
             asChild
             trapped={trapFocus}
@@ -558,8 +559,8 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
               </RovingFocusGroup.Root>
             </DismissableLayer>
           </FocusScope>
-        </MenuContentProvider>
-      </ScrollLockWrapper>
+        </ScrollLockWrapper>
+      </MenuContentProvider>
     );
   }
 );

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
     "react-remove-scroll": "2.5.4"

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -2,18 +2,19 @@ import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
-import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+import { useFocusGuards } from '@radix-ui/react-focus-guards';
+import { FocusScope } from '@radix-ui/react-focus-scope';
+import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
-import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
-import { FocusScope } from '@radix-ui/react-focus-scope';
 import { UnstablePortal } from '@radix-ui/react-portal';
-import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
-import { useId } from '@radix-ui/react-id';
-import { RemoveScroll } from 'react-remove-scroll';
+import { Slot } from '@radix-ui/react-slot';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { hideOthers } from 'aria-hidden';
+import { RemoveScroll } from 'react-remove-scroll';
 
 import type * as Radix from '@radix-ui/react-primitive';
 import type { Scope } from '@radix-ui/react-context';
@@ -261,7 +262,7 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
     }, []);
 
     return (
-      <RemoveScroll allowPinchZoom={context.allowPinchZoom}>
+      <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
         <PopoverContentImpl
           {...props}
           ref={composedRefs}

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-label": "workspace:*",
     "@radix-ui/react-portal": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*",

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -5,13 +5,14 @@ import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
+import { useDirection } from '@radix-ui/react-direction';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import { useLabelContext } from '@radix-ui/react-label';
 import { Portal } from '@radix-ui/react-portal';
 import { Primitive } from '@radix-ui/react-primitive';
-import { useDirection } from '@radix-ui/react-direction';
+import { Slot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
@@ -717,7 +718,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         searchRef={searchRef}
       >
         <Portal>
-          <RemoveScroll>
+          <RemoveScroll as={Slot}>
             <div
               ref={setContentWrapper}
               style={{ display: 'flex', flexDirection: 'column', position: 'fixed', zIndex: 0 }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,6 +3394,7 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-roving-focus": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: 2.5.4
@@ -3444,6 +3445,7 @@ __metadata:
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: ^1.1.1
     react-remove-scroll: 2.5.4
@@ -3605,6 +3607,7 @@ __metadata:
     "@radix-ui/react-label": "workspace:*"
     "@radix-ui/react-portal": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
+    "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     "@radix-ui/react-use-layout-effect": "workspace:*"


### PR DESCRIPTION
> **Note**: Easier to review without whitespace.

I realised a [change](https://github.com/radix-ui/primitives/pull/936/files#r736472636) we made to `Dialog` a long time ago wasn't carried over to other components.

Essentially this uses the fact that `RemoveScroll` has an `as` prop, combining it with our `Slot` to remove the extra wrapping div added by `RemoveScroll` without losing its functionality, essentially attaching it to our content element (or its wrapper).