### PR TITLE
[Popper] Allow more control over avoidCollisions

### DIFF
--- a/.yarn/versions/11f57b40.yml
+++ b/.yarn/versions/11f57b40.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": minor
+  "@radix-ui/react-dropdown-menu": minor
+  "@radix-ui/react-hover-card": minor
+  "@radix-ui/react-menu": minor
+  "@radix-ui/react-menubar": minor
+  "@radix-ui/react-popover": minor
+  "@radix-ui/react-popper": minor
+  "@radix-ui/react-select": minor
+  "@radix-ui/react-tooltip": minor
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -126,7 +126,7 @@ interface PopperContentProps extends PrimitiveDivProps {
   collisionPadding?: number | Partial<Record<Side, number>>;
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
-  avoidCollisions?: boolean;
+  avoidCollisions?: boolean | 'off' | 'flip' | 'shift' | 'auto';
   onPlaced?: () => void;
 }
 
@@ -143,7 +143,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       collisionPadding: collisionPaddingProp = 0,
       sticky = 'partial',
       hideWhenDetached = false,
-      avoidCollisions = true,
+      avoidCollisions = 'auto',
       onPlaced,
       ...contentProps
     } = props;
@@ -159,6 +159,9 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
     const arrowHeight = arrowSize?.height ?? 0;
 
     const desiredPlacement = (side + (align !== 'center' ? '-' + align : '')) as Placement;
+
+    const avoidCollisionsMode =
+      typeof avoidCollisions === 'string' ? avoidCollisions : avoidCollisions ? 'auto' : 'off';
 
     const collisionPadding =
       typeof collisionPaddingProp === 'number'
@@ -183,7 +186,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       middleware: [
         anchorCssProperties(),
         offset({ mainAxis: sideOffset + arrowHeight, alignmentAxis: alignOffset }),
-        avoidCollisions
+        avoidCollisionsMode === 'auto' || avoidCollisionsMode === 'shift'
           ? shift({
               mainAxis: true,
               crossAxis: false,
@@ -192,7 +195,9 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
             })
           : undefined,
         arrow ? floatingUIarrow({ element: arrow, padding: arrowPadding }) : undefined,
-        avoidCollisions ? flip({ ...detectOverflowOptions }) : undefined,
+        avoidCollisionsMode === 'auto' || avoidCollisionsMode === 'flip'
+          ? flip({ ...detectOverflowOptions })
+          : undefined,
         size({
           ...detectOverflowOptions,
           apply: ({ elements, availableWidth: width, availableHeight: height }) => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->
Ref #1568.

### Description

Expands the possible values for `avoidCollisions` to include the following:

- `auto` &mdash; current behavior (as of 1.0.0) &mdash; Shift along the main axis and flip over the cross axis
- `flip` &mdash; Flip along both axes, but don't shift
- `shift` &mdash; Shift along the main axis only, but don't flip
- `off` &mdash; disable collision avoidance

Boolean values are still accepted for compatibility:
- `true` &rarr; `auto`
- `false` &rarr; `off`

I looked for Stories that would be appropriate to extend, but couldn't find any that demonstrated the shift+flip/auto behavior. Happy to add one if a maintainer pointed me in the right direction.

### Open questions

- In `shift` mode, should we set `crossAxis: true`? Or should `flip` and `shift` act as strict behavioral subsets of `auto`, per the current implementation?