### PR TITLE
Fix checkbox  defaultChecked unexpected changing in form

### DIFF
--- a/.yarn/versions/a0df87d9.yml
+++ b/.yarn/versions/a0df87d9.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+
+declined:
+  - primitives

--- a/packages/react/checkbox/src/Checkbox.test.tsx
+++ b/packages/react/checkbox/src/Checkbox.test.tsx
@@ -120,6 +120,23 @@ describe('given a controlled `checked` Checkbox', () => {
   });
 });
 
+describe('given an uncontrolled `defaultChecked` Checkbox in form', () => {
+  it('should not change defaultChecked', () => {
+    expect.hasAssertions();
+    const rendered = render(
+      <form
+        onChange={(event) => {
+          const target = event.target as HTMLInputElement;
+          expect(target.defaultChecked).toBe(true);
+        }}
+      >
+        <CheckboxTest defaultChecked />
+      </form>
+    );
+    fireEvent.click(rendered.getByRole(CHECKBOX_ROLE));
+  });
+});
+
 function CheckboxTest(props: React.ComponentProps<typeof Checkbox>) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {

--- a/packages/react/checkbox/src/Checkbox.test.tsx
+++ b/packages/react/checkbox/src/Checkbox.test.tsx
@@ -120,20 +120,65 @@ describe('given a controlled `checked` Checkbox', () => {
   });
 });
 
-describe('given an uncontrolled `defaultChecked` Checkbox in form', () => {
-  it('should not change defaultChecked', () => {
-    expect.hasAssertions();
-    const rendered = render(
-      <form
-        onChange={(event) => {
-          const target = event.target as HTMLInputElement;
-          expect(target.defaultChecked).toBe(true);
-        }}
-      >
-        <CheckboxTest defaultChecked />
-      </form>
-    );
-    fireEvent.click(rendered.getByRole(CHECKBOX_ROLE));
+describe('given an uncontrolled Checkbox in form', () => {
+  describe('when clicking the checkbox', () => {
+    it('should receive change event with target `defaultChecked` same as the `defaultChecked` prop of Checkbox', (done) => {
+      const rendered = render(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            expect(target.defaultChecked).toBe(true);
+          }}
+        >
+          <CheckboxTest defaultChecked />
+        </form>
+      );
+      const checkbox = rendered.getByRole(CHECKBOX_ROLE);
+      fireEvent.click(checkbox);
+      rendered.rerender(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            expect(target.defaultChecked).toBe(false);
+            done();
+          }}
+        >
+          <CheckboxTest defaultChecked={false} />
+        </form>
+      );
+      fireEvent.click(checkbox);
+    });
+  });
+});
+
+describe('given a controlled Checkbox in a form', () => {
+  describe('when clicking the checkbox', () => {
+    it('should receive change event with target `defaultChecked` same as initial value of `checked` of Checkbox', (done) => {
+      const rendered = render(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            expect(target.defaultChecked).toBe(true);
+          }}
+        >
+          <CheckboxTest checked />
+        </form>
+      );
+      const checkbox = rendered.getByRole(CHECKBOX_ROLE);
+      fireEvent.click(checkbox);
+      rendered.rerender(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            expect(target.defaultChecked).toBe(true);
+            done();
+          }}
+        >
+          <CheckboxTest checked={false} />
+        </form>
+      );
+      fireEvent.click(checkbox);
+    });
   });
 });
 

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -20,7 +20,7 @@ const CHECKBOX_NAME = 'Checkbox';
 type ScopedProps<P> = P & { __scopeCheckbox?: Scope };
 const [createCheckboxContext, createCheckboxScope] = createContextScope(CHECKBOX_NAME);
 
-type CheckedState = boolean | 'indeterminate';
+export type CheckedState = boolean | 'indeterminate';
 
 type CheckboxContextValue = {
   state: CheckedState;
@@ -113,6 +113,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
             // rendered it **after** the button. This pulls it back to sit on top
             // of the button.
             style={{ transform: 'translateX(-100%)' }}
+            defaultChecked={isIndeterminate(defaultChecked) ? false : defaultChecked}
           />
         )}
       </CheckboxProvider>
@@ -168,7 +169,7 @@ interface BubbleInputProps extends Omit<InputProps, 'checked'> {
 }
 
 const BubbleInput = (props: BubbleInputProps) => {
-  const { control, checked, bubbles = true, ...inputProps } = props;
+  const { control, checked, bubbles = true, defaultChecked, ...inputProps } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const prevChecked = usePrevious(checked);
   const controlSize = useSize(control);
@@ -193,7 +194,7 @@ const BubbleInput = (props: BubbleInputProps) => {
     <input
       type="checkbox"
       aria-hidden
-      defaultChecked={defaultCheckedRef.current}
+      defaultChecked={defaultChecked ?? defaultCheckedRef.current}
       {...inputProps}
       tabIndex={-1}
       ref={ref}

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -188,11 +188,12 @@ const BubbleInput = (props: BubbleInputProps) => {
     }
   }, [prevChecked, checked, bubbles]);
 
+  const defaultCheckedRef = React.useRef(isIndeterminate(checked) ? false : checked);
   return (
     <input
       type="checkbox"
       aria-hidden
-      defaultChecked={isIndeterminate(checked) ? false : checked}
+      defaultChecked={defaultCheckedRef.current}
       {...inputProps}
       tabIndex={-1}
       ref={ref}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Fix #2133.

There are two modes to consider: controlled and uncontrolled.

In uncontrolled mode, the `defaultChecked` property of the input should match the `defaultChecked` prop of the Checkbox.

In controlled mode, the `defaultChecked` property of the input should be set to the initial checked state of the Checkbox.

Tests have been added.