### PR TITLE
[Select] add scroll button onClick for better touch experience

### DIFF
--- a/.yarn/versions/03e4cd61.yml
+++ b/.yarn/versions/03e4cd61.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": minor
+
+declined:
+  - primitives

--- a/.yarn/versions/03e4cd61.yml
+++ b/.yarn/versions/03e4cd61.yml
@@ -1,5 +1,5 @@
 releases:
-  "@radix-ui/react-select": minor
+  "@radix-ui/react-select": patch
 
 declined:
   - primitives

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -1027,6 +1027,7 @@ const scrollButtonClass = css({
   backgroundColor: '$white',
   color: '$black',
   cursor: 'default',
+  userSelect: 'none',
 });
 
 const scrollUpButtonClass = css(scrollButtonClass, {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1165,8 +1165,7 @@ SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
 const SCROLL_UP_BUTTON_NAME = 'SelectScrollUpButton';
 
 type SelectScrollUpButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollUpButtonProps
-  extends Omit<SelectScrollButtonImplProps, 'onAutoScroll' | 'onScroll'> {}
+interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
 
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
@@ -1199,12 +1198,6 @@ const SelectScrollUpButton = React.forwardRef<
           viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight;
         }
       }}
-      onScroll={() => {
-        const { viewport } = contentContext;
-        if (viewport) {
-          viewport.scrollTop = viewport.scrollTop - viewport.offsetHeight;
-        }
-      }}
     />
   ) : null;
 });
@@ -1218,8 +1211,7 @@ SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 const SCROLL_DOWN_BUTTON_NAME = 'SelectScrollDownButton';
 
 type SelectScrollDownButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollDownButtonProps
-  extends Omit<SelectScrollButtonImplProps, 'onAutoScroll' | 'onScroll'> {}
+interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
@@ -1255,12 +1247,6 @@ const SelectScrollDownButton = React.forwardRef<
           viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight;
         }
       }}
-      onScroll={() => {
-        const { viewport } = contentContext;
-        if (viewport) {
-          viewport.scrollTop = viewport.scrollTop + viewport.offsetHeight;
-        }
-      }}
     />
   ) : null;
 });
@@ -1270,14 +1256,13 @@ SelectScrollDownButton.displayName = SCROLL_DOWN_BUTTON_NAME;
 type SelectScrollButtonImplElement = React.ElementRef<typeof Primitive.div>;
 interface SelectScrollButtonImplProps extends PrimitiveDivProps {
   onAutoScroll(): void;
-  onScroll(): void;
 }
 
 const SelectScrollButtonImpl = React.forwardRef<
   SelectScrollButtonImplElement,
   SelectScrollButtonImplProps
 >((props: ScopedProps<SelectScrollButtonImplProps>, forwardedRef) => {
-  const { __scopeSelect, onAutoScroll, onScroll, ...scrollIndicatorProps } = props;
+  const { __scopeSelect, onAutoScroll, ...scrollIndicatorProps } = props;
   const contentContext = useSelectContentContext('SelectScrollButton', __scopeSelect);
   const autoScrollTimerRef = React.useRef<number | null>(null);
   const getItems = useCollection(__scopeSelect);
@@ -1308,9 +1293,10 @@ const SelectScrollButtonImpl = React.forwardRef<
       {...scrollIndicatorProps}
       ref={forwardedRef}
       style={{ flexShrink: 0, ...scrollIndicatorProps.style }}
-      onClick={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
-        contentContext.onItemLeave?.();
-        onScroll();
+      onPointerDown={composeEventHandlers(scrollIndicatorProps.onPointerDown, () => {
+        if (autoScrollTimerRef.current === null) {
+          autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
+        }
       })}
       onPointerMove={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
         contentContext.onItemLeave?.();

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1165,7 +1165,8 @@ SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
 const SCROLL_UP_BUTTON_NAME = 'SelectScrollUpButton';
 
 type SelectScrollUpButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollUpButtonProps
+  extends Omit<SelectScrollButtonImplProps, 'onAutoScroll' | 'onScroll'> {}
 
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
@@ -1198,6 +1199,12 @@ const SelectScrollUpButton = React.forwardRef<
           viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight;
         }
       }}
+      onScroll={() => {
+        const { viewport } = contentContext;
+        if (viewport) {
+          viewport.scrollTop = viewport.scrollTop - viewport.offsetHeight;
+        }
+      }}
     />
   ) : null;
 });
@@ -1211,7 +1218,8 @@ SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 const SCROLL_DOWN_BUTTON_NAME = 'SelectScrollDownButton';
 
 type SelectScrollDownButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollDownButtonProps
+  extends Omit<SelectScrollButtonImplProps, 'onAutoScroll' | 'onScroll'> {}
 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
@@ -1247,6 +1255,12 @@ const SelectScrollDownButton = React.forwardRef<
           viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight;
         }
       }}
+      onScroll={() => {
+        const { viewport } = contentContext;
+        if (viewport) {
+          viewport.scrollTop = viewport.scrollTop + viewport.offsetHeight;
+        }
+      }}
     />
   ) : null;
 });
@@ -1256,13 +1270,14 @@ SelectScrollDownButton.displayName = SCROLL_DOWN_BUTTON_NAME;
 type SelectScrollButtonImplElement = React.ElementRef<typeof Primitive.div>;
 interface SelectScrollButtonImplProps extends PrimitiveDivProps {
   onAutoScroll(): void;
+  onScroll(): void;
 }
 
 const SelectScrollButtonImpl = React.forwardRef<
   SelectScrollButtonImplElement,
   SelectScrollButtonImplProps
 >((props: ScopedProps<SelectScrollButtonImplProps>, forwardedRef) => {
-  const { __scopeSelect, onAutoScroll, ...scrollIndicatorProps } = props;
+  const { __scopeSelect, onAutoScroll, onScroll, ...scrollIndicatorProps } = props;
   const contentContext = useSelectContentContext('SelectScrollButton', __scopeSelect);
   const autoScrollTimerRef = React.useRef<number | null>(null);
   const getItems = useCollection(__scopeSelect);
@@ -1293,6 +1308,10 @@ const SelectScrollButtonImpl = React.forwardRef<
       {...scrollIndicatorProps}
       ref={forwardedRef}
       style={{ flexShrink: 0, ...scrollIndicatorProps.style }}
+      onClick={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
+        contentContext.onItemLeave?.();
+        onScroll();
+      })}
       onPointerMove={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
         contentContext.onItemLeave?.();
         if (autoScrollTimerRef.current === null) {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

These changes introduce an onClick event handler for the Select scroll buttons for better user experience on touch devices. This issue was highlighted by our QA engineer that scrolling the Select content with swipe gestures might not be obvious to some users. If they tried to click on the scroll buttons, nothing happened. After this change, clicking on the scroll buttons scrolls the viewport.

This change only enhances the touch experience. To test, 

1. Navigate to the Select Within Dialog story http://localhost:9009/?path=/story/components-select--within-dialog
2. Open browser devtools and enable mobile mode
3. Open the select and click on the scroll buttons

https://user-images.githubusercontent.com/36122/200658548-28ee7a1a-cb15-42ce-96cc-9eacdc11aaae.mov

