### PR TITLE
[Slider] better extend Thumb styles

### DIFF
--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -586,13 +586,6 @@ const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImpl
     }, [thumb, context.thumbs]);
 
     return (
-      <span
-        style={{
-          transform: 'var(--radix-slider-thumb-transform)',
-          position: 'absolute',
-          [orientation.startEdge]: `calc(${percent}% + ${thumbInBoundsOffset}px)`,
-        }}
-      >
         <Collection.ItemSlot scope={props.__scopeSlider}>
           <Primitive.span
             role="slider"
@@ -612,13 +605,21 @@ const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImpl
              * snap into the correct position during hydration which would be visually jarring for
              * slower connections.
              */
-            style={value === undefined ? { display: 'none' } : props.style}
+            style={
+              value === undefined
+                ? { display: 'none' }
+                : {
+                    ...props.style,
+                    transform: 'var(--radix-slider-thumb-transform)',
+                    position: 'absolute',
+                    [orientation.startEdge]: `calc(${percent}% + ${thumbInBoundsOffset}px)`,
+                  }
+            }
             onFocus={composeEventHandlers(props.onFocus, () => {
               context.valueIndexToChangeRef.current = index;
             })}
           />
         </Collection.ItemSlot>
-      </span>
     );
   }
 );


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Hey created a pr but maybe there is a something I'm missing

It removes the `Thumb` wrapping `span` tag and add the positioning styles straight to the `Primitive.span`
so that I can for example use a transform transition and have the thumb animate nicely to it's new value

here's a small before and after of applying a tailwind `transitions-all` class to the `Thumb` component


https://user-images.githubusercontent.com/6232729/223790318-40cbdc76-2988-4ef0-80be-cbaef8b9a58f.mov


https://user-images.githubusercontent.com/6232729/223790332-5ba0178c-839d-4061-b5cc-ca107576e7c8.mov


<!-- Describe the change you are introducing -->
