### PR TITLE
[Portal] Kill old portal and replace with new one

### DIFF
--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -6,7 +6,7 @@ import { useId } from '@radix-ui/react-id';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
@@ -136,7 +136,7 @@ const [PortalProvider, usePortalContext] = createDialogContext<PortalContextValu
   forceMount: undefined,
 });
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface DialogPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
@@ -153,9 +153,9 @@ const DialogPortal: React.FC<DialogPortalProps> = (props: ScopedProps<DialogPort
     <PortalProvider scope={__scopeDialog} forceMount={forceMount}>
       {React.Children.map(children, (child) => (
         <Presence present={forceMount || context.open}>
-          <UnstablePortal asChild container={container}>
+          <PortalPrimitive asChild container={container}>
             {child}
-          </UnstablePortal>
+          </PortalPrimitive>
         </Presence>
       ))}
     </PortalProvider>

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import * as Popper from '@radix-ui/react-popper';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal } from '@radix-ui/react-portal';
 import { FocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -488,7 +488,7 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
       </button>
       {open ? (
         <FocusGuards>
-          <UnstablePortal asChild>
+          <Portal asChild>
             <div
               style={{
                 position: 'fixed',
@@ -501,8 +501,8 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
                 opacity: 0.2,
               }}
             />
-          </UnstablePortal>
-          <UnstablePortal asChild>
+          </Portal>
+          <Portal asChild>
             <RemoveScroll as={Slot}>
               <DismissableLayer
                 asChild
@@ -537,7 +537,7 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
                 </FocusScope>
               </DismissableLayer>
             </RemoveScroll>
-          </UnstablePortal>
+          </Portal>
         </FocusGuards>
       ) : null}
     </>
@@ -584,7 +584,7 @@ function DummyPopover({
       {open ? (
         <FocusGuards>
           <ScrollContainer {...scrollLockWrapperProps}>
-            <UnstablePortal asChild>
+            <Portal asChild>
               <DismissableLayer
                 asChild
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
@@ -636,7 +636,7 @@ function DummyPopover({
                   </Popper.Content>
                 </FocusScope>
               </DismissableLayer>
-            </UnstablePortal>
+            </Portal>
           </ScrollContainer>
         </FocusGuards>
       ) : null}

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import * as Popper from '@radix-ui/react-popper';
-import { Portal } from '@radix-ui/react-portal';
+import { UnstablePortal } from '@radix-ui/react-portal';
 import { FocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -488,7 +488,7 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
       </button>
       {open ? (
         <FocusGuards>
-          <Portal>
+          <UnstablePortal asChild>
             <div
               style={{
                 position: 'fixed',
@@ -501,8 +501,8 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
                 opacity: 0.2,
               }}
             />
-          </Portal>
-          <Portal>
+          </UnstablePortal>
+          <UnstablePortal asChild>
             <RemoveScroll as={Slot}>
               <DismissableLayer
                 asChild
@@ -537,7 +537,7 @@ function DummyDialog({ children, openLabel = 'Open', closeLabel = 'Close' }: Dum
                 </FocusScope>
               </DismissableLayer>
             </RemoveScroll>
-          </Portal>
+          </UnstablePortal>
         </FocusGuards>
       ) : null}
     </>
@@ -572,6 +572,8 @@ function DummyPopover({
   const [open, setOpen] = React.useState(false);
   const openButtonRef = React.useRef(null);
   const ScrollContainer = preventScroll ? RemoveScroll : React.Fragment;
+  const scrollLockWrapperProps = preventScroll ? { as: Slot } : undefined;
+
   return (
     <Popper.Root>
       <Popper.Anchor asChild>
@@ -581,8 +583,8 @@ function DummyPopover({
       </Popper.Anchor>
       {open ? (
         <FocusGuards>
-          <Portal>
-            <ScrollContainer>
+          <ScrollContainer {...scrollLockWrapperProps}>
+            <UnstablePortal asChild>
               <DismissableLayer
                 asChild
                 disableOutsidePointerEvents={disableOutsidePointerEvents}
@@ -634,8 +636,8 @@ function DummyPopover({
                   </Popper.Content>
                 </FocusScope>
               </DismissableLayer>
-            </ScrollContainer>
-          </Portal>
+            </UnstablePortal>
+          </ScrollContainer>
         </FocusGuards>
       ) : null}
     </Popper.Root>

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -5,7 +5,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -147,7 +147,7 @@ const [PortalProvider, usePortalContext] = createHoverCardContext<PortalContextV
   forceMount: undefined,
 });
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface HoverCardPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
@@ -165,9 +165,9 @@ const HoverCardPortal: React.FC<HoverCardPortalProps> = (
   return (
     <PortalProvider scope={__scopeHoverCard} forceMount={forceMount}>
       <Presence present={forceMount || context.open}>
-        <UnstablePortal asChild container={container}>
+        <PortalPrimitive asChild container={container}>
           {children}
-        </UnstablePortal>
+        </PortalPrimitive>
       </Presence>
     </PortalProvider>
   );

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -10,7 +10,7 @@ import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
@@ -181,7 +181,7 @@ const [PortalProvider, usePortalContext] = createMenuContext<PortalContextValue>
   forceMount: undefined,
 });
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface MenuPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
@@ -197,9 +197,9 @@ const MenuPortal: React.FC<MenuPortalProps> = (props: ScopedProps<MenuPortalProp
   return (
     <PortalProvider scope={__scopeMenu} forceMount={forceMount}>
       <Presence present={forceMount || context.open}>
-        <UnstablePortal asChild container={container}>
+        <PortalPrimitive asChild container={container}>
           {children}
-        </UnstablePortal>
+        </PortalPrimitive>
       </Presence>
     </PortalProvider>
   );

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -8,7 +8,7 @@ import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
@@ -183,7 +183,7 @@ const [PortalProvider, usePortalContext] = createPopoverContext<PortalContextVal
   forceMount: undefined,
 });
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface PopoverPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
@@ -199,9 +199,9 @@ const PopoverPortal: React.FC<PopoverPortalProps> = (props: ScopedProps<PopoverP
   return (
     <PortalProvider scope={__scopePopover} forceMount={forceMount}>
       <Presence present={forceMount || context.open}>
-        <UnstablePortal asChild container={container}>
+        <PortalPrimitive asChild container={container}>
           {children}
-        </UnstablePortal>
+        </PortalPrimitive>
       </Presence>
     </PortalProvider>
   );

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css, keyframes } from '../../../../stitches.config';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal } from '@radix-ui/react-portal';
 import * as Popper from '@radix-ui/react-popper';
 
 export default { title: 'Components/Popper' };
@@ -58,12 +58,12 @@ export const Animated = () => {
         </Popper.Anchor>
 
         {open && (
-          <UnstablePortal asChild>
+          <Portal asChild>
             <Popper.Content className={animatedContentClass()} sideOffset={5}>
               <button onClick={() => setOpen(false)}>close</button>
               <Popper.Arrow className={arrowClass()} width={20} height={10} offset={25} />
             </Popper.Content>
-          </UnstablePortal>
+          </Portal>
         )}
       </Popper.Root>
     </Scrollable>
@@ -80,12 +80,12 @@ export const WithPortal = () => {
         </Popper.Anchor>
 
         {open && (
-          <UnstablePortal asChild>
+          <Portal asChild>
             <Popper.Content className={contentClass()} sideOffset={5}>
               <button onClick={() => setOpen(false)}>close</button>
               <Popper.Arrow className={arrowClass()} width={20} height={10} />
             </Popper.Content>
-          </UnstablePortal>
+          </Portal>
         )}
       </Popper.Root>
     </Scrollable>

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css, keyframes } from '../../../../stitches.config';
-import { Portal } from '@radix-ui/react-portal';
+import { UnstablePortal } from '@radix-ui/react-portal';
 import * as Popper from '@radix-ui/react-popper';
 
 export default { title: 'Components/Popper' };
@@ -58,12 +58,12 @@ export const Animated = () => {
         </Popper.Anchor>
 
         {open && (
-          <Portal>
+          <UnstablePortal asChild>
             <Popper.Content className={animatedContentClass()} sideOffset={5}>
               <button onClick={() => setOpen(false)}>close</button>
               <Popper.Arrow className={arrowClass()} width={20} height={10} offset={25} />
             </Popper.Content>
-          </Portal>
+          </UnstablePortal>
         )}
       </Popper.Root>
     </Scrollable>
@@ -80,12 +80,12 @@ export const WithPortal = () => {
         </Popper.Anchor>
 
         {open && (
-          <Portal>
+          <UnstablePortal asChild>
             <Popper.Content className={contentClass()} sideOffset={5}>
               <button onClick={() => setOpen(false)}>close</button>
               <Popper.Arrow className={arrowClass()} width={20} height={10} />
             </Popper.Content>
-          </Portal>
+          </UnstablePortal>
         )}
       </Popper.Root>
     </Scrollable>

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-use-layout-effect": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/react/portal/src/Portal.stories.tsx
+++ b/packages/react/portal/src/Portal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal } from '@radix-ui/react-portal';
 
 export default { title: 'Components/Portal' };
 
@@ -19,13 +19,13 @@ export const Base = () => (
       necessitatibus eius pariatur.
     </p>
 
-    <UnstablePortal>
+    <Portal>
       <h1>This content is rendered in a portal (another DOM tree)</h1>
       <p>
         Because of the portal, it can appear in a different DOM tree from the main one (by default a
         new element inside the body), even though it is part of the same React tree.
       </p>
-    </UnstablePortal>
+    </Portal>
   </div>
 );
 
@@ -36,12 +36,12 @@ export const CustomContainer = () => {
     <>
       <div style={{ maxWidth: 300, padding: 10, margin: 10, border: '1px solid' }}>
         <h1>Container A</h1>
-        <UnstablePortal asChild container={portalContainer}>
+        <Portal asChild container={portalContainer}>
           <p>
             This content is rendered in a portal inside Container A but appears inside Container B
             because we have used Container B as a container element for the Portal.
           </p>
-        </UnstablePortal>
+        </Portal>
       </div>
 
       <div
@@ -63,7 +63,7 @@ export const Chromatic = () => {
       <div style={{ padding: 10, margin: 10, border: '1px solid blue' }}>
         <p>Container A</p>
 
-        <UnstablePortal asChild>
+        <Portal asChild>
           <div
             style={{
               padding: 10,
@@ -81,20 +81,20 @@ export const Chromatic = () => {
               default a new element inside the body), even though it is part of the same React tree.
             </p>
           </div>
-        </UnstablePortal>
+        </Portal>
       </div>
 
       <h1>Custom container</h1>
       <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
         <p>Container B</p>
-        <UnstablePortal asChild container={portalContainer}>
+        <Portal asChild container={portalContainer}>
           <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
             <p>
               This content is rendered in a portal inside Container B but appears inside Container C
               because we have used Container C as a container element for the Portal.
             </p>
           </div>
-        </UnstablePortal>
+        </Portal>
       </div>
 
       <div ref={setPortalContainer} style={{ padding: 10, margin: 10, border: '1px solid' }}>
@@ -103,7 +103,7 @@ export const Chromatic = () => {
 
       <h1>zIndex and order</h1>
       <p>See squares in the top-left</p>
-      <UnstablePortal asChild>
+      <Portal asChild>
         <div
           style={{
             width: 20,
@@ -115,8 +115,8 @@ export const Chromatic = () => {
             zIndex: 9999999,
           }}
         />
-      </UnstablePortal>
-      <UnstablePortal asChild>
+      </Portal>
+      <Portal asChild>
         <div
           style={{
             width: 20,
@@ -130,8 +130,8 @@ export const Chromatic = () => {
             zIndex: 9999999,
           }}
         />
-      </UnstablePortal>
-      <UnstablePortal asChild>
+      </Portal>
+      <Portal asChild>
         <div
           style={{
             width: 20,
@@ -145,7 +145,7 @@ export const Chromatic = () => {
             zIndex: 9999999,
           }}
         />
-      </UnstablePortal>
+      </Portal>
     </div>
   );
 };

--- a/packages/react/portal/src/Portal.stories.tsx
+++ b/packages/react/portal/src/Portal.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Portal, UnstablePortal } from '@radix-ui/react-portal';
+import { UnstablePortal } from '@radix-ui/react-portal';
 
 export default { title: 'Components/Portal' };
 
@@ -19,33 +19,33 @@ export const Base = () => (
       necessitatibus eius pariatur.
     </p>
 
-    <Portal style={{ position: 'relative' }}>
+    <UnstablePortal>
       <h1>This content is rendered in a portal (another DOM tree)</h1>
       <p>
         Because of the portal, it can appear in a different DOM tree from the main one (by default a
         new element inside the body), even though it is part of the same React tree.
       </p>
-    </Portal>
+    </UnstablePortal>
   </div>
 );
 
 export const CustomContainer = () => {
-  const portalContainerRef = React.useRef<HTMLDivElement>(null);
+  const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);
 
   return (
     <>
       <div style={{ maxWidth: 300, padding: 10, margin: 10, border: '1px solid' }}>
         <h1>Container A</h1>
-        <Portal containerRef={portalContainerRef}>
+        <UnstablePortal asChild container={portalContainer}>
           <p>
             This content is rendered in a portal inside Container A but appears inside Container B
             because we have used Container B as a container element for the Portal.
           </p>
-        </Portal>
+        </UnstablePortal>
       </div>
 
       <div
-        ref={portalContainerRef}
+        ref={setPortalContainer}
         style={{ maxWidth: 300, padding: 10, margin: 10, border: '1px solid' }}
       >
         <h1>Container B</h1>
@@ -55,63 +55,6 @@ export const CustomContainer = () => {
 };
 
 export const Chromatic = () => {
-  const portalContainerRef = React.useRef<HTMLDivElement>(null);
-
-  return (
-    <div style={{ padding: 150 }}>
-      <h1>Default (append to body)</h1>
-      <div style={{ padding: 10, margin: 10, border: '1px solid blue' }}>
-        <p>Container A</p>
-
-        <Portal>
-          <div style={{ padding: 10, margin: 10, border: '1px solid blue' }}>
-            <p>This content is rendered in a portal (another DOM tree)</p>
-            <p>
-              Because of the portal, it can appear in a different DOM tree from the main one (by
-              default a new element inside the body), even though it is part of the same React tree.
-            </p>
-          </div>
-        </Portal>
-      </div>
-
-      <h1>Custom container</h1>
-      <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
-        <p>Container B</p>
-        <Portal containerRef={portalContainerRef}>
-          <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
-            <p>
-              This content is rendered in a portal inside Container B but appears inside Container C
-              because we have used Container C as a container element for the Portal.
-            </p>
-          </div>
-        </Portal>
-      </div>
-
-      <div ref={portalContainerRef} style={{ padding: 10, margin: 10, border: '1px solid' }}>
-        <p>Container C</p>
-      </div>
-
-      <h1>zIndex and order</h1>
-      <p>See squares in the top-left</p>
-      <Portal>
-        <div style={{ width: 20, height: 20, backgroundColor: 'red' }} />
-      </Portal>
-      <Portal>
-        <div
-          style={{ width: 20, height: 20, backgroundColor: 'green', marginLeft: 10, marginTop: 10 }}
-        />
-      </Portal>
-      <Portal>
-        <div
-          style={{ width: 20, height: 20, backgroundColor: 'blue', marginLeft: 20, marginTop: 20 }}
-        />
-      </Portal>
-    </div>
-  );
-};
-Chromatic.parameters = { chromatic: { disable: false } };
-
-export const ChromaticUnstablePortal = () => {
   const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);
 
   return (
@@ -120,7 +63,7 @@ export const ChromaticUnstablePortal = () => {
       <div style={{ padding: 10, margin: 10, border: '1px solid blue' }}>
         <p>Container A</p>
 
-        <UnstablePortal>
+        <UnstablePortal asChild>
           <div
             style={{
               padding: 10,
@@ -144,7 +87,7 @@ export const ChromaticUnstablePortal = () => {
       <h1>Custom container</h1>
       <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
         <p>Container B</p>
-        <UnstablePortal container={portalContainer}>
+        <UnstablePortal asChild container={portalContainer}>
           <div style={{ padding: 10, margin: 10, border: '1px solid green' }}>
             <p>
               This content is rendered in a portal inside Container B but appears inside Container C
@@ -160,7 +103,7 @@ export const ChromaticUnstablePortal = () => {
 
       <h1>zIndex and order</h1>
       <p>See squares in the top-left</p>
-      <UnstablePortal>
+      <UnstablePortal asChild>
         <div
           style={{
             width: 20,
@@ -173,7 +116,7 @@ export const ChromaticUnstablePortal = () => {
           }}
         />
       </UnstablePortal>
-      <UnstablePortal>
+      <UnstablePortal asChild>
         <div
           style={{
             width: 20,
@@ -188,7 +131,7 @@ export const ChromaticUnstablePortal = () => {
           }}
         />
       </UnstablePortal>
-      <UnstablePortal>
+      <UnstablePortal asChild>
         <div
           style={{
             width: 20,
@@ -206,4 +149,4 @@ export const ChromaticUnstablePortal = () => {
     </div>
   );
 };
-ChromaticUnstablePortal.parameters = { chromatic: { disable: false } };
+Chromatic.parameters = { chromatic: { disable: false } };

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { Primitive } from '@radix-ui/react-primitive';
 
 import type * as Radix from '@radix-ui/react-primitive';
-
-const MAX_Z_INDEX = 2147483647;
 
 /* -------------------------------------------------------------------------------------------------
  * Portal
@@ -16,77 +13,17 @@ const PORTAL_NAME = 'Portal';
 type PortalElement = React.ElementRef<typeof Primitive.div>;
 type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface PortalProps extends PrimitiveDivProps {
-  containerRef?: React.RefObject<HTMLElement>;
-}
-
-const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
-  const { containerRef, style, ...portalProps } = props;
-  const hostElement = containerRef?.current ?? globalThis?.document?.body;
-  const [, forceUpdate] = React.useState({});
-
-  /**
-   * containerRef.current won't be set on first render, so we force a re-render.
-   * Because we do this in `useLayoutEffect`, we still avoid a flash.
-   */
-  useLayoutEffect(() => {
-    forceUpdate({});
-  }, []);
-
-  if (hostElement) {
-    return ReactDOM.createPortal(
-      <Primitive.div
-        data-radix-portal=""
-        {...portalProps}
-        ref={forwardedRef}
-        style={
-          /**
-           * If the Portal is injected in `body`, we assume we want whatever is portalled
-           * to appear on top of everything. Ideally this would be handled by making sure the
-           * app root creates a new stacking context, however this is quite hard to automate.
-           * For this reason, we have opted for setting the max z-index on the portal itself.
-           */
-          hostElement === document.body
-            ? {
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                zIndex: MAX_Z_INDEX,
-                ...style,
-              }
-            : undefined
-        }
-      />,
-      hostElement
-    );
-  }
-
-  // bail out of ssr
-  return null;
-});
-
-Portal.displayName = PORTAL_NAME;
-
-/* -------------------------------------------------------------------------------------------------
- * UnstablePortal
- * -----------------------------------------------------------------------------------------------*/
-
-const UNSTABLE_PORTAL_NAME = 'Portal';
-
-type UnstablePortalElement = React.ElementRef<typeof Primitive.div>;
-interface UnstablePortalProps extends PrimitiveDivProps {
   container?: HTMLElement | null;
 }
 
-const UnstablePortal = React.forwardRef<UnstablePortalElement, UnstablePortalProps>(
-  (props, forwardedRef) => {
-    const { container = globalThis?.document?.body, ...portalProps } = props;
-    return container
-      ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
-      : null;
-  }
-);
+const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
+  const { container = globalThis?.document?.body, ...portalProps } = props;
+  return container
+    ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
+    : null;
+});
 
-UnstablePortal.displayName = UNSTABLE_PORTAL_NAME;
+Portal.displayName = PORTAL_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
@@ -94,8 +31,7 @@ const Root = Portal;
 
 export {
   Portal,
-  UnstablePortal,
   //
   Root,
 };
-export type { PortalProps, UnstablePortalProps };
+export type { PortalProps };

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -11,7 +11,7 @@ import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import { useLabelContext } from '@radix-ui/react-label';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
@@ -352,13 +352,13 @@ SelectIcon.displayName = ICON_NAME;
 
 const PORTAL_NAME = 'SelectPortal';
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface SelectPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
 }
 
 const SelectPortal: React.FC<SelectPortalProps> = (props: ScopedProps<SelectPortalProps>) => {
-  return <UnstablePortal asChild {...props} />;
+  return <PortalPrimitive asChild {...props} />;
 };
 
 SelectPortal.displayName = PORTAL_NAME;

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -4,7 +4,7 @@ import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import * as DismissableLayer from '@radix-ui/react-dismissable-layer';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
@@ -553,7 +553,7 @@ const ToastAnnounce: React.FC<ToastAnnounceProps> = (props: ScopedProps<ToastAnn
   }, []);
 
   return isAnnounced ? null : (
-    <UnstablePortal asChild>
+    <Portal asChild>
       <VisuallyHidden asChild>
         <div {...announceProps}>
           {renderChildren && (
@@ -563,7 +563,7 @@ const ToastAnnounce: React.FC<ToastAnnounceProps> = (props: ScopedProps<ToastAnn
           )}
         </div>
       </VisuallyHidden>
-    </UnstablePortal>
+    </Portal>
   );
 };
 

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -6,7 +6,7 @@ import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
-import { UnstablePortal } from '@radix-ui/react-portal';
+import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slottable } from '@radix-ui/react-slot';
@@ -286,7 +286,7 @@ const [PortalProvider, usePortalContext] = createTooltipContext<PortalContextVal
   forceMount: undefined,
 });
 
-type PortalProps = React.ComponentPropsWithoutRef<typeof UnstablePortal>;
+type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface TooltipPortalProps extends Omit<PortalProps, 'asChild'> {
   children?: React.ReactNode;
   /**
@@ -302,9 +302,9 @@ const TooltipPortal: React.FC<TooltipPortalProps> = (props: ScopedProps<TooltipP
   return (
     <PortalProvider scope={__scopeTooltip} forceMount={forceMount}>
       <Presence present={forceMount || context.open}>
-        <UnstablePortal asChild container={container}>
+        <PortalPrimitive asChild container={container}>
           {children}
-        </UnstablePortal>
+        </PortalPrimitive>
       </Presence>
     </PortalProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,7 +3481,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/react-primitive": "workspace:*"
-    "@radix-ui/react-use-layout-effect": "workspace:*"
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0


### PR DESCRIPTION
> **Note**: needs to be rebased once #1459 is merged

---

> **Warning**
> Breaking changes in docs:
> - Breaking changes for `Portal` util: manual z-index management + `containerRef` to `container` prop
> - update docs page for `Portal`