### PR TITLE
[Accordion] Refactor AccordionItem data-state to use getState helper

### DIFF
--- a/.yarn/versions/fd8abcfb.yml
+++ b/.yarn/versions/fd8abcfb.yml
@@ -1,0 +1,3 @@
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -390,7 +390,7 @@ const AccordionItem = React.forwardRef<AccordionItemElement, AccordionItemProps>
       >
         <CollapsiblePrimitive.Root
           data-orientation={accordionContext.orientation}
-          data-state={open ? 'open' : 'closed'}
+          data-state={getState(open)}
           {...collapsibleScope}
           {...accordionItemProps}
           ref={forwardedRef}


### PR DESCRIPTION
### Description

Makes use of the existing `getState` function in AccordionItem