### PR TITLE
[DropdownMenu] Allow click events that are not only triggered by pointers

### DIFF
--- a/.yarn/versions/c89fd021.yml
+++ b/.yarn/versions/c89fd021.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -114,7 +114,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+          onMouseDown={composeEventHandlers(props.onMouseDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {


### PR DESCRIPTION
Fixes #1986.

Pretty simple change, but it makes sure that Dropdown button click events that are triggered by anything other than pointers  are also listened to. One case for this is the Vimium browser extension as mentioned in the linked issue, which doesn't trigger neither a pointer or keydown event.
