### PR TITLE
Add `use client` directive to support Next.js 13

### DIFF
--- a/packages/react/accessible-icon/src/AccessibleIcon.tsx
+++ b/packages/react/accessible-icon/src/AccessibleIcon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 

--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { createCollection } from '@radix-ui/react-collection';

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/announce/src/Announce.tsx
+++ b/packages/react/announce/src/Announce.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/arrow/src/Arrow.tsx
+++ b/packages/react/arrow/src/Arrow.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 

--- a/packages/react/aspect-ratio/src/AspectRatio.tsx
+++ b/packages/react/aspect-ratio/src/AspectRatio.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/collection/src/Collection.tsx
+++ b/packages/react/collection/src/Collection.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/compose-refs/src/composeRefs.tsx
+++ b/packages/react/compose-refs/src/composeRefs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 type PossibleRef<T> = React.Ref<T> | undefined;

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/context/src/createContext.tsx
+++ b/packages/react/context/src/createContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 function createContext<ContextValueType extends object | null>(

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/direction/src/Direction.tsx
+++ b/packages/react/direction/src/Direction.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 type Direction = 'ltr' | 'rtl';

--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { composeRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/focus-guards/src/FocusGuards.tsx
+++ b/packages/react/focus-guards/src/FocusGuards.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 /** Number of components which have requested interest to have focus guards */

--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/form/src/Form.tsx
+++ b/packages/react/form/src/Form.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/id/src/id.tsx
+++ b/packages/react/id/src/id.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';

--- a/packages/react/menubar/src/Menubar.tsx
+++ b/packages/react/menubar/src/Menubar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { createCollection } from '@radix-ui/react-collection';
 import { useDirection } from '@radix-ui/react-direction';

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /// <reference types="resize-observer-browser" />
 
 import * as React from 'react';

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   useFloating,

--- a/packages/react/portal/src/Portal.tsx
+++ b/packages/react/portal/src/Portal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Slot } from '@radix-ui/react-slot';

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /// <reference types="resize-observer-browser" />
 
 import * as React from 'react';

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { clamp } from '@radix-ui/number';

--- a/packages/react/separator/src/Separator.tsx
+++ b/packages/react/separator/src/Separator.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { clamp } from '@radix-ui/number';
 import { composeEventHandlers } from '@radix-ui/primitive';

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeRefs } from '@radix-ui/react-compose-refs';
 

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { composeEventHandlers } from '@radix-ui/primitive';

--- a/packages/react/toggle-group/src/ToggleGroup.tsx
+++ b/packages/react/toggle-group/src/ToggleGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';

--- a/packages/react/toggle/src/Toggle.tsx
+++ b/packages/react/toggle/src/Toggle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';

--- a/packages/react/toolbar/src/Toolbar.tsx
+++ b/packages/react/toolbar/src/Toolbar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';

--- a/packages/react/use-callback-ref/src/useCallbackRef.tsx
+++ b/packages/react/use-callback-ref/src/useCallbackRef.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 /**

--- a/packages/react/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react/use-controllable-state/src/useControllableState.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 

--- a/packages/react/use-escape-keydown/src/useEscapeKeydown.tsx
+++ b/packages/react/use-escape-keydown/src/useEscapeKeydown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 

--- a/packages/react/use-layout-effect/src/useLayoutEffect.tsx
+++ b/packages/react/use-layout-effect/src/useLayoutEffect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 /**

--- a/packages/react/use-previous/src/usePrevious.tsx
+++ b/packages/react/use-previous/src/usePrevious.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 function usePrevious<T>(value: T) {

--- a/packages/react/use-rect/src/useRect.tsx
+++ b/packages/react/use-rect/src/useRect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { observeElementRect } from '@radix-ui/rect';
 

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /// <reference types="resize-observer-browser" />
 
 import * as React from 'react';

--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Adds `use client` directive to components so that they are treated as client components when using Next.js 13 with React server components.
