### PR TITLE
[Popper] Upgrade floating-ui

### DIFF
--- a/.yarn/versions/09c74da3.yml
+++ b/.yarn/versions/09c74da3.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -24,6 +24,46 @@ export const Styled = () => {
   );
 };
 
+// Original issue: https://github.com/radix-ui/primitives/issues/2128
+export const Boundary = () => {
+  const [boundary, setBoundary] = React.useState<HTMLDivElement | null>(null);
+
+  return (
+    <div
+      style={{
+        border: '3px dashed red',
+        width: '200px',
+        height: '200px',
+      }}
+      ref={setBoundary}
+    >
+      <Popover.Root>
+        <Popover.Trigger asChild>
+          <button>open</button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            style={{
+              boxSizing: 'border-box',
+              borderRadius: '8px',
+              padding: '8px',
+              color: 'white',
+              backgroundColor: 'black',
+              width: 'var(--radix-popper-available-width)',
+              height: 'var(--radix-popper-available-height)',
+            }}
+            sideOffset={5}
+            collisionBoundary={boundary}
+          >
+            out of bound out of bound out of bound out of bound out of bound out of bound out of
+            bound out of bound out of bound
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+};
+
 export const Modality = () => {
   return (
     <div

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@floating-ui/react-dom": "^1.3.0",
+    "@floating-ui/react-dom": "^2.0.0",
     "@radix-ui/react-arrow": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@floating-ui/react-dom": "0.7.2",
+    "@floating-ui/react-dom": "^1.3.0",
     "@radix-ui/react-arrow": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -108,10 +108,6 @@ type PopperContentContextValue = {
 const [PopperContentProvider, useContentContext] =
   createPopperContext<PopperContentContextValue>(CONTENT_NAME);
 
-const [PositionContextProvider, usePositionContext] = createPopperContext(CONTENT_NAME, {
-  hasParent: false,
-});
-
 type Boundary = Element | null;
 
 type PopperContentElement = React.ElementRef<typeof Primitive.div>;
@@ -227,24 +223,6 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
     }, [content]);
 
-    const { hasParent } = usePositionContext(CONTENT_NAME, __scopePopper);
-    const isRoot = !hasParent;
-
-    const commonProps = {
-      'data-side': placedSide,
-      'data-align': placedAlign,
-      ...contentProps,
-      ref: composedRefs,
-      style: {
-        ...contentProps.style,
-        // if the PopperContent hasn't been placed yet (not all measurements done)
-        // we prevent animations so that users's animation don't kick in too early referring wrong sides
-        animation: !isPositioned ? 'none' : undefined,
-        // hide the content if using the hide middleware and should be hidden
-        opacity: middlewareData.hide?.referenceHidden ? 0 : undefined,
-      },
-    };
-
     return (
       <div
         ref={refs.setFloating}
@@ -272,13 +250,20 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
           arrowY={arrowY}
           shouldHideArrow={cannotCenterArrow}
         >
-          {isRoot ? (
-            <PositionContextProvider scope={__scopePopper} hasParent>
-              <Primitive.div {...commonProps} />
-            </PositionContextProvider>
-          ) : (
-            <Primitive.div {...commonProps} />
-          )}
+          <Primitive.div
+            data-side={placedSide}
+            data-align={placedAlign}
+            {...contentProps}
+            ref={composedRefs}
+            style={{
+              ...contentProps.style,
+              // if the PopperContent hasn't been placed yet (not all measurements done)
+              // we prevent animations so that users's animation don't kick in too early referring wrong sides
+              animation: !isPositioned ? 'none' : undefined,
+              // hide the content if using the hide middleware and should be hidden
+              opacity: middlewareData.hide?.referenceHidden ? 0 : undefined,
+            }}
+          />
         </PopperContentProvider>
       </div>
     );

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -183,15 +183,14 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         whileElementsMounted: autoUpdate,
         middleware: [
           offset({ mainAxis: sideOffset + arrowHeight, alignmentAxis: alignOffset }),
-          avoidCollisions
-            ? shift({
-                mainAxis: true,
-                crossAxis: false,
-                limiter: sticky === 'partial' ? limitShift() : undefined,
-                ...detectOverflowOptions,
-              })
-            : undefined,
-          avoidCollisions ? flip({ ...detectOverflowOptions }) : undefined,
+          avoidCollisions &&
+            shift({
+              mainAxis: true,
+              crossAxis: false,
+              limiter: sticky === 'partial' ? limitShift() : undefined,
+              ...detectOverflowOptions,
+            }),
+          avoidCollisions && flip({ ...detectOverflowOptions }),
           size({
             ...detectOverflowOptions,
             apply: ({ elements, rects, availableWidth, availableHeight }) => {
@@ -203,10 +202,10 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
               contentStyle.setProperty('--radix-popper-anchor-height', `${anchorHeight}px`);
             },
           }),
-          arrow ? floatingUIarrow({ element: arrow, padding: arrowPadding }) : undefined,
+          arrow && floatingUIarrow({ element: arrow, padding: arrowPadding }),
           transformOrigin({ arrowWidth, arrowHeight }),
-          hideWhenDetached ? hide({ strategy: 'referenceHidden' }) : undefined,
-        ].filter(isDefined),
+          hideWhenDetached && hide({ strategy: 'referenceHidden' }),
+        ],
       });
 
     // assign the reference dynamically once `Content` has mounted so we can collocate the logic
@@ -388,10 +387,6 @@ const PopperArrow = React.forwardRef<PopperArrowElement, PopperArrowProps>(funct
 PopperArrow.displayName = ARROW_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
-
-function isDefined<T>(value: T | undefined): value is T {
-  return value !== undefined;
-}
 
 function isNotNull<T>(value: T | null): value is T {
   return value !== null;

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -251,7 +251,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         data-radix-popper-content-wrapper=""
         style={{
           ...floatingStyles,
-          transform: isPositioned ? floatingStyles.transform : 'translate3d(0, -200%, 0)', // keep off the page when measuring
+          transform: isPositioned ? floatingStyles.transform : 'translate(0, -200%)', // keep off the page when measuring
           minWidth: 'max-content',
           zIndex: contentZIndex,
           ['--radix-popper-transform-origin' as any]: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,32 +1655,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "@floating-ui/core@npm:0.7.3"
-  checksum: f48f9fb0d19dcbe7a68c38e8de7fabb11f0c0e6e0ef215ae60b5004900bacb1386e7b89cb377d91a90ff7d147ea1f06c2905136ecf34dea162d9696d8f448d5f
+"@floating-ui/core@npm:^1.2.3":
+  version: 1.2.4
+  resolution: "@floating-ui/core@npm:1.2.4"
+  checksum: 1c163ea1804e2b0a28fda6e32efed0e242d0db8081fd24aab9d1cbb100f94a558709231c483bf74bf09a9204ea6e7845813d43b5322ceb6ee63285308f68f65b
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^0.5.3":
-  version: 0.5.4
-  resolution: "@floating-ui/dom@npm:0.5.4"
+"@floating-ui/dom@npm:^1.2.1":
+  version: 1.2.4
+  resolution: "@floating-ui/dom@npm:1.2.4"
   dependencies:
-    "@floating-ui/core": ^0.7.3
-  checksum: 9f9d8a51a828c6be5f187204aa6d293c6c9ef70d51dcc5891a4d85683745fceebf79ff8826d0f75ae41b45c3b138367d339756f27f41be87a8770742ebc0de42
+    "@floating-ui/core": ^1.2.3
+  checksum: 5c24a2e8f04e436390646c8a4431c6cb79e03711fbb0f818b87d613a6be8971bc560a830b702aaa51a0ebc4d0c45deb06f3140c14125dc1ac770365bf66ee903
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@floating-ui/react-dom@npm:0.7.2"
+"@floating-ui/react-dom@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@floating-ui/react-dom@npm:1.3.0"
   dependencies:
-    "@floating-ui/dom": ^0.5.3
-    use-isomorphic-layout-effect: ^1.1.1
+    "@floating-ui/dom": ^1.2.1
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: bc3f2b5557f87f6f4bbccfe3e8d097abafad61a41083d3b79f3499f27590e273bcb3dc7136c2444841ee7a8c0d2a70cc1385458c16103fa8b70eade80c24af52
+  checksum: ce0ad3e3bbe43cfd15a6a0d5cccede02175c845862bfab52027995ab99c6b29630180dc7d146f76ebb34730f90a6ab9bf193c8984fe8d7f56062308e4ca98f77
   languageName: node
   linkType: hard
 
@@ -3515,7 +3514,7 @@ __metadata:
   resolution: "@radix-ui/react-popper@workspace:packages/react/popper"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@floating-ui/react-dom": 0.7.2
+    "@floating-ui/react-dom": ^1.3.0
     "@radix-ui/react-arrow": "workspace:*"
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"
@@ -18065,18 +18064,6 @@ typescript@^4.6.3:
     "@types/react":
       optional: true
   checksum: 7913df383a5a6fcb399212eedefaac2e0c6f843555202d4e3010bac3848afe38ecaa3d0d6500ad1d936fbeffd637e6c517e68edb024af5e6beca7f27f3ce7b21
-  languageName: node
-  linkType: hard
-
-"use-isomorphic-layout-effect@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,31 +1655,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.2.3":
-  version: 1.2.4
-  resolution: "@floating-ui/core@npm:1.2.4"
-  checksum: 1c163ea1804e2b0a28fda6e32efed0e242d0db8081fd24aab9d1cbb100f94a558709231c483bf74bf09a9204ea6e7845813d43b5322ceb6ee63285308f68f65b
+"@floating-ui/core@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@floating-ui/core@npm:1.2.6"
+  checksum: e4aa96c435277f1720d4bc939e17a79b1e1eebd589c20b622d3c646a5273590ff889b8c6e126f7be61873cf8c4d7db7d418895986ea19b8b0d0530de32504c3a
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.2.1":
-  version: 1.2.4
-  resolution: "@floating-ui/dom@npm:1.2.4"
+"@floating-ui/dom@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@floating-ui/dom@npm:1.2.7"
   dependencies:
-    "@floating-ui/core": ^1.2.3
-  checksum: 5c24a2e8f04e436390646c8a4431c6cb79e03711fbb0f818b87d613a6be8971bc560a830b702aaa51a0ebc4d0c45deb06f3140c14125dc1ac770365bf66ee903
+    "@floating-ui/core": ^1.2.6
+  checksum: f330228b909ecf241fea1db780a97c842acaea74d2a5ce99456040f9932a80d12c6a77e1c7d56a2700fe6bc85f961f76a7f3bd2640c3a5b2bc497ccc65074519
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@floating-ui/react-dom@npm:1.3.0"
+"@floating-ui/react-dom@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@floating-ui/react-dom@npm:2.0.0"
   dependencies:
-    "@floating-ui/dom": ^1.2.1
+    "@floating-ui/dom": ^1.2.7
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: ce0ad3e3bbe43cfd15a6a0d5cccede02175c845862bfab52027995ab99c6b29630180dc7d146f76ebb34730f90a6ab9bf193c8984fe8d7f56062308e4ca98f77
+  checksum: c5dd02b7babf9c26d5e11b8ebe58411131b37844f7d6362a767cd1eedfb506ca6db3228fb192e0a5822c9289a5b500e2ef31e069dce28a0fbec4722f22bcdd95
   languageName: node
   linkType: hard
 
@@ -3514,7 +3514,7 @@ __metadata:
   resolution: "@radix-ui/react-popper@workspace:packages/react/popper"
   dependencies:
     "@babel/runtime": ^7.13.10
-    "@floating-ui/react-dom": ^1.3.0
+    "@floating-ui/react-dom": ^2.0.0
     "@radix-ui/react-arrow": "workspace:*"
     "@radix-ui/react-compose-refs": "workspace:*"
     "@radix-ui/react-context": "workspace:*"


### PR DESCRIPTION
### Description

This PR upgrades major version of `@floating-ui/react-dom` in `Popper` component.

Noticeble release notes from Floating UI:

- https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fcore%401.0.0
- https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fdom%401.2.5
- https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Freact-dom%401.1.0
- https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Freact-dom%401.0.1
- https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Freact-dom%402.0.0

The PR does the following:

- Upgrades `@floating-ui/react-dom` to `2.0.0`.
- Changes  `@floating-ui/react-dom` from fixed version to minor version. Since Floating UI uses semantic versioning, it should be safe to use minor version and it will reduce a chance of duplicate packages for Floating UI for the end users.
- Removes unnecessary logic/workarounds after the upgrade.
- Removed filtering falsy values in `middleware` because now it's done inside `@floating-ui/react-dom`.

Affected issues:
- Fixes #2128