### PR TITLE
Fix Text Selection of HoverCard

### DIFF
--- a/.yarn/versions/4606939a.yml
+++ b/.yarn/versions/4606939a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-hover-card": patch
+
+declined:
+  - primitives

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -24,6 +24,53 @@ export const Basic = () => {
   );
 };
 
+export const LockTextSelection = () => {
+  return (
+    <>
+      <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
+        <HoverCard.Root allowOutsideSelection={false}>
+          <HoverCard.Trigger href="/" className={triggerClass()}>
+            trigger
+          </HoverCard.Trigger>
+          <HoverCard.Portal>
+            <HoverCard.Content className={contentClass()} sideOffset={5}>
+              <HoverCard.Arrow className={arrowClass()} width={20} height={10} />
+              <div>Unable to select outside of hover card</div>
+            </HoverCard.Content>
+          </HoverCard.Portal>
+        </HoverCard.Root>
+      </div>
+      <div>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque rem laborum provident fuga
+        omnis, enim distinctio id quod incidunt necessitatibus! Itaque quo quasi fuga, est
+        laboriosam incidunt officia dolorum iste reiciendis deserunt ipsam impedit ipsa, eos
+        blanditiis ex sequi eaque? Consequuntur modi, excepturi in asperiores ullam dolorum
+        voluptatem porro iure!
+      </div>
+      <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
+        <HoverCard.Root>
+          <HoverCard.Trigger href="/" className={triggerClass()}>
+            trigger
+          </HoverCard.Trigger>
+          <HoverCard.Portal>
+            <HoverCard.Content className={contentClass()} sideOffset={5}>
+              <HoverCard.Arrow className={arrowClass()} width={20} height={10} />
+              <div>Able to select outside of hover card</div>
+            </HoverCard.Content>
+          </HoverCard.Portal>
+        </HoverCard.Root>
+      </div>
+      <div>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque rem laborum provident fuga
+        omnis, enim distinctio id quod incidunt necessitatibus! Itaque quo quasi fuga, est
+        laboriosam incidunt officia dolorum iste reiciendis deserunt ipsam impedit ipsa, eos
+        blanditiis ex sequi eaque? Consequuntur modi, excepturi in asperiores ullam dolorum
+        voluptatem porro iure!
+      </div>
+    </>
+  );
+};
+
 export const AsyncUpdate = () => {
   const [open, setOpen] = React.useState(false);
   const [contentLoaded, setContentLoaded] = React.useState(false);


### PR DESCRIPTION
Addresses: #1470

Implemented: 
- When selecting text in the Hover Card, don't allow the selection to spill out of the Hover Card bounds.
- Don't close Hover Card on mouse out if there's an active text selection; require an additional pointer down instead.

I implemented a selection lock on outside text when the card is open by settings the user-select on document.body to 'none' and on the interior content to 'text'. This method is pretty hacky and doesn't work on force mounts. I'm also not sure if this has some unknown side effects. As such, I made the selection lock an opt-in prop. 

Honestly, the first feature could just be implemented by the developer, but the second one seems like it needs to be implemented internally.