### PR TITLE
[Toast] Fix timer issues

### DIFF
--- a/.yarn/versions/7845b662.yml
+++ b/.yarn/versions/7845b662.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-toast": patch
+
+declined:
+  - primitives

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -191,24 +191,27 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
         };
 
         const handleFocusOutResume = (event: FocusEvent) => {
-          // Only resume when focus moves out of the wrapper
-          if (!wrapper.contains(event.relatedTarget as HTMLElement)) {
-            handleResume();
-          }
+          const isFocusMovingOutside = !wrapper.contains(event.relatedTarget as HTMLElement);
+          if (isFocusMovingOutside) handleResume();
+        };
+
+        const handlePointerLeaveResume = () => {
+          const isFocusInside = wrapper.contains(document.activeElement);
+          if (!isFocusInside) handleResume();
         };
 
         // Toasts are not in the viewport React tree so we need to bind DOM events
         wrapper.addEventListener('focusin', handlePause);
         wrapper.addEventListener('focusout', handleFocusOutResume);
         wrapper.addEventListener('pointermove', handlePause);
-        wrapper.addEventListener('pointerleave', handleResume);
+        wrapper.addEventListener('pointerleave', handlePointerLeaveResume);
         window.addEventListener('blur', handlePause);
         window.addEventListener('focus', handleResume);
         return () => {
           wrapper.removeEventListener('focusin', handlePause);
           wrapper.removeEventListener('focusout', handleFocusOutResume);
           wrapper.removeEventListener('pointermove', handlePause);
-          wrapper.removeEventListener('pointerleave', handleResume);
+          wrapper.removeEventListener('pointerleave', handlePointerLeaveResume);
           window.removeEventListener('blur', handlePause);
           window.removeEventListener('focus', handleResume);
         };


### PR DESCRIPTION
Address timer issues mentioned in https://github.com/radix-ui/primitives/pull/1669#issuecomment-1252282997

The underlying issue is that the pause handling doesn't account for multiple calls in succession. Because we're now exposing `onPause` and `onResume` it made more sense to address the issue at source with the duplicate events being fired.

@benoitgrelard might be easier to hop on a call to go over this.