### PR TITLE
[Presence] Ensure `onAnimationEnd` when closing

### DIFF
--- a/.yarn/versions/8a3bd6ee.yml
+++ b/.yarn/versions/8a3bd6ee.yml
@@ -1,0 +1,22 @@
+releases:
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-presence": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/presence/src/Presence.stories.tsx
+++ b/packages/react/presence/src/Presence.stories.tsx
@@ -35,6 +35,7 @@ export const WithDeferredMountAnimation = () => {
   const timerRef = React.useRef(0);
   const [open, setOpen] = React.useState(false);
   const [animate, setAnimate] = React.useState(false);
+  const [animationEndCount, setAnimationEndCount] = React.useState(0);
 
   React.useEffect(() => {
     if (open) {
@@ -45,15 +46,28 @@ export const WithDeferredMountAnimation = () => {
     }
   }, [open]);
 
+  const handleAnimationEnd = React.useCallback(() => {
+    setAnimationEndCount((count) => count + 1);
+  }, []);
+
   return (
     <>
       <p>
         Deferred animation should unmount correctly when toggled. Content will flash briefly while
         we wait for animation to be applied.
       </p>
-      <Toggles nodeRef={ref} open={open} onOpenChange={setOpen} />
+      <Toggles
+        nodeRef={ref}
+        open={open}
+        onOpenChange={setOpen}
+        animationEndCount={animationEndCount}
+      />
       <Presence present={open}>
-        <div className={animate ? mountAnimationClass() : undefined} ref={ref}>
+        <div
+          className={animate ? mountAnimationClass() : undefined}
+          onAnimationEnd={handleAnimationEnd}
+          ref={ref}
+        >
           Content
         </div>
       </Presence>
@@ -64,12 +78,27 @@ export const WithDeferredMountAnimation = () => {
 function Animation(props: React.ComponentProps<'div'>) {
   const ref = React.useRef<HTMLDivElement>(null);
   const [open, setOpen] = React.useState(false);
+  const [animationEndCount, setAnimationEndCount] = React.useState(0);
+
+  const handleAnimationEnd = React.useCallback(() => {
+    setAnimationEndCount((count) => count + 1);
+  }, []);
 
   return (
     <>
-      <Toggles nodeRef={ref} open={open} onOpenChange={setOpen} />
+      <Toggles
+        nodeRef={ref}
+        open={open}
+        onOpenChange={setOpen}
+        animationEndCount={animationEndCount}
+      />
       <Presence present={open}>
-        <div {...props} data-state={open ? 'open' : 'closed'} ref={ref}>
+        <div
+          {...props}
+          data-state={open ? 'open' : 'closed'}
+          onAnimationEnd={handleAnimationEnd}
+          ref={ref}
+        >
           Content
         </div>
       </Presence>
@@ -77,7 +106,7 @@ function Animation(props: React.ComponentProps<'div'>) {
   );
 }
 
-function Toggles({ open, onOpenChange, nodeRef }: any) {
+function Toggles({ open, onOpenChange, animationEndCount, nodeRef }: any) {
   function handleToggleVisibility() {
     const node = nodeRef.current;
     if (node) {
@@ -102,6 +131,10 @@ function Toggles({ open, onOpenChange, nodeRef }: any) {
         <button type="button" onClick={handleToggleVisibility}>
           toggle
         </button>
+      </fieldset>
+      <fieldset>
+        <legend>Animation end counter</legend>
+        <output>{animationEndCount}</output>
       </fieldset>
     </form>
   );


### PR DESCRIPTION
Make sure that `onAnimationEnd` is fired for consumers, after the closing animation of a component.

Fixes: #1020

_I hit #1020 when implementing an imperative API over toasts, where I want to remove a toast from the list of open toasts after it finishes its "close" animation. I expect wanting to know when an element finishes closing to be a relatively common need._
