### PR TITLE
[DismissableLayer] Add DOM event handlers to ownerDocument

### DIFF
--- a/.yarn/versions/8165e81a.yml
+++ b/.yarn/versions/8165e81a.yml
@@ -1,0 +1,17 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-escape-keydown": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import * as Popper from '@radix-ui/react-popper';
 import { Portal } from '@radix-ui/react-portal';
@@ -643,3 +644,23 @@ function DummyPopover({
     </Popper.Root>
   );
 }
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popupWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popupWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popupWindow.document.createElement('div');
+    popupWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<DismissableBox />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};

--- a/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { css } from '../../../../stitches.config';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import * as Dialog from '@radix-ui/react-dialog';
@@ -812,6 +813,43 @@ export const WithTooltip = () => (
     </DropdownMenu.Root>
   </div>
 );
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popupWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popupWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popupWindow.document.createElement('div');
+    popupWindow.document.body.append(containerNode);
+
+    ReactDOM.render(
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal container={containerNode}>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('undo')}>
+              Undo
+            </DropdownMenu.Item>
+            <DropdownMenu.Item className={itemClass()} onSelect={() => console.log('redo')}>
+              Redo
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+      containerNode
+    );
+  }, []);
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};
 
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);

--- a/packages/react/use-escape-keydown/src/useEscapeKeydown.tsx
+++ b/packages/react/use-escape-keydown/src/useEscapeKeydown.tsx
@@ -4,7 +4,10 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 /**
  * Listens for when the escape key is down
  */
-function useEscapeKeydown(onEscapeKeyDownProp?: (event: KeyboardEvent) => void) {
+function useEscapeKeydown(
+  onEscapeKeyDownProp?: (event: KeyboardEvent) => void,
+  ownerDocument: Document = document
+) {
   const onEscapeKeyDown = useCallbackRef(onEscapeKeyDownProp);
 
   React.useEffect(() => {
@@ -13,9 +16,9 @@ function useEscapeKeydown(onEscapeKeyDownProp?: (event: KeyboardEvent) => void) 
         onEscapeKeyDown(event);
       }
     };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onEscapeKeyDown]);
+    ownerDocument.addEventListener('keydown', handleKeyDown);
+    return () => ownerDocument.removeEventListener('keydown', handleKeyDown);
+  }, [onEscapeKeyDown, ownerDocument]);
 }
 
 export { useEscapeKeydown };


### PR DESCRIPTION
### Description

Adding event handlers  to the `document` global is not correct when the element is rendered in a popup window. This changes the `usePointerDownOutside`, `useFocusOutside` and `useEscapeKeydown` hooks used by `DimissableLayer ` to take into account the correct document.

Fixes #1676