### PR TITLE
[DropdownMenu] Prevent passing keydown event to the focused MenuItem from MenuTrigger

### DIFF
--- a/.yarn/versions/975c6613.yml
+++ b/.yarn/versions/975c6613.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -126,7 +126,11 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           })}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
-            if (['Enter', ' '].includes(event.key)) context.onOpenToggle();
+            if (['Enter', ' '].includes(event.key)) {
+              context.onOpenToggle();
+              // prevent passing keydown event to the focused MenuItem element in Firefox
+              if (!context.open) event.preventDefault();
+            }
             if (event.key === 'ArrowDown') context.onOpenChange(true);
             // prevent keypresses from scrolling window
             if ([' ', 'ArrowDown'].includes(event.key)) event.preventDefault();

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -126,14 +126,11 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           })}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
-            if (['Enter', ' '].includes(event.key)) {
-              context.onOpenToggle();
-              // prevent passing keydown event to the focused MenuItem element in Firefox
-              if (!context.open) event.preventDefault();
-            }
+            if (['Enter', ' '].includes(event.key)) context.onOpenToggle();
             if (event.key === 'ArrowDown') context.onOpenChange(true);
-            // prevent keypresses from scrolling window
-            if ([' ', 'ArrowDown'].includes(event.key)) event.preventDefault();
+            // prevent keydown from scrolling window / first focused item to execute
+            // that keydown (inadvertently closing the menu)
+            if (['Enter', ' ', 'ArrowDown'].includes(event.key)) event.preventDefault();
           })}
         />
       </MenuPrimitive.Anchor>


### PR DESCRIPTION
### Description

This fix should prevent passing `onKeyDown` to the focused `DropdownMenuItem` from `DropdownMenuTrigger` which triggered `onClick` event on `a` or `button` elements.

---
Closes #1268
Closes #1397
Closes #1622
Closes #1655
