### PR TITLE
[Select] Bring parity with other primitives

### DIFF
--- a/.yarn/versions/5b3099df.yml
+++ b/.yarn/versions/5b3099df.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives
+  - ssr-testing

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-direction": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",
+    "@radix-ui/react-focus-guards": "workspace:*",
     "@radix-ui/react-focus-scope": "workspace:*",
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-label": "workspace:*",

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -16,34 +16,36 @@ export const Styled = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.Viewport className={viewportClass()}>
-            <Select.Item className={itemClass()} value="one">
-              <Select.ItemText>
-                One<span aria-hidden> 👍</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="two">
-              <Select.ItemText>
-                Two<span aria-hidden> 👌</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="three">
-              <Select.ItemText>
-                Three<span aria-hidden> 🤘</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-          </Select.Viewport>
-        </Select.Content>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.Viewport className={viewportClass()}>
+              <Select.Item className={itemClass()} value="one">
+                <Select.ItemText>
+                  One<span aria-hidden> 👍</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="two">
+                <Select.ItemText>
+                  Two<span aria-hidden> 👌</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="three">
+                <Select.ItemText>
+                  Three<span aria-hidden> 🤘</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -72,34 +74,36 @@ export const Controlled = () => {
             </Select.Value>
             <Select.Icon />
           </Select.Trigger>
-          <Select.Content className={contentClass()}>
-            <Select.Viewport className={viewportClass()}>
-              <Select.Item className={itemClass()} value="fr">
-                <Select.ItemText>
-                  France<span aria-hidden> 🇫🇷</span>
-                </Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-              <Select.Item className={itemClass()} value="uk">
-                <Select.ItemText>
-                  United Kingdom<span aria-hidden> 🇬🇧</span>
-                </Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-              <Select.Item className={itemClass()} value="es">
-                <Select.ItemText>
-                  Spain<span aria-hidden> 🇪🇸</span>
-                </Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-            </Select.Viewport>
-          </Select.Content>
+          <Select.Portal>
+            <Select.Content className={contentClass()}>
+              <Select.Viewport className={viewportClass()}>
+                <Select.Item className={itemClass()} value="fr">
+                  <Select.ItemText>
+                    France<span aria-hidden> 🇫🇷</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="uk">
+                  <Select.ItemText>
+                    United Kingdom<span aria-hidden> 🇬🇧</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="es">
+                  <Select.ItemText>
+                    Spain<span aria-hidden> 🇪🇸</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
         </Select.Root>
       </Label>
     </div>
@@ -123,28 +127,30 @@ export const Position = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-          <Select.Viewport className={viewportClass()}>
-            {Array.from({ length: 50 }, (_, i) => {
-              const value = `item-${i + 1}`;
-              return (
-                <Select.Item
-                  key={value}
-                  className={itemClass()}
-                  value={value}
-                  disabled={i > 5 && i < 9}
-                >
-                  <Select.ItemText>item {i + 1}</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              );
-            })}
-          </Select.Viewport>
-          <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-        </Select.Content>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+            <Select.Viewport className={viewportClass()}>
+              {Array.from({ length: 50 }, (_, i) => {
+                const value = `item-${i + 1}`;
+                return (
+                  <Select.Item
+                    key={value}
+                    className={itemClass()}
+                    value={value}
+                    disabled={i > 5 && i < 9}
+                  >
+                    <Select.ItemText>item {i + 1}</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                );
+              })}
+            </Select.Viewport>
+            <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -159,28 +165,30 @@ export const NoDefaultValue = () => (
           <Select.Value placeholder="Pick an option" />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.Viewport className={viewportClass()}>
-            <Select.Item className={itemClass()} value="one" disabled>
-              <Select.ItemText>One</Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="two">
-              <Select.ItemText>Two</Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="three">
-              <Select.ItemText>Three</Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-          </Select.Viewport>
-        </Select.Content>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.Viewport className={viewportClass()}>
+              <Select.Item className={itemClass()} value="one" disabled>
+                <Select.ItemText>One</Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="two">
+                <Select.ItemText>Two</Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="three">
+                <Select.ItemText>Three</Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -195,22 +203,24 @@ export const Typeahead = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-          <Select.Viewport className={viewportClass()}>
-            {foodGroups.map((foodGroup) =>
-              foodGroup.foods.map((food) => (
-                <Select.Item key={food.value} className={itemClass()} value={food.value}>
-                  <Select.ItemText>{food.label}</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              ))
-            )}
-          </Select.Viewport>
-          <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-        </Select.Content>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+            <Select.Viewport className={viewportClass()}>
+              {foodGroups.map((foodGroup) =>
+                foodGroup.foods.map((food) => (
+                  <Select.Item key={food.value} className={itemClass()} value={food.value}>
+                    <Select.ItemText>{food.label}</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                ))
+              )}
+            </Select.Viewport>
+            <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -225,41 +235,43 @@ export const WithGroups = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-          <Select.Viewport className={viewportClass()}>
-            {foodGroups.map((foodGroup, index) => {
-              const hasLabel = foodGroup.label !== undefined;
-              return (
-                <React.Fragment key={index}>
-                  <Select.Group className={groupStyles()}>
-                    {hasLabel && (
-                      <Select.Label className={labelClass()} key={foodGroup.label}>
-                        {foodGroup.label}
-                      </Select.Label>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+            <Select.Viewport className={viewportClass()}>
+              {foodGroups.map((foodGroup, index) => {
+                const hasLabel = foodGroup.label !== undefined;
+                return (
+                  <React.Fragment key={index}>
+                    <Select.Group className={groupStyles()}>
+                      {hasLabel && (
+                        <Select.Label className={labelClass()} key={foodGroup.label}>
+                          {foodGroup.label}
+                        </Select.Label>
+                      )}
+                      {foodGroup.foods.map((food) => (
+                        <Select.Item
+                          key={food.value}
+                          className={hasLabel ? itemInGroupClass() : itemClass()}
+                          value={food.value}
+                        >
+                          <Select.ItemText>{food.label}</Select.ItemText>
+                          <Select.ItemIndicator className={indicatorClass()}>
+                            <TickIcon />
+                          </Select.ItemIndicator>
+                        </Select.Item>
+                      ))}
+                    </Select.Group>
+                    {index < foodGroups.length - 1 && (
+                      <Select.Separator className={separatorClass()} />
                     )}
-                    {foodGroup.foods.map((food) => (
-                      <Select.Item
-                        key={food.value}
-                        className={hasLabel ? itemInGroupClass() : itemClass()}
-                        value={food.value}
-                      >
-                        <Select.ItemText>{food.label}</Select.ItemText>
-                        <Select.ItemIndicator className={indicatorClass()}>
-                          <TickIcon />
-                        </Select.ItemIndicator>
-                      </Select.Item>
-                    ))}
-                  </Select.Group>
-                  {index < foodGroups.length - 1 && (
-                    <Select.Separator className={separatorClass()} />
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </Select.Viewport>
-          <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-        </Select.Content>
+                  </React.Fragment>
+                );
+              })}
+            </Select.Viewport>
+            <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -267,28 +279,30 @@ export const WithGroups = () => (
 
 export const Labelling = () => {
   const content = (
-    <Select.Content className={contentClass()}>
-      <Select.Viewport className={viewportClass()}>
-        <Select.Item className={itemClass()} value="0-18">
-          <Select.ItemText>0 to 18</Select.ItemText>
-          <Select.ItemIndicator className={indicatorClass()}>
-            <TickIcon />
-          </Select.ItemIndicator>
-        </Select.Item>
-        <Select.Item className={itemClass()} value="18-40">
-          <Select.ItemText>18 to 40</Select.ItemText>
-          <Select.ItemIndicator className={indicatorClass()}>
-            <TickIcon />
-          </Select.ItemIndicator>
-        </Select.Item>
-        <Select.Item className={itemClass()} value="40+">
-          <Select.ItemText>Over 40</Select.ItemText>
-          <Select.ItemIndicator className={indicatorClass()}>
-            <TickIcon />
-          </Select.ItemIndicator>
-        </Select.Item>
-      </Select.Viewport>
-    </Select.Content>
+    <Select.Portal>
+      <Select.Content className={contentClass()}>
+        <Select.Viewport className={viewportClass()}>
+          <Select.Item className={itemClass()} value="0-18">
+            <Select.ItemText>0 to 18</Select.ItemText>
+            <Select.ItemIndicator className={indicatorClass()}>
+              <TickIcon />
+            </Select.ItemIndicator>
+          </Select.Item>
+          <Select.Item className={itemClass()} value="18-40">
+            <Select.ItemText>18 to 40</Select.ItemText>
+            <Select.ItemIndicator className={indicatorClass()}>
+              <TickIcon />
+            </Select.ItemIndicator>
+          </Select.Item>
+          <Select.Item className={itemClass()} value="40+">
+            <Select.ItemText>Over 40</Select.ItemText>
+            <Select.ItemIndicator className={indicatorClass()}>
+              <TickIcon />
+            </Select.ItemIndicator>
+          </Select.Item>
+        </Select.Viewport>
+      </Select.Content>
+    </Select.Portal>
   );
   return (
     <div style={{ padding: 50 }}>
@@ -345,34 +359,36 @@ export const RightToLeft = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Content className={contentClass()}>
-          <Select.Viewport className={viewportClass()}>
-            <Select.Item className={itemClass()} value="one">
-              <Select.ItemText>
-                تفاح<span aria-hidden> 🍎</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="two">
-              <Select.ItemText>
-                حفنة من الموز<span aria-hidden> 🍌</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item className={itemClass()} value="three">
-              <Select.ItemText>
-                الفراولة<span aria-hidden> 🍓</span>
-              </Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-          </Select.Viewport>
-        </Select.Content>
+        <Select.Portal>
+          <Select.Content className={contentClass()}>
+            <Select.Viewport className={viewportClass()}>
+              <Select.Item className={itemClass()} value="one">
+                <Select.ItemText>
+                  تفاح<span aria-hidden> 🍎</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="two">
+                <Select.ItemText>
+                  حفنة من الموز<span aria-hidden> 🍌</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={itemClass()} value="three">
+                <Select.ItemText>
+                  الفراولة<span aria-hidden> 🍓</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
       </Select.Root>
     </Label>
   </div>
@@ -407,28 +423,30 @@ export const WithinForm = () => {
             <Select.Value />
             <Select.Icon />
           </Select.Trigger>
-          <Select.Content className={contentClass()}>
-            <Select.Viewport className={viewportClass()}>
-              <Select.Item className={itemClass()} value="fr">
-                <Select.ItemText>France</Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-              <Select.Item className={itemClass()} value="uk">
-                <Select.ItemText>United Kingdom</Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-              <Select.Item className={itemClass()} value="es">
-                <Select.ItemText>Spain</Select.ItemText>
-                <Select.ItemIndicator className={indicatorClass()}>
-                  <TickIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-            </Select.Viewport>
-          </Select.Content>
+          <Select.Portal>
+            <Select.Content className={contentClass()}>
+              <Select.Viewport className={viewportClass()}>
+                <Select.Item className={itemClass()} value="fr">
+                  <Select.ItemText>France</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="uk">
+                  <Select.ItemText>United Kingdom</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="es">
+                  <Select.ItemText>Spain</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
         </Select.Root>
       </Label>
       <br />
@@ -451,20 +469,24 @@ export const WithinDialog = () => (
             <Select.Value />
             <Select.Icon />
           </Select.Trigger>
-          <Select.Content className={contentClass()}>
-            <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-            <Select.Viewport className={viewportClass()}>
-              {Array.from({ length: 30 }, (_, i) => (
-                <Select.Item key={i} className={itemClass()} value={String(i)}>
-                  <Select.ItemText>Item {i}</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              ))}
-            </Select.Viewport>
-            <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-          </Select.Content>
+          <Select.Portal>
+            <Select.Content className={contentClass()}>
+              <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+              <Select.Viewport className={viewportClass()}>
+                {Array.from({ length: 30 }, (_, i) => (
+                  <Select.Item key={i} className={itemClass()} value={String(i)}>
+                    <Select.ItemText>Item {i}</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                ))}
+              </Select.Viewport>
+              <Select.ScrollDownButton className={scrollDownButtonClass()}>
+                ▼
+              </Select.ScrollDownButton>
+            </Select.Content>
+          </Select.Portal>
         </Select.Root>
       </Label>
       <Dialog.Close>Close Dialog</Dialog.Close>
@@ -526,20 +548,22 @@ export const ChromaticNoDefaultValue = () => (
         <Select.Value />
         <Select.Icon />
       </Select.Trigger>
-      <Select.Content className={contentClass()} style={{ opacity: 0.7 }}>
-        <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-        <Select.Viewport className={viewportClass()}>
-          {Array.from({ length: 10 }, (_, i) => (
-            <Select.Item key={i} className={itemClass()} value={String(i)} disabled={i < 5}>
-              <Select.ItemText>{String(i)}</Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-          ))}
-        </Select.Viewport>
-        <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-      </Select.Content>
+      <Select.Portal>
+        <Select.Content className={contentClass()} style={{ opacity: 0.7 }}>
+          <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+          <Select.Viewport className={viewportClass()}>
+            {Array.from({ length: 10 }, (_, i) => (
+              <Select.Item key={i} className={itemClass()} value={String(i)} disabled={i < 5}>
+                <Select.ItemText>{String(i)}</Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+          <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+        </Select.Content>
+      </Select.Portal>
     </Select.Root>
 
     <Select.Root open>
@@ -547,20 +571,22 @@ export const ChromaticNoDefaultValue = () => (
         <Select.Value placeholder="Pick an option" />
         <Select.Icon />
       </Select.Trigger>
-      <Select.Content className={contentClass()} style={{ opacity: 0.7 }}>
-        <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
-        <Select.Viewport className={viewportClass()}>
-          {Array.from({ length: 10 }, (_, i) => (
-            <Select.Item key={i} className={itemClass()} value={String(i)} disabled={i < 5}>
-              <Select.ItemText>{String(i)}</Select.ItemText>
-              <Select.ItemIndicator className={indicatorClass()}>
-                <TickIcon />
-              </Select.ItemIndicator>
-            </Select.Item>
-          ))}
-        </Select.Viewport>
-        <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
-      </Select.Content>
+      <Select.Portal>
+        <Select.Content className={contentClass()} style={{ opacity: 0.7 }}>
+          <Select.ScrollUpButton className={scrollUpButtonClass()}>▲</Select.ScrollUpButton>
+          <Select.Viewport className={viewportClass()}>
+            {Array.from({ length: 10 }, (_, i) => (
+              <Select.Item key={i} className={itemClass()} value={String(i)} disabled={i < 5}>
+                <Select.ItemText>{String(i)}</Select.ItemText>
+                <Select.ItemIndicator className={indicatorClass()}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+          <Select.ScrollDownButton className={scrollDownButtonClass()}>▼</Select.ScrollDownButton>
+        </Select.Content>
+      </Select.Portal>
     </Select.Root>
   </div>
 );
@@ -591,28 +617,30 @@ export const Cypress = () => {
               <Select.Value />
               <Select.Icon />
             </Select.Trigger>
-            <Select.Content className={contentClass()}>
-              <Select.Viewport className={viewportClass()}>
-                <Select.Item className={itemClass()} value="S">
-                  <Select.ItemText>Small</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-                <Select.Item className={itemClass()} value="M">
-                  <Select.ItemText>Medium</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-                <Select.Item className={itemClass()} value="L">
-                  <Select.ItemText>Large</Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              </Select.Viewport>
-            </Select.Content>
+            <Select.Portal>
+              <Select.Content className={contentClass()}>
+                <Select.Viewport className={viewportClass()}>
+                  <Select.Item className={itemClass()} value="S">
+                    <Select.ItemText>Small</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={itemClass()} value="M">
+                    <Select.ItemText>Medium</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={itemClass()} value="L">
+                    <Select.ItemText>Large</Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                </Select.Viewport>
+              </Select.Content>
+            </Select.Portal>
           </Select.Root>
         </Label>
         <button type="submit">buy</button>
@@ -639,33 +667,35 @@ const ChromaticSelect = React.forwardRef<
       <Select.Value />
       <Select.Icon />
     </Select.Trigger>
-    <Select.Content
-      className={paddedElement === 'content' ? contentClassWithPadding() : contentClass()}
-      style={{ opacity: 0.7 }}
-    >
-      <Select.ScrollUpButton
-        className={scrollUpButtonClass()}
-        style={paddedElement === 'content' ? { marginTop: -5 } : undefined}
+    <Select.Portal>
+      <Select.Content
+        className={paddedElement === 'content' ? contentClassWithPadding() : contentClass()}
+        style={{ opacity: 0.7 }}
       >
-        ▲
-      </Select.ScrollUpButton>
-      <Select.Viewport className={paddedElement === 'viewport' ? viewportClass() : undefined}>
-        {Array.from({ length: count }, (_, i) => (
-          <Select.Item key={i} className={itemClass()} value={String(i)}>
-            <Select.ItemText>{String(i)}</Select.ItemText>
-            <Select.ItemIndicator className={indicatorClass()}>
-              <TickIcon />
-            </Select.ItemIndicator>
-          </Select.Item>
-        ))}
-      </Select.Viewport>
-      <Select.ScrollDownButton
-        className={scrollDownButtonClass()}
-        style={paddedElement === 'content' ? { marginBottom: -5 } : undefined}
-      >
-        ▼
-      </Select.ScrollDownButton>
-    </Select.Content>
+        <Select.ScrollUpButton
+          className={scrollUpButtonClass()}
+          style={paddedElement === 'content' ? { marginTop: -5 } : undefined}
+        >
+          ▲
+        </Select.ScrollUpButton>
+        <Select.Viewport className={paddedElement === 'viewport' ? viewportClass() : undefined}>
+          {Array.from({ length: count }, (_, i) => (
+            <Select.Item key={i} className={itemClass()} value={String(i)}>
+              <Select.ItemText>{String(i)}</Select.ItemText>
+              <Select.ItemIndicator className={indicatorClass()}>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+          ))}
+        </Select.Viewport>
+        <Select.ScrollDownButton
+          className={scrollDownButtonClass()}
+          style={paddedElement === 'content' ? { marginBottom: -5 } : undefined}
+        >
+          ▼
+        </Select.ScrollDownButton>
+      </Select.Content>
+    </Select.Portal>
   </Select.Root>
 ));
 

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -834,6 +834,8 @@ const contentClass = css({
   position: 'relative',
   overflow: 'hidden',
   '&:focus-within': { borderColor: '$black' },
+
+  zIndex: 100,
 });
 
 const contentClassWithPadding = css(contentClass, {

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -834,8 +834,6 @@ const contentClass = css({
   position: 'relative',
   overflow: 'hidden',
   '&:focus-within': { borderColor: '$black' },
-
-  zIndex: 100,
 });
 
 const contentClassWithPadding = css(contentClass, {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -470,6 +470,11 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     // the last element in the DOM (because of the `Portal`)
     useFocusGuards();
 
+    const [contentZIndex, setContentZIndex] = React.useState<string>();
+    useLayoutEffect(() => {
+      if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
+    }, [content]);
+
     const focusFirst = React.useCallback(
       (candidates: Array<HTMLElement | null>) => {
         const [firstItem, ...restItems] = getItems().map((item) => item.ref.current);
@@ -751,7 +756,12 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
           <div
             ref={setContentWrapper}
-            style={{ display: 'flex', flexDirection: 'column', position: 'fixed', zIndex: 0 }}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'fixed',
+              zIndex: contentZIndex,
+            }}
           >
             <FocusScope
               asChild

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -63,10 +63,12 @@ type SelectContextValue = {
   name: SelectProps['name'];
   autoComplete: SelectProps['autoComplete'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
+  allowPinchZoom: SelectProps['allowPinchZoom'];
 };
 
 const [SelectProvider, useSelectContext] = createSelectContext<SelectContextValue>(SELECT_NAME);
 
+type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface SelectProps {
   children?: React.ReactNode;
   value?: string;
@@ -78,6 +80,10 @@ interface SelectProps {
   dir?: Direction;
   name?: string;
   autoComplete?: string;
+  /**
+   * @see https://github.com/theKashey/react-remove-scroll#usage
+   */
+  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -93,6 +99,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     dir,
     name,
     autoComplete,
+    allowPinchZoom,
   } = props;
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
   const [valueNode, setValueNode] = React.useState<SelectValueElement | null>(null);
@@ -128,6 +135,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
       name={name}
       autoComplete={autoComplete}
       triggerPointerDownPosRef={triggerPointerDownPosRef}
+      allowPinchZoom={allowPinchZoom}
     >
       <Collection.Provider scope={__scopeSelect}>{children}</Collection.Provider>
     </SelectProvider>
@@ -723,7 +731,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         searchRef={searchRef}
       >
         <Portal>
-          <RemoveScroll as={Slot}>
+          <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
             <div
               ref={setContentWrapper}
               style={{ display: 'flex', flexDirection: 'column', position: 'fixed', zIndex: 0 }}

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -7,6 +7,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useDirection } from '@radix-ui/react-direction';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import { useLabelContext } from '@radix-ui/react-label';
@@ -438,6 +439,10 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     React.useEffect(() => {
       if (content) return hideOthers(content);
     }, [content]);
+
+    // Make sure the whole tree has focus guards as our `Select` may be
+    // the last element in the DOM (because of the `Portal`)
+    useFocusGuards();
 
     const focusFirst = React.useCallback(
       (candidates: Array<HTMLElement | null>) => {

--- a/ssr-testing/pages/select.tsx
+++ b/ssr-testing/pages/select.tsx
@@ -9,32 +9,7 @@ export default function SelectPage() {
           <Select.Value />
           <Select.Icon>▼</Select.Icon>
         </Select.Trigger>
-        <Select.Content>
-          <Select.ScrollUpButton>▲</Select.ScrollUpButton>
-          <Select.Viewport>
-            <Select.Item value="1">
-              <Select.ItemText>Item 1</Select.ItemText>
-              <Select.ItemIndicator>✔</Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item value="2">
-              <Select.ItemText>Item 2</Select.ItemText>
-              <Select.ItemIndicator>✔</Select.ItemIndicator>
-            </Select.Item>
-            <Select.Item value="3">
-              <Select.ItemText>Item 3</Select.ItemText>
-              <Select.ItemIndicator>✔</Select.ItemIndicator>
-            </Select.Item>
-          </Select.Viewport>
-          <Select.ScrollDownButton>▼</Select.ScrollDownButton>
-        </Select.Content>
-      </Select.Root>
-
-      <form>
-        <Select.Root>
-          <Select.Trigger>
-            <Select.Value placeholder="Pick an option" />
-            <Select.Icon>▼</Select.Icon>
-          </Select.Trigger>
+        <Select.Portal>
           <Select.Content>
             <Select.ScrollUpButton>▲</Select.ScrollUpButton>
             <Select.Viewport>
@@ -53,6 +28,35 @@ export default function SelectPage() {
             </Select.Viewport>
             <Select.ScrollDownButton>▼</Select.ScrollDownButton>
           </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+
+      <form>
+        <Select.Root>
+          <Select.Trigger>
+            <Select.Value placeholder="Pick an option" />
+            <Select.Icon>▼</Select.Icon>
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content>
+              <Select.ScrollUpButton>▲</Select.ScrollUpButton>
+              <Select.Viewport>
+                <Select.Item value="1">
+                  <Select.ItemText>Item 1</Select.ItemText>
+                  <Select.ItemIndicator>✔</Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item value="2">
+                  <Select.ItemText>Item 2</Select.ItemText>
+                  <Select.ItemIndicator>✔</Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item value="3">
+                  <Select.ItemText>Item 3</Select.ItemText>
+                  <Select.ItemIndicator>✔</Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+              <Select.ScrollDownButton>▼</Select.ScrollDownButton>
+            </Select.Content>
+          </Select.Portal>
         </Select.Root>
       </form>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,6 +3602,7 @@ __metadata:
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-direction": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"
+    "@radix-ui/react-focus-guards": "workspace:*"
     "@radix-ui/react-focus-scope": "workspace:*"
     "@radix-ui/react-id": "workspace:*"
     "@radix-ui/react-label": "workspace:*"


### PR DESCRIPTION
> **Note**: Easier to review without whitespace. Might be even easier commit by commit.

- Add missing focus guards https://github.com/radix-ui/primitives/commit/e88481cdbcac53b8de93e7f0fde82353faafd1e3
- Add support for `allowPinchZoom` https://github.com/radix-ui/primitives/commit/96dcffaa847be3b60355da4faab0d344847224e3
- Expose new portal part https://github.com/radix-ui/primitives/commit/43cb78a5b763c1557885cad279b64c21581d53f4
- Copy z-index to wrapper https://github.com/radix-ui/primitives/commit/41ed89b59618ba494010088bc9056fb618ee015d

---

> **Warning**
> Breaking changes in docs:
> - new `Portal` part, with `container` prop
> - manual z-index management
> - update demos/marketing comps