### PR TITLE
[Menu] Only close one submenu per escape keypress, per WAI-ARIA

### DIFF
--- a/.yarn/versions/a03fb8cd.yml
+++ b/.yarn/versions/a03fb8cd.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1191,7 +1191,9 @@ const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentPro
                 if (event.target !== subContext.trigger) context.onOpenChange(false);
               })}
               onEscapeKeyDown={composeEventHandlers(props.onEscapeKeyDown, (event) => {
-                rootContext.onClose();
+                context.onOpenChange(false);
+                // We focus manually because we prevented it in `onCloseAutoFocus`
+                subContext.trigger?.focus();
                 // ensure pressing escape in submenu doesn't escape full screen mode
                 event.preventDefault();
               })}


### PR DESCRIPTION
Fixes radix-ui/primitives#1933

### Description

Pretty simple: [the WAI-ARIA pattern says](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) when you press escape in a submenu, instead of closing the submenu and all its ancestors, just close the submenu and return focus to the triggering menuitem, as if you had pressed the left arrow.

> Escape: Close the menu that contains focus and return focus to the element or context, e.g., menu button or parent menuitem, from which the menu was opened.

I didn't realize this was in the pattern, and it's not what macOS does (it matches the existing behaviour of closing the entire menu), but it's not unreasonable. And I suppose matching the WAI-ARIA pattern is the stated design goal.
