### PR TITLE
[Popper] Consistently calculate logical alignments

### DIFF
--- a/.yarn/versions/6263b97f.yml
+++ b/.yarn/versions/6263b97f.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -331,6 +331,78 @@ export const Chromatic = () => {
           </div>
         </div>
       </div>
+      <div
+        style={{
+          marginTop: 50,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 150,
+          border: '1px solid black',
+        }}
+      >
+        <h1>Logical "start" alignment (LTR)</h1>
+        <Popper.Root>
+          <Popper.Anchor className={anchorClass({ size: 'small' })}>11</Popper.Anchor>
+          <Popper.Content align="start" className={contentClass({ size: 'small' })} sideOffset={5}>
+            <Popper.Arrow className={arrowClass()} width={10} height={5} />
+            11
+          </Popper.Content>
+        </Popper.Root>
+
+        <Popper.Root>
+          <Popper.Anchor className={anchorClass({ size: 'small' })}>12</Popper.Anchor>
+          <Portal asChild>
+            <Popper.Content
+              align="start"
+              className={contentClass({ size: 'small' })}
+              sideOffset={5}
+            >
+              <Popper.Arrow className={arrowClass()} width={10} height={5} />
+              12 (portalled)
+            </Popper.Content>
+          </Portal>
+        </Popper.Root>
+      </div>
+      <div
+        style={{
+          marginTop: 50,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 150,
+          border: '1px solid black',
+        }}
+      >
+        <h1>Logical "start" alignment (RTL)</h1>
+        <Popper.Root>
+          <Popper.Anchor className={anchorClass({ size: 'small' })}>13</Popper.Anchor>
+          <Popper.Content
+            align="start"
+            className={contentClass({ size: 'small' })}
+            sideOffset={5}
+            dir="rtl"
+          >
+            <Popper.Arrow className={arrowClass()} width={10} height={5} />
+            13
+          </Popper.Content>
+        </Popper.Root>
+
+        <Popper.Root>
+          <Popper.Anchor className={anchorClass({ size: 'small' })}>14</Popper.Anchor>
+          <Portal asChild>
+            <Popper.Content
+              align="start"
+              className={contentClass({ size: 'small' })}
+              sideOffset={5}
+              dir="rtl"
+            >
+              <Popper.Arrow className={arrowClass()} width={10} height={5} />
+              14 (portalled)
+            </Popper.Content>
+          </Portal>
+        </Popper.Root>
+      </div>
     </div>
   );
 };

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -267,6 +267,10 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
             middlewareData.transformOrigin?.y,
           ].join(' '),
         }}
+        // Floating UI interally calculates logical alignment based the `dir` attribute on
+        // the reference/floating node, we must add this attribute here to ensure
+        // this is calculated when portalled as well as inline.
+        dir={props.dir}
       >
         <PopperContentProvider
           scope={__scopePopper}


### PR DESCRIPTION
Floating UI automatically accounts for logical position for alignment:

> The -start and -end alignments are [logical](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties)
 and will adapt to the writing direction (e.g. RTL) as expected.

https://floating-ui.com/docs/computeposition#placement

However, this is applied inconsistently in our code as the referenced `floating` node does not received the `dir` attribute.

Floating UI[ needs this attribute](https://github.com/floating-ui/floating-ui/blob/1cf071044771e38607c6740a3f903916a819e1e1/packages/core/src/middleware/autoPlacement.ts#L102) to invert correctly.

This change fixes an inconsistency with our logical alignment whereby using `dir="rtl"` on our primitives is inconsistent when using `Portal` with defaults. In the portalled case unless `rtl` is applied to the body this logical inversion will not happen.