### PR TITLE
[Popper] Remove old `offset` prop from `Arrow`'s types

### DIFF
--- a/.yarn/versions/65e485ad.yml
+++ b/.yarn/versions/65e485ad.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -310,15 +310,13 @@ const OPPOSITE_SIDE: Record<Side, Side> = {
 
 type PopperArrowElement = React.ElementRef<typeof ArrowPrimitive.Root>;
 type ArrowProps = Radix.ComponentPropsWithoutRef<typeof ArrowPrimitive.Root>;
-interface PopperArrowProps extends ArrowProps {
-  offset?: number;
-}
+interface PopperArrowProps extends ArrowProps {}
 
 const PopperArrow = React.forwardRef<PopperArrowElement, PopperArrowProps>(function PopperArrow(
   props: ScopedProps<PopperArrowProps>,
   forwardedRef
 ) {
-  const { __scopePopper, offset, ...arrowProps } = props;
+  const { __scopePopper, ...arrowProps } = props;
   const contentContext = useContentContext(ARROW_NAME, __scopePopper);
   const baseSide = OPPOSITE_SIDE[contentContext.placedSide];
 


### PR DESCRIPTION
Forgot to remove it from the types before…