### PR TITLE
[Dialog] fix accessibility issue - remove focusable elements from ARIA hidden element

### DIFF
--- a/.yarn/versions/385e36b4.yml
+++ b/.yarn/versions/385e36b4.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -107,6 +107,7 @@ const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>
         aria-expanded={context.open}
         aria-controls={context.contentId}
         data-state={getState(context.open)}
+        tabIndex={context.open ? -1 : 0}
         {...triggerProps}
         ref={composedTriggerRef}
         onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
DialogTrigger button should not be focusable when the Dialog box is open. Please see https://dequeuniversity.com/rules/axe/4.5/aria-hidden-focus?application=axeAPI. This PR addresses the issue by setting the value for `tabIndex` attribute to `-1` when the Dialog is open and to `0` when the Dialog is closed

Testing - 

<img width="1718" alt="Dialog_TabIndex" src="https://user-images.githubusercontent.com/1871667/233267335-fe16331d-028c-4b40-b98d-3ea21051dd12.png">
