### PR TITLE
[Menu] Expose onEntryFocus

### DIFF
--- a/.yarn/versions/7eff1081.yml
+++ b/.yarn/versions/7eff1081.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": minor
+  "@radix-ui/react-dropdown-menu": minor
+  "@radix-ui/react-menu": minor
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -343,6 +343,7 @@ interface MenuContentImplProps
    * @defaultValue false
    */
   loop?: RovingFocusGroupProps['loop'];
+  onEntryFocus?: RovingFocusGroupProps['onEntryFocus'];
 
   onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
   onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
@@ -483,10 +484,10 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                 loop={loop}
                 currentTabStopId={currentItemId}
                 onCurrentTabStopIdChange={setCurrentItemId}
-                onEntryFocus={(event) => {
+                onEntryFocus={composeEventHandlers(props.onEntryFocus, (event) => {
                   // only focus first item when using keyboard
                   if (!rootContext.isUsingKeyboardRef.current) event.preventDefault();
-                }}
+                })}
               >
                 <PopperPrimitive.Content
                   role="menu"


### PR DESCRIPTION
This PR exposes the cited event to allow some primitives to opt out of the default `focusFirst` when menu is opened
