### PR TITLE
[Slot] Add support for nested children (#1825)

### DIFF
--- a/.yarn/versions/782f744b.yml
+++ b/.yarn/versions/782f744b.yml
@@ -1,0 +1,4 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-slot": major
+  "@radix-ui/react-tooltip": patch

--- a/packages/react/alert-dialog/src/AlertDialog.tsx
+++ b/packages/react/alert-dialog/src/AlertDialog.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
-import { createContextScope } from '@radix-ui/react-context';
+import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import { createContextScope } from '@radix-ui/react-context';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { createDialogScope } from '@radix-ui/react-dialog';
-import { composeEventHandlers } from '@radix-ui/primitive';
 import { Slottable } from '@radix-ui/react-slot';
+import * as React from 'react';
 
-import type * as Radix from '@radix-ui/react-primitive';
 import type { Scope } from '@radix-ui/react-context';
+import type * as Radix from '@radix-ui/react-primitive';
 
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog
@@ -141,10 +141,16 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
              * This is because we want the accessibility checks to run only once the content is actually
              * open and that behaviour is already encapsulated in `DialogContent`.
              */}
-            <Slottable>{children}</Slottable>
-            {process.env.NODE_ENV === 'development' && (
-              <DescriptionWarning contentRef={contentRef} />
-            )}
+            <Slottable child={children}>
+              {(child) => (
+                <>
+                  {child}
+                  {process.env.NODE_ENV === 'development' && (
+                    <DescriptionWarning contentRef={contentRef} />
+                  )}
+                </>
+              )}
+            </Slottable>
           </DialogPrimitive.Content>
         </AlertDialogContentProvider>
       </DialogPrimitive.WarningProvider>
@@ -272,36 +278,36 @@ const Title = AlertDialogTitle;
 const Description = AlertDialogDescription;
 
 export {
-  createAlertDialogScope,
+  Action,
   //
   AlertDialog,
-  AlertDialogTrigger,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogContent,
   AlertDialogAction,
   AlertDialogCancel,
-  AlertDialogTitle,
+  AlertDialogContent,
   AlertDialogDescription,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Cancel,
+  Content,
+  Description,
+  Overlay,
+  Portal,
   //
   Root,
-  Trigger,
-  Portal,
-  Overlay,
-  Content,
-  Action,
-  Cancel,
   Title,
-  Description,
+  Trigger,
+  createAlertDialogScope,
 };
 export type {
-  AlertDialogProps,
-  AlertDialogTriggerProps,
-  AlertDialogPortalProps,
-  AlertDialogOverlayProps,
-  AlertDialogContentProps,
   AlertDialogActionProps,
   AlertDialogCancelProps,
-  AlertDialogTitleProps,
+  AlertDialogContentProps,
   AlertDialogDescriptionProps,
+  AlertDialogOverlayProps,
+  AlertDialogPortalProps,
+  AlertDialogProps,
+  AlertDialogTitleProps,
+  AlertDialogTriggerProps,
 };

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Slot, Slottable } from '@radix-ui/react-slot';
+import * as React from 'react';
 
 export default { title: 'Utilities/Slot' };
 
@@ -274,8 +274,14 @@ const SlotWithoutSlottable = React.forwardRef<
 
 const SlotWithSlottable = ({ children, ...props }: any) => (
   <Slot {...props}>
-    <Slottable>{children}</Slottable>
-    <span>world</span>
+    <Slottable child={children}>
+      {(child) => (
+        <>
+          {child}
+          <span>world</span>
+        </>
+      )}
+    </Slottable>
   </Slot>
 );
 
@@ -335,9 +341,15 @@ const Button = React.forwardRef<
         ...props.style,
       }}
     >
-      {iconLeft}
-      <Slottable>{children}</Slottable>
-      {iconRight}
+      <Slottable child={children}>
+        {(child) => (
+          <>
+            {iconLeft}
+            {child}
+            {iconRight}
+          </>
+        )}
+      </Slottable>
     </Comp>
   );
 });

--- a/packages/react/slot/src/Slot.test.tsx
+++ b/packages/react/slot/src/Slot.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
 import { Slot, Slottable } from '@radix-ui/react-slot';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
 
 describe('given a slotted Trigger', () => {
   describe('with onClick on itself', () => {
@@ -151,9 +151,15 @@ const Button = React.forwardRef<
   const Comp = asChild ? Slot : 'button';
   return (
     <Comp {...props} ref={forwardedRef}>
-      {iconLeft}
-      <Slottable>{children}</Slottable>
-      {iconRight}
+      <Slottable child={children}>
+        {(child) => (
+          <>
+            {iconLeft}
+            {child}
+            {iconRight}
+          </>
+        )}
+      </Slottable>
     </Comp>
   );
 });

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
@@ -12,9 +11,10 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { Slottable } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
+import * as React from 'react';
 
-import type * as Radix from '@radix-ui/react-primitive';
 import type { Scope } from '@radix-ui/react-context';
+import type * as Radix from '@radix-ui/react-primitive';
 
 type ScopedProps<P = {}> = P & { __scopeTooltip?: Scope };
 const [createTooltipContext, createTooltipScope] = createContextScope('Tooltip', [
@@ -548,12 +548,18 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
             },
           }}
         >
-          <Slottable>{children}</Slottable>
-          <VisuallyHiddenContentContextProvider scope={__scopeTooltip} isInside={true}>
-            <VisuallyHiddenPrimitive.Root id={context.contentId} role="tooltip">
-              {ariaLabel || children}
-            </VisuallyHiddenPrimitive.Root>
-          </VisuallyHiddenContentContextProvider>
+          <Slottable child={children}>
+            {(child) => (
+              <>
+                {child}
+                <VisuallyHiddenContentContextProvider scope={__scopeTooltip} isInside={true}>
+                  <VisuallyHiddenPrimitive.Root id={context.contentId} role="tooltip">
+                    {ariaLabel || children}
+                  </VisuallyHiddenPrimitive.Root>
+                </VisuallyHiddenContentContextProvider>
+              </>
+            )}
+          </Slottable>
         </PopperPrimitive.Content>
       </DismissableLayer>
     );
@@ -738,26 +744,26 @@ const Content = TooltipContent;
 const Arrow = TooltipArrow;
 
 export {
-  createTooltipScope,
-  //
-  TooltipProvider,
-  Tooltip,
-  TooltipTrigger,
-  TooltipPortal,
-  TooltipContent,
-  TooltipArrow,
+  Arrow,
+  Content,
+  Portal,
   //
   Provider,
   Root,
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  //
+  TooltipProvider,
+  TooltipTrigger,
   Trigger,
-  Portal,
-  Content,
-  Arrow,
+  createTooltipScope,
 };
 export type {
+  TooltipArrowProps,
+  TooltipContentProps,
+  TooltipPortalProps,
   TooltipProps,
   TooltipTriggerProps,
-  TooltipPortalProps,
-  TooltipContentProps,
-  TooltipArrowProps,
 };


### PR DESCRIPTION
### Description

This PR modifies the way `Slottable` works, adding support for nested children without the need to parse them.

Fixes #1825

### Example

```tsx
import React from 'react';
import { Slot, Slottable } from '@radix-ui/react-slot';

function Button({ asChild, children, ...props }) {
  const Component = asChild ? Slot : "button";

  return (
    <Component {...props}>
      <Slottable child={children}>
        {(child) => (
          <div>
            <div>icon</div>
            <div>{child}</div>
            <div>icon</div>
          </div>
        )}
      </Slottable>
    </Component>
  );
}
```