### PR TITLE
[RadioGroup, Select, Slider, Switch] Reset primitives to default state when form resets

### DIFF
--- a/.yarn/versions/ce1d24ea.yml
+++ b/.yarn/versions/ce1d24ea.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+
+declined:
+  - primitives

--- a/packages/react/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/react/radio-group/src/RadioGroup.stories.tsx
@@ -78,7 +78,12 @@ export const Unset = () => (
 );
 
 export const WithinForm = () => {
-  const [data, setData] = React.useState({ optional: '', required: '', stopprop: '' });
+  const [data, setData] = React.useState({
+    optional: '',
+    required: '',
+    withDefault: '',
+    stopprop: '',
+  });
 
   return (
     <form
@@ -125,6 +130,24 @@ export const WithinForm = () => {
       <br />
 
       <fieldset>
+        <legend>with default: {data.withDefault}</legend>
+        <RadioGroup.Root className={rootClass()} name="withDefault" defaultValue="2">
+          <RadioGroup.Item className={itemClass()} value="1">
+            <RadioGroup.Indicator className={indicatorClass()} />
+          </RadioGroup.Item>
+          <RadioGroup.Item className={itemClass()} value="2">
+            <RadioGroup.Indicator className={indicatorClass()} />
+          </RadioGroup.Item>
+          <RadioGroup.Item className={itemClass()} value="3">
+            <RadioGroup.Indicator className={indicatorClass()} />
+          </RadioGroup.Item>
+        </RadioGroup.Root>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
         <legend>stop propagation value: {data.stopprop}</legend>
         <RadioGroup.Root className={rootClass()} name="stopprop">
           <RadioGroup.Item
@@ -154,6 +177,7 @@ export const WithinForm = () => {
       <br />
       <br />
 
+      <button type="reset">Reset</button>
       <button>Submit</button>
     </form>
   );

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -75,6 +75,17 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
       defaultProp: defaultValue,
       onChange: onValueChange,
     });
+    const initialValueRef = React.useRef(value);
+    const [radioGroup, setRadioGroup] = React.useState<HTMLDivElement | null>(null);
+    const composedRefs = useComposedRefs(forwardedRef, (node) => setRadioGroup(node));
+    React.useEffect(() => {
+      const form = radioGroup?.closest('form');
+      if (form) {
+        const reset = () => setValue(initialValueRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [radioGroup, setValue]);
 
     return (
       <RadioGroupProvider
@@ -99,7 +110,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
             data-disabled={disabled ? '' : undefined}
             dir={direction}
             {...groupProps}
-            ref={forwardedRef}
+            ref={composedRefs}
           />
         </RovingFocusGroup.Root>
       </RadioGroupProvider>

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -504,6 +504,7 @@ export const WithinForm = () => {
         </Select.Root>
       </Label>
       <br />
+      <button type="reset">Reset</button>
       <button type="submit">Submit</button>
       <br />
       <pre>{JSON.stringify(data, null, 2)}</pre>
@@ -567,6 +568,7 @@ export const DisabledWithinForm = () => {
         </Select.Root>
       </Label>
       <br />
+      <button type="reset">Reset</button>
       <button type="submit">Submit</button>
       <br />
       <pre>{JSON.stringify(data, null, 2)}</pre>
@@ -630,6 +632,7 @@ export const RequiredWithinForm = () => {
         </Select.Root>
       </Label>
       <br />
+      <button type="reset">Reset</button>
       <button type="submit">Submit</button>
       <br />
       <pre>{JSON.stringify(data, null, 2)}</pre>

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -139,6 +139,17 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const nativeSelectKey = Array.from(nativeOptionsSet)
     .map((option) => option.props.value)
     .join(';');
+  const initialSelectedOptionRef = React.useRef(value);
+  React.useEffect(() => {
+    const form = trigger?.form;
+    if (form) {
+      const reset = () => {
+        setValue(initialSelectedOptionRef.current);
+      };
+      form.addEventListener('reset', reset);
+      return () => form.removeEventListener('reset', reset);
+    }
+  }, [trigger, setValue]);
 
   return (
     <PopperPrimitive.Root {...popperScope}>
@@ -191,7 +202,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
           >
-            {value === undefined ? <option value="" /> : null}
+            {!value ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}
           </BubbleSelect>
         ) : null}
@@ -330,11 +341,12 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
       <Primitive.span
         {...valueProps}
         ref={composedRefs}
+        key={context.value}
         // we don't want events from the portalled `SelectValue` children to bubble
         // through the item they came from
         style={{ pointerEvents: 'none' }}
       >
-        {context.value === undefined && placeholder !== undefined ? placeholder : children}
+        {!context.value && placeholder !== undefined ? placeholder : children}
       </Primitive.span>
     );
   }

--- a/packages/react/slider/src/Slider.stories.tsx
+++ b/packages/react/slider/src/Slider.stories.tsx
@@ -296,6 +296,8 @@ export const WithinForm = () => {
           <Slider.Thumb className={thumbClass()} />
         </Slider.Root>
       </fieldset>
+
+      <button type="reset">Reset</button>
     </form>
   );
 };

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -109,6 +109,15 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
       },
     });
     const valuesBeforeSlideStartRef = React.useRef(values);
+    const initialValuesRef = React.useRef(values);
+    React.useEffect(() => {
+      const form = slider?.closest('form');
+      if (form) {
+        const reset = () => setValues(initialValuesRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [slider, setValues]);
 
     function handleSlideStart(value: number) {
       const closestIndex = getClosestValueIndex(values, value);

--- a/packages/react/switch/src/Switch.stories.tsx
+++ b/packages/react/switch/src/Switch.stories.tsx
@@ -78,6 +78,16 @@ export const WithinForm = () => {
       <br />
 
       <fieldset>
+        <legend>required checked: {String(data.required)}</legend>
+        <Switch.Root className={rootClass()} name="default_checked" defaultChecked>
+          <Switch.Thumb className={thumbClass()} />
+        </Switch.Root>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
         <legend>stop propagation checked: {String(data.stopprop)}</legend>
         <Switch.Root
           className={rootClass()}
@@ -91,6 +101,7 @@ export const WithinForm = () => {
       <br />
       <br />
 
+      <button type="reset">Reset</button>
       <button>Submit</button>
     </form>
   );

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -54,6 +54,15 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
       defaultProp: defaultChecked,
       onChange: onCheckedChange,
     });
+    const initialCheckedStateRef = React.useRef(checked);
+    React.useEffect(() => {
+      const form = button?.form;
+      if (form) {
+        const reset = () => setChecked(initialCheckedStateRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [button, setChecked]);
 
     return (
       <SwitchProvider scope={__scopeSwitch} checked={checked} disabled={disabled}>


### PR DESCRIPTION
Implements #983 for primitives RadioGroup, Select, Slider, Switch.

For Slider and RadioGroup I think we dont't have the auto-assigned `form` property to take advatage, because the primitives are not exactly form elements.

The Select is probably the trickiest of those primitives because of the hidden native `select` and how it resets itself. I could find a workaround, but I'm not sure if my solution is the best one (probably not).