### PR TITLE
[Toast] Manually reverse tab order

### DIFF
--- a/.yarn/versions/6629a53c.yml
+++ b/.yarn/versions/6629a53c.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toast": patch
+
+declined:
+  - primitives

--- a/cypress/integration/Toast.spec.ts
+++ b/cypress/integration/Toast.spec.ts
@@ -1,0 +1,98 @@
+describe('Toast', () => {
+  beforeEach(() => {
+    cy.visitStory('toast--cypress');
+  });
+
+  function actionIsFocused(identifier: number) {
+    cy.findByText(`Toast ${identifier} action`).should('be.focused');
+  }
+
+  function closeIsFocused(identifier: number) {
+    cy.findByText(`Toast ${identifier} close`).should('be.focused');
+  }
+
+  function toastIsFocused(identifier: number) {
+    cy.get(`[data-cy="toast-${identifier}"]`).should('be.focused');
+  }
+
+  describe('given zero toasts', () => {
+    it('should not interrupt natural tab order in the document', () => {
+      cy.findByText('Focusable before viewport').focus();
+
+      cy.realPress('Tab');
+      cy.findByText('Focusable after viewport').should('be.focused');
+
+      cy.realPress(['Shift', 'Tab']);
+      cy.findByText('Focusable before viewport').should('be.focused');
+    });
+  });
+
+  describe('given multiple toasts', () => {
+    beforeEach(() => {
+      cy.findByText('Add toast').click();
+      cy.findByText('Add toast').click();
+    });
+
+    it('should reverse tab order from most recent to least', () => {
+      cy.findByText('Focusable before viewport').focus();
+
+      cy.realPress('Tab');
+      toastIsFocused(2);
+
+      // Forward tab
+      cy.realPress('Tab');
+      closeIsFocused(2);
+
+      cy.realPress('Tab');
+      actionIsFocused(2);
+
+      cy.realPress('Tab');
+      toastIsFocused(1);
+
+      cy.realPress('Tab');
+      closeIsFocused(1);
+
+      cy.realPress('Tab');
+      actionIsFocused(1);
+
+      // End of viewport
+      cy.realPress('Tab');
+      cy.findByText('Focusable after viewport').should('be.focused');
+
+      // Backwards tab
+      cy.realPress(['Shift', 'Tab']);
+      actionIsFocused(1);
+
+      cy.realPress(['Shift', 'Tab']);
+      closeIsFocused(1);
+
+      cy.realPress(['Shift', 'Tab']);
+      toastIsFocused(1);
+
+      cy.realPress(['Shift', 'Tab']);
+      actionIsFocused(2);
+
+      cy.realPress(['Shift', 'Tab']);
+      closeIsFocused(2);
+
+      cy.realPress(['Shift', 'Tab']);
+      toastIsFocused(2);
+
+      // Start of viewport
+      cy.realPress(['Shift', 'Tab']);
+      cy.findByText('Focusable before viewport').should('be.focused');
+    });
+
+    it('should tab forwards from viewport to latest toast or backwards into the document', () => {
+      // Tab forward from viewport
+      cy.realPress('F8');
+      cy.realPress('Tab');
+      toastIsFocused(2);
+
+      // Tab backward from viewport
+      cy.realPress('F8');
+      cy.realPress(['Shift', 'Tab']);
+      cy.findByText('Focusable before viewport').should('be.focused');
+    });
+  });
+});

--- a/cypress/integration/Toast.spec.ts
+++ b/cypress/integration/Toast.spec.ts
@@ -3,16 +3,12 @@ describe('Toast', () => {
     cy.visitStory('toast--cypress');
   });
 
-  function actionIsFocused(identifier: number) {
-    cy.findByText(`Toast ${identifier} action`).should('be.focused');
-  }
-
-  function closeIsFocused(identifier: number) {
-    cy.findByText(`Toast ${identifier} close`).should('be.focused');
+  function buttonIsFocused(identifier: number) {
+    cy.findByText(`Toast button ${identifier}`).should('be.focused');
   }
 
   function toastIsFocused(identifier: number) {
-    cy.get(`[data-cy="toast-${identifier}"]`).should('be.focused');
+    cy.findByTestId(`toast-${identifier}`).should('be.focused');
   }
 
   describe('given zero toasts', () => {
@@ -41,19 +37,19 @@ describe('Toast', () => {
 
       // Forward tab
       cy.realPress('Tab');
-      closeIsFocused(2);
+      buttonIsFocused(2.1);
 
       cy.realPress('Tab');
-      actionIsFocused(2);
+      buttonIsFocused(2.2);
 
       cy.realPress('Tab');
       toastIsFocused(1);
 
       cy.realPress('Tab');
-      closeIsFocused(1);
+      buttonIsFocused(1.1);
 
       cy.realPress('Tab');
-      actionIsFocused(1);
+      buttonIsFocused(1.2);
 
       // End of viewport
       cy.realPress('Tab');
@@ -61,19 +57,19 @@ describe('Toast', () => {
 
       // Backwards tab
       cy.realPress(['Shift', 'Tab']);
-      actionIsFocused(1);
+      buttonIsFocused(1.2);
 
       cy.realPress(['Shift', 'Tab']);
-      closeIsFocused(1);
+      buttonIsFocused(1.1);
 
       cy.realPress(['Shift', 'Tab']);
       toastIsFocused(1);
 
       cy.realPress(['Shift', 'Tab']);
-      actionIsFocused(2);
+      buttonIsFocused(2.2);
 
       cy.realPress(['Shift', 'Tab']);
-      closeIsFocused(2);
+      buttonIsFocused(2.1);
 
       cy.realPress(['Shift', 'Tab']);
       toastIsFocused(2);

--- a/packages/react/toast/package.json
+++ b/packages/react/toast/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@radix-ui/primitive": "workspace:*",
+    "@radix-ui/react-collection": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dismissable-layer": "workspace:*",

--- a/packages/react/toast/src/Toast.stories.tsx
+++ b/packages/react/toast/src/Toast.stories.tsx
@@ -195,6 +195,49 @@ export const Animated = () => {
   );
 };
 
+export const Cypress = () => {
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <Toast.Provider>
+      <button onClick={() => setCount((count) => count + 1)}>Add toast</button>
+
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', maxWidth: 700, margin: 'auto' }}
+      >
+        <button>Focusable before viewport</button>
+
+        {[...Array(count)].map((_, index) => {
+          const identifier = index + 1;
+          return (
+            <Toast.Root key={index} open className={rootClass()} data-cy={`toast-${identifier}`}>
+              <Toast.Title className={titleClass()}>Toast {identifier} title</Toast.Title>
+              <Toast.Description className={descriptionClass()}>
+                Toast {identifier} description
+              </Toast.Description>
+
+              <Toast.Close className={buttonClass()} aria-label="Close">
+                Toast {identifier} close
+              </Toast.Close>
+              <Toast.Action
+                altText="Go and perform an action"
+                className={buttonClass()}
+                style={{ marginTop: 10 }}
+              >
+                Toast {identifier} action
+              </Toast.Action>
+            </Toast.Root>
+          );
+        })}
+
+        <Toast.Viewport className={viewportClass()} />
+
+        <button>Focusable after viewport</button>
+      </div>
+    </Toast.Provider>
+  );
+};
+
 const SNAPSHOT_DELAY = 300;
 export const Chromatic = () => {
   const [dismissedBackgroundOpen, setDismissedBackgroundOpen] = React.useState(true);

--- a/packages/react/toast/src/Toast.stories.tsx
+++ b/packages/react/toast/src/Toast.stories.tsx
@@ -201,7 +201,6 @@ export const Cypress = () => {
   return (
     <Toast.Provider>
       <button onClick={() => setCount((count) => count + 1)}>Add toast</button>
-
       <div
         style={{ display: 'flex', justifyContent: 'space-between', maxWidth: 700, margin: 'auto' }}
       >
@@ -210,26 +209,30 @@ export const Cypress = () => {
         {[...Array(count)].map((_, index) => {
           const identifier = index + 1;
           return (
-            <Toast.Root key={index} open className={rootClass()} data-cy={`toast-${identifier}`}>
+            <Toast.Root
+              key={index}
+              open
+              className={rootClass()}
+              data-testid={`toast-${identifier}`}
+            >
               <Toast.Title className={titleClass()}>Toast {identifier} title</Toast.Title>
               <Toast.Description className={descriptionClass()}>
                 Toast {identifier} description
               </Toast.Description>
 
               <Toast.Close className={buttonClass()} aria-label="Close">
-                Toast {identifier} close
+                Toast button {identifier}.1
               </Toast.Close>
               <Toast.Action
                 altText="Go and perform an action"
                 className={buttonClass()}
                 style={{ marginTop: 10 }}
               >
-                Toast {identifier} action
+                Toast button {identifier}.2
               </Toast.Action>
             </Toast.Root>
           );
         })}
-
         <Toast.Viewport className={viewportClass()} />
 
         <button>Focusable after viewport</button>
@@ -240,15 +243,14 @@ export const Cypress = () => {
 
 const SNAPSHOT_DELAY = 300;
 export const Chromatic = () => {
-  const [dismissedBackgroundOpen, setDismissedBackgroundOpen] = React.useState(true);
-  const [dismissedForegroundOpen, setDismissedForegroundOpen] = React.useState(true);
+  const [open, setOpen] = React.useState(true);
   return (
     <>
-      <h1>Stacking</h1>
+      <h1>Order</h1>
       <Toast.Provider duration={Infinity}>
-        <Toast.Root type="foreground" className={rootClass()}>
+        <Toast.Root className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Stacking foreground</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast 1</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -256,9 +258,9 @@ export const Chromatic = () => {
             Action
           </Toast.Action>
         </Toast.Root>
-        <Toast.Root type="background" className={rootClass()}>
+        <Toast.Root className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Stacking background</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast 2</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -270,11 +272,12 @@ export const Chromatic = () => {
       </Toast.Provider>
 
       <h1>Uncontrolled</h1>
-      <h2>Background open</h2>
+
+      <h2>Open</h2>
       <Toast.Provider>
-        <Toast.Root type="background" duration={Infinity} className={rootClass()}>
+        <Toast.Root duration={Infinity} className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Uncontrolled background open</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -285,49 +288,9 @@ export const Chromatic = () => {
         <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
       </Toast.Provider>
 
-      <h2>Background closed</h2>
+      <h2>Closed</h2>
       <Toast.Provider>
-        <Toast.Root
-          type="background"
-          defaultOpen={false}
-          duration={Infinity}
-          className={rootClass()}
-        >
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Uncontrolled background closed</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground open</h2>
-      <Toast.Provider>
-        <Toast.Root type="foreground" duration={Infinity} className={rootClass()}>
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Uncontrolled foreground open</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground closed</h2>
-      <Toast.Provider>
-        <Toast.Root
-          type="foreground"
-          defaultOpen={false}
-          duration={Infinity}
-          className={rootClass()}
-        >
+        <Toast.Root defaultOpen={false} duration={Infinity} className={rootClass()}>
           <div className={headerClass()}>
             <Toast.Title className={titleClass()}>Title</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
@@ -343,11 +306,12 @@ export const Chromatic = () => {
       </Toast.Provider>
 
       <h1>Controlled</h1>
-      <h2>Background open</h2>
+
+      <h2>Open</h2>
       <Toast.Provider>
-        <Toast.Root type="background" open duration={Infinity} className={rootClass()}>
+        <Toast.Root open duration={Infinity} className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Controlled background open</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -358,41 +322,11 @@ export const Chromatic = () => {
         <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
       </Toast.Provider>
 
-      <h2>Background closed</h2>
+      <h2>Closed</h2>
       <Toast.Provider>
-        <Toast.Root type="background" open={false} duration={Infinity} className={rootClass()}>
+        <Toast.Root open={false} duration={Infinity} className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Controlled background closed</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground open</h2>
-      <Toast.Provider>
-        <Toast.Root type="foreground" open duration={Infinity} className={rootClass()}>
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Controlled foreground open</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground closed</h2>
-      <Toast.Provider>
-        <Toast.Root type="foreground" open={false} duration={Infinity} className={rootClass()}>
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Controlled foreground closed</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -404,11 +338,11 @@ export const Chromatic = () => {
       </Toast.Provider>
 
       <h1>Dismissed</h1>
-      <h2>Background uncontrolled</h2>
+      <h2>Uncontrolled</h2>
       <Toast.Provider>
-        <Toast.Root type="background" duration={SNAPSHOT_DELAY - 100} className={rootClass()}>
+        <Toast.Root duration={SNAPSHOT_DELAY - 100} className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Dismissed background uncontrolled</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -419,53 +353,16 @@ export const Chromatic = () => {
         <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
       </Toast.Provider>
 
-      <h2>Background controlled</h2>
+      <h2>Controlled</h2>
       <Toast.Provider>
         <Toast.Root
-          type="background"
           duration={SNAPSHOT_DELAY - 100}
-          open={dismissedBackgroundOpen}
-          onOpenChange={setDismissedBackgroundOpen}
+          open={open}
+          onOpenChange={setOpen}
           className={rootClass()}
         >
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Dismissed background controlled</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground uncontrolled</h2>
-      <Toast.Provider>
-        <Toast.Root type="foreground" duration={SNAPSHOT_DELAY - 100} className={rootClass()}>
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Dismissed foreground uncontrolled</Toast.Title>
-            <Toast.Close className={closeClass()}>×</Toast.Close>
-          </div>
-          <Toast.Description className={descriptionClass()}>Description</Toast.Description>
-          <Toast.Action altText="alternative" className={buttonClass()} style={{ marginTop: 10 }}>
-            Action
-          </Toast.Action>
-        </Toast.Root>
-        <Toast.Viewport className={chromaticViewport()}></Toast.Viewport>
-      </Toast.Provider>
-
-      <h2>Foreground controlled</h2>
-      <Toast.Provider>
-        <Toast.Root
-          type="foreground"
-          duration={SNAPSHOT_DELAY - 100}
-          open={dismissedForegroundOpen}
-          onOpenChange={setDismissedForegroundOpen}
-          className={rootClass()}
-        >
-          <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Dismissed foreground controlled</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -481,7 +378,7 @@ export const Chromatic = () => {
       <Toast.Provider duration={SNAPSHOT_DELAY - 100}>
         <Toast.Root className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Provider duration</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -496,7 +393,7 @@ export const Chromatic = () => {
       <Toast.Provider duration={Infinity}>
         <Toast.Root duration={SNAPSHOT_DELAY - 100} className={rootClass()}>
           <div className={headerClass()}>
-            <Toast.Title className={titleClass()}>Provider duration overidden</Toast.Title>
+            <Toast.Title className={titleClass()}>Toast</Toast.Title>
             <Toast.Close className={closeClass()}>×</Toast.Close>
           </div>
           <Toast.Description className={descriptionClass()}>Description</Toast.Description>
@@ -514,7 +411,7 @@ Chromatic.parameters = { chromatic: { disable: false, delay: SNAPSHOT_DELAY } };
 /* -----------------------------------------------------------------------------------------------*/
 
 const ToastUpgradeAvailable = (props: React.ComponentProps<typeof Toast.Root>) => (
-  <Toast.Root type="background" className={rootClass()} {...props}>
+  <Toast.Root className={rootClass()} {...props}>
     <div className={headerClass()}>
       <Toast.Title className={titleClass()}>Upgrade available</Toast.Title>
       <Toast.Close className={closeClass()} aria-label="Close">
@@ -535,7 +432,7 @@ const ToastUpgradeAvailable = (props: React.ComponentProps<typeof Toast.Root>) =
 );
 
 const ToastSubscribeSuccess = (props: React.ComponentProps<typeof Toast.Root>) => (
-  <Toast.Root type="foreground" className={rootClass()} {...props}>
+  <Toast.Root className={rootClass()} {...props}>
     <div className={successHeaderClass()}>
       <Toast.Title className={titleClass()}>Success!</Toast.Title>
       <Toast.Close className={closeClass()} aria-label="Close">

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -280,10 +280,10 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
           <FocusProxy
             ref={headFocusProxyRef}
             onFocusFromOutsideViewport={() => {
-              const tabbleCandidates = getSortedTabbableCandidates({
+              const tabbableCandidates = getSortedTabbableCandidates({
                 tabbingDirection: 'forwards',
               });
-              focusFirst(tabbleCandidates);
+              focusFirst(tabbableCandidates);
             }}
           />
         )}
@@ -298,10 +298,10 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
           <FocusProxy
             ref={tailFocusProxyRef}
             onFocusFromOutsideViewport={() => {
-              const tabbleCandidates = getSortedTabbableCandidates({
+              const tabbableCandidates = getSortedTabbableCandidates({
                 tabbingDirection: 'backwards',
               });
-              focusFirst(tabbleCandidates);
+              focusFirst(tabbableCandidates);
             }}
           />
         )}

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -546,7 +546,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   aria-live={type === 'foreground' ? 'assertive' : 'polite'}
                   aria-atomic
                   // Prevent voice over from announcing before the label is rendered
-                  aria-hidden={!renderLabel}
+                  aria-hidden={!renderLabel || undefined}
                   tabIndex={0}
                   data-state={open ? 'open' : 'closed'}
                   data-swipe-direction={context.swipeDirection}

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { createCollection } from '@radix-ui/react-collection';
 import { createContextScope } from '@radix-ui/react-context';
 import * as DismissableLayer from '@radix-ui/react-dismissable-layer';
 import { Presence } from '@radix-ui/react-presence';
@@ -21,6 +22,8 @@ import type { Scope } from '@radix-ui/react-context';
 
 const PROVIDER_NAME = 'ToastProvider';
 
+const [Collection, useCollection, createCollectionScope] = createCollection<ToastElement>('Toast');
+
 type SwipeDirection = 'up' | 'down' | 'left' | 'right';
 type ToastProviderContextValue = {
   label: string;
@@ -37,7 +40,7 @@ type ToastProviderContextValue = {
 };
 
 type ScopedProps<P> = P & { __scopeToast?: Scope };
-const [createToastContext, createToastScope] = createContextScope('Toast');
+const [createToastContext, createToastScope] = createContextScope('Toast', [createCollectionScope]);
 const [ToastProviderProvider, useToastProviderContext] =
   createToastContext<ToastProviderContextValue>(PROVIDER_NAME);
 
@@ -80,22 +83,24 @@ const ToastProvider: React.FC<ToastProviderProps> = (props: ScopedProps<ToastPro
   const isFocusedToastEscapeKeyDownRef = React.useRef(false);
   const isClosePausedRef = React.useRef(false);
   return (
-    <ToastProviderProvider
-      scope={__scopeToast}
-      label={label}
-      duration={duration}
-      swipeDirection={swipeDirection}
-      swipeThreshold={swipeThreshold}
-      toastCount={toastCount}
-      viewport={viewport}
-      onViewportChange={setViewport}
-      onToastAdd={React.useCallback(() => setToastCount((prevCount) => prevCount + 1), [])}
-      onToastRemove={React.useCallback(() => setToastCount((prevCount) => prevCount - 1), [])}
-      isFocusedToastEscapeKeyDownRef={isFocusedToastEscapeKeyDownRef}
-      isClosePausedRef={isClosePausedRef}
-    >
-      {children}
-    </ToastProviderProvider>
+    <Collection.Provider scope={__scopeToast}>
+      <ToastProviderProvider
+        scope={__scopeToast}
+        label={label}
+        duration={duration}
+        swipeDirection={swipeDirection}
+        swipeThreshold={swipeThreshold}
+        toastCount={toastCount}
+        viewport={viewport}
+        onViewportChange={setViewport}
+        onToastAdd={React.useCallback(() => setToastCount((prevCount) => prevCount + 1), [])}
+        onToastRemove={React.useCallback(() => setToastCount((prevCount) => prevCount - 1), [])}
+        isFocusedToastEscapeKeyDownRef={isFocusedToastEscapeKeyDownRef}
+        isClosePausedRef={isClosePausedRef}
+      >
+        {children}
+      </ToastProviderProvider>
+    </Collection.Provider>
   );
 };
 
@@ -145,10 +150,14 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
       ...viewportProps
     } = props;
     const context = useToastProviderContext(VIEWPORT_NAME, __scopeToast);
+    const getItems = useCollection(__scopeToast);
     const wrapperRef = React.useRef<HTMLDivElement>(null);
+    const headFocusProxyRef = React.useRef<FocusProxyElement>(null);
+    const tailFocusProxyRef = React.useRef<FocusProxyElement>(null);
     const ref = React.useRef<ToastViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
     const hotkeyLabel = hotkey.join('+').replace(/Key/g, '').replace(/Digit/g, '');
+    const hasToasts = context.toastCount > 0;
 
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -195,34 +204,63 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
       }
     }, [context.isClosePausedRef]);
 
+    const getSortedCandidates = React.useCallback(
+      ({ direction }: { direction: 'forwards' | 'backwards' }) => {
+        const items = getItems();
+        const candidateGroups = items.map((item) => {
+          const itemNode = item.ref.current!;
+          const itemGroup = [itemNode, ...getTabbableCandidates(itemNode)];
+          return direction === 'forwards' ? itemGroup.reverse() : itemGroup;
+        });
+        return (direction === 'forwards' ? candidateGroups : candidateGroups.reverse()).flat();
+      },
+      [getItems]
+    );
+
     React.useEffect(() => {
       const viewport = ref.current;
-      // Re-order DOM so most recent toasts are at top of DOM structure to improve tab order
+      // We programmatically manage tabbing as we are unable to influence
+      // the source order with portals, this allows us to reverse the
+      // tab order so that it runs from most recent toast to least
       if (viewport) {
-        const prepended: Set<Node> = new Set();
-        const observer = new MutationObserver((mutations) => {
-          const addedNodes = mutations
-            .map((mutation) => Array.from(mutation.addedNodes))
-            .reduce((a, b) => a.concat(b));
+        const handleKeyDown = (event: KeyboardEvent) => {
+          const isMetaKey = event.altKey || event.ctrlKey || event.metaKey;
+          const isTabKey = event.key === 'Tab' && !isMetaKey;
 
-          addedNodes.forEach((node) => {
-            // mutation will immediately fire again when we prepend so we only prepend if
-            // it hasn't just prepended.
-            if (!prepended.has(node)) {
-              viewport.prepend(node);
-              prepended.add(node);
-            } else {
-              // this else catches the case where the mutation fires immediately after prepend.
-              // we remove from cache after it prepends to allow observer to catch future updates
-              // to DOM order, e.g. if `key` changes for a toast and is reportalled to bottom.
-              prepended.delete(node);
+          if (isTabKey) {
+            const focusedElement = document.activeElement;
+            const isMovingBackwards = event.shiftKey;
+            const targetIsViewport = event.target === viewport;
+
+            // If we're back tabbing after jumping to the viewport then we simply
+            // proxy focus out to the preceding document
+            if (targetIsViewport && isMovingBackwards) {
+              headFocusProxyRef.current?.focus();
+              return;
             }
-          });
-        });
-        observer.observe(viewport, { childList: true });
-        return () => observer.disconnect();
+
+            // Otherwise manually reverse the tab order
+            const direction = isMovingBackwards ? 'forwards' : 'backwards';
+            const sortedCandidates = getSortedCandidates({ direction });
+            const index = sortedCandidates.findIndex((candidate) => candidate === focusedElement);
+            if (focusFirst(sortedCandidates.slice(index + 1))) {
+              event.preventDefault();
+            } else {
+              // If we can't focus that means we're at the edges so we
+              // proxy to the corresponding exit point and let the browser handle
+              // tab/shift+tab keypress and implicitly pass focus to the next valid element in the document
+              isMovingBackwards
+                ? headFocusProxyRef.current?.focus()
+                : tailFocusProxyRef.current?.focus();
+            }
+          }
+        };
+
+        // Toasts are not in the viewport React tree so we need to bind DOM events
+        viewport.addEventListener('keydown', handleKeyDown);
+        return () => viewport.removeEventListener('keydown', handleKeyDown);
       }
-    }, []);
+    }, [getItems, getSortedCandidates]);
 
     return (
       <DismissableLayer.Branch
@@ -233,19 +271,66 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
         tabIndex={-1}
         // incase list has size when empty (e.g. padding), we remove pointer events so
         // it doesn't prevent interactions with page elements that it overlays
-        style={{ pointerEvents: context.toastCount > 0 ? undefined : 'none' }}
+        style={{ pointerEvents: hasToasts ? undefined : 'none' }}
       >
+        {hasToasts && (
+          <FocusProxy
+            ref={headFocusProxyRef}
+            onEntranceFocus={() => focusFirst(getSortedCandidates({ direction: 'backwards' }))}
+          />
+        )}
         {/**
          * tabindex on the the list so that it can be focused when items are removed. we focus
          * the list instead of the viewport so it announces number of items remaining.
          */}
-        <Primitive.ol tabIndex={-1} {...viewportProps} ref={composedRefs} />
+        <Collection.Slot scope={__scopeToast}>
+          <Primitive.ol tabIndex={-1} {...viewportProps} ref={composedRefs} />
+        </Collection.Slot>
+        {hasToasts && (
+          <FocusProxy
+            ref={tailFocusProxyRef}
+            onEntranceFocus={() => focusFirst(getSortedCandidates({ direction: 'forwards' }))}
+          />
+        )}
       </DismissableLayer.Branch>
     );
   }
 );
 
 ToastViewport.displayName = VIEWPORT_NAME;
+
+/* -----------------------------------------------------------------------------------------------*/
+
+const FOCUS_PROXY_NAME = 'ToastFocusProxy';
+
+type FocusProxyElement = React.ElementRef<typeof VisuallyHidden>;
+type VisuallyHiddenProps = Radix.ComponentPropsWithoutRef<typeof VisuallyHidden>;
+interface FocusProxyProps extends VisuallyHiddenProps {
+  onEntranceFocus(): void;
+}
+
+const FocusProxy = React.forwardRef<FocusProxyElement, ScopedProps<FocusProxyProps>>(
+  (props, forwardedRef) => {
+    const { __scopeToast, onEntranceFocus, ...proxyProps } = props;
+    const context = useToastProviderContext(FOCUS_PROXY_NAME, __scopeToast);
+
+    return (
+      <VisuallyHidden
+        aria-hidden
+        tabIndex={0}
+        {...proxyProps}
+        ref={forwardedRef}
+        onFocus={(event) => {
+          const prevFocusedElement = event.relatedTarget as HTMLElement | null;
+          const isEntranceFocus = !context.viewport?.contains(prevFocusedElement);
+          if (isEntranceFocus) onEntranceFocus();
+        }}
+      />
+    );
+  }
+);
+
+FocusProxy.displayName = FOCUS_PROXY_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * Toast
@@ -433,97 +518,106 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       <>
         <ToastInteractiveProvider scope={__scopeToast} isInteractive onClose={handleClose}>
           {ReactDOM.createPortal(
-            <DismissableLayer.Root
-              asChild
-              onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                if (!context.isFocusedToastEscapeKeyDownRef.current) handleClose();
-                context.isFocusedToastEscapeKeyDownRef.current = false;
-              })}
-            >
-              <Primitive.li
-                role="status"
-                aria-live={type === 'foreground' ? 'assertive' : 'polite'}
-                aria-atomic
-                // Prevent voice over from announcing before the label is rendered
-                aria-hidden={!renderLabel || undefined}
-                tabIndex={0}
-                data-state={open ? 'open' : 'closed'}
-                data-swipe-direction={context.swipeDirection}
-                {...toastProps}
-                ref={composedRefs}
-                style={{ userSelect: 'none', touchAction: 'none', ...props.style }}
-                onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-                  if (event.key !== 'Escape') return;
-                  onEscapeKeyDown?.(event.nativeEvent);
-                  if (!event.nativeEvent.defaultPrevented) {
-                    context.isFocusedToastEscapeKeyDownRef.current = true;
-                    handleClose();
-                  }
-                })}
-                onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
-                  if (event.button !== 0) return;
-                  pointerStartRef.current = { x: event.clientX, y: event.clientY };
-                })}
-                onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
-                  if (!pointerStartRef.current) return;
-                  const x = event.clientX - pointerStartRef.current.x;
-                  const y = event.clientY - pointerStartRef.current.y;
-                  const hasSwipeMoveStarted = Boolean(swipeDeltaRef.current);
-                  const isHorizontalSwipe = ['left', 'right'].includes(context.swipeDirection);
-                  const clamp = ['left', 'up'].includes(context.swipeDirection)
-                    ? Math.min
-                    : Math.max;
-                  const clampedX = isHorizontalSwipe ? clamp(0, x) : 0;
-                  const clampedY = !isHorizontalSwipe ? clamp(0, y) : 0;
-                  const moveStartBuffer = event.pointerType === 'touch' ? 10 : 2;
-                  const delta = { x: clampedX, y: clampedY };
-                  const eventDetail = { originalEvent: event, delta };
-                  if (hasSwipeMoveStarted) {
-                    swipeDeltaRef.current = delta;
-                    handleAndDispatchCustomEvent(TOAST_SWIPE_MOVE, onSwipeMove, eventDetail, {
-                      discrete: false,
-                    });
-                  } else if (isDeltaInDirection(delta, context.swipeDirection, moveStartBuffer)) {
-                    swipeDeltaRef.current = delta;
-                    handleAndDispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail, {
-                      discrete: false,
-                    });
-                    (event.target as HTMLElement).setPointerCapture(event.pointerId);
-                  } else if (Math.abs(x) > moveStartBuffer || Math.abs(y) > moveStartBuffer) {
-                    // User is swiping in wrong direction so we disable swipe gesture
-                    // for the current pointer down interaction
-                    pointerStartRef.current = null;
-                  }
-                })}
-                onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
-                  const delta = swipeDeltaRef.current;
-                  (event.target as HTMLElement).releasePointerCapture(event.pointerId);
-                  swipeDeltaRef.current = null;
-                  pointerStartRef.current = null;
-                  if (delta) {
-                    const toast = event.currentTarget;
-                    const eventDetail = { originalEvent: event, delta };
-                    if (isDeltaInDirection(delta, context.swipeDirection, context.swipeThreshold)) {
-                      handleAndDispatchCustomEvent(TOAST_SWIPE_END, onSwipeEnd, eventDetail, {
-                        discrete: true,
-                      });
-                    } else {
-                      handleAndDispatchCustomEvent(TOAST_SWIPE_CANCEL, onSwipeCancel, eventDetail, {
-                        discrete: true,
-                      });
-                    }
-                    // Prevent click event from triggering on items within the toast when
-                    // pointer up is part of a swipe gesture
-                    toast.addEventListener('click', (event) => event.preventDefault(), {
-                      once: true,
-                    });
-                  }
+            <Collection.ItemSlot scope={__scopeToast}>
+              <DismissableLayer.Root
+                asChild
+                onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
+                  if (!context.isFocusedToastEscapeKeyDownRef.current) handleClose();
+                  context.isFocusedToastEscapeKeyDownRef.current = false;
                 })}
               >
-                <VisuallyHidden>{renderLabel && context.label}</VisuallyHidden>
-                <Slottable>{children}</Slottable>
-              </Primitive.li>
-            </DismissableLayer.Root>,
+                <Primitive.li
+                  role="status"
+                  aria-live={type === 'foreground' ? 'assertive' : 'polite'}
+                  aria-atomic
+                  // Prevent voice over from announcing before the label is rendered
+                  aria-hidden={!renderLabel}
+                  tabIndex={0}
+                  data-state={open ? 'open' : 'closed'}
+                  data-swipe-direction={context.swipeDirection}
+                  {...toastProps}
+                  ref={composedRefs}
+                  style={{ userSelect: 'none', touchAction: 'none', ...props.style }}
+                  onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+                    if (event.key !== 'Escape') return;
+                    onEscapeKeyDown?.(event.nativeEvent);
+                    if (!event.nativeEvent.defaultPrevented) {
+                      context.isFocusedToastEscapeKeyDownRef.current = true;
+                      handleClose();
+                    }
+                  })}
+                  onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+                    if (event.button !== 0) return;
+                    pointerStartRef.current = { x: event.clientX, y: event.clientY };
+                  })}
+                  onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
+                    if (!pointerStartRef.current) return;
+                    const x = event.clientX - pointerStartRef.current.x;
+                    const y = event.clientY - pointerStartRef.current.y;
+                    const hasSwipeMoveStarted = Boolean(swipeDeltaRef.current);
+                    const isHorizontalSwipe = ['left', 'right'].includes(context.swipeDirection);
+                    const clamp = ['left', 'up'].includes(context.swipeDirection)
+                      ? Math.min
+                      : Math.max;
+                    const clampedX = isHorizontalSwipe ? clamp(0, x) : 0;
+                    const clampedY = !isHorizontalSwipe ? clamp(0, y) : 0;
+                    const moveStartBuffer = event.pointerType === 'touch' ? 10 : 2;
+                    const delta = { x: clampedX, y: clampedY };
+                    const eventDetail = { originalEvent: event, delta };
+                    if (hasSwipeMoveStarted) {
+                      swipeDeltaRef.current = delta;
+                      handleAndDispatchCustomEvent(TOAST_SWIPE_MOVE, onSwipeMove, eventDetail, {
+                        discrete: false,
+                      });
+                    } else if (isDeltaInDirection(delta, context.swipeDirection, moveStartBuffer)) {
+                      swipeDeltaRef.current = delta;
+                      handleAndDispatchCustomEvent(TOAST_SWIPE_START, onSwipeStart, eventDetail, {
+                        discrete: false,
+                      });
+                      (event.target as HTMLElement).setPointerCapture(event.pointerId);
+                    } else if (Math.abs(x) > moveStartBuffer || Math.abs(y) > moveStartBuffer) {
+                      // User is swiping in wrong direction so we disable swipe gesture
+                      // for the current pointer down interaction
+                      pointerStartRef.current = null;
+                    }
+                  })}
+                  onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
+                    const delta = swipeDeltaRef.current;
+                    (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+                    swipeDeltaRef.current = null;
+                    pointerStartRef.current = null;
+                    if (delta) {
+                      const toast = event.currentTarget;
+                      const eventDetail = { originalEvent: event, delta };
+                      if (
+                        isDeltaInDirection(delta, context.swipeDirection, context.swipeThreshold)
+                      ) {
+                        handleAndDispatchCustomEvent(TOAST_SWIPE_END, onSwipeEnd, eventDetail, {
+                          discrete: true,
+                        });
+                      } else {
+                        handleAndDispatchCustomEvent(
+                          TOAST_SWIPE_CANCEL,
+                          onSwipeCancel,
+                          eventDetail,
+                          {
+                            discrete: true,
+                          }
+                        );
+                      }
+                      // Prevent click event from triggering on items within the toast when
+                      // pointer up is part of a swipe gesture
+                      toast.addEventListener('click', (event) => event.preventDefault(), {
+                        once: true,
+                      });
+                    }
+                  })}
+                >
+                  <VisuallyHidden>{renderLabel && context.label}</VisuallyHidden>
+                  <Slottable>{children}</Slottable>
+                </Primitive.li>
+              </DismissableLayer.Root>
+            </Collection.ItemSlot>,
             context.viewport
           )}
         </ToastInteractiveProvider>
@@ -695,6 +789,44 @@ function useNextFrame(callback = () => {}) {
       window.cancelAnimationFrame(raf2);
     };
   }, [fn]);
+}
+
+/**
+ * Returns a list of potential tabbable candidates.
+ *
+ * NOTE: This is only a close approximation. For example it doesn't take into account cases like when
+ * elements are not visible. This cannot be worked out easily by just reading a property, but rather
+ * necessitate runtime knowledge (computed styles, etc). We deal with these cases separately.
+ *
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker
+ * Credit: https://github.com/discord/focus-layers/blob/master/src/util/wrapFocus.tsx#L1
+ */
+function getTabbableCandidates(container: HTMLElement) {
+  const nodes: HTMLElement[] = [];
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
+    acceptNode: (node: any) => {
+      const isHiddenInput = node.tagName === 'INPUT' && node.type === 'hidden';
+      if (node.disabled || node.hidden || isHiddenInput) return NodeFilter.FILTER_SKIP;
+      // `.tabIndex` is not the same as the `tabindex` attribute. It works on the
+      // runtime's understanding of tabbability, so this automatically accounts
+      // for any kind of element that could be tabbed to.
+      return node.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement);
+  // we do not take into account the order of nodes with positive `tabIndex` as it
+  // hinders accessibility to have tab order different from visual order.
+  return nodes;
+}
+
+function focusFirst(candidates: HTMLElement[]) {
+  const previouslyFocusedElement = document.activeElement;
+  return candidates.some((candidate) => {
+    // if focus is already where we want to go, we don't want to keep going through the candidates
+    if (candidate === previouslyFocusedElement) return true;
+    candidate.focus();
+    return document.activeElement !== previouslyFocusedElement;
+  });
 }
 
 const Provider = ToastProvider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,6 +3712,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.13.10
     "@radix-ui/primitive": "workspace:*"
+    "@radix-ui/react-collection": "workspace:*"
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
     "@radix-ui/react-dismissable-layer": "workspace:*"


### PR DESCRIPTION
fixes https://github.com/radix-ui/primitives/issues/1322
builds on https://github.com/radix-ui/primitives/pull/1468

> Most recent should be tabbed to first and unfortunately, most recent will be at the bottom of the viewport DOM.

As described in https://github.com/radix-ui/primitives/issues/1322 – We use portals to move `Toasts` into the `Viewport`, out of the box this causes issues with keyboard accessibility as the append only nature of portals means our source order places most recent toasts last. We were previously using mutation observer to re-order the DOM and solve for it, unfortunately this causes issues with animation libraries which depend on a stable DOM order.

After much investigation there appears to be no fool proof way to re-order DOM without causing issues downstream. Instead this change manages focus programatically so that the tab order reflects newest -> oldest toast without touching the DOM structure.