### PR TITLE
ES Modules: switch from .module.js to .mjs

### DIFF
--- a/packages/core/number/package.json
+++ b/packages/core/number/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/core/rect/package.json
+++ b/packages/core/rect/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "src",

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/compose-refs/package.json
+++ b/packages/react/compose-refs/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/context/package.json
+++ b/packages/react/context/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/direction/package.json
+++ b/packages/react/direction/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/id/package.json
+++ b/packages/react/id/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/menubar/package.json
+++ b/packages/react/menubar/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/navigation-menu/package.json
+++ b/packages/react/navigation-menu/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/primitive/package.json
+++ b/packages/react/primitive/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/slot/package.json
+++ b/packages/react/slot/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/toast/package.json
+++ b/packages/react/toast/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/toggle-group/package.json
+++ b/packages/react/toggle-group/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/toggle/package.json
+++ b/packages/react/toggle/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-callback-ref/package.json
+++ b/packages/react/use-callback-ref/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-controllable-state/package.json
+++ b/packages/react/use-controllable-state/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-escape-keydown/package.json
+++ b/packages/react/use-escape-keydown/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-layout-effect/package.json
+++ b/packages/react/use-layout-effect/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-previous/package.json
+++ b/packages/react/use-previous/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-rect/package.json
+++ b/packages/react/use-rect/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/use-size/package.json
+++ b/packages/react/use-size/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Hi all!

This PR simply changes the module exports from `.module.js` to `.mjs` hoping that it will resolve #1848.

Parcel will respect this and compile the files accordingly.