### PR TITLE
Adds composePreventableEvent

### DIFF
--- a/.yarn/versions/17c4f847.yml
+++ b/.yarn/versions/17c4f847.yml
@@ -1,0 +1,30 @@
+releases:
+  "@radix-ui/primitive": major
+  "@radix-ui/react-accordion": patch
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives
+  - ssr-testing

--- a/.yarn/versions/17c4f847.yml
+++ b/.yarn/versions/17c4f847.yml
@@ -8,8 +8,10 @@ releases:
   "@radix-ui/react-dialog": patch
   "@radix-ui/react-dismissable-layer": patch
   "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-form": "patch"
   "@radix-ui/react-hover-card": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": "patch"
   "@radix-ui/react-navigation-menu": patch
   "@radix-ui/react-popover": patch
   "@radix-ui/react-radio-group": patch

--- a/packages/core/primitive/src/index.ts
+++ b/packages/core/primitive/src/index.ts
@@ -1,1 +1,1 @@
-export { composeEventHandlers } from './primitive';
+export { composeEventHandlers, composePreventableEventHandlers } from './primitive';

--- a/packages/core/primitive/src/primitive.tsx
+++ b/packages/core/primitive/src/primitive.tsx
@@ -1,15 +1,52 @@
-function composeEventHandlers<E>(
-  originalEventHandler?: (event: E) => void,
-  ourEventHandler?: (event: E) => void,
-  { checkForDefaultPrevented = true } = {}
-) {
-  return function handleEvent(event: E) {
-    originalEventHandler?.(event);
+/**
+ * Type to define a possible event handler
+ */
+type PossibleHandler<E> = ((event: E) => void) | undefined;
 
-    if (checkForDefaultPrevented === false || !((event as unknown) as Event).defaultPrevented) {
-      return ourEventHandler?.(event);
+/**
+ * Merges multiple event handlers into a single event handler array
+ * @param event Shared event for all merged event handlers
+ * @param handlers Event handlers that will be merged
+ * @returns A single event handler array of all provided handlers
+ */
+function mergeEventHandlers<E>(event: E, ...handlers: PossibleHandler<E>[]) {
+  return handlers.forEach((handler) => {
+    return handler?.(event);
+  });
+}
+
+/**
+ * Composes multiple event handlers into a single event handler function
+ * @param handlers Array of event handlers that will be composed
+ * @returns A single event handler function composed from all provided handlers
+ */
+function composeEventHandlers<E>(...handlers: PossibleHandler<E>[]) {
+  // return the composed event handler
+  return function (event: E) {
+    return mergeEventHandlers(event, ...handlers);
+  };
+}
+
+/**
+ * Composes multiple preventable event handlers into a single handler
+ * @param original Original event handler that we are composing from, this handler will always execute
+ * @param handlers Array of additional event handlers that will only execute when the event has not been prevented
+ * @returns A single event handler function composed from all provided handlers
+ */
+function composePreventableEventHandlers<E>(
+  original: PossibleHandler<E>,
+  ...handlers: PossibleHandler<E>[]
+) {
+  // return the composed event handler
+  return function (event: E) {
+    // original event handler will always execute
+    original?.(event);
+
+    // additional event handlers will only execute when default is not prevented
+    if (!(event as unknown as Event).defaultPrevented) {
+      return mergeEventHandlers(event, ...handlers);
     }
   };
 }
 
-export { composeEventHandlers };
+export { composeEventHandlers, composePreventableEventHandlers };

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
@@ -228,7 +228,7 @@ const AccordionImpl = React.forwardRef<AccordionImplElement, AccordionImplProps>
     const direction = useDirection(dir);
     const isDirectionLTR = direction === 'ltr';
 
-    const handleKeyDown = composeEventHandlers(props.onKeyDown, (event) => {
+    const handleKeyDown = composePreventableEventHandlers(props.onKeyDown, (event) => {
       if (!ACCORDION_KEYS.includes(event.key)) return;
       const target = event.target as HTMLElement;
       const triggerCollection = getItems().filter((item) => !item.ref.current?.disabled);

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -3,7 +3,7 @@ import { createContextScope } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { createDialogScope } from '@radix-ui/react-dialog';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { Slottable } from '@radix-ui/react-slot';
 
 import type { Scope } from '@radix-ui/react-context';
@@ -127,10 +127,13 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
             {...dialogScope}
             {...contentProps}
             ref={composedRefs}
-            onOpenAutoFocus={composeEventHandlers(contentProps.onOpenAutoFocus, (event) => {
-              event.preventDefault();
-              cancelRef.current?.focus({ preventScroll: true });
-            })}
+            onOpenAutoFocus={composePreventableEventHandlers(
+              contentProps.onOpenAutoFocus,
+              (event) => {
+                event.preventDefault();
+                cancelRef.current?.focus({ preventScroll: true });
+              }
+            )}
             onPointerDownOutside={(event) => event.preventDefault()}
             onInteractOutside={(event) => event.preventDefault()}
           >

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { usePrevious } from '@radix-ui/react-use-previous';
 import { useSize } from '@radix-ui/react-use-size';
@@ -84,11 +84,11 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
           value={value}
           {...checkboxProps}
           ref={composedRefs}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
             // According to WAI ARIA, Checkboxes don't activate on enter keypress
             if (event.key === 'Enter') event.preventDefault();
           })}
-          onClick={composeEventHandlers(props.onClick, (event) => {
+          onClick={composePreventableEventHandlers(props.onClick, (event) => {
             setChecked((prevChecked) => (isIndeterminate(prevChecked) ? true : !prevChecked));
             if (isFormControl) {
               hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
@@ -100,7 +100,7 @@ const CollapsibleTrigger = React.forwardRef<CollapsibleTriggerElement, Collapsib
         disabled={context.disabled}
         {...triggerProps}
         ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+        onClick={composePreventableEventHandlers(props.onClick, context.onOpenToggle)}
       />
     );
   }

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as MenuPrimitive from '@radix-ui/react-menu';
@@ -124,7 +124,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
           onContextMenu={
             disabled
               ? props.onContextMenu
-              : composeEventHandlers(props.onContextMenu, (event) => {
+              : composePreventableEventHandlers(props.onContextMenu, (event) => {
                   // clearing the long press here because some platforms already support
                   // long press to trigger a `contextmenu` event
                   clearLongPress();
@@ -135,7 +135,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
           onPointerDown={
             disabled
               ? props.onPointerDown
-              : composeEventHandlers(
+              : composePreventableEventHandlers(
                   props.onPointerDown,
                   whenTouchOrPen((event) => {
                     // clear the long press here in case there's multiple touch points
@@ -147,17 +147,20 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
           onPointerMove={
             disabled
               ? props.onPointerMove
-              : composeEventHandlers(props.onPointerMove, whenTouchOrPen(clearLongPress))
+              : composePreventableEventHandlers(props.onPointerMove, whenTouchOrPen(clearLongPress))
           }
           onPointerCancel={
             disabled
               ? props.onPointerCancel
-              : composeEventHandlers(props.onPointerCancel, whenTouchOrPen(clearLongPress))
+              : composePreventableEventHandlers(
+                  props.onPointerCancel,
+                  whenTouchOrPen(clearLongPress)
+                )
           }
           onPointerUp={
             disabled
               ? props.onPointerUp
-              : composeEventHandlers(props.onPointerUp, whenTouchOrPen(clearLongPress))
+              : composePreventableEventHandlers(props.onPointerUp, whenTouchOrPen(clearLongPress))
           }
         />
       </>

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContext, createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
@@ -108,7 +108,7 @@ const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>
         data-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}
-        onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+        onClick={composePreventableEventHandlers(props.onClick, context.onOpenToggle)}
       />
     );
   }
@@ -273,22 +273,25 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
         // (closed !== unmounted when animating out)
         trapFocus={context.open}
         disableOutsidePointerEvents
-        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+        onCloseAutoFocus={composePreventableEventHandlers(props.onCloseAutoFocus, (event) => {
           event.preventDefault();
           context.triggerRef.current?.focus();
         })}
-        onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
-          const originalEvent = event.detail.originalEvent;
-          const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
-          const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+        onPointerDownOutside={composePreventableEventHandlers(
+          props.onPointerDownOutside,
+          (event) => {
+            const originalEvent = event.detail.originalEvent;
+            const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
+            const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
 
-          // If the event is a right-click, we shouldn't close because
-          // it is effectively as if we right-clicked the `Overlay`.
-          if (isRightClick) event.preventDefault();
-        })}
+            // If the event is a right-click, we shouldn't close because
+            // it is effectively as if we right-clicked the `Overlay`.
+            if (isRightClick) event.preventDefault();
+          }
+        )}
         // When focus is trapped, a `focusout` event may still happen.
         // We make sure we don't trigger our `onDismiss` in such case.
-        onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+        onFocusOutside={composePreventableEventHandlers(props.onFocusOutside, (event) =>
           event.preventDefault()
         )}
       />
@@ -478,7 +481,7 @@ const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(
         type="button"
         {...closeProps}
         ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(false))}
+        onClick={composePreventableEventHandlers(props.onClick, () => context.onOpenChange(false))}
       />
     );
   }

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
@@ -163,9 +163,15 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
             : undefined,
           ...props.style,
         }}
-        onFocusCapture={composeEventHandlers(props.onFocusCapture, focusOutside.onFocusCapture)}
-        onBlurCapture={composeEventHandlers(props.onBlurCapture, focusOutside.onBlurCapture)}
-        onPointerDownCapture={composeEventHandlers(
+        onFocusCapture={composePreventableEventHandlers(
+          props.onFocusCapture,
+          focusOutside.onFocusCapture
+        )}
+        onBlurCapture={composePreventableEventHandlers(
+          props.onBlurCapture,
+          focusOutside.onBlurCapture
+        )}
+        onPointerDownCapture={composePreventableEventHandlers(
           props.onPointerDownCapture,
           pointerDownOutside.onPointerDownCapture
         )}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { composeRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -113,7 +113,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+          onPointerDown={composePreventableEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {
@@ -123,7 +123,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
               if (!context.open) event.preventDefault();
             }
           })}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
             if (['Enter', ' '].includes(event.key)) context.onOpenToggle();
             if (event.key === 'ArrowDown') context.onOpenChange(true);
@@ -182,13 +182,13 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
         {...menuScope}
         {...contentProps}
         ref={forwardedRef}
-        onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+        onCloseAutoFocus={composePreventableEventHandlers(props.onCloseAutoFocus, (event) => {
           if (!hasInteractedOutsideRef.current) context.triggerRef.current?.focus();
           hasInteractedOutsideRef.current = false;
           // Always prevent auto focus because we either focus manually or want user agent focus
           event.preventDefault();
         })}
-        onInteractOutside={composeEventHandlers(props.onInteractOutside, (event) => {
+        onInteractOutside={composePreventableEventHandlers(props.onInteractOutside, (event) => {
           const originalEvent = event.detail.originalEvent as PointerEvent;
           const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
           const isRightClick = originalEvent.button === 2 || ctrlLeftClick;

--- a/packages/react/form/src/Form.tsx
+++ b/packages/react/form/src/Form.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
@@ -164,7 +164,7 @@ const Form = React.forwardRef<FormElement, FormProps>(
             {...rootProps}
             ref={composedFormRef}
             // focus first invalid control when the form is submitted
-            onInvalid={composeEventHandlers(props.onInvalid, (event) => {
+            onInvalid={composePreventableEventHandlers(props.onInvalid, (event) => {
               const firstInvalidControl = getFirstInvalidControl(event.currentTarget);
               if (firstInvalidControl === event.target) firstInvalidControl.focus();
 
@@ -172,11 +172,9 @@ const Form = React.forwardRef<FormElement, FormProps>(
               event.preventDefault();
             })}
             // clear server errors when the form is re-submitted
-            onSubmit={composeEventHandlers(props.onSubmit, onClearServerErrors, {
-              checkForDefaultPrevented: false,
-            })}
+            onSubmit={composeEventHandlers(props.onSubmit, onClearServerErrors)}
             // clear server errors when the form is reset
-            onReset={composeEventHandlers(props.onReset, onClearServerErrors)}
+            onReset={composePreventableEventHandlers(props.onReset, onClearServerErrors)}
           />
         </AriaDescriptionProvider>
       </ValidationProvider>
@@ -403,11 +401,11 @@ const FormControl = React.forwardRef<FormControlElement, FormControlProps>(
         ref={composedRef}
         id={id}
         name={name}
-        onInvalid={composeEventHandlers(props.onInvalid, (event) => {
+        onInvalid={composePreventableEventHandlers(props.onInvalid, (event) => {
           const control = event.currentTarget;
           updateControlValidity(control);
         })}
-        onChange={composeEventHandlers(props.onChange, (event) => {
+        onChange={composePreventableEventHandlers(props.onChange, (event) => {
           // reset validity when user changes value
           resetControlValidity();
         })}

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -131,12 +131,20 @@ const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTrig
           data-state={context.open ? 'open' : 'closed'}
           {...triggerProps}
           ref={forwardedRef}
-          onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
-          onPointerLeave={composeEventHandlers(props.onPointerLeave, excludeTouch(context.onClose))}
-          onFocus={composeEventHandlers(props.onFocus, context.onOpen)}
-          onBlur={composeEventHandlers(props.onBlur, context.onClose)}
+          onPointerEnter={composePreventableEventHandlers(
+            props.onPointerEnter,
+            excludeTouch(context.onOpen)
+          )}
+          onPointerLeave={composePreventableEventHandlers(
+            props.onPointerLeave,
+            excludeTouch(context.onClose)
+          )}
+          onFocus={composePreventableEventHandlers(props.onFocus, context.onOpen)}
+          onBlur={composePreventableEventHandlers(props.onBlur, context.onClose)}
           // prevent focus event on touch devices
-          onTouchStart={composeEventHandlers(props.onTouchStart, (event) => event.preventDefault())}
+          onTouchStart={composePreventableEventHandlers(props.onTouchStart, (event) =>
+            event.preventDefault()
+          )}
         />
       </PopperPrimitive.Anchor>
     );
@@ -213,8 +221,14 @@ const HoverCardContent = React.forwardRef<HoverCardContentElement, HoverCardCont
         <HoverCardContentImpl
           data-state={context.open ? 'open' : 'closed'}
           {...contentProps}
-          onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
-          onPointerLeave={composeEventHandlers(props.onPointerLeave, excludeTouch(context.onClose))}
+          onPointerEnter={composePreventableEventHandlers(
+            props.onPointerEnter,
+            excludeTouch(context.onOpen)
+          )}
+          onPointerLeave={composePreventableEventHandlers(
+            props.onPointerLeave,
+            excludeTouch(context.onClose)
+          )}
           ref={forwardedRef}
         />
       </Presence>
@@ -323,7 +337,7 @@ const HoverCardContentImpl = React.forwardRef<
       onInteractOutside={onInteractOutside}
       onEscapeKeyDown={onEscapeKeyDown}
       onPointerDownOutside={onPointerDownOutside}
-      onFocusOutside={composeEventHandlers(onFocusOutside, (event) => {
+      onFocusOutside={composePreventableEventHandlers(onFocusOutside, (event) => {
         event.preventDefault();
       })}
       onDismiss={context.onDismiss}
@@ -331,7 +345,7 @@ const HoverCardContentImpl = React.forwardRef<
       <PopperPrimitive.Content
         {...popperScope}
         {...contentProps}
-        onPointerDown={composeEventHandlers(contentProps.onPointerDown, (event) => {
+        onPointerDown={composePreventableEventHandlers(contentProps.onPointerDown, (event) => {
           // Contain selection to current layer
           if (event.currentTarget.contains(event.target as HTMLElement)) {
             setContainSelection(true);

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composeEventHandlers, composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -147,7 +147,7 @@ const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerPro
         data-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}
-        onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+        onClick={composePreventableEventHandlers(props.onClick, context.onOpenToggle)}
       />
     );
 
@@ -265,27 +265,21 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
           // (closed !== unmounted when animating out)
           trapFocus={context.open}
           disableOutsidePointerEvents
-          onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
+          onCloseAutoFocus={composePreventableEventHandlers(props.onCloseAutoFocus, (event) => {
             event.preventDefault();
             if (!isRightClickOutsideRef.current) context.triggerRef.current?.focus();
           })}
-          onPointerDownOutside={composeEventHandlers(
-            props.onPointerDownOutside,
-            (event) => {
-              const originalEvent = event.detail.originalEvent;
-              const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
-              const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+          onPointerDownOutside={composeEventHandlers(props.onPointerDownOutside, (event) => {
+            const originalEvent = event.detail.originalEvent;
+            const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
+            const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
 
-              isRightClickOutsideRef.current = isRightClick;
-            },
-            { checkForDefaultPrevented: false }
-          )}
+            isRightClickOutsideRef.current = isRightClick;
+          })}
           // When focus is trapped, a `focusout` event may still happen.
           // We make sure we don't trigger our `onDismiss` in such case.
-          onFocusOutside={composeEventHandlers(
-            props.onFocusOutside,
-            (event) => event.preventDefault(),
-            { checkForDefaultPrevented: false }
+          onFocusOutside={composeEventHandlers(props.onFocusOutside, (event) =>
+            event.preventDefault()
           )}
         />
       </RemoveScroll>
@@ -456,7 +450,7 @@ const PopoverClose = React.forwardRef<PopoverCloseElement, PopoverCloseProps>(
         type="button"
         {...closeProps}
         ref={forwardedRef}
-        onClick={composeEventHandlers(props.onClick, () => context.onOpenChange(false))}
+        onClick={composePreventableEventHandlers(props.onClick, () => context.onOpenChange(false))}
       />
     );
   }

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useSize } from '@radix-ui/react-use-size';
@@ -59,7 +59,7 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
           value={value}
           {...radioProps}
           ref={composedRefs}
-          onClick={composeEventHandlers(props.onClick, (event) => {
+          onClick={composePreventableEventHandlers(props.onClick, (event) => {
             // radios cannot be unchecked so we only communicate a checked state
             if (!checked) onCheck?.();
             if (isFormControl) {

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
@@ -163,11 +163,11 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
           name={context.name}
           ref={composedRefs}
           onCheck={() => context.onValueChange(itemProps.value)}
-          onKeyDown={composeEventHandlers((event) => {
+          onKeyDown={composePreventableEventHandlers((event) => {
             // According to WAI ARIA, radio groups don't activate items on enter keypress
             if (event.key === 'Enter') event.preventDefault();
           })}
-          onFocus={composeEventHandlers(itemProps.onFocus, () => {
+          onFocus={composePreventableEventHandlers(itemProps.onFocus, () => {
             /**
              * Our `RovingFocusGroup` will focus the radio when navigating with arrow keys
              * and we need to "check" it in that case. We click it to "check" it (instead

--- a/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup.Root>;
@@ -200,7 +200,7 @@ const Button = (props: ButtonProps) => {
             : {}),
         }}
         onClick={props.disabled ? undefined : () => setValue(props.value)}
-        onFocus={composeEventHandlers(props.onFocus, (event) => {
+        onFocus={composePreventableEventHandlers(props.onFocus, (event) => {
           if (contextValue !== undefined) {
             event.target.click();
           }

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -159,10 +159,10 @@ const RovingFocusGroupImpl = React.forwardRef<
         {...groupProps}
         ref={composedRefs}
         style={{ outline: 'none', ...props.style }}
-        onMouseDown={composeEventHandlers(props.onMouseDown, () => {
+        onMouseDown={composePreventableEventHandlers(props.onMouseDown, () => {
           isClickFocusRef.current = true;
         })}
-        onFocus={composeEventHandlers(props.onFocus, (event) => {
+        onFocus={composePreventableEventHandlers(props.onFocus, (event) => {
           // We normally wouldn't need this check, because we already check
           // that the focus is on the current target and not bubbling to it.
           // We do this because Safari doesn't focus buttons when clicked, and
@@ -187,7 +187,7 @@ const RovingFocusGroupImpl = React.forwardRef<
 
           isClickFocusRef.current = false;
         })}
-        onBlur={composeEventHandlers(props.onBlur, () => setIsTabbingBackOut(false))}
+        onBlur={composePreventableEventHandlers(props.onBlur, () => setIsTabbingBackOut(false))}
       />
     </RovingFocusProvider>
   );
@@ -243,15 +243,15 @@ const RovingFocusGroupItem = React.forwardRef<RovingFocusItemElement, RovingFocu
           data-orientation={context.orientation}
           {...itemProps}
           ref={forwardedRef}
-          onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
+          onMouseDown={composePreventableEventHandlers(props.onMouseDown, (event) => {
             // We prevent focusing non-focusable items on `mousedown`.
             // Even though the item has tabIndex={-1}, that only means take it out of the tab order.
             if (!focusable) event.preventDefault();
             // Safari doesn't focus a button when clicked so we run our logic on mousedown also
             else context.onItemFocus(id);
           })}
-          onFocus={composeEventHandlers(props.onFocus, () => context.onItemFocus(id))}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          onFocus={composePreventableEventHandlers(props.onFocus, () => context.onItemFocus(id))}
+          onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
             if (event.key === 'Tab' && event.shiftKey) {
               context.onItemShiftTab();
               return;

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -9,7 +9,7 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useDirection } from '@radix-ui/react-direction';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { clamp } from '@radix-ui/number';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useStateMachine } from './useStateMachine';
 
 import type { Scope } from '@radix-ui/react-context';
@@ -367,8 +367,12 @@ const ScrollAreaScrollbarScroll = React.forwardRef<
         data-state={state === 'hidden' ? 'hidden' : 'visible'}
         {...scrollbarProps}
         ref={forwardedRef}
-        onPointerEnter={composeEventHandlers(props.onPointerEnter, () => send('POINTER_ENTER'))}
-        onPointerLeave={composeEventHandlers(props.onPointerLeave, () => send('POINTER_LEAVE'))}
+        onPointerEnter={composePreventableEventHandlers(props.onPointerEnter, () =>
+          send('POINTER_ENTER')
+        )}
+        onPointerLeave={composePreventableEventHandlers(props.onPointerLeave, () =>
+          send('POINTER_LEAVE')
+        )}
       />
     </Presence>
   );
@@ -730,7 +734,7 @@ const ScrollAreaScrollbarImpl = React.forwardRef<
         {...scrollbarProps}
         ref={composeRefs}
         style={{ position: 'absolute', ...scrollbarProps.style }}
-        onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+        onPointerDown={composePreventableEventHandlers(props.onPointerDown, (event) => {
           const mainPointer = 0;
           if (event.button === mainPointer) {
             const element = event.target as HTMLElement;
@@ -744,8 +748,8 @@ const ScrollAreaScrollbarImpl = React.forwardRef<
             handleDragScroll(event);
           }
         })}
-        onPointerMove={composeEventHandlers(props.onPointerMove, handleDragScroll)}
-        onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
+        onPointerMove={composePreventableEventHandlers(props.onPointerMove, handleDragScroll)}
+        onPointerUp={composePreventableEventHandlers(props.onPointerUp, (event) => {
           const element = event.target as HTMLElement;
           if (element.hasPointerCapture(event.pointerId)) {
             element.releasePointerCapture(event.pointerId);
@@ -840,14 +844,20 @@ const ScrollAreaThumbImpl = React.forwardRef<ScrollAreaThumbImplElement, ScrollA
           height: 'var(--radix-scroll-area-thumb-height)',
           ...style,
         }}
-        onPointerDownCapture={composeEventHandlers(props.onPointerDownCapture, (event) => {
-          const thumb = event.target as HTMLElement;
-          const thumbRect = thumb.getBoundingClientRect();
-          const x = event.clientX - thumbRect.left;
-          const y = event.clientY - thumbRect.top;
-          scrollbarContext.onThumbPointerDown({ x, y });
-        })}
-        onPointerUp={composeEventHandlers(props.onPointerUp, scrollbarContext.onThumbPointerUp)}
+        onPointerDownCapture={composePreventableEventHandlers(
+          props.onPointerDownCapture,
+          (event) => {
+            const thumb = event.target as HTMLElement;
+            const thumbRect = thumb.getBoundingClientRect();
+            const x = event.clientX - thumbRect.left;
+            const y = event.clientY - thumbRect.top;
+            scrollbarContext.onThumbPointerDown({ x, y });
+          }
+        )}
+        onPointerUp={composePreventableEventHandlers(
+          props.onPointerUp,
+          scrollbarContext.onThumbPointerUp
+        )}
       />
     );
   }

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { clamp } from '@radix-ui/number';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -238,6 +238,8 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
     };
 
     return (
+          onClick={composePreventableEventHandlers(triggerProps.onClick, (event) => {
+          onPointerDown={composePreventableEventHandlers(triggerProps.onPointerDown, (event) => {
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
           type="button"
@@ -270,6 +272,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
               target.releasePointerCapture(event.pointerId);
             }
 
+          onKeyDown={composePreventableEventHandlers(triggerProps.onKeyDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (event.button === 0 && event.ctrlKey === false) {
@@ -1071,7 +1074,7 @@ const SelectViewport = React.forwardRef<SelectViewportElement, SelectViewportPro
               overflow: 'auto',
               ...viewportProps.style,
             }}
-            onScroll={composeEventHandlers(viewportProps.onScroll, (event) => {
+            onScroll={composePreventableEventHandlers(viewportProps.onScroll, (event) => {
               const viewport = event.currentTarget;
               const { contentWrapper, shouldExpandOnScrollRef } = viewportContext;
               if (shouldExpandOnScrollRef?.current && contentWrapper) {
@@ -1239,10 +1242,10 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             tabIndex={disabled ? undefined : -1}
             {...itemProps}
             ref={composedRefs}
-            onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
-            onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
-            onPointerUp={composeEventHandlers(itemProps.onPointerUp, handleSelect)}
-            onPointerMove={composeEventHandlers(itemProps.onPointerMove, (event) => {
+            onFocus={composePreventableEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
+            onBlur={composePreventableEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
+            onPointerUp={composePreventableEventHandlers(itemProps.onPointerUp, handleSelect)}
+            onPointerMove={composePreventableEventHandlers(itemProps.onPointerMove, (event) => {
               if (disabled) {
                 contentContext.onItemLeave?.();
               } else {
@@ -1251,12 +1254,12 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
                 event.currentTarget.focus({ preventScroll: true });
               }
             })}
-            onPointerLeave={composeEventHandlers(itemProps.onPointerLeave, (event) => {
+            onPointerLeave={composePreventableEventHandlers(itemProps.onPointerLeave, (event) => {
               if (event.currentTarget === document.activeElement) {
                 contentContext.onItemLeave?.();
               }
             })}
-            onKeyDown={composeEventHandlers(itemProps.onKeyDown, (event) => {
+            onKeyDown={composePreventableEventHandlers(itemProps.onKeyDown, (event) => {
               const isTypingAhead = contentContext.searchRef?.current !== '';
               if (isTypingAhead && event.key === ' ') return;
               if (SELECTION_KEYS.includes(event.key)) handleSelect();
@@ -1497,7 +1500,7 @@ const SelectScrollButtonImpl = React.forwardRef<
           autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
         }
       })}
-      onPointerLeave={composeEventHandlers(scrollIndicatorProps.onPointerLeave, () => {
+      onPointerLeave={composePreventableEventHandlers(scrollIndicatorProps.onPointerLeave, () => {
         clearAutoScrollTimer();
       })}
     />

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -238,8 +238,6 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
     };
 
     return (
-          onClick={composePreventableEventHandlers(triggerProps.onClick, (event) => {
-          onPointerDown={composePreventableEventHandlers(triggerProps.onPointerDown, (event) => {
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
           type="button"
@@ -256,7 +254,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
           {...triggerProps}
           ref={composedRefs}
           // Enable compatibility with native label or custom `Label` "click" for Safari:
-          onClick={composeEventHandlers(triggerProps.onClick, (event) => {
+          onClick={composePreventableEventHandlers(triggerProps.onClick, (event) => {
             // Whilst browsers generally have no issue focusing the trigger when clicking
             // on a label, Safari seems to struggle with the fact that there's no `onClick`.
             // We force `focus` in this case. Note: this doesn't create any other side-effect
@@ -264,7 +262,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
             // this only runs for a label "click"
             event.currentTarget.focus();
           })}
-          onPointerDown={composeEventHandlers(triggerProps.onPointerDown, (event) => {
+          onPointerDown={composePreventableEventHandlers(triggerProps.onPointerDown, (event) => {
             // prevent implicit pointer capture
             // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
             const target = event.target as HTMLElement;
@@ -272,7 +270,6 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
               target.releasePointerCapture(event.pointerId);
             }
 
-          onKeyDown={composePreventableEventHandlers(triggerProps.onKeyDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (event.button === 0 && event.ctrlKey === false) {
@@ -285,7 +282,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
               event.preventDefault();
             }
           })}
-          onKeyDown={composeEventHandlers(triggerProps.onKeyDown, (event) => {
+          onKeyDown={composePreventableEventHandlers(triggerProps.onKeyDown, (event) => {
             const isTypingAhead = searchRef.current !== '';
             const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
             if (!isModifierKey && event.key.length === 1) handleTypeaheadSearch(event.key);
@@ -691,7 +688,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
               // we prevent open autofocus because we manually focus the selected item
               event.preventDefault();
             }}
-            onUnmountAutoFocus={composeEventHandlers(onCloseAutoFocus, (event) => {
+            onUnmountAutoFocus={composePreventableEventHandlers(onCloseAutoFocus, (event) => {
               context.trigger?.focus({ preventScroll: true });
               event.preventDefault();
             })}
@@ -724,7 +721,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                   outline: 'none',
                   ...contentProps.style,
                 }}
-                onKeyDown={composeEventHandlers(contentProps.onKeyDown, (event) => {
+                onKeyDown={composePreventableEventHandlers(contentProps.onKeyDown, (event) => {
                   const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
 
                   // select should not be navigated using tab key so we prevent it
@@ -1489,12 +1486,12 @@ const SelectScrollButtonImpl = React.forwardRef<
       {...scrollIndicatorProps}
       ref={forwardedRef}
       style={{ flexShrink: 0, ...scrollIndicatorProps.style }}
-      onPointerDown={composeEventHandlers(scrollIndicatorProps.onPointerDown, () => {
+      onPointerDown={composePreventableEventHandlers(scrollIndicatorProps.onPointerDown, () => {
         if (autoScrollTimerRef.current === null) {
           autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
         }
       })}
-      onPointerMove={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
+      onPointerMove={composePreventableEventHandlers(scrollIndicatorProps.onPointerMove, () => {
         contentContext.onItemLeave?.();
         if (autoScrollTimerRef.current === null) {
           autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { clamp } from '@radix-ui/number';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -159,7 +159,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
               data-disabled={disabled ? '' : undefined}
               {...sliderProps}
               ref={forwardedRef}
-              onPointerDown={composeEventHandlers(sliderProps.onPointerDown, () => {
+              onPointerDown={composePreventableEventHandlers(sliderProps.onPointerDown, () => {
                 if (!disabled) valuesBeforeSlideStartRef.current = values;
               })}
               min={min}
@@ -408,7 +408,7 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
       <Primitive.span
         {...sliderProps}
         ref={forwardedRef}
-        onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+        onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
           if (event.key === 'Home') {
             onHomeKeyDown(event);
             // Prevent scrolling to page start
@@ -423,7 +423,7 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
             event.preventDefault();
           }
         })}
-        onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+        onPointerDown={composePreventableEventHandlers(props.onPointerDown, (event) => {
           const target = event.target as HTMLElement;
           target.setPointerCapture(event.pointerId);
           // Prevent browser focus behaviour because we focus a thumb manually when values change.
@@ -436,11 +436,11 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
             onSlideStart(event);
           }
         })}
-        onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
+        onPointerMove={composePreventableEventHandlers(props.onPointerMove, (event) => {
           const target = event.target as HTMLElement;
           if (target.hasPointerCapture(event.pointerId)) onSlideMove(event);
         })}
-        onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
+        onPointerUp={composePreventableEventHandlers(props.onPointerUp, (event) => {
           const target = event.target as HTMLElement;
           if (target.hasPointerCapture(event.pointerId)) {
             target.releasePointerCapture(event.pointerId);
@@ -605,7 +605,7 @@ const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImpl
              * slower connections.
              */
             style={value === undefined ? { display: 'none' } : props.style}
-            onFocus={composeEventHandlers(props.onFocus, () => {
+            onFocus={composePreventableEventHandlers(props.onFocus, () => {
               context.valueIndexToChangeRef.current = index;
             })}
           />

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -67,7 +67,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
           value={value}
           {...switchProps}
           ref={composedRefs}
-          onClick={composeEventHandlers(props.onClick, (event) => {
+          onClick={composePreventableEventHandlers(props.onClick, (event) => {
             setChecked((prevChecked) => !prevChecked);
             if (isFormControl) {
               hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
 import { Presence } from '@radix-ui/react-presence';
@@ -178,7 +178,7 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
           id={triggerId}
           {...triggerProps}
           ref={forwardedRef}
-          onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
+          onMouseDown={composePreventableEventHandlers(props.onMouseDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {
@@ -188,10 +188,10 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
               event.preventDefault();
             }
           })}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
             if ([' ', 'Enter'].includes(event.key)) context.onValueChange(value);
           })}
-          onFocus={composeEventHandlers(props.onFocus, () => {
+          onFocus={composePreventableEventHandlers(props.onFocus, () => {
             // handle "automatic" activation if necessary
             // ie. activate tab following focus
             const isAutomaticActivation = context.activationMode !== 'manual';

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createCollection } from '@radix-ui/react-collection';
 import { createContextScope } from '@radix-ui/react-context';
@@ -396,23 +396,23 @@ const Toast = React.forwardRef<ToastElement, ToastProps>(
           onClose={() => setOpen(false)}
           onPause={useCallbackRef(props.onPause)}
           onResume={useCallbackRef(props.onResume)}
-          onSwipeStart={composeEventHandlers(props.onSwipeStart, (event) => {
+          onSwipeStart={composePreventableEventHandlers(props.onSwipeStart, (event) => {
             event.currentTarget.setAttribute('data-swipe', 'start');
           })}
-          onSwipeMove={composeEventHandlers(props.onSwipeMove, (event) => {
+          onSwipeMove={composePreventableEventHandlers(props.onSwipeMove, (event) => {
             const { x, y } = event.detail.delta;
             event.currentTarget.setAttribute('data-swipe', 'move');
             event.currentTarget.style.setProperty('--radix-toast-swipe-move-x', `${x}px`);
             event.currentTarget.style.setProperty('--radix-toast-swipe-move-y', `${y}px`);
           })}
-          onSwipeCancel={composeEventHandlers(props.onSwipeCancel, (event) => {
+          onSwipeCancel={composePreventableEventHandlers(props.onSwipeCancel, (event) => {
             event.currentTarget.setAttribute('data-swipe', 'cancel');
             event.currentTarget.style.removeProperty('--radix-toast-swipe-move-x');
             event.currentTarget.style.removeProperty('--radix-toast-swipe-move-y');
             event.currentTarget.style.removeProperty('--radix-toast-swipe-end-x');
             event.currentTarget.style.removeProperty('--radix-toast-swipe-end-y');
           })}
-          onSwipeEnd={composeEventHandlers(props.onSwipeEnd, (event) => {
+          onSwipeEnd={composePreventableEventHandlers(props.onSwipeEnd, (event) => {
             const { x, y } = event.detail.delta;
             event.currentTarget.setAttribute('data-swipe', 'end');
             event.currentTarget.style.removeProperty('--radix-toast-swipe-move-x');
@@ -564,7 +564,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
             <Collection.ItemSlot scope={__scopeToast}>
               <DismissableLayer.Root
                 asChild
-                onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
+                onEscapeKeyDown={composePreventableEventHandlers(onEscapeKeyDown, () => {
                   if (!context.isFocusedToastEscapeKeyDownRef.current) handleClose();
                   context.isFocusedToastEscapeKeyDownRef.current = false;
                 })}
@@ -580,7 +580,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   {...toastProps}
                   ref={composedRefs}
                   style={{ userSelect: 'none', touchAction: 'none', ...props.style }}
-                  onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+                  onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
                     if (event.key !== 'Escape') return;
                     onEscapeKeyDown?.(event.nativeEvent);
                     if (!event.nativeEvent.defaultPrevented) {
@@ -588,11 +588,11 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                       handleClose();
                     }
                   })}
-                  onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+                  onPointerDown={composePreventableEventHandlers(props.onPointerDown, (event) => {
                     if (event.button !== 0) return;
                     pointerStartRef.current = { x: event.clientX, y: event.clientY };
                   })}
-                  onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
+                  onPointerMove={composePreventableEventHandlers(props.onPointerMove, (event) => {
                     if (!pointerStartRef.current) return;
                     const x = event.clientX - pointerStartRef.current.x;
                     const y = event.clientY - pointerStartRef.current.y;
@@ -623,7 +623,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                       pointerStartRef.current = null;
                     }
                   })}
-                  onPointerUp={composeEventHandlers(props.onPointerUp, (event) => {
+                  onPointerUp={composePreventableEventHandlers(props.onPointerUp, (event) => {
                     const delta = swipeDeltaRef.current;
                     const target = event.target as HTMLElement;
                     if (target.hasPointerCapture(event.pointerId)) {
@@ -798,7 +798,7 @@ const ToastClose = React.forwardRef<ToastCloseElement, ToastCloseProps>(
           type="button"
           {...closeProps}
           ref={forwardedRef}
-          onClick={composeEventHandlers(props.onClick, interactiveContext.onClose)}
+          onClick={composePreventableEventHandlers(props.onClick, interactiveContext.onClose)}
         />
       </ToastAnnounceExclude>
     );

--- a/packages/react/toggle/src/Toggle.tsx
+++ b/packages/react/toggle/src/Toggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive } from '@radix-ui/react-primitive';
 
@@ -45,7 +45,7 @@ const Toggle = React.forwardRef<ToggleElement, ToggleProps>((props, forwardedRef
       data-disabled={props.disabled ? '' : undefined}
       {...buttonProps}
       ref={forwardedRef}
-      onClick={composeEventHandlers(props.onClick, () => {
+      onClick={composePreventableEventHandlers(props.onClick, () => {
         if (!props.disabled) {
           setPressed(!pressed);
         }

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
@@ -139,7 +139,7 @@ const ToolbarLink = React.forwardRef<ToolbarLinkElement, ToolbarLinkProps>(
         <Primitive.a
           {...linkProps}
           ref={forwardedRef}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
+          onKeyDown={composePreventableEventHandlers(props.onKeyDown, (event) => {
             if (event.key === ' ') event.currentTarget.click();
           })}
         />

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -279,7 +279,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           data-state={context.stateAttribute}
           {...triggerProps}
           ref={composedRefs}
-          onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
+          onPointerMove={composePreventableEventHandlers(props.onPointerMove, (event) => {
             if (event.pointerType === 'touch') return;
             if (
               !hasPointerMoveOpenedRef.current &&
@@ -289,19 +289,19 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
               hasPointerMoveOpenedRef.current = true;
             }
           })}
-          onPointerLeave={composeEventHandlers(props.onPointerLeave, () => {
+          onPointerLeave={composePreventableEventHandlers(props.onPointerLeave, () => {
             context.onTriggerLeave();
             hasPointerMoveOpenedRef.current = false;
           })}
-          onPointerDown={composeEventHandlers(props.onPointerDown, () => {
+          onPointerDown={composePreventableEventHandlers(props.onPointerDown, () => {
             isPointerDownRef.current = true;
             document.addEventListener('pointerup', handlePointerUp, { once: true });
           })}
-          onFocus={composeEventHandlers(props.onFocus, () => {
+          onFocus={composePreventableEventHandlers(props.onFocus, () => {
             if (!isPointerDownRef.current) context.onOpen();
           })}
-          onBlur={composeEventHandlers(props.onBlur, context.onClose)}
-          onClick={composeEventHandlers(props.onClick, context.onClose)}
+          onBlur={composePreventableEventHandlers(props.onBlur, context.onClose)}
+          onClick={composePreventableEventHandlers(props.onClick, context.onClose)}
         />
       </PopperPrimitive.Anchor>
     );

--- a/ssr-testing/app/roving-focus-group/page.tsx
+++ b/ssr-testing/app/roving-focus-group/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { composeEventHandlers } from '@radix-ui/primitive';
+import { composePreventableEventHandlers } from '@radix-ui/primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 
 type RovingFocusGroupProps = React.ComponentProps<typeof RovingFocusGroup.Root>;
@@ -159,7 +159,7 @@ const Button = (props: ButtonProps) => {
             : {}),
         }}
         onClick={props.disabled ? undefined : () => setValue(props.value)}
-        onFocus={composeEventHandlers(props.onFocus, (event) => {
+        onFocus={composePreventableEventHandlers(props.onFocus, (event) => {
           if (contextValue !== undefined) {
             event.target.click();
           }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

I noticed #905 and I had a similar need for a utility like this.  

- Aims to improve the `checkForDefaultPrevented` api by splitting `composeEventHandlers` into two separate functions (`composeEventHandlers` & `composePreventableEventHandlers`).
- Replaces a majority of the calls for `composeEventHandlers` with the new `composePreventableEventHandlers`.
- Replaces calls where `checkForDefaultPrevented` was false with the reworked `composeEventHandlers` function.  

closes #905 
