### PR TITLE
[RadioGroup] Add `disabled` prop to `Root`

### DIFF
--- a/.yarn/versions/f15929a4.yml
+++ b/.yarn/versions/f15929a4.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-radio-group": minor
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/react/radio-group/src/RadioGroup.stories.tsx
@@ -248,7 +248,7 @@ export const Chromatic = () => {
         </RadioGroup.Item>
       </RadioGroup.Root>
 
-      <h1>Disabled</h1>
+      <h1>Disabled item</h1>
       <RadioGroup.Root className={rootClass()}>
         <RadioGroup.Item className={itemClass()} value="1">
           <RadioGroup.Indicator className={indicatorClass()} />
@@ -257,6 +257,34 @@ export const Chromatic = () => {
           <RadioGroup.Indicator className={indicatorClass()} />
         </RadioGroup.Item>
         <RadioGroup.Item className={itemClass()} value="3">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+      </RadioGroup.Root>
+
+      <h1>Disabled root</h1>
+      <RadioGroup.Root className={rootClass()} disabled>
+        <RadioGroup.Item className={itemClass()} value="1">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        {/* Not possible to set `disabled` back to `false` since it's set on the root (this item
+            should still be disabled). */}
+        <RadioGroup.Item className={itemClass()} value="2" disabled={false}>
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemClass()} value="3">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+      </RadioGroup.Root>
+
+      <h1>All items disabled</h1>
+      <RadioGroup.Root className={rootClass()}>
+        <RadioGroup.Item className={itemClass()} value="1" disabled>
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemClass()} value="2" disabled>
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemClass()} value="3" disabled>
           <RadioGroup.Indicator className={indicatorClass()} />
         </RadioGroup.Item>
       </RadioGroup.Root>
@@ -330,7 +358,7 @@ export const Chromatic = () => {
         </RadioGroup.Item>
       </RadioGroup.Root>
 
-      <h2>Disabled</h2>
+      <h2>Disabled item</h2>
       <RadioGroup.Root className={rootAttrClass()} defaultValue="3">
         <RadioGroup.Item className={itemAttrClass()} value="1">
           <RadioGroup.Indicator className={indicatorAttrClass()} />
@@ -351,6 +379,32 @@ export const Chromatic = () => {
           <RadioGroup.Indicator className={indicatorAttrClass()} />
         </RadioGroup.Item>
         <RadioGroup.Item className={itemAttrClass()} value="3">
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+      </RadioGroup.Root>
+
+      <h2>Disabled root</h2>
+      <RadioGroup.Root className={rootAttrClass()} defaultValue="3" disabled>
+        <RadioGroup.Item className={itemAttrClass()} value="1">
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemAttrClass()} value="2">
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemAttrClass()} value="3">
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+      </RadioGroup.Root>
+
+      <h2>All items disabled</h2>
+      <RadioGroup.Root className={rootAttrClass()} defaultValue="3">
+        <RadioGroup.Item className={itemAttrClass()} value="1" disabled>
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemAttrClass()} value="2" disabled>
+          <RadioGroup.Indicator className={indicatorAttrClass()} />
+        </RadioGroup.Item>
+        <RadioGroup.Item className={itemAttrClass()} value="3" disabled>
           <RadioGroup.Indicator className={indicatorAttrClass()} />
         </RadioGroup.Item>
       </RadioGroup.Root>
@@ -422,6 +476,8 @@ const styles = {
   backgroundColor: 'rgba(0, 0, 255, 0.3)',
   border: '2px solid blue',
   padding: 10,
+
+  '&[tabindex="0"]': { boxShadow: 'inset 0 0 0 2px yellow' },
 
   '&:disabled': { opacity: 0.5 },
   '&[data-disabled]': { borderStyle: 'dashed' },

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -20,7 +20,7 @@ const ARROW_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
 const RADIO_GROUP_NAME = 'RadioGroup';
 
 type ScopedProps<P> = P & { __scopeRadioGroup?: Scope };
-const [createRadioGroupContet, createRadioGroupScope] = createContextScope(RADIO_GROUP_NAME, [
+const [createRadioGroupContext, createRadioGroupScope] = createContextScope(RADIO_GROUP_NAME, [
   createRovingFocusGroupScope,
   createRadioScope,
 ]);
@@ -35,7 +35,7 @@ type RadioGroupContextValue = {
 };
 
 const [RadioGroupProvider, useRadioGroupContext] =
-  createRadioGroupContet<RadioGroupContextValue>(RADIO_GROUP_NAME);
+  createRadioGroupContext<RadioGroupContextValue>(RADIO_GROUP_NAME);
 
 type RadioGroupElement = React.ElementRef<typeof Primitive.div>;
 type RovingFocusGroupProps = Radix.ComponentPropsWithoutRef<typeof RovingFocusGroup.Root>;

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -30,6 +30,7 @@ const useRadioScope = createRadioScope();
 type RadioGroupContextValue = {
   name?: string;
   required: boolean;
+  disabled: boolean;
   value?: string;
   onValueChange(value: string): void;
 };
@@ -43,6 +44,7 @@ type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface RadioGroupProps extends PrimitiveDivProps {
   name?: RadioGroupContextValue['name'];
   required?: Radix.ComponentPropsWithoutRef<typeof Radio>['required'];
+  disabled?: Radix.ComponentPropsWithoutRef<typeof Radio>['disabled'];
   dir?: RovingFocusGroupProps['dir'];
   orientation?: RovingFocusGroupProps['orientation'];
   loop?: RovingFocusGroupProps['loop'];
@@ -59,6 +61,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
       defaultValue,
       value: valueProp,
       required = false,
+      disabled = false,
       orientation,
       dir,
       loop = true,
@@ -78,6 +81,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
         scope={__scopeRadioGroup}
         name={name}
         required={required}
+        disabled={disabled}
         value={value}
         onValueChange={setValue}
       >
@@ -92,6 +96,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
             role="radiogroup"
             aria-required={required}
             aria-orientation={orientation}
+            data-disabled={disabled ? '' : undefined}
             dir={direction}
             {...groupProps}
             ref={forwardedRef}
@@ -120,6 +125,7 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
   (props: ScopedProps<RadioGroupItemProps>, forwardedRef) => {
     const { __scopeRadioGroup, disabled, ...itemProps } = props;
     const context = useRadioGroupContext(ITEM_NAME, __scopeRadioGroup);
+    const isDisabled = context.disabled || disabled;
     const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeRadioGroup);
     const radioScope = useRadioScope(__scopeRadioGroup);
     const ref = React.useRef<React.ElementRef<typeof Radio>>(null);
@@ -146,11 +152,11 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
       <RovingFocusGroup.Item
         asChild
         {...rovingFocusGroupScope}
-        focusable={!disabled}
+        focusable={!isDisabled}
         active={checked}
       >
         <Radio
-          disabled={disabled}
+          disabled={isDisabled}
           required={context.required}
           checked={checked}
           {...radioScope}

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -114,12 +114,14 @@ export const EdgeCases = () => {
   const [extra, setExtra] = React.useState(false);
   const [disabled, setDisabled] = React.useState(false);
   const [hidden, setHidden] = React.useState(false);
+  const [disabled3To5, setDisabled3To5] = React.useState(false);
 
   return (
     <>
       <button onClick={() => setExtra((x) => !x)}>Add/remove extra</button>
       <button onClick={() => setDisabled((x) => !x)}>Disable/Enable "One"</button>
       <button onClick={() => setHidden((x) => !x)}>Hide/show "One"</button>
+      <button onClick={() => setDisabled3To5((x) => !x)}>Disable/Enable "Three" to "Five"</button>
       <hr />
 
       <ButtonGroup>
@@ -130,12 +132,19 @@ export const EdgeCases = () => {
         <Button value="two" disabled>
           Two
         </Button>
-        <Button value="three">Three</Button>
-        <Button value="four" style={{ display: 'none' }}>
+        <Button value="three" disabled={disabled3To5}>
+          Three
+        </Button>
+        <Button value="four" disabled={disabled3To5} style={{ display: 'none' }}>
           Four
         </Button>
-        <Button value="five">Five</Button>
+        <Button value="five" disabled={disabled3To5}>
+          Five
+        </Button>
       </ButtonGroup>
+
+      <hr />
+      <button type="button">Focusable outside of group</button>
     </>
   );
 };
@@ -173,7 +182,7 @@ const Button = (props: ButtonProps) => {
     contextValue !== undefined && props.value !== undefined && contextValue === props.value;
 
   return (
-    <RovingFocusGroup.Item asChild active={isSelected}>
+    <RovingFocusGroup.Item asChild active={isSelected} focusable={!props.disabled}>
       <button
         {...props}
         style={{


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Allows setting `disabled` on the root `RadioGroup`, setting all `Radio` items as `disabled`.

The `RovingFocusGroup` has be altered to become unfocusable when it has no focusable items.