### PR TITLE
Remove primitive element types from `Portal` part

### DIFF
--- a/.yarn/versions/ca844fc6.yml
+++ b/.yarn/versions/ca844fc6.yml
@@ -1,0 +1,16 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-portal": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -129,8 +129,12 @@ const [PortalProvider, usePortalContext] = createDialogContext<PortalContextValu
 });
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface DialogPortalProps extends Omit<PortalProps, 'asChild'> {
+interface DialogPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -158,8 +158,12 @@ const [PortalProvider, usePortalContext] = createHoverCardContext<PortalContextV
 });
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface HoverCardPortalProps extends Omit<PortalProps, 'asChild'> {
+interface HoverCardPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -167,8 +167,12 @@ const [PortalProvider, usePortalContext] = createMenuContext<PortalContextValue>
 });
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface MenuPortalProps extends Omit<PortalProps, 'asChild'> {
+interface MenuPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -176,8 +176,12 @@ const [PortalProvider, usePortalContext] = createPopoverContext<PortalContextVal
 });
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface PopoverPortalProps extends Omit<PortalProps, 'asChild'> {
+interface PopoverPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -13,6 +13,9 @@ const PORTAL_NAME = 'Portal';
 type PortalElement = React.ElementRef<typeof Primitive.div>;
 type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface PortalProps extends PrimitiveDivProps {
+  /**
+   * An optional different container where the portaled content should be appended.
+   */
   container?: HTMLElement | null;
 }
 

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -14,7 +14,7 @@ type PortalElement = React.ElementRef<typeof Primitive.div>;
 type PrimitiveDivProps = Radix.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface PortalProps extends PrimitiveDivProps {
   /**
-   * An optional different container where the portaled content should be appended.
+   * An optional container where the portaled content should be appended.
    */
   container?: HTMLElement | null;
 }

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -371,8 +371,12 @@ SelectIcon.displayName = ICON_NAME;
 const PORTAL_NAME = 'SelectPortal';
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface SelectPortalProps extends Omit<PortalProps, 'asChild'> {
+interface SelectPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
 }
 
 const SelectPortal: React.FC<SelectPortalProps> = (props: ScopedProps<SelectPortalProps>) => {

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -323,8 +323,12 @@ const [PortalProvider, usePortalContext] = createTooltipContext<PortalContextVal
 });
 
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
-interface TooltipPortalProps extends Omit<PortalProps, 'asChild'> {
+interface TooltipPortalProps {
   children?: React.ReactNode;
+  /**
+   * Specify a container element to portal the content into.
+   */
+  container?: PortalProps['container'];
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.


### PR DESCRIPTION
Removed primitive element types from `Portal` part in all primitives and added JSDoc to the `container` prop in the `Portal` utility

Fixes #1974 