### PR TITLE
[DropdownMenu] Close the menu when mousing up outside

### DIFF
--- a/.yarn/versions/6cfad450.yml
+++ b/.yarn/versions/6cfad450.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-dropdown-menu": patch
+
+declined:
+  - primitives

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -201,7 +201,8 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
           event.preventDefault();
         };
         const handlePointerUp = (event: PointerEvent) => {
-          // If the pointer hasn't moved by a certain threshold then we prevent selecting item on `click`.
+          // If the pointer hasn't moved by a certain threshold then we prevent selecting item.
+          // See https://github.com/radix-ui/primitives/issues/1620
           if (pointerMoveDelta.x <= 10 && pointerMoveDelta.y <= 10) {
             // We need to prevent the click event because where the item select happens
             document.addEventListener('click', handleClick, {


### PR DESCRIPTION
As said in #657, I bring some improvements from `Select` like:

- mousing up outside should close the menu

and this also Fixes #1620
