### PR TITLE
[AlertDialog][ContextMenu][Dialog][DropdownMenu][Popover][Select] Remove `allowPinchZoom` prop

### DIFF
--- a/.yarn/versions/374cfd97.yml
+++ b/.yarn/versions/374cfd97.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -34,20 +34,15 @@ type ContextMenuContextValue = {
 const [ContextMenuProvider, useContextMenuContext] =
   createContextMenuContext<ContextMenuContextValue>(CONTEXT_MENU_NAME);
 
-type MenuRootProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 interface ContextMenuProps {
   children?: React.ReactNode;
   onOpenChange?(open: boolean): void;
   dir?: Direction;
   modal?: boolean;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: MenuRootProps['allowPinchZoom'];
 }
 
 const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuProps>) => {
-  const { __scopeContextMenu, children, onOpenChange, dir, modal = true, allowPinchZoom } = props;
+  const { __scopeContextMenu, children, onOpenChange, dir, modal = true } = props;
   const [open, setOpen] = React.useState(false);
   const menuScope = useMenuScope(__scopeContextMenu);
   const handleOpenChangeProp = useCallbackRef(onOpenChange);
@@ -73,7 +68,6 @@ const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuP
         open={open}
         onOpenChange={handleOpenChange}
         modal={modal}
-        allowPinchZoom={allowPinchZoom}
       >
         {children}
       </MenuPrimitive.Root>

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -223,22 +223,6 @@ export const ForcedMount = () => (
   </Dialog.Root>
 );
 
-export const AllowPinchZoom = () => (
-  <div style={{ display: 'grid', placeItems: 'center', height: '200vh' }}>
-    <Dialog.Root allowPinchZoom>
-      <Dialog.Trigger className={triggerClass()}>open</Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Overlay className={overlayClass()} />
-        <Dialog.Content className={contentDefaultClass()}>
-          <Dialog.Title>Booking info</Dialog.Title>
-          <Dialog.Description>Please enter the info for your booking below.</Dialog.Description>
-          <Dialog.Close className={closeClass()}>close</Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  </div>
-);
-
 export const InnerScrollable = () => (
   <Dialog.Root>
     <Dialog.Trigger className={triggerClass()}>open</Dialog.Trigger>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -36,22 +36,16 @@ type DialogContextValue = {
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
   modal: boolean;
-  allowPinchZoom: DialogProps['allowPinchZoom'];
 };
 
 const [DialogProvider, useDialogContext] = createDialogContext<DialogContextValue>(DIALOG_NAME);
 
-type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface DialogProps {
   children?: React.ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   modal?: boolean;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
 }
 
 const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
@@ -62,7 +56,6 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
     defaultOpen,
     onOpenChange,
     modal = true,
-    allowPinchZoom,
   } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const contentRef = React.useRef<DialogContentElement>(null);
@@ -84,7 +77,6 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
       onOpenChange={setOpen}
       onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
       modal={modal}
-      allowPinchZoom={allowPinchZoom}
     >
       {children}
     </DialogProvider>
@@ -205,7 +197,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
     return (
       // Make sure `Content` is scrollable even when it doesn't live inside `RemoveScroll`
       // ie. when `Overlay` and `Content` are siblings
-      <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom} shards={[context.contentRef]}>
+      <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
         <Primitive.div
           data-state={getState(context.open)}
           {...overlayProps}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -39,7 +39,6 @@ type DropdownMenuContextValue = {
 const [DropdownMenuProvider, useDropdownMenuContext] =
   createDropdownMenuContext<DropdownMenuContextValue>(DROPDOWN_MENU_NAME);
 
-type MenuRootProps = Radix.ComponentPropsWithoutRef<typeof MenuPrimitive.Root>;
 interface DropdownMenuProps {
   children?: React.ReactNode;
   dir?: Direction;
@@ -47,10 +46,6 @@ interface DropdownMenuProps {
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   modal?: boolean;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: MenuRootProps['allowPinchZoom'];
 }
 
 const DropdownMenu: React.FC<DropdownMenuProps> = (props: ScopedProps<DropdownMenuProps>) => {
@@ -62,7 +57,6 @@ const DropdownMenu: React.FC<DropdownMenuProps> = (props: ScopedProps<DropdownMe
     defaultOpen,
     onOpenChange,
     modal = true,
-    allowPinchZoom,
   } = props;
   const menuScope = useMenuScope(__scopeDropdownMenu);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -83,14 +77,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = (props: ScopedProps<DropdownMe
       onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
       modal={modal}
     >
-      <MenuPrimitive.Root
-        {...menuScope}
-        open={open}
-        onOpenChange={setOpen}
-        dir={dir}
-        modal={modal}
-        allowPinchZoom={allowPinchZoom}
-      >
+      <MenuPrimitive.Root {...menuScope} open={open} onOpenChange={setOpen} dir={dir} modal={modal}>
         {children}
       </MenuPrimitive.Root>
     </DropdownMenuProvider>

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -73,34 +73,20 @@ type MenuRootContextValue = {
   isUsingKeyboardRef: React.RefObject<boolean>;
   dir: Direction;
   modal: boolean;
-  allowPinchZoom: MenuProps['allowPinchZoom'];
 };
 
 const [MenuRootProvider, useMenuRootContext] = createMenuContext<MenuRootContextValue>(MENU_NAME);
 
-type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface MenuProps {
   children?: React.ReactNode;
   open?: boolean;
   onOpenChange?(open: boolean): void;
   dir?: Direction;
   modal?: boolean;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
 }
 
 const Menu: React.FC<MenuProps> = (props: ScopedProps<MenuProps>) => {
-  const {
-    __scopeMenu,
-    open = false,
-    children,
-    dir,
-    onOpenChange,
-    modal = true,
-    allowPinchZoom,
-  } = props;
+  const { __scopeMenu, open = false, children, dir, onOpenChange, modal = true } = props;
   const popperScope = usePopperScope(__scopeMenu);
   const [content, setContent] = React.useState<MenuContentElement | null>(null);
   const isUsingKeyboardRef = React.useRef(false);
@@ -139,7 +125,6 @@ const Menu: React.FC<MenuProps> = (props: ScopedProps<MenuProps>) => {
           isUsingKeyboardRef={isUsingKeyboardRef}
           dir={direction}
           modal={modal}
-          allowPinchZoom={allowPinchZoom}
         >
           {children}
         </MenuRootProvider>
@@ -399,7 +384,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
 
     const ScrollLockWrapper = disableOutsideScroll ? RemoveScroll : React.Fragment;
     const scrollLockWrapperProps = disableOutsideScroll
-      ? { as: Slot, allowPinchZoom: rootContext.allowPinchZoom }
+      ? { as: Slot, allowPinchZoom: true }
       : undefined;
 
     const handleTypeaheadSearch = (key: string) => {

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -41,23 +41,17 @@ type PopoverContextValue = {
   onCustomAnchorAdd(): void;
   onCustomAnchorRemove(): void;
   modal: boolean;
-  allowPinchZoom: PopoverProps['allowPinchZoom'];
 };
 
 const [PopoverProvider, usePopoverContext] =
   createPopoverContext<PopoverContextValue>(POPOVER_NAME);
 
-type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface PopoverProps {
   children?: React.ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   modal?: boolean;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
 }
 
 const Popover: React.FC<PopoverProps> = (props: ScopedProps<PopoverProps>) => {
@@ -68,7 +62,6 @@ const Popover: React.FC<PopoverProps> = (props: ScopedProps<PopoverProps>) => {
     defaultOpen,
     onOpenChange,
     modal = false,
-    allowPinchZoom,
   } = props;
   const popperScope = usePopperScope(__scopePopover);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -92,7 +85,6 @@ const Popover: React.FC<PopoverProps> = (props: ScopedProps<PopoverProps>) => {
         onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
         onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}
         modal={modal}
-        allowPinchZoom={allowPinchZoom}
       >
         {children}
       </PopoverProvider>
@@ -262,7 +254,7 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
     }, []);
 
     return (
-      <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
+      <RemoveScroll as={Slot} allowPinchZoom>
         <PopoverContentImpl
           {...props}
           ref={composedRefs}

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -61,7 +61,6 @@ type SelectContextValue = {
   onOpenChange(open: boolean): void;
   dir: SelectProps['dir'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
-  allowPinchZoom: SelectProps['allowPinchZoom'];
 };
 
 const [SelectProvider, useSelectContext] = createSelectContext<SelectContextValue>(SELECT_NAME);
@@ -75,7 +74,6 @@ type SelectNativeOptionsContextValue = {
 const [SelectNativeOptionsProvider, useSelectNativeOptionsContext] =
   createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
 
-type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
 interface SelectProps {
   children?: React.ReactNode;
   value?: string;
@@ -87,10 +85,6 @@ interface SelectProps {
   dir?: Direction;
   name?: string;
   autoComplete?: string;
-  /**
-   * @see https://github.com/theKashey/react-remove-scroll#usage
-   */
-  allowPinchZoom?: RemoveScrollProps['allowPinchZoom'];
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -106,7 +100,6 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     dir,
     name,
     autoComplete,
-    allowPinchZoom,
   } = props;
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
   const [valueNode, setValueNode] = React.useState<SelectValueElement | null>(null);
@@ -153,7 +146,6 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
       onOpenChange={setOpen}
       dir={direction}
       triggerPointerDownPosRef={triggerPointerDownPosRef}
-      allowPinchZoom={allowPinchZoom}
     >
       <Collection.Provider scope={__scopeSelect}>
         <SelectNativeOptionsProvider
@@ -753,7 +745,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         shouldExpandOnScrollRef={shouldExpandOnScrollRef}
         searchRef={searchRef}
       >
-        <RemoveScroll as={Slot} allowPinchZoom={context.allowPinchZoom}>
+        <RemoveScroll as={Slot} allowPinchZoom>
           <div
             ref={setContentWrapper}
             style={{


### PR DESCRIPTION
- `allowPinchZoom` was `false` by default, which is by default an accessibility issue.
- It also means if users want it back, it's impossible to bring back without the extra prop
- after experimenting with our own remove scroll ideas during hack week, we concluded pinch zooming should be allowed by default and that if users want to disallow that, they can do it themselves, so we're removing the prop and hardcoding to `true` for now so we don't create an extra breaking change for it after v1.