### PR TITLE
[Popper][Popover][Dropdown] Allow PopperContent to be rendered positioned "fixed" with fixed/sticky anchors

### DIFF
--- a/.yarn/versions/8a17a5ac.yml
+++ b/.yarn/versions/8a17a5ac.yml
@@ -1,0 +1,10 @@
+releases:
+  "@radix-ui/popper": minor
+  "@radix-ui/react-context-menu": minor
+  "@radix-ui/react-dropdown-menu": minor
+  "@radix-ui/react-hover-card": minor
+  "@radix-ui/react-menu": minor
+  "@radix-ui/react-popover": minor
+  "@radix-ui/react-popper": minor
+  "@radix-ui/react-tooltip": minor
+  primitives: minor

--- a/packages/core/popper/src/index.ts
+++ b/packages/core/popper/src/index.ts
@@ -1,2 +1,2 @@
 export { getPlacementData, SIDE_OPTIONS, ALIGN_OPTIONS } from './popper';
-export type { Side, Align } from './popper';
+export type { Side, Align, Position } from './popper';

--- a/packages/core/popper/src/popper.ts
+++ b/packages/core/popper/src/popper.ts
@@ -8,6 +8,7 @@ type Side = typeof SIDE_OPTIONS[number];
 type Align = typeof ALIGN_OPTIONS[number];
 type Point = { x: number; y: number };
 type Size = { width: number; height: number };
+type Position = 'absolute' | 'fixed';
 
 type GetPlacementDataOptions = {
   /** The rect of the anchor we are placing around */
@@ -32,6 +33,8 @@ type GetPlacementDataOptions = {
   collisionBoundariesRect?: ClientRect;
   /** The tolerance used for collisions, ie. if we want them to trigger a bit earlier (default: 0) */
   collisionTolerance?: number;
+  /** An option to render the popover content fixed relative to the anchor (default: absolute) */
+  position?: Position;
 };
 
 type PlacementData = {
@@ -64,6 +67,7 @@ function getPlacementData({
   shouldAvoidCollisions = true,
   collisionBoundariesRect,
   collisionTolerance = 0,
+  position = 'absolute',
 }: GetPlacementDataOptions): PlacementData {
   // if we're not ready to do all the measurements yet,
   // we return some good default styles
@@ -88,7 +92,7 @@ function getPlacementData({
 
   // if we don't need to avoid collisions, we can stop here
   if (shouldAvoidCollisions === false) {
-    const popperStyles = getPlacementStylesForPoint(popperPoint);
+    const popperStyles = getPlacementStylesForPoint(popperPoint, position);
 
     let arrowStyles = UNMEASURED_ARROW_STYLES;
     if (arrowSize) {
@@ -152,7 +156,7 @@ function getPlacementData({
   const placedPopperPoint = allPlacementPoints[placedSide][placedAlign];
 
   // compute adjusted popper / arrow styles
-  const popperStyles = getPlacementStylesForPoint(placedPopperPoint);
+  const popperStyles = getPlacementStylesForPoint(placedPopperPoint, position);
 
   let arrowStyles = UNMEASURED_ARROW_STYLES;
   if (arrowSize) {
@@ -301,11 +305,13 @@ function getAlignAccountingForCollisions(
   return align;
 }
 
-function getPlacementStylesForPoint(point: Point): CSS.Properties {
-  const x = Math.round(point.x + window.scrollX);
-  const y = Math.round(point.y + window.scrollY);
+function getPlacementStylesForPoint(point: Point, position: Position): CSS.Properties {
+  const isFixed = position === 'fixed';
+  const x = Math.round(point.x + (isFixed ? 0 : window.scrollX));
+  const y = Math.round(point.y + (isFixed ? 0 : window.scrollY));
+
   return {
-    position: 'absolute',
+    position: isFixed ? 'fixed' : 'absolute',
     top: 0,
     left: 0,
     minWidth: 'max-content',
@@ -510,4 +516,4 @@ function getCollisions(
 type Collisions = ReturnType<typeof getCollisions>;
 
 export { getPlacementData, SIDE_OPTIONS, ALIGN_OPTIONS };
-export type { Side, Align };
+export type { Side, Align, Position };

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -40,6 +40,54 @@ export const Styled = () => (
   </div>
 );
 
+export const Fixed = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}>
+    <div style={{ position: 'fixed', top: '0', bottom: '0' }}>
+      <DropdownMenu.Root modal={false}>
+        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} position="fixed">
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+              One
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+              Two
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+              Three
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  </div>
+);
+
+export const Sticky = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '300vh' }}>
+    <div style={{ position: 'sticky', top: '0', bottom: '0' }}>
+      <DropdownMenu.Root modal={false}>
+        <DropdownMenu.Trigger className={triggerClass()}>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className={contentClass()} sideOffset={5} position="fixed">
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('one')}>
+              One
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('two')}>
+              Two
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('three')}>
+              Three
+            </DropdownMenu.Item>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  </div>
+);
+
 export const Modality = () => {
   return (
     <div

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -86,6 +86,48 @@ export const Controlled = () => {
   );
 };
 
+export const Sticky = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '300vh' }}
+    >
+      <div style={{ position: 'sticky', top: '0', bottom: '0' }}>
+        <Popover.Root>
+          <Popover.Trigger className={triggerClass()}>open</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content className={contentClass()} sideOffset={5} position="fixed">
+              <Popover.Close className={closeClass()}>close</Popover.Close>
+              <Popover.Arrow className={arrowClass()} width={20} height={10} />
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+        <input />
+      </div>
+    </div>
+  );
+};
+
+export const Fixed = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '300vh' }}
+    >
+      <div style={{ position: 'fixed', top: '0', bottom: '0' }}>
+        <Popover.Root>
+          <Popover.Trigger className={triggerClass()}>open</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content className={contentClass()} sideOffset={5} position="fixed">
+              <Popover.Close className={closeClass()}>close</Popover.Close>
+              <Popover.Arrow className={arrowClass()} width={20} height={10} />
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+        <input />
+      </div>
+    </div>
+  );
+};
+
 export const Animated = () => {
   return (
     <div

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ArrowPrimitive from '@radix-ui/react-arrow';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
-import { getPlacementData } from '@radix-ui/popper';
+import { getPlacementData, Position } from '@radix-ui/popper';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { useRect } from '@radix-ui/react-use-rect';
@@ -98,6 +98,7 @@ interface PopperContentProps extends PrimitiveDivProps {
   alignOffset?: number;
   collisionTolerance?: number;
   avoidCollisions?: boolean;
+  position?: Position;
 }
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
@@ -110,6 +111,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       alignOffset,
       collisionTolerance,
       avoidCollisions = true,
+      position = 'absolute',
       ...contentProps
     } = props;
 
@@ -142,6 +144,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       shouldAvoidCollisions: avoidCollisions,
       collisionBoundariesRect,
       collisionTolerance,
+      position,
     });
     const isPlaced = placedSide !== undefined;
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->
Hi team, thanks for all the awesome work, it's really appreciated! This library has allowed us to move SO much quicker 🙌

### Description
- As raised in #781, popovers/dropdowns aren't positioned relative to the anchor and scroll away when rendered in fixed/sticky containers.
- This fix allows for an optional prop (`position`) to be passed to the `PopperContent` component to override the `absolute` positioning as `fixed`, and ensure that they do not scroll away.
- When fixed, it removes the scroll offset in `getPlacementStylesForPoint` as this is no longer needed as the content is rendered "relative" to the anchor.

[popper-fixed-sticky.webm](https://user-images.githubusercontent.com/11038993/177214737-2cd1d3fd-37f7-4c25-a13d-0e716a1a696e.webm)

