### PR TITLE
[Toast] Fix dom conflicts with announce

### DIFF
--- a/.yarn/versions/e8601616.yml
+++ b/.yarn/versions/e8601616.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toast": patch
+
+declined:
+  - primitives

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -425,7 +425,6 @@ type SwipeEvent = { currentTarget: EventTarget & ToastElement } & Omit<
 >;
 
 const [ToastInteractiveProvider, useToastInteractiveContext] = createToastContext(TOAST_NAME, {
-  isInteractive: false,
   onClose() {},
 });
 
@@ -463,8 +462,8 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       ...toastProps
     } = props;
     const context = useToastProviderContext(TOAST_NAME, __scopeToast);
-    const ref = React.useRef<ToastImplElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
+    const [node, setNode] = React.useState<ToastImplElement | null>(null);
+    const composedRefs = useComposedRefs(forwardedRef, (node) => setNode(node));
     const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
     const swipeDeltaRef = React.useRef<{ x: number; y: number } | null>(null);
     const duration = durationProp || context.duration;
@@ -475,7 +474,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
     const handleClose = useCallbackRef(() => {
       // focus viewport if focus is within toast to read the remaining toast
       // count to SR users and ensure focus isn't lost
-      const isFocusInToast = ref.current?.contains(document.activeElement);
+      const isFocusInToast = node?.contains(document.activeElement);
       if (isFocusInToast) context.viewport?.focus();
       onClose();
     });
@@ -522,21 +521,27 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       return () => onToastRemove();
     }, [onToastAdd, onToastRemove]);
 
+    const announceTextContent = React.useMemo(() => {
+      return node ? getAnnounceTextContent(node) : null;
+    }, [node]);
+
     if (!context.viewport) return null;
 
     return (
       <>
-        <ToastAnnounce
-          __scopeToast={__scopeToast}
-          // Toasts are always role=status to avoid stuttering issues with role=alert in SRs.
-          role="status"
-          aria-live={type === 'foreground' ? 'assertive' : 'polite'}
-          aria-atomic
-        >
-          {props.children}
-        </ToastAnnounce>
+        {announceTextContent && (
+          <ToastAnnounce
+            __scopeToast={__scopeToast}
+            // Toasts are always role=status to avoid stuttering issues with role=alert in SRs.
+            role="status"
+            aria-live={type === 'foreground' ? 'assertive' : 'polite'}
+            aria-atomic
+          >
+            {announceTextContent}
+          </ToastAnnounce>
+        )}
 
-        <ToastInteractiveProvider scope={__scopeToast} isInteractive onClose={handleClose}>
+        <ToastInteractiveProvider scope={__scopeToast} onClose={handleClose}>
           {ReactDOM.createPortal(
             <Collection.ItemSlot scope={__scopeToast}>
               <DismissableLayer.Root
@@ -655,50 +660,30 @@ ToastImpl.propTypes = {
 /* -----------------------------------------------------------------------------------------------*/
 
 interface ToastAnnounceProps
-  extends React.ComponentPropsWithoutRef<'div'>,
-    ScopedProps<{ children?: ToastImplProps['children'] }> {}
+  extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'>,
+    ScopedProps<{ children: string[] }> {}
 
 const ToastAnnounce: React.FC<ToastAnnounceProps> = (props: ScopedProps<ToastAnnounceProps>) => {
   const { __scopeToast, children, ...announceProps } = props;
   const context = useToastProviderContext(TOAST_NAME, __scopeToast);
   const [renderAnnounceText, setRenderAnnounceText] = React.useState(false);
   const [isAnnounced, setIsAnnounced] = React.useState(false);
-  const [fragment, setFragment] = React.useState<DocumentFragment>();
-  const [rootFragmentNode, setRootFragmentNode] = React.useState<HTMLDivElement | null>(null);
-
-  // We portal children into a document fragment so that we can extract the bare text nodes
-  // before rendering to the DOM. This avoids issues with duplicate `children`
-  // and animation libraries when composing via `asChild`.
-  const announceTextContent = React.useMemo(() => {
-    return rootFragmentNode ? getAnnounceTextContent(rootFragmentNode) : null;
-  }, [rootFragmentNode]);
-
-  // setting the fragment in `useLayoutEffect` as `DocumentFragment` doesn't exist on the server
-  useLayoutEffect(() => {
-    setFragment(new DocumentFragment());
-  }, []);
 
   // render text content in the next frame to ensure toast is announced in NVDA
   useNextFrame(() => setRenderAnnounceText(true));
 
+  // cleanup after announcing
   React.useEffect(() => {
     const timer = window.setTimeout(() => setIsAnnounced(true), 1000);
     return () => window.clearTimeout(timer);
   }, []);
 
   return isAnnounced ? null : (
-    <>
-      {fragment && (
-        <Portal container={fragment as any} ref={setRootFragmentNode}>
-          {context.label} {children}
-        </Portal>
-      )}
-      <Portal asChild>
-        <VisuallyHidden {...announceProps}>
-          {renderAnnounceText && announceTextContent}
-        </VisuallyHidden>
-      </Portal>
-    </>
+    <Portal asChild>
+      <VisuallyHidden {...announceProps}>
+        {renderAnnounceText && `${context.label} ${children}`}
+      </VisuallyHidden>
+    </Portal>
   );
 };
 
@@ -759,12 +744,11 @@ interface ToastActionProps extends ToastCloseProps {
 const ToastAction = React.forwardRef<ToastActionElement, ToastActionProps>(
   (props: ScopedProps<ToastActionProps>, forwardedRef) => {
     const { altText, ...actionProps } = props;
-    const context = useToastInteractiveContext(ACTION_NAME, props.__scopeToast);
     if (!altText) return null;
-    return context.isInteractive ? (
-      <ToastClose {...actionProps} ref={forwardedRef} />
-    ) : (
-      <span>{altText}</span>
+    return (
+      <ToastAnnounceExclude altText={altText} asChild>
+        <ToastClose {...actionProps} ref={forwardedRef} />
+      </ToastAnnounceExclude>
     );
   }
 );
@@ -794,18 +778,44 @@ const ToastClose = React.forwardRef<ToastCloseElement, ToastCloseProps>(
   (props: ScopedProps<ToastCloseProps>, forwardedRef) => {
     const { __scopeToast, ...closeProps } = props;
     const interactiveContext = useToastInteractiveContext(CLOSE_NAME, __scopeToast);
-    return interactiveContext.isInteractive ? (
-      <Primitive.button
-        type="button"
-        {...closeProps}
-        ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, interactiveContext.onClose)}
-      />
-    ) : null;
+
+    return (
+      <ToastAnnounceExclude asChild>
+        <Primitive.button
+          type="button"
+          {...closeProps}
+          ref={forwardedRef}
+          onClick={composeEventHandlers(props.onClick, interactiveContext.onClose)}
+        />
+      </ToastAnnounceExclude>
+    );
   }
 );
 
 ToastClose.displayName = CLOSE_NAME;
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type ToastAnnounceExcludeElement = React.ElementRef<typeof Primitive.div>;
+interface ToastAnnounceExcludeProps extends PrimitiveDivProps {
+  altText?: string;
+}
+
+const ToastAnnounceExclude = React.forwardRef<
+  ToastAnnounceExcludeElement,
+  ToastAnnounceExcludeProps
+>((props: ScopedProps<ToastAnnounceExcludeProps>, forwardedRef) => {
+  const { __scopeToast, altText, ...announceHiddenProps } = props;
+
+  return (
+    <Primitive.div
+      data-radix-toast-announce-exclude={altText ? undefined : ''}
+      data-radix-toast-announce-alt={altText || undefined}
+      {...announceHiddenProps}
+      ref={forwardedRef}
+    />
+  );
+});
 
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -864,8 +874,16 @@ function getAnnounceTextContent(container: HTMLElement) {
   childNodes.forEach((node) => {
     if (node.nodeType === node.TEXT_NODE && node.textContent) textContent.push(node.textContent);
     if (isHTMLElement(node)) {
-      const isHidden = node.ariaHidden || node.hidden || node.style.display === 'none';
-      if (!isHidden) textContent.push(...getAnnounceTextContent(node));
+      const isHidden =
+        node.ariaHidden ||
+        node.hidden ||
+        node.style.display === 'none' ||
+        node.dataset.radixToastAnnounceExclude === '';
+
+      const altText = node.dataset.radixToastAnnounceAlt;
+      const textNodes = altText ? [altText] : getAnnounceTextContent(node);
+
+      if (!isHidden) textContent.push(...textNodes);
     }
   });
 


### PR DESCRIPTION
While working on toast I realised that internal refs attached to children were behaving strangely, they were returning `null` after 1 second.

I tracked this back to the changes in https://github.com/radix-ui/primitives/pull/1528/files where we render `ToastAnnounce` into a `documentFragment`. As soon as that fragment is removed we lose the reference to it as well.

This change avoids rendering two sets of children entirely. Instead we query for text content from `Toast.Root` and filter out what we don't need using data attrs