### PR TITLE
Fix dispatch onPointerDownOutside on touch when click inside

### DIFF
--- a/.yarn/versions/852d0fe8.yml
+++ b/.yarn/versions/852d0fe8.yml
@@ -1,0 +1,17 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -262,8 +262,7 @@ function usePointerDownOutside(
           handleAndDispatchPointerDownOutsideEvent();
         }
       } else {
-        // We need to remove the event listener in case the outside click has
-        // been canceled
+        // We need to remove the event listener in case the outside click has been canceled
         ownerDocument.removeEventListener('click', handleClickRef.current);
       }
       isPointerInsideReactTreeRef.current = false;

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -262,7 +262,7 @@ function usePointerDownOutside(
           handleAndDispatchPointerDownOutsideEvent();
         }
       } else {
-        // We need to remove the event listener in case the outside click has been canceled
+        // We need to remove the event listener in case the outside click has been canceled.
         // See: https://github.com/radix-ui/primitives/issues/2171
         ownerDocument.removeEventListener('click', handleClickRef.current);
       }

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -261,6 +261,10 @@ function usePointerDownOutside(
         } else {
           handleAndDispatchPointerDownOutsideEvent();
         }
+      } else {
+        // We need to remove the event listener in case the outside click has
+        // been canceled
+        ownerDocument.removeEventListener('click', handleClickRef.current);
       }
       isPointerInsideReactTreeRef.current = false;
     };

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -263,6 +263,7 @@ function usePointerDownOutside(
         }
       } else {
         // We need to remove the event listener in case the outside click has been canceled
+        // See: https://github.com/radix-ui/primitives/issues/2171
         ownerDocument.removeEventListener('click', handleClickRef.current);
       }
       isPointerInsideReactTreeRef.current = false;


### PR DESCRIPTION
The click event is not properly cleared when canceled on touch devices, causing content to close when clicked inside.

Fixes https://github.com/radix-ui/primitives/issues/2171