### PR TITLE
Fix failing dependency installations in CI

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,6 +16,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Read Node version
+        id: node_version
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+      - name: Set Node version
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ steps.node_version.outputs.NVMRC }}'
       - name: Install dependencies
         run: yarn
       - name: Publish to Chromatic

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,6 +13,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Read Node version
+        id: node_version
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+      - name: Set Node version
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ steps.node_version.outputs.NVMRC }}'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT

--- a/.yarn/versions/170035f7.yml
+++ b/.yarn/versions/170035f7.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives


### PR DESCRIPTION
Chromatic and Version check actions were failing at the installation step due to a mismatch in node version when running locally vs CI.

This change pins these actions to use the version specified in `.nvmrc`, resolving the issue.