### PR TITLE
Remove use of deprecated set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Read Node version
+        id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-        id: nvm
       - name: Set Node version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version: '${{ steps.node_version.outputs.NVMRC }}'
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Read Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Set Node version
         uses: actions/setup-node@v1
@@ -20,7 +20,7 @@ jobs:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set node version
+      - name: Read Node version
         id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v2
+      - name: Set Node version
+        uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Set node version
         id: node_version
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.yarn/versions/1b9a477c.yml
+++ b/.yarn/versions/1b9a477c.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives


### PR DESCRIPTION


<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Remove use of set-output from GitHub actions, which has been deprecated

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
