### PR TITLE
[Tooltip] Add "closeDelayDuration" prop

### DIFF
--- a/packages/react/tooltip/src/Tooltip.stories.tsx
+++ b/packages/react/tooltip/src/Tooltip.stories.tsx
@@ -237,6 +237,67 @@ export const CustomDurations = () => (
         </Tooltip.Root>
       </Tooltip.Provider>
     </div>
+    <h1>Close delay duration</h1>
+    <h2>Default (0ms after pointer leaves trigger or content area)</h2>
+    <div style={{ display: 'flex', gap: 50 }}>
+      <Tooltip.Root>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      <Tooltip.Root>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      <Tooltip.Root>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </div>
+    <h2>Custom (800ms after pointer leaves trigger or content area)</h2>
+    <div style={{ display: 'flex', gap: 50 }}>
+      <Tooltip.Root closeDelayDuration={800}>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      <Tooltip.Root closeDelayDuration={800}>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      <Tooltip.Root closeDelayDuration={800}>
+        <Tooltip.Trigger className={triggerClass()}>Hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={contentClass()} sideOffset={5}>
+            Nicely done!
+            <Tooltip.Arrow className={arrowClass()} offset={10} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </div>
   </Tooltip.Provider>
 );
 

--- a/packages/react/tooltip/src/Tooltip.test.tsx
+++ b/packages/react/tooltip/src/Tooltip.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { render, RenderResult, waitFor, fireEvent } from '@testing-library/react';
+import { Provider, Trigger, Content, Root } from './Tooltip';
+
+const TRIGGER_ID = 'trigger';
+const CONTENT_ID = 'content';
+const CLOSE_DELAY_DURATION = 800;
+
+const TooltipTest = () => (
+  <Provider closeDelayDuration={CLOSE_DELAY_DURATION} delayDuration={0}>
+    <Root>
+      <Trigger data-testid={TRIGGER_ID}>{TRIGGER_ID}</Trigger>
+      <Content data-testid={CONTENT_ID}>{CONTENT_ID}</Content>
+    </Root>
+  </Provider>
+);
+
+describe('given a default Tooltip', () => {
+  let rendered: RenderResult;
+  let trigger: HTMLElement;
+  let content: HTMLElement;
+
+  beforeEach(async () => {
+    rendered = render(<TooltipTest />);
+    trigger = rendered.getByTestId(TRIGGER_ID);
+    fireEvent.pointerMove(trigger);
+    await waitFor(async () => {
+      content = rendered.getByRole('tooltip');
+    });
+  });
+
+  test('should show the tooltip after the mouse has left the trigger', async () => {
+    fireEvent.pointerLeave(trigger);
+    expect(content).toBeVisible();
+  });
+
+  test('should show the tooltip after the mouse has left the content', async () => {
+    fireEvent.pointerLeave(content);
+    fireEvent.pointerLeave(trigger);
+    expect(content).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

✅ - 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
✅ - 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
✅ - 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR adds a `closeDelayDuration` prop to the Tooltip primitive to allow the consumer to set a custom duration from when the pointer leaves the tooltip's content or trigger area until the tooltip closes. Like the existing `delayDuration` prop, this value can be set on the `TooltipProvider` or on an individual `Tooltip`. For context, in usability testing, we found the tooltip closed unexpectedly when the user accidentally moved the pointer out of the content or trigger area. 

https://github.com/radix-ui/primitives/assets/6387301/a929e2dd-be16-4be2-9f48-55504d9ee168



