### PR TITLE
[DropdownMenu][ContextMenu] Don't exit fullscreen when esc-ing out of a submenu

### DIFF
--- a/.yarn/versions/c21771b2.yml
+++ b/.yarn/versions/c21771b2.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/c21771b2.yml
+++ b/.yarn/versions/c21771b2.yml
@@ -2,6 +2,7 @@ releases:
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dropdown-menu": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
 
 declined:
   - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1187,7 +1187,10 @@ const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentPro
                 // on pointer interaction.
                 if (event.target !== subContext.trigger) context.onOpenChange(false);
               })}
-              onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, rootContext.onClose)}
+              onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, (event) => {
+                event.preventDefault();
+                rootContext.onClose();
+              })}
               onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
                 // Submenu key events bubble through portals. We only care about keys in this menu.
                 const isKeyDownInside = event.currentTarget.contains(event.target as HTMLElement);

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1188,8 +1188,9 @@ const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentPro
                 if (event.target !== subContext.trigger) context.onOpenChange(false);
               })}
               onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, (event) => {
-                event.preventDefault();
                 rootContext.onClose();
+                // ensure pressing escape in submenu doesn't escape full screen mode
+                event.preventDefault();
               })}
               onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
                 // Submenu key events bubble through portals. We only care about keys in this menu.


### PR DESCRIPTION
Fixes radix-ui/primitives#1751

### Description

I kept looking at it, and I think this is probably the right place for this `preventDefault`? It even seems like another option for `composeEventHandlers` that would automatically `preventDefault` might make sense. I don't wanna tell you how to design your library, though.
