### PR TITLE
Limit focus retention to when the document body is the activeElement

### DIFF
--- a/.yarn/versions/310b65b7.yml
+++ b/.yarn/versions/310b65b7.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -112,9 +112,11 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
       // to keep focus trapped correctly.
       function handleMutations(mutations: MutationRecord[]) {
         const focusedElement = document.activeElement as HTMLElement | null;
-        for (const mutation of mutations) {
-          if (mutation.removedNodes.length > 0) {
-            if (!container?.contains(focusedElement)) focus(container);
+        if (focusedElement === document.body) {
+          for (const mutation of mutations) {
+            if (mutation.removedNodes.length > 0) {
+              if (!container?.contains(focusedElement)) focus(container);
+            }
           }
         }
       }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

DOM nodes may be removed from the tree without having focus. In this case, the mutationObserver is greedy and steals focus that it should not be managing. As described in the adjacent comment, when the focused node is removed, browser focus is assigned to the body. By ensuring the body is the activeElement, we avoid stealing focus when the removed node did not have focus to begin with.

Addresses https://github.com/radix-ui/primitives/issues/2180
