### PR TITLE
[Collapsible][Accordion] Fix initial animation playback in Firefox and Safari

### DIFF
--- a/.yarn/versions/4f235e95.yml
+++ b/.yarn/versions/4f235e95.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-collapsible": patch
+
+declined:
+  - primitives

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -176,11 +176,13 @@ const CollapsibleContentImpl = React.forwardRef<
     if (node) {
       originalStylesRef.current = originalStylesRef.current || {
         transitionDuration: node.style.transitionDuration,
+        animationName: node.style.animationName,
         animationDuration: node.style.animationDuration,
         animationFillMode: node.style.animationFillMode,
       };
       // block any animations/transitions so the element renders at its full dimensions
       node.style.transitionDuration = '0s';
+      node.style.animationName = 'none';
       node.style.animationDuration = '0s';
       node.style.animationFillMode = 'none';
 
@@ -192,6 +194,7 @@ const CollapsibleContentImpl = React.forwardRef<
       // kick off any animations/transitions that were originally set up if it isn't the initial mount
       if (!isMountAnimationPreventedRef.current) {
         node.style.transitionDuration = originalStylesRef.current.transitionDuration;
+        node.style.animationName = originalStylesRef.current.animationName;
         node.style.animationDuration = originalStylesRef.current.animationDuration;
         node.style.animationFillMode = originalStylesRef.current.animationFillMode;
       }

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -177,14 +177,10 @@ const CollapsibleContentImpl = React.forwardRef<
       originalStylesRef.current = originalStylesRef.current || {
         transitionDuration: node.style.transitionDuration,
         animationName: node.style.animationName,
-        animationDuration: node.style.animationDuration,
-        animationFillMode: node.style.animationFillMode,
       };
       // block any animations/transitions so the element renders at its full dimensions
       node.style.transitionDuration = '0s';
       node.style.animationName = 'none';
-      node.style.animationDuration = '0s';
-      node.style.animationFillMode = 'none';
 
       // get width and height from full dimensions
       const rect = node.getBoundingClientRect();
@@ -195,8 +191,6 @@ const CollapsibleContentImpl = React.forwardRef<
       if (!isMountAnimationPreventedRef.current) {
         node.style.transitionDuration = originalStylesRef.current.transitionDuration;
         node.style.animationName = originalStylesRef.current.animationName;
-        node.style.animationDuration = originalStylesRef.current.animationDuration;
-        node.style.animationFillMode = originalStylesRef.current.animationFillMode;
       }
 
       setIsPresent(present);


### PR DESCRIPTION
closes https://github.com/radix-ui/primitives/issues/1265

After some exploration it dawned that perhaps these browsers need a little bump to replay the animation from scratch for the initial size retrieval.

I'll try and validate this behaviour in a smaller example but this does fix the issue.

@benoitgrelard Do you remember why we moved away from the [clearing the shorthand](https://github.com/radix-ui/primitives/pull/1044/files) in the first place? I remember that had problems but i'm questioning if removing the name property alone is all we need.