### PR TITLE
[Select] Fix dispatch touch events when closing

### DIFF
--- a/.yarn/versions/53c72647.yml
+++ b/.yarn/versions/53c72647.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1190,6 +1190,8 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
       contentContext.itemRefCallback?.(node, value, disabled)
     );
     const textId = useId();
+    const isPointerDownRef = React.useRef(false);
+    const isPointerUpRef = React.useRef(false);
 
     const handleSelect = () => {
       if (!disabled) {
@@ -1229,7 +1231,17 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             ref={composedRefs}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
-            onPointerUp={composeEventHandlers(itemProps.onPointerUp, handleSelect)}
+            onClick={composeEventHandlers(itemProps.onClick, () => {
+              if (isPointerUpRef.current) handleSelect();
+            })}
+            onPointerUp={composeEventHandlers(itemProps.onPointerUp, (event) => {
+              isPointerUpRef.current = true;
+              if (!isPointerDownRef.current) event.currentTarget.click();
+            })}
+            onPointerDown={composeEventHandlers(
+              itemProps.onPointerDown,
+              () => (isPointerDownRef.current = true)
+            )}
             onPointerMove={composeEventHandlers(itemProps.onPointerMove, (event) => {
               if (disabled) {
                 contentContext.onItemLeave?.();


### PR DESCRIPTION
### Description

I'm using a similar approach as used in [`Menu`](https://github.com/radix-ui/primitives/blob/main/packages/react/menu/src/Menu.tsx#L636-L646) to select an item which uses the `onClick` event. I couldn't test if it works in safari because I don't have access to one, so if you guys can test it there, thanks :pray:

Fixes #1658
