### PR TITLE
[Popper] Add support for limiting height to available space

### DIFF
--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -334,6 +334,54 @@ export const Chromatic = () => {
     </div>
   );
 };
+
+export const LimitHeightToAvailableSpace = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Scrollable>
+      <Popper.Root>
+        <Popper.Anchor className={anchorClass()} onClick={() => setOpen(true)}>
+          open
+        </Popper.Anchor>
+
+        {open && (
+          <Popper.Content
+            limitHeightToAvailableSpace
+            className={contentClass({
+              size: 'auto',
+            })}
+            sideOffset={5}
+          >
+            <button onClick={() => setOpen(false)}>close</button>
+            <p>
+              Lacinia hendrerit auctor nam quisque augue suscipit feugiat, sit at imperdiet vitae
+              lacus. Dolor sit dui posuere faucibus non pharetra laoreet conubia, augue rhoncus cras
+              nisl sodales proin hac ipsum, per hendrerit sed volutpat natoque curae consectetur.
+              Curae blandit neque vehicula vel mauris vulputate per felis sociosqu, sodales integer
+              sollicitudin id litora accumsan viverra pulvinar, mus non adipiscing dolor facilisis
+              habitasse mi leo. Litora faucibus eu pulvinar tempus gravida iaculis consectetur risus
+              euismod fringilla, dui posuere viverra sapien tortor mattis et dolor tempor sem
+              conubia, taciti sociis mus rhoncus cubilia praesent dapibus aliquet quis. Diam
+              hendrerit aliquam metus dolor fusce lorem, non gravida arcu primis posuere ipsum
+              adipiscing, mus sollicitudin eros lacinia mollis.
+            </p>
+            <p>
+              Habitant fames mi massa mollis fusce congue nascetur magna bibendum inceptos accumsan,
+              potenti ipsum ac sollicitudin taciti dis rhoncus lacinia fermentum placerat. Himenaeos
+              taciti egestas lacinia maecenas ornare ultricies, auctor vitae nulla mi posuere leo
+              mollis, eleifend lacus rutrum ante curabitur. Nullam mi quisque nulla enim pretium
+              facilisi interdum morbi, himenaeos velit fames pellentesque eget nascetur laoreet vel
+              rutrum, malesuada risus ad netus dolor et scelerisque.
+            </p>
+
+            <Popper.Arrow className={arrowClass()} width={20} height={10} />
+          </Popper.Content>
+        )}
+      </Popper.Root>
+    </Scrollable>
+  );
+};
+
 Chromatic.parameters = { chromatic: { disable: false } };
 
 const Scrollable = (props: any) => (
@@ -371,6 +419,7 @@ const contentClass = css({
     size: {
       small: { width: 100, height: 50 },
       large: { width: 300, height: 150 },
+      auto: { width: 300, height: 'calc(100% - 20px)', overflow: 'auto' },
     },
   },
   defaultVariants: {

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -419,7 +419,7 @@ const contentClass = css({
     size: {
       small: { width: 100, height: 50 },
       large: { width: 300, height: 150 },
-      auto: { width: 300, overflow: 'auto' },
+      auto: { width: 300, height: 'calc(100% - 20px)', overflow: 'auto' },
     },
   },
   defaultVariants: {

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -419,7 +419,7 @@ const contentClass = css({
     size: {
       small: { width: 100, height: 50 },
       large: { width: 300, height: 150 },
-      auto: { width: 300, height: 'calc(100% - 20px)', overflow: 'auto' },
+      auto: { width: 300, overflow: 'auto' },
     },
   },
   defaultVariants: {

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -199,8 +199,15 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         hideWhenDetached ? hide({ strategy: 'referenceHidden' }) : undefined,
         limitHeightToAvailableSpace
           ? size({
-              apply: ({ availableHeight }) => {
-                setLimitedHeight(availableHeight);
+              ...detectOverflowOptions,
+              apply: ({ availableHeight, elements }) => {
+                if (availableHeight <= elements.floating.clientHeight) {
+                  elements.floating.style.height = `${availableHeight}px`;
+                  setLimitedHeight(availableHeight);
+                } else {
+                  elements.floating.style.height = 'auto';
+                  setLimitedHeight(undefined);
+                }
               },
             })
           : undefined,
@@ -255,6 +262,10 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       ref: composedRefs,
       style: {
         ...contentProps.style,
+        height:
+          contentProps.style?.height ?? limitHeightToAvailableSpace
+            ? `calc(100% - ${arrowSize?.height ?? 0}px)`
+            : undefined,
         // if the PopperContent hasn't been placed yet (not all measurements done)
         // we prevent animations so that users's animation don't kick in too early referring wrong sides
         animation: !isPlaced ? 'none' : undefined,

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -8,6 +8,7 @@ import {
   hide,
   arrow as floatingUIarrow,
   flip,
+  size,
 } from '@floating-ui/react-dom';
 import * as ArrowPrimitive from '@radix-ui/react-arrow';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -125,6 +126,10 @@ interface PopperContentProps extends PrimitiveDivProps {
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
   avoidCollisions?: boolean;
+  /**
+   * Limit the height of the content to the available space.
+   */
+  limitHeightToAvailableSpace?: boolean;
 }
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
@@ -141,12 +146,14 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       sticky = 'partial',
       hideWhenDetached = false,
       avoidCollisions = true,
+      limitHeightToAvailableSpace = false,
       ...contentProps
     } = props;
 
     const context = usePopperContext(CONTENT_NAME, __scopePopper);
 
     const [content, setContent] = React.useState<HTMLDivElement | null>(null);
+    const [limitedHeight, setLimitedHeight] = React.useState<number | undefined>(undefined);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
 
     const [arrow, setArrow] = React.useState<HTMLSpanElement | null>(null);
@@ -190,6 +197,13 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         avoidCollisions ? flip({ ...detectOverflowOptions }) : undefined,
         transformOrigin({ arrowWidth, arrowHeight }),
         hideWhenDetached ? hide({ strategy: 'referenceHidden' }) : undefined,
+        limitHeightToAvailableSpace
+          ? size({
+              apply: ({ availableHeight }) => {
+                setLimitedHeight(availableHeight);
+              },
+            })
+          : undefined,
       ].filter(isDefined),
     });
 
@@ -257,6 +271,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
           position: strategy,
           left: 0,
           top: 0,
+          height: limitedHeight,
           transform: isPlaced
             ? `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`
             : 'translate3d(0, -200%, 0)', // keep off the page when measuring

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -262,10 +262,6 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       ref: composedRefs,
       style: {
         ...contentProps.style,
-        height:
-          contentProps.style?.height ?? limitHeightToAvailableSpace
-            ? `calc(100% - ${arrowSize?.height ?? 0}px)`
-            : undefined,
         // if the PopperContent hasn't been placed yet (not all measurements done)
         // we prevent animations so that users's animation don't kick in too early referring wrong sides
         animation: !isPlaced ? 'none' : undefined,


### PR DESCRIPTION
### Description

Add support for limiting height to available space. Fixes #1596

Basically introduces a prop for popper based components that can limit the height of the content based on available space:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/11449728/182717171-e234a7eb-e3b8-42fc-9992-f9756f85721a.png">
