### PR TITLE
Prevent ToolbarItem click from firing twice

### DIFF
--- a/.yarn/versions/8da3c08f.yml
+++ b/.yarn/versions/8da3c08f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-toolbar": patch

--- a/.yarn/versions/8da3c08f.yml
+++ b/.yarn/versions/8da3c08f.yml
@@ -1,2 +1,5 @@
 releases:
   "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/toolbar/src/Toolbar.test.tsx
+++ b/packages/react/toolbar/src/Toolbar.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent, getByText } from '@testing-library/react';
+import * as Toolbar from '@radix-ui/react-toolbar';
+
+
+const component = (props: any) => {
+  return render(
+    <Toolbar.Root>
+      <Toolbar.ToggleGroup type="single">
+        <Toolbar.ToggleItem value="left" onClick={props.onClick}>
+          Left
+        </Toolbar.ToggleItem>
+      </Toolbar.ToggleGroup>
+    </Toolbar.Root>
+  );
+}
+
+describe('given a default Toolbar', () => {
+  it('should have no accessibility violations', async () => {
+    const spy = jest.fn();
+
+    const rendered = component({
+      onClick: spy
+    })
+
+    fireEvent(
+      getByText(rendered.container, 'Left'),
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/toolbar/src/Toolbar.test.tsx
+++ b/packages/react/toolbar/src/Toolbar.test.tsx
@@ -16,7 +16,7 @@ const component = (props: any) => {
 }
 
 describe('given a default Toolbar', () => {
-  it('should have no accessibility violations', async () => {
+  it('Click event should be called just once', async () => {
     const spy = jest.fn();
 
     const rendered = component({

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -202,9 +202,10 @@ const ToolbarToggleItem = React.forwardRef<ToolbarToggleItemElement, ToolbarTogg
   (props: ScopedProps<ToolbarToggleItemProps>, forwardedRef) => {
     const { __scopeToolbar, ...toggleItemProps } = props;
     const toggleGroupScope = useToggleGroupScope(__scopeToolbar);
-    const scope = { __scopeMenu: props.__scopeMenu };
+    const scope = { __scopeToolbar: props.__scopeToolbar };
+
     return (
-      <ToolbarButton asChild {...props}>
+      <ToolbarButton asChild {...scope}>
         <ToggleGroupPrimitive.Item {...toggleGroupScope} {...toggleItemProps} ref={forwardedRef} />
       </ToolbarButton>
     );

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -202,6 +202,7 @@ const ToolbarToggleItem = React.forwardRef<ToolbarToggleItemElement, ToolbarTogg
   (props: ScopedProps<ToolbarToggleItemProps>, forwardedRef) => {
     const { __scopeToolbar, ...toggleItemProps } = props;
     const toggleGroupScope = useToggleGroupScope(__scopeToolbar);
+    const scope = { __scopeMenu: props.__scopeMenu };
     return (
       <ToolbarButton asChild {...props}>
         <ToggleGroupPrimitive.Item {...toggleGroupScope} {...toggleItemProps} ref={forwardedRef} />


### PR DESCRIPTION
### Description
Fixes issue with Toggle Item firing Click event twice, bug reported here:
https://github.com/radix-ui/primitives/issues/1525

This PR was based into another related issue reported back in january
https://github.com/radix-ui/primitives/pull/1157

The PR follows same principle, creating an scoped preventing multiple click event to be triggered, also i've added a Unit test to ensure the Click gets called just once.