### PR TITLE
In Select, associate label with native select in a Form

### DIFF
--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -92,6 +92,7 @@ interface SelectProps {
   autoComplete?: string;
   disabled?: boolean;
   required?: boolean;
+  id?: string;
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -109,6 +110,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     autoComplete,
     disabled,
     required,
+    id,
   } = props;
   const popperScope = usePopperScope(__scopeSelect);
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
@@ -190,6 +192,10 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             // enable form autofill
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
+            id={id}
+            onFocus={() => {
+              if (trigger) trigger.focus();
+            }}
           >
             {value === undefined ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

This PR aims to make Select component resilient for Playwright, so that _[selectOption](https://playwright.dev/docs/api/class-page#page-select-option)_ works with _getByLabel_.

consider a Select in a Form:

```javascript
import * as Form from "@radix-ui/react-form";
import * as Select from "@radix-ui/react-select";

const MyForm = () => {
  return (
    <Form.Root>
      <Form.Field name="country">
        <Form.Label>Country</Form.Label>
        <Form.Control asChild>
          <Select.Root>        // Select receives id same as "for" attribute of label tag
            <Select.Trigger>
              <Select.Value />
              <Select.Icon />
            </Select.Trigger>
            <Select.Portal>
              <Select.Content>
                <Select.Viewport>{/* options */}</Select.Viewport>
              </Select.Content>
            </Select.Portal>
          </Select.Root>
        </Form.Control>
      </Form.Field>
    </Form.Root>
  );
};
```

```javascript
page.getByLabel('Label').selectOption("option")  // before: not work because label is associated with trigger button
                                                                                     // after: works because label is associated with the real select element
```

### Details

It seems the child of `Form.Control` always receives an `id`, which is the same as the label's `for` attribute, and the `id` is not used in the `Select` component. I have used the `id` to associate the label with the real select element instead of the trigger button, so that a testing framework like Playwright can use the label to find the select and select options. This makes the test code have no need to know about implementation details.

Additionally, to keep the behavior of on label clicked, control gets focused, and the focus event is forwarded to the button trigger.

I think this change is more of an improvement. I'm not sure if some tests or stories should be added, but if it's required, I'm glad to do it.