### PR TITLE
Fix position when use anchor css properties

### DIFF
--- a/.yarn/versions/c47b2fc0.yml
+++ b/.yarn/versions/c47b2fc0.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -193,11 +193,11 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         avoidCollisions ? flip({ ...detectOverflowOptions }) : undefined,
         size({
           ...detectOverflowOptions,
-          apply: ({ elements, rects, availableWidth: width, availableHeight: height }) => {
+          apply: ({ elements, rects, availableWidth, availableHeight }) => {
             const { width: anchorWidth, height: anchorHeight } = rects.reference;
             const contentStyle = elements.floating.style;
-            contentStyle.setProperty('--radix-popper-available-width', `${width}px`);
-            contentStyle.setProperty('--radix-popper-available-height', `${height}px`);
+            contentStyle.setProperty('--radix-popper-available-width', `${availableWidth}px`);
+            contentStyle.setProperty('--radix-popper-available-height', `${availableHeight}px`);
             contentStyle.setProperty('--radix-popper-anchor-width', `${anchorWidth}px`);
             contentStyle.setProperty('--radix-popper-anchor-height', `${anchorHeight}px`);
           },

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -194,14 +194,14 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         size({
           ...detectOverflowOptions,
           apply: ({ elements, rects, availableWidth: width, availableHeight: height }) => {
-            const { width: popperWidth, height: popperHeight } = rects.reference;
+            const { width: anchorWidth, height: anchorHeight } = rects.reference;
 
             elements.floating.style.setProperty('--radix-popper-available-width', `${width}px`);
             elements.floating.style.setProperty('--radix-popper-available-height', `${height}px`);
-            elements.floating.style.setProperty('--radix-popper-anchor-width', `${popperWidth}px`);
+            elements.floating.style.setProperty('--radix-popper-anchor-width', `${anchorWidth}px`);
             elements.floating.style.setProperty(
               '--radix-popper-anchor-height',
-              `${popperHeight}px`
+              `${anchorHeight}px`
             );
           },
         }),

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -195,14 +195,11 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
           ...detectOverflowOptions,
           apply: ({ elements, rects, availableWidth: width, availableHeight: height }) => {
             const { width: anchorWidth, height: anchorHeight } = rects.reference;
-
-            elements.floating.style.setProperty('--radix-popper-available-width', `${width}px`);
-            elements.floating.style.setProperty('--radix-popper-available-height', `${height}px`);
-            elements.floating.style.setProperty('--radix-popper-anchor-width', `${anchorWidth}px`);
-            elements.floating.style.setProperty(
-              '--radix-popper-anchor-height',
-              `${anchorHeight}px`
-            );
+            const contentStyle = elements.floating.style;
+            contentStyle.setProperty('--radix-popper-available-width', `${width}px`);
+            contentStyle.setProperty('--radix-popper-available-height', `${height}px`);
+            contentStyle.setProperty('--radix-popper-anchor-width', `${anchorWidth}px`);
+            contentStyle.setProperty('--radix-popper-anchor-height', `${anchorHeight}px`);
           },
         }),
         arrow ? floatingUIarrow({ element: arrow, padding: arrowPadding }) : undefined,

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -396,11 +396,24 @@ function isNotNull<T>(value: T | null): value is T {
 
 const anchorCssProperties = (): Middleware => ({
   name: 'anchorCssProperties',
-  fn(data) {
-    const { rects, elements } = data;
+  async fn(data) {
+    const { rects, elements, platform } = data;
     const { width, height } = rects.reference;
+    const { width: popperWidth, height: popperHeight } = rects.floating;
+
     elements.floating.style.setProperty('--radix-popper-anchor-width', `${width}px`);
     elements.floating.style.setProperty('--radix-popper-anchor-height', `${height}px`);
+
+    const nextDimensions = await platform.getDimensions(elements.floating);
+
+    if (popperWidth !== nextDimensions.width || popperHeight !== nextDimensions.height) {
+      return {
+        reset: {
+          rects: true,
+        },
+      };
+    }
+
     return {};
   },
 });


### PR DESCRIPTION
### Description

[Reset the middleware lifecycle](https://floating-ui.com/docs/middleware#resetting-the-lifecycle) to calculate the right position when using `--radix-popper-anchor-width` or `--radix-popper-anchor-height`.

See the behavior in some primitives although works with `Select`

https://codesandbox.io/p/sandbox/cocky-wood-wgqnuy

Fixes #1968
Fixes #2017 

