### PR TITLE
[Menu] Support typeahead without "menu" role

### DIFF
--- a/.yarn/versions/790cf30d.yml
+++ b/.yarn/versions/790cf30d.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -492,6 +492,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                   role="menu"
                   aria-orientation="vertical"
                   data-state={getOpenState(context.open)}
+                  data-radix-menu-content=""
                   dir={rootContext.dir}
                   {...popperScope}
                   {...contentProps}
@@ -500,7 +501,8 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                   onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
                     // submenu key events bubble through portals. We only care about keys in this menu.
                     const target = event.target as HTMLElement;
-                    const isKeyDownInside = target.closest('[role="menu"]') === event.currentTarget;
+                    const isKeyDownInside =
+                      target.closest('[data-radix-menu-content]') === event.currentTarget;
                     const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
                     const isCharacterKey = event.key.length === 1;
                     if (isKeyDownInside) {


### PR DESCRIPTION
### Description

Fixes an issue where typeahead wouldn't work on menus if the user changes the "role" attribute of the menu content component (e.g. by setting `role="listbox"`).

Hit this when implementing a custom "select multiple" component on top of a dropdown menu. When changing the role of the menu to "listbox", typeahead would no longer work.
