### PR TITLE
[Tooltip] Shouldn't open if trigger is clicked **before** the tooltip opens

### DIFF
--- a/.yarn/versions/cd691ba7.yml
+++ b/.yarn/versions/cd691ba7.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -302,12 +302,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             if (!isPointerDownRef.current) context.onOpen();
           })}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            // keyboard click will occur under different conditions for different node
-            // types so we use `onClick` instead of `onKeyDown` to respect that
-            const isKeyboardClick = event.detail === 0;
-            if (isKeyboardClick) context.onClose();
-          })}
+          onClick={composeEventHandlers(props.onClick, context.onClose)}
         />
       </PopperPrimitive.Anchor>
     );


### PR DESCRIPTION
### Description

<!-- Describe the change you are introducing -->

closes #1691 

**What was done?**

   Cancel the **trigger** event **onClick**. 
 
 **More details?**
 
 The tooltip appears if the user stays hovered over the trigger component, but if the user clicks the trigger before the timeout activates the tooltip(which by default is 700ms), then the tooltip text no longer appears.


https://user-images.githubusercontent.com/25510810/192797127-7262d02a-9a80-4739-8215-54b3136a93f9.mov


     

