### PR TITLE
[Select] Add `disabled` prop to `Root`

### DIFF
--- a/.yarn/versions/d05a249e.yml
+++ b/.yarn/versions/d05a249e.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": minor
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -457,6 +457,69 @@ export const WithinForm = () => {
   );
 };
 
+export const DisabledWithinForm = () => {
+  const [data, setData] = React.useState({});
+
+  function handleChange(event: React.FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    setData(Object.fromEntries((formData as any).entries()));
+  }
+
+  return (
+    <form
+      style={{ padding: 50 }}
+      onSubmit={(event) => {
+        handleChange(event);
+        event.preventDefault();
+      }}
+      onChange={handleChange}
+    >
+      <Label style={{ display: 'block' }}>
+        Name
+        <input name="name" autoComplete="name" style={{ display: 'block' }} />
+      </Label>
+      <br />
+      <Label style={{ display: 'block' }}>
+        Country
+        <Select.Root name="country" autoComplete="country" defaultValue="fr" disabled>
+          <Select.Trigger className={triggerClass()}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={contentClass()}>
+              <Select.Viewport className={viewportClass()}>
+                <Select.Item className={itemClass()} value="fr">
+                  <Select.ItemText>France</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="uk">
+                  <Select.ItemText>United Kingdom</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="es">
+                  <Select.ItemText>Spain</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+      <br />
+      <button type="submit">Submit</button>
+      <br />
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </form>
+  );
+};
+
 export const WithinDialog = () => (
   <Dialog.Root>
     <Dialog.Trigger>Open Dialog</Dialog.Trigger>

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -60,6 +60,7 @@ type SelectContextValue = {
   onOpenChange(open: boolean): void;
   dir: SelectProps['dir'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
+  disabled?: boolean;
 };
 
 const [SelectProvider, useSelectContext] = createSelectContext<SelectContextValue>(SELECT_NAME);
@@ -84,6 +85,7 @@ interface SelectProps {
   dir?: Direction;
   name?: string;
   autoComplete?: string;
+  disabled?: boolean;
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -99,6 +101,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     dir,
     name,
     autoComplete,
+    disabled,
   } = props;
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
   const [valueNode, setValueNode] = React.useState<SelectValueElement | null>(null);
@@ -145,6 +148,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
       onOpenChange={setOpen}
       dir={direction}
       triggerPointerDownPosRef={triggerPointerDownPosRef}
+      disabled={disabled}
     >
       <Collection.Provider scope={__scopeSelect}>
         <SelectNativeOptionsProvider
@@ -174,6 +178,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
           value={value}
           // enable form autofill
           onChange={(event) => setValue(event.target.value)}
+          disabled={disabled}
         >
           {Array.from(nativeOptionsSet)}
         </BubbleSelect>
@@ -196,8 +201,9 @@ interface SelectTriggerProps extends PrimitiveButtonProps {}
 
 const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>(
   (props: ScopedProps<SelectTriggerProps>, forwardedRef) => {
-    const { __scopeSelect, disabled = false, ...triggerProps } = props;
+    const { __scopeSelect, ...triggerProps } = props;
     const context = useSelectContext(TRIGGER_NAME, __scopeSelect);
+    const disabled = props.disabled || context.disabled;
     const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
     const getItems = useCollection(__scopeSelect);
 

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -201,9 +201,9 @@ interface SelectTriggerProps extends PrimitiveButtonProps {}
 
 const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>(
   (props: ScopedProps<SelectTriggerProps>, forwardedRef) => {
-    const { __scopeSelect, disabled: disabledProp = false, ...triggerProps } = props;
+    const { __scopeSelect, disabled = false, ...triggerProps } = props;
     const context = useSelectContext(TRIGGER_NAME, __scopeSelect);
-    const disabled = disabledProp || context.disabled;
+    const isDisabled = context.disabled || disabled;
     const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
     const getItems = useCollection(__scopeSelect);
 
@@ -217,7 +217,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
     });
 
     const handleOpen = () => {
-      if (!disabled) {
+      if (!isDisabled) {
         context.onOpenChange(true);
         // reset typeahead when we open
         resetTypeahead();
@@ -233,8 +233,8 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
         aria-autocomplete="none"
         dir={context.dir}
         data-state={context.open ? 'open' : 'closed'}
-        disabled={disabled}
-        data-disabled={disabled ? '' : undefined}
+        disabled={isDisabled}
+        data-disabled={isDisabled ? '' : undefined}
         data-placeholder={context.value === undefined ? '' : undefined}
         {...triggerProps}
         ref={composedRefs}

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -201,9 +201,9 @@ interface SelectTriggerProps extends PrimitiveButtonProps {}
 
 const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>(
   (props: ScopedProps<SelectTriggerProps>, forwardedRef) => {
-    const { __scopeSelect, ...triggerProps } = props;
+    const { __scopeSelect, disabled: disabledProp = false, ...triggerProps } = props;
     const context = useSelectContext(TRIGGER_NAME, __scopeSelect);
-    const disabled = props.disabled || context.disabled;
+    const disabled = disabledProp || context.disabled;
     const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
     const getItems = useCollection(__scopeSelect);
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This will add `disabled` prop to `<Select.Root>` to disable its trigger and the BubbleSelect when it's inside a form.
It's different from disabling the trigger only because the select value will not be submitted

![image](https://user-images.githubusercontent.com/48067039/193731014-5d542312-bf20-49a7-988b-22701ff8642d.png)

