### PR TITLE
Remove  prettier-ignore from @radix-ui/react-primitive

### DIFF
--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -18,9 +18,6 @@ const NODES = [
   'ul',
 ] as const;
 
-// Temporary while we await merge of this fix:
-// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55396
-// prettier-ignore
 type PropsWithoutRef<P> = P extends any ? ('ref' extends keyof P ? Pick<P, Exclude<keyof P, 'ref'>> : P) : P;
 type ComponentPropsWithoutRef<T extends React.ElementType> = PropsWithoutRef<
   React.ComponentProps<T>


### PR DESCRIPTION
### Description

Removes the prettier-ignore rule from the react primitive component as the referenced pull request has been merged
