### PR TITLE
[Select] Prevent items longer than the window width to be positioned outside of the viewport

### DIFF
--- a/.yarn/versions/ed1540a2.yml
+++ b/.yarn/versions/ed1540a2.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-select": patch

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -802,17 +802,25 @@ const SelectItemAlignedPosition = React.forwardRef<
       const valueNodeRect = context.valueNode.getBoundingClientRect();
       const itemTextRect = selectedItemText.getBoundingClientRect();
 
+      console.log('selectedItemText', selectedItemText);
+
       if (context.dir !== 'rtl') {
         const itemTextOffset = itemTextRect.left - contentRect.left;
         const left = valueNodeRect.left - itemTextOffset;
         const leftDelta = triggerRect.left - left;
         const minContentWidth = triggerRect.width + leftDelta;
         const contentWidth = Math.max(minContentWidth, contentRect.width);
-        const rightEdge = window.innerWidth - CONTENT_MARGIN;
-        const clampedLeft = clamp(left, [CONTENT_MARGIN, rightEdge - contentWidth]);
 
-        contentWrapper.style.minWidth = minContentWidth + 'px';
-        contentWrapper.style.left = clampedLeft + 'px';
+        if (contentWidth >= window.innerWidth) {
+          contentWrapper.style.left = CONTENT_MARGIN + 'px';
+          contentWrapper.style.maxWidth = window.innerWidth - CONTENT_MARGIN * 2 + 'px';
+        } else {
+          const rightEdge =
+            contentWidth <= window.innerWidth ? window.innerWidth - CONTENT_MARGIN : contentWidth;
+          const clampedLeft = clamp(left, [CONTENT_MARGIN, rightEdge - contentWidth]);
+          contentWrapper.style.left = clampedLeft + 'px';
+          contentWrapper.style.minWidth = minContentWidth + 'px';
+        }
       } else {
         const itemTextOffset = contentRect.right - itemTextRect.right;
         const right = window.innerWidth - valueNodeRect.right - itemTextOffset;
@@ -822,8 +830,13 @@ const SelectItemAlignedPosition = React.forwardRef<
         const leftEdge = window.innerWidth - CONTENT_MARGIN;
         const clampedRight = clamp(right, [CONTENT_MARGIN, leftEdge - contentWidth]);
 
-        contentWrapper.style.minWidth = minContentWidth + 'px';
-        contentWrapper.style.right = clampedRight + 'px';
+        if (contentWidth >= window.innerWidth) {
+          contentWrapper.style.right = window.innerWidth - CONTENT_MARGIN + 'px';
+          contentWrapper.style.maxWidth = window.innerWidth - CONTENT_MARGIN * 2 + 'px';
+        } else {
+          contentWrapper.style.minWidth = minContentWidth + 'px';
+          contentWrapper.style.right = clampedRight + 'px';
+        }
       }
 
       // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
fixes [2049](https://github.com/radix-ui/primitives/issues/2049)

### Description
As described in issue [2049](https://github.com/radix-ui/primitives/issues/2049), if you have an item that is longer than your screen width (on a small screen for example), you will have a negative offset, pushing the content out of the viewport.

This PR proposes to compare the `contentWidth` with the `window.innerWidth` before affecting `left`/`right` position and `minWidth` to the element and fallback to a default value (default margin for the position and screenWidth - default margins for the `maxWidth`). 

This is the `simplest` solution I've found, but if you have suggestions to improve it, I'll be happy to discuss about it 🙂. 