### PR TITLE
[Menu] Only require onCheckedChange to handle boolean values

### DIFF
--- a/.yarn/versions/a93e3f6a.yml
+++ b/.yarn/versions/a93e3f6a.yml
@@ -1,0 +1,7 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/a93e3f6a.yml
+++ b/.yarn/versions/a93e3f6a.yml
@@ -2,6 +2,7 @@ releases:
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dropdown-menu": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
 
 declined:
   - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -753,7 +753,7 @@ type CheckedState = boolean | 'indeterminate';
 
 interface MenuCheckboxItemProps extends MenuItemProps {
   checked?: CheckedState;
-  onCheckedChange?: (checked: CheckedState) => void;
+  onCheckedChange?: (checked: boolean) => void;
 }
 
 const MenuCheckboxItem = React.forwardRef<MenuCheckboxItemElement, MenuCheckboxItemProps>(

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -753,6 +753,7 @@ type CheckedState = boolean | 'indeterminate';
 
 interface MenuCheckboxItemProps extends MenuItemProps {
   checked?: CheckedState;
+  // `onCheckedChange` can never be called with `"indeterminate"` from the inside
   onCheckedChange?: (checked: boolean) => void;
 }
 


### PR DESCRIPTION
### Description

This makes using `CheckboxItem` with TypeScript a bit simpler, as it doesn't require state managed up the tree to allow indeterminate states if it doesn't want to. More practically, it makes this allowed:

```tsx
const [checked, setChecked] = useState(false);
<CheckboxItem
  checked={checked}
  onCheckedChange={setChecked}
/>
```

Previously that would result in a type error, because `setChecked` didn't permit indeterminate states. However, `CheckboxItem` never actually sets itself into an indeterminate state—that can only be set via props—meaning we shouldn't have to support that case if we don't want to.

I've marked this as a patch version because, despite changing a type definition, function types are contravariant in TypeScript, i.e. any function which is assignable to `(value: boolean | "indeterminate") => void` is also assignable to `(value: boolean) => void`, so I don't think this should break any existing usage. 

You can see the current state of things in [this CodeSandbox](https://codesandbox.io/s/oncheckedchange-indeterminate-ohj17n?file=/src/App.tsx), as well as the workaround required if you only want your state to be boolean.