### PR TITLE
[Popper] Add option to always re-position popper (rAF-based)

### DIFF
--- a/.yarn/versions/6d1dbdd9.yml
+++ b/.yarn/versions/6d1dbdd9.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -92,6 +92,48 @@ export const WithPortal = () => {
   );
 };
 
+export const WithRAF = () => {
+  const [open, setOpen] = React.useState(false);
+  const [left, setLeft] = React.useState(0);
+  React.useEffect(() => {
+    const intervalId = setInterval(() => {
+      setLeft((prev) => (prev + 50) % 300);
+    }, 500);
+    return () => clearInterval(intervalId);
+  }, []);
+  return (
+    <Scrollable>
+      <Popper.Root>
+        <Popper.Anchor
+          className={anchorClass()}
+          onClick={() => setOpen(true)}
+          style={{ marginLeft: left }}
+        >
+          open
+        </Popper.Anchor>
+
+        {open && (
+          <Portal asChild>
+            <Popper.Content
+              className={contentClass()}
+              sideOffset={5}
+              autoUpdateOptions={{
+                ancestorResize: true,
+                ancestorScroll: true,
+                animationFrame: true,
+                elementResize: true,
+              }}
+            >
+              <button onClick={() => setOpen(false)}>close</button>
+              <Popper.Arrow className={arrowClass()} width={20} height={10} />
+            </Popper.Content>
+          </Portal>
+        )}
+      </Popper.Root>
+    </Scrollable>
+  );
+};
+
 export const Chromatic = () => {
   const [scrollContainer1, setScrollContainer1] = React.useState<HTMLDivElement | null>(null);
   const [scrollContainer2, setScrollContainer2] = React.useState<HTMLDivElement | null>(null);

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -92,7 +92,7 @@ export const WithPortal = () => {
   );
 };
 
-export const WithRAF = () => {
+export const WithUpdatePositionStrategyAlways = () => {
   const [open, setOpen] = React.useState(false);
   const [left, setLeft] = React.useState(0);
   React.useEffect(() => {
@@ -117,12 +117,7 @@ export const WithRAF = () => {
             <Popper.Content
               className={contentClass()}
               sideOffset={5}
-              autoUpdateOptions={{
-                ancestorResize: true,
-                ancestorScroll: true,
-                animationFrame: true,
-                elementResize: true,
-              }}
+              updatePositionStrategy="always"
             >
               <button onClick={() => setOpen(false)}>close</button>
               <Popper.Arrow className={arrowClass()} width={20} height={10} />

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -123,6 +123,12 @@ interface PopperContentProps extends PrimitiveDivProps {
   hideWhenDetached?: boolean;
   avoidCollisions?: boolean;
   onPlaced?: () => void;
+  autoUpdateOptions?: {
+    ancestorScroll?: boolean;
+    ancestorResize?: boolean;
+    elementResize?: boolean;
+    animationFrame?: boolean;
+  };
 }
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
@@ -139,6 +145,12 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       sticky = 'partial',
       hideWhenDetached = false,
       avoidCollisions = true,
+      autoUpdateOptions = {
+        ancestorScroll: true,
+        ancestorResize: true,
+        elementResize: true,
+        animationFrame: false,
+      },
       onPlaced,
       ...contentProps
     } = props;
@@ -174,7 +186,8 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       // default to `fixed` strategy so users don't have to pick and we also avoid focus scroll issues
       strategy: 'fixed',
       placement: desiredPlacement,
-      whileElementsMounted: autoUpdate,
+      whileElementsMounted: (referenceEl, floatingEl, update) =>
+        autoUpdate(referenceEl, floatingEl, update, autoUpdateOptions),
       elements: {
         reference: context.anchor,
       },

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -117,18 +117,13 @@ interface PopperContentProps extends PrimitiveDivProps {
   align?: Align;
   alignOffset?: number;
   arrowPadding?: number;
+  avoidCollisions?: boolean;
   collisionBoundary?: Boundary | Boundary[];
   collisionPadding?: number | Partial<Record<Side, number>>;
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
-  avoidCollisions?: boolean;
+  updatePositionStrategy?: 'optimized' | 'always';
   onPlaced?: () => void;
-  autoUpdateOptions?: {
-    ancestorScroll?: boolean;
-    ancestorResize?: boolean;
-    elementResize?: boolean;
-    animationFrame?: boolean;
-  };
 }
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
@@ -140,17 +135,12 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       align = 'center',
       alignOffset = 0,
       arrowPadding = 0,
+      avoidCollisions = true,
       collisionBoundary = [],
       collisionPadding: collisionPaddingProp = 0,
       sticky = 'partial',
       hideWhenDetached = false,
-      avoidCollisions = true,
-      autoUpdateOptions = {
-        ancestorScroll: true,
-        ancestorResize: true,
-        elementResize: true,
-        animationFrame: false,
-      },
+      updatePositionStrategy = 'optimized',
       onPlaced,
       ...contentProps
     } = props;
@@ -186,8 +176,12 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       // default to `fixed` strategy so users don't have to pick and we also avoid focus scroll issues
       strategy: 'fixed',
       placement: desiredPlacement,
-      whileElementsMounted: (referenceEl, floatingEl, update) =>
-        autoUpdate(referenceEl, floatingEl, update, autoUpdateOptions),
+      whileElementsMounted: (...args) => {
+        const cleanup = autoUpdate(...args, {
+          animationFrame: updatePositionStrategy === 'always',
+        });
+        return cleanup;
+      },
       elements: {
         reference: context.anchor,
       },


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Allow passing [autoUpdateOptions](https://floating-ui.com/docs/autoupdate#options) to floating-ui, which allows using requestAnimationFrame to keep tooltip attached to element that is being moved programmatically.  Not sure if this is the ideal API for enabling this behavior (maybe a boolean prop like `enableRequestAnimationFrameUpdate` or something would be simpler), feel free to change.

Originally asked about this here: https://github.com/radix-ui/primitives/discussions/2006

Closes #1612
Closes #2006