### PR TITLE
[Small Feat] Use inertOthers instead of hideOthers

### DIFF
--- a/.yarn/versions/0f4adb39.yml
+++ b/.yarn/versions/0f4adb39.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-dialog": minor
+  "@radix-ui/react-menu": minor
+  "@radix-ui/react-popover": minor
+  "@radix-ui/react-select": minor
+
+declined:
+  - primitives
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-context-menu"
+  - "@radix-ui/react-dropdown-menu"
+  - "@radix-ui/react-menubar"

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -29,7 +29,7 @@
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
-    "aria-hidden": "^1.1.1",
+    "aria-hidden": "^1.2.2",
     "react-remove-scroll": "2.5.5"
   },
   "peerDependencies": {

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -11,7 +11,7 @@ import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
-import { hideOthers } from 'aria-hidden';
+import { inertOthers } from 'aria-hidden';
 import { Slot } from '@radix-ui/react-slot';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -259,7 +259,7 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
     React.useEffect(() => {
       const content = contentRef.current;
-      if (content) return hideOthers(content);
+      if (content) return inertOthers(content);
     }, []);
 
     return (

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -33,7 +33,7 @@
     "@radix-ui/react-roving-focus": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
-    "aria-hidden": "^1.1.1",
+    "aria-hidden": "^1.2.2",
     "react-remove-scroll": "2.5.5"
   },
   "peerDependencies": {

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -17,7 +17,7 @@ import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
 import { Slot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
-import { hideOthers } from 'aria-hidden';
+import { inertOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -261,7 +261,7 @@ const MenuRootContentModal = React.forwardRef<MenuRootContentTypeElement, MenuRo
     // Hide everything from ARIA except the `MenuContent`
     React.useEffect(() => {
       const content = ref.current;
-      if (content) return hideOthers(content);
+      if (content) return inertOthers(content);
     }, []);
 
     return (

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
-    "aria-hidden": "^1.1.1",
+    "aria-hidden": "^1.2.2",
     "react-remove-scroll": "2.5.5"
   },
   "peerDependencies": {

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -13,7 +13,7 @@ import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { hideOthers } from 'aria-hidden';
+import { inertOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -250,7 +250,7 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
     React.useEffect(() => {
       const content = contentRef.current;
-      if (content) return hideOthers(content);
+      if (content) return inertOthers(content);
     }, []);
 
     return (

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-use-layout-effect": "workspace:*",
     "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
-    "aria-hidden": "^1.1.1",
+    "aria-hidden": "^1.2.2",
     "react-remove-scroll": "2.5.5"
   },
   "peerDependencies": {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -20,7 +20,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { usePrevious } from '@radix-ui/react-use-previous';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import { hideOthers } from 'aria-hidden';
+import { inertOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -515,7 +515,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
     React.useEffect(() => {
-      if (content) return hideOthers(content);
+      if (content) return inertOthers(content);
     }, [content]);
 
     // Make sure the whole tree has focus guards as our `Select` may be

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,7 +3272,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
-    aria-hidden: ^1.1.1
+    aria-hidden: ^1.2.2
     react-remove-scroll: 2.5.5
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
@@ -3413,7 +3413,7 @@ __metadata:
     "@radix-ui/react-roving-focus": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
-    aria-hidden: ^1.1.1
+    aria-hidden: ^1.2.2
     react-remove-scroll: 2.5.5
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
@@ -3485,7 +3485,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
-    aria-hidden: ^1.1.1
+    aria-hidden: ^1.2.2
     react-remove-scroll: 2.5.5
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
@@ -3651,7 +3651,7 @@ __metadata:
     "@radix-ui/react-use-layout-effect": "workspace:*"
     "@radix-ui/react-use-previous": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
-    aria-hidden: ^1.1.1
+    aria-hidden: ^1.2.2
     react-remove-scroll: 2.5.5
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
@@ -6204,12 +6204,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-hidden@npm:^1.1.1":
-  version: 1.1.3
-  resolution: "aria-hidden@npm:1.1.3"
+"aria-hidden@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "aria-hidden@npm:1.2.2"
   dependencies:
-    tslib: ^1.0.0
-  checksum: 2d40a328246baac7ae0b243ebe0cbef53c836c5f78c9212e9c1ff93f3aee185bd9aa51773e161e0025722d691c9d5f125070f6175a7074c4a57778ddc30d9e74
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0 || ^18.0.0
+    react: ^16.9.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: ee1a3688db5491eeb87b73eea624614f24ef62a74cf9e47bc8229dde1ff7457f7e4a26425cadc0d3efd89380305e6fb4a4e505bccdee16beaa4686014861d7b1
   languageName: node
   linkType: hard
 
@@ -17610,7 +17616,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.0.0, tslib@npm:^1.8.1":
+"tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd


### PR DESCRIPTION
### Description

This is not a big feature; while trying to open a PR on another issue (the forced "modal mode" the Select component), I found that aria-hidden had been updated and had implemented the "inertOthers".
Inert is the new [W3C's](https://html.spec.whatwg.org/multipage/interaction.html#modal-dialogs-and-inert-subtrees) way to hide elements, instead of relying on an aria attribute.