### PR TITLE
Use Owner document for selected components

### DIFF
--- a/.yarn/versions/3c40b6be.yml
+++ b/.yarn/versions/3c40b6be.yml
@@ -1,0 +1,22 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+undecided:
+  - primitives

--- a/.yarn/versions/3c40b6be.yml
+++ b/.yarn/versions/3c40b6be.yml
@@ -3,6 +3,7 @@ releases:
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dialog": patch
   "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-guards": patch
   "@radix-ui/react-focus-scope": patch
   "@radix-ui/react-hover-card": patch
   "@radix-ui/react-menu": patch

--- a/.yarn/versions/3c40b6be.yml
+++ b/.yarn/versions/3c40b6be.yml
@@ -18,5 +18,5 @@ releases:
   "@radix-ui/react-toolbar": patch
   "@radix-ui/react-tooltip": patch
 
-undecided:
+declined:
   - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -368,11 +368,14 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
     const { __scopeDialog, trapFocus, onOpenAutoFocus, onCloseAutoFocus, ...contentProps } = props;
     const context = useDialogContext(CONTENT_NAME, __scopeDialog);
     const contentRef = React.useRef<HTMLDivElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, contentRef);
+    const [ownerDocument, setOwnerDocument] = React.useState(document);
+    const composedRefs = useComposedRefs(forwardedRef, contentRef, (node) =>
+      setOwnerDocument(node?.ownerDocument ?? document)
+    );
 
     // Make sure the whole tree has focus guards as our `Dialog` will be
     // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
+    useFocusGuards(ownerDocument);
 
     return (
       <>

--- a/packages/react/focus-guards/src/FocusGuards.tsx
+++ b/packages/react/focus-guards/src/FocusGuards.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 let count = 0;
 
 function FocusGuards(props: any) {
-  useFocusGuards();
+  useFocusGuards(props.ownerDocument);
   return props.children;
 }
 
@@ -12,24 +12,24 @@ function FocusGuards(props: any) {
  * Injects a pair of focus guards at the edges of the whole DOM tree
  * to ensure `focusin` & `focusout` events can be caught consistently.
  */
-function useFocusGuards() {
+function useFocusGuards(ownerDocument = document) {
   React.useEffect(() => {
-    const edgeGuards = document.querySelectorAll('[data-radix-focus-guard]');
-    document.body.insertAdjacentElement('afterbegin', edgeGuards[0] ?? createFocusGuard());
-    document.body.insertAdjacentElement('beforeend', edgeGuards[1] ?? createFocusGuard());
+    const edgeGuards = ownerDocument.querySelectorAll('[data-radix-focus-guard]');
+    ownerDocument.body.insertAdjacentElement('afterbegin', edgeGuards[0] ?? createFocusGuard());
+    ownerDocument.body.insertAdjacentElement('beforeend', edgeGuards[1] ?? createFocusGuard());
     count++;
 
     return () => {
       if (count === 1) {
-        document.querySelectorAll('[data-radix-focus-guard]').forEach((node) => node.remove());
+        ownerDocument.querySelectorAll('[data-radix-focus-guard]').forEach((node) => node.remove());
       }
       count--;
     };
   }, []);
 }
 
-function createFocusGuard() {
-  const element = document.createElement('span');
+function createFocusGuard(ownerDocument = document) {
+  const element = ownerDocument.createElement('span');
   element.setAttribute('data-radix-focus-guard', '');
   element.tabIndex = 0;
   element.style.cssText = 'outline: none; opacity: 0; position: fixed; pointer-events: none';

--- a/packages/react/focus-guards/src/FocusGuards.tsx
+++ b/packages/react/focus-guards/src/FocusGuards.tsx
@@ -25,7 +25,7 @@ function useFocusGuards(ownerDocument = document) {
       }
       count--;
     };
-  }, []);
+  }, [ownerDocument]);
 }
 
 function createFocusGuard(ownerDocument = document) {

--- a/packages/react/focus-scope/src/FocusScope.stories.tsx
+++ b/packages/react/focus-scope/src/FocusScope.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FocusScope } from '@radix-ui/react-focus-scope';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/FocusScope' };
 
@@ -107,6 +108,26 @@ export const Multiple = () => {
       <div>
         <input />
       </div>
+    </div>
+  );
+};
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popuoWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popuoWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popuoWindow.document.createElement('div');
+    popuoWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Basic />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
     </div>
   );
 };

--- a/packages/react/hover-card/src/HoverCard.stories.tsx
+++ b/packages/react/hover-card/src/HoverCard.stories.tsx
@@ -3,17 +3,18 @@ import { css, keyframes } from '../../../../stitches.config';
 import * as Dialog from '@radix-ui/react-dialog';
 import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/react-popper';
 import * as HoverCard from '@radix-ui/react-hover-card';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/HoverCard' };
 
-export const Basic = () => {
+export const Basic = ({ container }: { container?: HTMLElement }) => {
   return (
     <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
       <HoverCard.Root>
         <HoverCard.Trigger href="/" className={triggerClass()}>
           trigger
         </HoverCard.Trigger>
-        <HoverCard.Portal>
+        <HoverCard.Portal container={container}>
           <HoverCard.Content className={contentClass()} sideOffset={5}>
             <HoverCard.Arrow className={arrowClass()} width={20} height={10} />
             <CardContentPlaceholder />
@@ -444,6 +445,30 @@ export const WithSlottedContent = () => (
     </HoverCard.Portal>
   </HoverCard.Root>
 );
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popoverWindow = window.open(
+      undefined,
+      undefined,
+      'width=300,height=300,top=100,left=100'
+    );
+    if (!popoverWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popoverWindow.document.createElement('div');
+    popoverWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Basic container={popoverWindow.document.body} />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};
 
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -3,14 +3,15 @@ import { css, keyframes } from '../../../../stitches.config';
 import * as Menu from '@radix-ui/react-menu';
 import { foodGroups } from '../../../../test-data/foods';
 import { DirectionProvider } from '@radix-ui/react-direction';
+import ReactDOM from 'react-dom';
 
 export default {
   title: 'Components/Menu',
   excludeStories: ['TickIcon', 'classes'],
 };
 
-export const Styled = () => (
-  <MenuWithAnchor>
+export const Styled = ({ container }: { container?: HTMLElement }) => (
+  <MenuWithAnchor container={container}>
     <Menu.Item className={itemClass()} onSelect={() => window.alert('undo')}>
       Undo
     </Menu.Item>
@@ -364,18 +365,44 @@ export const Animated = () => {
   );
 };
 
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popoverWindow = window.open(
+      undefined,
+      undefined,
+      'width=300,height=300,top=100,left=100'
+    );
+    if (!popoverWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popoverWindow.document.createElement('div');
+    popoverWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Styled container={popoverWindow.document.body} />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};
+
 type MenuProps = Omit<
   React.ComponentProps<typeof Menu.Root> & React.ComponentProps<typeof Menu.Content>,
   'trapFocus' | 'onCloseAutoFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'
->;
+> & {
+  container?: HTMLElement;
+};
 
 const MenuWithAnchor: React.FC<MenuProps> = (props) => {
-  const { open = true, children, ...contentProps } = props;
+  const { open = true, children, container, ...contentProps } = props;
   return (
     <Menu.Root open={open} onOpenChange={() => {}} modal={false}>
       {/* inline-block allows anchor to move when rtl changes on document */}
       <Menu.Anchor style={{ display: 'inline-block' }} />
-      <Menu.Portal>
+      <Menu.Portal container={container}>
         <Menu.Content
           className={contentClass()}
           onCloseAutoFocus={(event) => event.preventDefault()}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -424,7 +424,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
 
     // Make sure the whole tree has focus guards as our `MenuContent` may be
     // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
+    useFocusGuards(ownerDocument);
 
     const isPointerMovingToSubmenu = React.useCallback((event: React.PointerEvent) => {
       const isMovingTowards = pointerDirRef.current === pointerGraceIntentRef.current?.side;

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -2,17 +2,18 @@ import * as React from 'react';
 import { css, keyframes } from '../../../../stitches.config';
 import { SIDE_OPTIONS, ALIGN_OPTIONS } from '@radix-ui/react-popper';
 import * as Popover from '@radix-ui/react-popover';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/Popover' };
 
-export const Styled = () => {
+export const Styled = ({ container = document.body }) => {
   return (
     <div
       style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
     >
       <Popover.Root>
         <Popover.Trigger className={triggerClass()}>open</Popover.Trigger>
-        <Popover.Portal>
+        <Popover.Portal container={container}>
           <Popover.Content className={contentClass()} sideOffset={5}>
             <Popover.Close className={closeClass()}>close</Popover.Close>
             <Popover.Arrow className={arrowClass()} width={20} height={10} />
@@ -237,6 +238,30 @@ export const WithSlottedTrigger = () => {
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>
+  );
+};
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popoverWindow = window.open(
+      undefined,
+      undefined,
+      'width=300,height=300,top=100,left=100'
+    );
+    if (!popoverWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popoverWindow.document.createElement('div');
+    popoverWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Styled container={popoverWindow.document.body} />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
   );
 };
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -376,10 +376,14 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
     } = props;
     const context = usePopoverContext(CONTENT_NAME, __scopePopover);
     const popperScope = usePopperScope(__scopePopover);
+    const [ownerDocument, setOwnerDocument] = React.useState(document);
+    const composedRefs = useComposedRefs(forwardedRef, (node) =>
+      setOwnerDocument(node?.ownerDocument ?? document)
+    );
 
     // Make sure the whole tree has focus guards as our `Popover` may be
     // the last element in the DOM (beacuse of the `Portal`)
-    useFocusGuards();
+    useFocusGuards(ownerDocument);
 
     return (
       <FocusScope
@@ -404,7 +408,7 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
             id={context.contentId}
             {...popperScope}
             {...contentProps}
-            ref={forwardedRef}
+            ref={composedRefs}
             style={{
               ...contentProps.style,
               // re-namespace exposed content custom property

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { css, keyframes } from '../../../../stitches.config';
 import { Portal } from '@radix-ui/react-portal';
 import * as Popper from '@radix-ui/react-popper';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/Popper' };
 
@@ -89,6 +90,26 @@ export const WithPortal = () => {
         )}
       </Popper.Root>
     </Scrollable>
+  );
+};
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popperWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popperWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popperWindow.document.createElement('div');
+    popperWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Styled />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
   );
 };
 

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -207,7 +207,10 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
 
     const [contentZIndex, setContentZIndex] = React.useState<string>();
     useLayoutEffect(() => {
-      if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
+      if (content) {
+        const win = content.ownerDocument.defaultView ?? window;
+        setContentZIndex(win.getComputedStyle(content).zIndex);
+      }
     }, [content]);
 
     const { hasParent, positionUpdateFns } = usePositionContext(CONTENT_NAME, __scopePopper);

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -18,7 +18,6 @@ interface PortalProps extends PrimitiveDivProps {
 
 const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
   const { container = globalThis?.document?.body, ...portalProps } = props;
-
   return container
     ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
     : null;

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -18,6 +18,7 @@ interface PortalProps extends PrimitiveDivProps {
 
 const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
   const { container = globalThis?.document?.body, ...portalProps } = props;
+
   return container
     ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
     : null;

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
+import ReactDOM from 'react-dom';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup.Root>;
 
@@ -146,6 +147,26 @@ export const EdgeCases = () => {
       <hr />
       <button type="button">Focusable outside of group</button>
     </>
+  );
+};
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popperWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popperWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popperWindow.document.createElement('div');
+    popperWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Basic />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
   );
 };
 

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -4,10 +4,11 @@ import * as Select from '@radix-ui/react-select';
 import { Label } from '@radix-ui/react-label';
 import * as Dialog from '@radix-ui/react-dialog';
 import { foodGroups } from '../../../../test-data/foods';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/Select' };
 
-export const Styled = () => (
+export const Styled = ({ container }: { container?: HTMLElement }) => (
   <div style={{ padding: 50 }}>
     <Label>
       Choose a number:
@@ -16,7 +17,7 @@ export const Styled = () => (
           <Select.Value />
           <Select.Icon />
         </Select.Trigger>
-        <Select.Portal>
+        <Select.Portal container={container}>
           <Select.Content className={contentClass()}>
             <Select.Viewport className={viewportClass()}>
               <Select.Item className={itemClass()} value="one">
@@ -619,6 +620,30 @@ export const WithinDialog = () => (
     </Dialog.Content>
   </Dialog.Root>
 );
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popoverWindow = window.open(
+      undefined,
+      undefined,
+      'width=300,height=300,top=100,left=100'
+    );
+    if (!popoverWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popoverWindow.document.createElement('div');
+    popoverWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Styled container={popoverWindow.document.body} />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};
 
 export const ChromaticShortOptionsPaddedContent = () => (
   <ChromaticStoryShortOptions paddedElement="content" />

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -479,7 +479,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
 
     // Make sure the whole tree has focus guards as our `Select` may be
     // the last element in the DOM (because of the `Portal`)
-    useFocusGuards();
+    useFocusGuards(ownerDocument);
 
     const [contentZIndex, setContentZIndex] = React.useState<string>();
     useLayoutEffect(() => {

--- a/packages/react/toast/src/Toast.stories.tsx
+++ b/packages/react/toast/src/Toast.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { css, keyframes } from '../../../../stitches.config';
 import * as Toast from '@radix-ui/react-toast';
+import ReactDOM from 'react-dom';
 
 export default { title: 'Components/Toast' };
 
@@ -254,6 +255,30 @@ export const Cypress = () => {
         <button>Focusable after viewport</button>
       </div>
     </Toast.Provider>
+  );
+};
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popoverWindow = window.open(
+      undefined,
+      undefined,
+      'width=300,height=300,top=100,left=100'
+    );
+    if (!popoverWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popoverWindow.document.createElement('div');
+    popoverWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Controlled />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
   );
 };
 

--- a/packages/react/toolbar/src/Toolbar.stories.tsx
+++ b/packages/react/toolbar/src/Toolbar.stories.tsx
@@ -5,6 +5,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { classes } from '../../menu/src/Menu.stories';
 import { Toggle } from '@radix-ui/react-toggle';
 import * as Toolbar from '@radix-ui/react-toolbar';
+import ReactDOM from 'react-dom';
 
 const { contentClass: dropdownMenuContentClass, itemClass: dropdownMenuItemClass } = classes;
 
@@ -16,6 +17,26 @@ export const Styled = () => (
     <ToolbarExample title="Vertical" orientation="vertical"></ToolbarExample>
   </>
 );
+
+export const InPopupWindow = () => {
+  const handlePopupClick = React.useCallback(() => {
+    const popperWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');
+    if (!popperWindow) {
+      console.error('Failed to open popup window, check your popup blocker settings');
+      return;
+    }
+
+    const containerNode = popperWindow.document.createElement('div');
+    popperWindow.document.body.append(containerNode);
+
+    ReactDOM.render(<Styled />, containerNode);
+  }, []);
+  return (
+    <div style={{ fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <button onClick={handlePopupClick}>Open Popup</button>
+    </div>
+  );
+};
 
 export const Chromatic = () => (
   <div style={{ padding: 50 }}>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Related to #1677 and #1721

Use `ownerDocument` instead of `document` in the following components:

- PopOver
- FocusScope
- Toolbar
- Menu
- Popper
- RovingFocusGroup
- Select
- Toast
- HoverCard
- FocusGuard

The stitch styles do not get applied in the popup window because of how stitch is used here. Due to this issue, it's very hard to ensure that components like `NavigationMenu` are working correctly in the popup window.
