### PR TITLE
[Select] fix invalid pointerId in Firefox Cypress test

### DIFF
--- a/.yarn/versions/82e6e50f.yml
+++ b/.yarn/versions/82e6e50f.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -257,7 +257,10 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
         onPointerDown={composeEventHandlers(triggerProps.onPointerDown, (event) => {
           // prevent implicit pointer capture
           // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
-          (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+          const target = event.target as HTMLElement;
+          if (target.hasPointerCapture(event.pointerId)) {
+            target.releasePointerCapture(event.pointerId);
+          }
 
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
           // but not when the control key is pressed (avoiding MacOS right click)


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Fixes https://github.com/cypress-io/cypress/issues/24459

> Looks like the invalid pointer ID is thrown If the pointerId does not match any the active pointers and so returns void and throws a DOMException with the name InvalidPointerId . I believe this is happening because the captured pointer is being automatically released by firefox a fraction earlier, so by the time the pointerdown listener is called, the component no longer has a valid pointerID as it has implicitly been released thereby throwing an error.
>
> According to https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture "the [hasPointerCapture](https://www.w3.org/TR/pointerevents3/#dom-element-haspointercapture) API may be used (eg. within any [pointerdown](https://www.w3.org/TR/pointerevents3/#dfn-pointerdown) listener) to determine if `setPointerCapture was called on the target element"

To verify fix, run `npx cypress run --headed --browser firefox --spec cypress/integration/Select.spec.ts`

<img width="986" alt="image" src="https://user-images.githubusercontent.com/36122/199657501-cac87571-b3bd-4dee-9a7c-ba6dd1d7e392.png">

### Known issues

Headless Firefox does not work. See https://github.com/cypress-io/cypress/issues/24459#issuecomment-1301673757

