### PR TITLE
[Dialog] Allow first focus on anchors

### DIFF
--- a/.yarn/versions/694d49d6.yml
+++ b/.yarn/versions/694d49d6.yml
@@ -1,0 +1,10 @@
+releases:
+  "@radix-ui/react-dialog": minor
+  "@radix-ui/react-focus-scope": minor
+  primitives: minor
+
+declined:
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-select"

--- a/packages/react/dialog/src/Dialog.stories.tsx
+++ b/packages/react/dialog/src/Dialog.stories.tsx
@@ -92,6 +92,25 @@ export const FocusTrap = () => (
   </>
 );
 
+export const AutoFocusOnAnchor = () => (
+  <>
+    <Dialog.Root>
+      <Dialog.Trigger>open</Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className={overlayClass()} />
+        <Dialog.Content className={contentDefaultClass()}>
+          <Dialog.Title>Title</Dialog.Title>
+          <Dialog.Description>Description</Dialog.Description>
+          <div>
+            <a href="https://google.com">Some link somewhere</a>
+          </div>
+          <Dialog.Close>close</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  </>
+);
+
 export const CustomFocus = () => {
   const firstNameRef = React.useRef<HTMLInputElement>(null);
   const searchFieldRef = React.useRef<HTMLInputElement>(null);

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -361,11 +361,23 @@ interface DialogContentImplProps extends Omit<DismissableLayerProps, 'onDismiss'
    * Can be prevented.
    */
   onCloseAutoFocus?: FocusScopeProps['onUnmountAutoFocus'];
+
+  /**
+   * Allow anchors to be focused first.
+   */
+  allowAnchorAsFirstFocus?: FocusScopeProps['allowAnchorAsFirstFocus'];
 }
 
 const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogContentImplProps>(
   (props: ScopedProps<DialogContentImplProps>, forwardedRef) => {
-    const { __scopeDialog, trapFocus, onOpenAutoFocus, onCloseAutoFocus, ...contentProps } = props;
+    const {
+      __scopeDialog,
+      trapFocus,
+      onOpenAutoFocus,
+      onCloseAutoFocus,
+      allowAnchorAsFirstFocus,
+      ...contentProps
+    } = props;
     const context = useDialogContext(CONTENT_NAME, __scopeDialog);
     const contentRef = React.useRef<HTMLDivElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, contentRef);
@@ -382,6 +394,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
           trapped={trapFocus}
           onMountAutoFocus={onOpenAutoFocus}
           onUnmountAutoFocus={onCloseAutoFocus}
+          allowAnchorAsFirstFocus={allowAnchorAsFirstFocus}
         >
           <DismissableLayer
             role="dialog"

--- a/packages/react/focus-scope/src/FocusScope.test.tsx
+++ b/packages/react/focus-scope/src/FocusScope.test.tsx
@@ -115,6 +115,49 @@ describe('FocusScope', () => {
       waitFor(() => expect(handleLastFocusableElementBlur).toHaveBeenCalledTimes(1));
     });
   });
+
+  describe('given a FocusScope where the first focusable element is an anchor', () => {
+    let rendered: RenderResult;
+    let tabbableFirst: HTMLInputElement;
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope asChild loop trapped>
+            <form>
+              <a href="https://www.radix-ui.com">Radix</a>
+              <button>{INNER_SUBMIT_LABEL}</button>
+            </form>
+          </FocusScope>
+        </div>
+      );
+      tabbableFirst = rendered.getByText(INNER_SUBMIT_LABEL) as HTMLInputElement;
+    });
+
+    it('should skip the first anchor', () => {
+      waitFor(() => expect(tabbableFirst).toHaveFocus());
+    });
+  });
+
+  describe('given a FocusScope and we allow anchor to be focused where the first focusable element is an anchor', () => {
+    let rendered: RenderResult;
+    let tabbableFirst: HTMLInputElement;
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope asChild loop trapped allowAnchorAsFirstFocus>
+            <form>
+              <a href="https://www.radix-ui.com">Radix</a>
+              <button>{INNER_SUBMIT_LABEL}</button>
+            </form>
+          </FocusScope>
+        </div>
+      );
+      tabbableFirst = rendered.getByText('Radix') as HTMLInputElement;
+    });
+    it('should focus on the first anchor', () => {
+      waitFor(() => expect(tabbableFirst).toHaveFocus());
+    });
+  });
 });
 
 function TestField({ label, ...props }: { label: string } & React.ComponentProps<'input'>) {

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -45,6 +45,11 @@ interface FocusScopeProps extends PrimitiveDivProps {
    * Can be prevented.
    */
   onUnmountAutoFocus?: (event: Event) => void;
+
+  /**
+   * Allow anchors to be focused first.
+   */
+  allowAnchorAsFirstFocus?: boolean;
 }
 
 const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, forwardedRef) => {
@@ -53,6 +58,7 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
     trapped = false,
     onMountAutoFocus: onMountAutoFocusProp,
     onUnmountAutoFocus: onUnmountAutoFocusProp,
+    allowAnchorAsFirstFocus = false,
     ...scopeProps
   } = props;
   const [container, setContainer] = React.useState<HTMLElement | null>(null);
@@ -111,7 +117,12 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
         container.addEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
         container.dispatchEvent(mountEvent);
         if (!mountEvent.defaultPrevented) {
-          focusFirst(removeLinks(getTabbableCandidates(container)), { select: true });
+          focusFirst(
+            allowAnchorAsFirstFocus
+              ? getTabbableCandidates(container)
+              : removeLinks(getTabbableCandidates(container)),
+            { select: true }
+          );
           if (document.activeElement === previouslyFocusedElement) {
             focus(container);
           }
@@ -138,7 +149,7 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
         }, 0);
       };
     }
-  }, [container, onMountAutoFocus, onUnmountAutoFocus, focusScope]);
+  }, [container, onMountAutoFocus, onUnmountAutoFocus, focusScope, allowAnchorAsFirstFocus]);
 
   // Takes care of looping focus (when tabbing whilst at the edges)
   const handleKeyDown = React.useCallback(


### PR DESCRIPTION
### Description

Introducing a flag to allow first focus on anchors. This can be extremely useful for dialogs that have navigation elements. Think a drawer with nav elements.