### PR TITLE
Re-namespace new custom properties from `Popper`

### DIFF
--- a/.yarn/versions/132571b4.yml
+++ b/.yarn/versions/132571b4.yml
@@ -1,0 +1,9 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -229,9 +229,14 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
         }}
         style={{
           ...props.style,
-          // re-namespace exposed content custom property
-          ['--radix-context-menu-content-transform-origin' as any]:
-            'var(--radix-popper-transform-origin)',
+          // re-namespace exposed content custom properties
+          ...{
+            '--radix-context-menu-content-transform-origin': 'var(--radix-popper-transform-origin)',
+            '--radix-context-menu-content-available-width': 'var(--radix-popper-available-width)',
+            '--radix-context-menu-content-available-height': 'var(--radix-popper-available-height)',
+            '--radix-context-menu-trigger-width': 'var(--radix-popper-anchor-width)',
+            '--radix-context-menu-trigger-height': 'var(--radix-popper-anchor-height)',
+          },
         }}
       />
     );
@@ -501,9 +506,14 @@ const ContextMenuSubContent = React.forwardRef<
       ref={forwardedRef}
       style={{
         ...props.style,
-        // re-namespace exposed content custom property
-        ['--radix-context-menu-content-transform-origin' as any]:
-          'var(--radix-popper-transform-origin)',
+        // re-namespace exposed content custom properties
+        ...{
+          '--radix-context-menu-content-transform-origin': 'var(--radix-popper-transform-origin)',
+          '--radix-context-menu-content-available-width': 'var(--radix-popper-available-width)',
+          '--radix-context-menu-content-available-height': 'var(--radix-popper-available-height)',
+          '--radix-context-menu-trigger-width': 'var(--radix-popper-anchor-width)',
+          '--radix-context-menu-trigger-height': 'var(--radix-popper-anchor-height)',
+        },
       }}
     />
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -197,9 +197,16 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
         })}
         style={{
           ...props.style,
-          // re-namespace exposed content custom property
-          ['--radix-dropdown-menu-content-transform-origin' as any]:
-            'var(--radix-popper-transform-origin)',
+          // re-namespace exposed content custom properties
+          ...{
+            '--radix-dropdown-menu-content-transform-origin':
+              'var(--radix-popper-transform-origin)',
+            '--radix-dropdown-menu-content-available-width': 'var(--radix-popper-available-width)',
+            '--radix-dropdown-menu-content-available-height':
+              'var(--radix-popper-available-height)',
+            '--radix-dropdown-menu-trigger-width': 'var(--radix-popper-anchor-width)',
+            '--radix-dropdown-menu-trigger-height': 'var(--radix-popper-anchor-height)',
+          },
         }}
       />
     );
@@ -467,9 +474,14 @@ const DropdownMenuSubContent = React.forwardRef<
       ref={forwardedRef}
       style={{
         ...props.style,
-        // re-namespace exposed content custom property
-        ['--radix-dropdown-menu-content-transform-origin' as any]:
-          'var(--radix-popper-transform-origin)',
+        // re-namespace exposed content custom properties
+        ...{
+          '--radix-dropdown-menu-content-transform-origin': 'var(--radix-popper-transform-origin)',
+          '--radix-dropdown-menu-content-available-width': 'var(--radix-popper-available-width)',
+          '--radix-dropdown-menu-content-available-height': 'var(--radix-popper-available-height)',
+          '--radix-dropdown-menu-trigger-width': 'var(--radix-popper-anchor-width)',
+          '--radix-dropdown-menu-trigger-height': 'var(--radix-popper-anchor-height)',
+        },
       }}
     />
   );

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -339,12 +339,17 @@ const HoverCardContentImpl = React.forwardRef<
         ref={composedRefs}
         style={{
           ...contentProps.style,
-          // re-namespace exposed content custom property
-          ['--radix-hover-card-content-transform-origin' as any]:
-            'var(--radix-popper-transform-origin)',
           userSelect: containSelection ? 'text' : undefined,
           // Safari requires prefix
           WebkitUserSelect: containSelection ? 'text' : undefined,
+          // re-namespace exposed content custom properties
+          ...{
+            '--radix-hover-card-content-transform-origin': 'var(--radix-popper-transform-origin)',
+            '--radix-hover-card-content-available-width': 'var(--radix-popper-available-width)',
+            '--radix-hover-card-content-available-height': 'var(--radix-popper-available-height)',
+            '--radix-hover-card-trigger-width': 'var(--radix-popper-anchor-width)',
+            '--radix-hover-card-trigger-height': 'var(--radix-popper-anchor-height)',
+          },
         }}
       />
     </DismissableLayer>

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -407,9 +407,14 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
             ref={forwardedRef}
             style={{
               ...contentProps.style,
-              // re-namespace exposed content custom property
-              ['--radix-popover-content-transform-origin' as any]:
-                'var(--radix-popper-transform-origin)',
+              // re-namespace exposed content custom properties
+              ...{
+                '--radix-popover-content-transform-origin': 'var(--radix-popper-transform-origin)',
+                '--radix-popover-content-available-width': 'var(--radix-popper-available-width)',
+                '--radix-popover-content-available-height': 'var(--radix-popper-available-height)',
+                '--radix-popover-trigger-width': 'var(--radix-popper-anchor-width)',
+                '--radix-popover-trigger-height': 'var(--radix-popper-anchor-height)',
+              },
             }}
           />
         </DismissableLayer>

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -540,9 +540,14 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
           ref={forwardedRef}
           style={{
             ...contentProps.style,
-            // re-namespace exposed content custom property
-            ['--radix-tooltip-content-transform-origin' as any]:
-              'var(--radix-popper-transform-origin)',
+            // re-namespace exposed content custom properties
+            ...{
+              '--radix-tooltip-content-transform-origin': 'var(--radix-popper-transform-origin)',
+              '--radix-tooltip-content-available-width': 'var(--radix-popper-available-width)',
+              '--radix-tooltip-content-available-height': 'var(--radix-popper-available-height)',
+              '--radix-tooltip-trigger-width': 'var(--radix-popper-anchor-width)',
+              '--radix-tooltip-trigger-height': 'var(--radix-popper-anchor-height)',
+            },
           }}
         >
           <Slottable>{children}</Slottable>


### PR DESCRIPTION
Fixes #1596
Closes #393

### Description

This PR re-namespaces the newly available custom properties from `Popper` into dependent components (`ContextMenu`, `DropdownMenu`, `HoverCard`, `Popover`, `Tooltip`).

These were introduced in `Popper` and used in `Select` here: #1853

---

Related PRs (now redudant): #1597, #1659 
