### PR TITLE
Always constrain popper to collison boundary

### DIFF
--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -8,6 +8,7 @@ import {
   hide,
   arrow as floatingUIarrow,
   flip,
+  size,
 } from '@floating-ui/react-dom';
 import * as ArrowPrimitive from '@radix-ui/react-arrow';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -188,6 +189,14 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
           : undefined,
         arrow ? floatingUIarrow({ element: arrow, padding: arrowPadding }) : undefined,
         avoidCollisions ? flip({ ...detectOverflowOptions }) : undefined,
+        size({
+          apply({ availableWidth, availableHeight, elements }) {
+            Object.assign(elements.floating.style, {
+              maxWidth: `${availableWidth}px`,
+              maxHeight: `${availableHeight}px`,
+            });
+          },
+        }),
         transformOrigin({ arrowWidth, arrowHeight }),
         hideWhenDetached ? hide({ strategy: 'referenceHidden' }) : undefined,
       ].filter(isDefined),
@@ -246,6 +255,8 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         animation: !isPlaced ? 'none' : undefined,
         // hide the content if using the hide middleware and should be hidden
         opacity: middlewareData.hide?.referenceHidden ? 0 : undefined,
+        maxHeight: 'inherit',
+        overflow: 'auto',
       },
     };
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Fixes
https://github.com/radix-ui/primitives/issues/393

### Description
Adds [`size`](https://floating-ui.com/docs/size) to the middleware pipeline to ensure the resulting placement doesn't overflow the collision boundary. Instead, the content will be given a max height and overflows will be handled with scrolling.

### Goal / Motivation
Allow Dropdown menus that go outside the collision boundary to be scrollable instead of just going off screen where users cannot use them.

### Approach / Alternatives
I'm not married to the approach I currently have in the PR. What I dislike about it is that it makes the assumption that consumers of the library will want their content to scroll when the popper goes outside the collision boundary. I do think that it's a good default however, so it's the approach I went with. One of the primary downsides is that having the scroll behavior on the content is gets coupled with other styles that get passed in for the content itself). For example, a menu with a border-radius & border will cause clipping with the scrollbar:
<img width="211" alt="Screen Shot 2023-01-04 at 2 11 16 PM" src="https://user-images.githubusercontent.com/5732252/210659674-0c6cf329-0e13-43cd-ad51-05ac935740d4.png">


Alternative:
- Store the `availableWidth` and `availableHeight` in the `middlewareData` (also passed into the `apply` fn used with `size`) and then store them on the content wrapper as CSS variables (e.g. `--radix-popper-available-height` & `--radix-popper-available-width`). This would avoid introducing new behavior, but also allow consumers to apply their own styling using the CSS vars (example below). Additionally, it would allow people to setup their own scroll behavior, which would allow them to use a [parent/child div to separate the content styles from the border styles, which would allow better looking scrollbars](https://stackoverflow.com/a/60163005).
```
<DropdownMenu.Content
  style={{
    maxHeight: 'var(--radix-popper-available-height)',
    overflowY: 'auto',
  }}
>
  {children}
</DropdownMenu.Content>
```
