### PR TITLE
[Tooltip] Improve grace area calculation

### DIFF
--- a/.yarn/versions/2590f83c.yml
+++ b/.yarn/versions/2590f83c.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -353,6 +353,7 @@ TooltipPortal.displayName = PORTAL_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const CONTENT_NAME = 'TooltipContent';
+const GRACE_AREA_BLEED_PX = 5;
 
 type TooltipContentElement = TooltipContentImplElement;
 interface TooltipContentProps extends TooltipContentImplProps {
@@ -412,15 +413,35 @@ const TooltipContentHoverable = React.forwardRef<
       const currentTarget = event.currentTarget as HTMLElement;
       const exitPoint = { x: event.clientX, y: event.clientY };
       const exitSide = getExitSideFromRect(exitPoint, currentTarget.getBoundingClientRect());
-
-      const bleed = exitSide === 'right' || exitSide === 'bottom' ? -5 : 5;
-      const isXAxis = exitSide === 'right' || exitSide === 'left';
-      const startPoint = isXAxis
-        ? { x: event.clientX + bleed, y: event.clientY }
-        : { x: event.clientX, y: event.clientY + bleed };
-
+      const startPoints = [];
+      switch (exitSide) {
+        case 'top':
+          startPoints.push(
+            { x: exitPoint.x - GRACE_AREA_BLEED_PX, y: exitPoint.y + GRACE_AREA_BLEED_PX },
+            { x: exitPoint.x + GRACE_AREA_BLEED_PX, y: exitPoint.y + GRACE_AREA_BLEED_PX }
+          );
+          break;
+        case 'bottom':
+          startPoints.push(
+            { x: exitPoint.x - GRACE_AREA_BLEED_PX, y: exitPoint.y - GRACE_AREA_BLEED_PX },
+            { x: exitPoint.x + GRACE_AREA_BLEED_PX, y: exitPoint.y - GRACE_AREA_BLEED_PX }
+          );
+          break;
+        case 'left':
+          startPoints.push(
+            { x: exitPoint.x + GRACE_AREA_BLEED_PX, y: exitPoint.y - GRACE_AREA_BLEED_PX },
+            { x: exitPoint.x + GRACE_AREA_BLEED_PX, y: exitPoint.y + GRACE_AREA_BLEED_PX }
+          );
+          break;
+        case 'right':
+          startPoints.push(
+            { x: exitPoint.x - GRACE_AREA_BLEED_PX, y: exitPoint.y - GRACE_AREA_BLEED_PX },
+            { x: exitPoint.x - GRACE_AREA_BLEED_PX, y: exitPoint.y + GRACE_AREA_BLEED_PX }
+          );
+          break;
+      }
       const hoverTargetPoints = getPointsFromRect(hoverTarget.getBoundingClientRect());
-      const graceArea = getHull([startPoint, ...hoverTargetPoints]);
+      const graceArea = getHull([...startPoints, ...hoverTargetPoints]);
       setPointerGraceArea(graceArea);
       onPointerInTransitChange(true);
     },


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

https://github.com/radix-ui/primitives/assets/6387301/e866a6e2-dec5-4d35-b69b-c03cdac432bb

Following up on discussion in [#2148](https://github.com/radix-ui/primitives/pull/2148) and prior work in #1960, this PR improves the grace area calculation for the Tooltip component (closing #1855). The approach here approach follows the logic outlined by @benoitgrelard in #1960: Instead of a single start point, the logic now pre-appends two start points which are determined as follows relative to the exit point:

Given a side ("top" | "bottom" | "left" | "right"):
- the two points should extend along that side in both directions
- the two points should be pushed towards the the opposite side

<!-- Describe the change you are introducing -->

Closes #1855