### PR TITLE
[Slot] Allow slot to override child's handlers instead of composing

### DIFF
--- a/.yarn/versions/4ff09dfe.yml
+++ b/.yarn/versions/4ff09dfe.yml
@@ -1,0 +1,12 @@
+releases:
+  "@radix-ui/react-slot": patch
+
+declined:
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-collection"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-primitive"
+  - "@radix-ui/react-select"
+  - "@radix-ui/react-tooltip"

--- a/.yarn/versions/4ff09dfe.yml
+++ b/.yarn/versions/4ff09dfe.yml
@@ -1,7 +1,8 @@
 releases:
-  "@radix-ui/react-slot": patch
+  "@radix-ui/react-slot": minor
 
 declined:
+  - primitives
   - "@radix-ui/react-alert-dialog"
   - "@radix-ui/react-collection"
   - "@radix-ui/react-dialog"

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -53,6 +53,26 @@ export const WithComposedEvents = () => (
   </>
 );
 
+export const WithOverwrittenEvents = () => (
+  <>
+    <h1>Should log both</h1>
+    <SlotWithPreventableEvent>
+      <button onClick={() => console.log('button click')}>Child event not prevented</button>
+    </SlotWithPreventableEvent>
+
+    <h1>Should log "Slot click"</h1>
+    <SlotWithOverwrittenChildEvent>
+      <button
+        onClick={(event) => {
+          console.log('button click');
+        }}
+      >
+        Child event prevented
+      </button>
+    </SlotWithOverwrittenChildEvent>
+  </>
+);
+
 export const ButtonAsLink = () => (
   <>
     <h1>Button with left/right icons</h1>
@@ -295,6 +315,16 @@ const SlotWithPreventableEvent = (props: any) => (
       if (!event.defaultPrevented) {
         console.log(event.target);
       }
+    }}
+  />
+);
+
+const SlotWithOverwrittenChildEvent = (props: any) => (
+  <Slot
+    {...props}
+    dangerouslyOverrideHandlersInsteadOfComposing={['onClick']}
+    onClick={(event) => {
+      console.log('Slot click');
     }}
   />
 );

--- a/packages/react/slot/src/Slot.stories.tsx
+++ b/packages/react/slot/src/Slot.stories.tsx
@@ -322,7 +322,7 @@ const SlotWithPreventableEvent = (props: any) => (
 const SlotWithOverwrittenChildEvent = (props: any) => (
   <Slot
     {...props}
-    dangerouslyOverrideHandlersInsteadOfComposing={['onClick']}
+    dangerouslyoverridehandlersinsteadofcomposing={['onClick']}
     onClick={(event) => {
       console.log('Slot click');
     }}

--- a/packages/react/slot/src/Slot.test.tsx
+++ b/packages/react/slot/src/Slot.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Slot, Slottable } from '@radix-ui/react-slot';
+import { Slot, SlotProps, Slottable } from '@radix-ui/react-slot';
 
 describe('given a slotted Trigger', () => {
   describe('with onClick on itself', () => {
@@ -106,6 +106,36 @@ describe('given a slotted Trigger', () => {
       expect(handleChildClick).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('with onClick on itself AND the child, and overriding the child click handler', () => {
+    const handleTriggerClick = jest.fn();
+    const handleChildClick = jest.fn();
+
+    beforeEach(() => {
+      handleTriggerClick.mockReset();
+      handleChildClick.mockReset();
+      render(
+        <Trigger
+          as={Slot}
+          onClick={handleTriggerClick}
+          dangerouslyoverridehandlersinsteadofcomposing={['onClick']}
+        >
+          <button type="button" onClick={handleChildClick}>
+            Click me
+          </button>
+        </Trigger>
+      );
+      fireEvent.click(screen.getByRole('button'));
+    });
+
+    it("should call the Trigger's onClick", async () => {
+      expect(handleTriggerClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT call the child's onClick", async () => {
+      expect(handleChildClick).toHaveBeenCalledTimes(0);
+    });
+  });
 });
 
 describe('given a Button with Slottable', () => {
@@ -136,7 +166,7 @@ describe('given a Button with Slottable', () => {
   });
 });
 
-type TriggerProps = React.ComponentProps<'button'> & { as: React.ElementType };
+type TriggerProps = React.ComponentProps<'button'> & { as: React.ElementType } & SlotProps;
 
 const Trigger = ({ as: Comp = 'button', ...props }: TriggerProps) => <Comp {...props} />;
 

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -7,7 +7,7 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
 
 interface SlotProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
-  dangerouslyOverrideHandlersInsteadOfComposing?: string[];
+  dangerouslyoverridehandlersinsteadofcomposing?: string[];
 }
 
 const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
@@ -56,7 +56,7 @@ Slot.displayName = 'Slot';
 
 interface SlotCloneProps {
   children: React.ReactNode;
-  dangerouslyOverrideHandlersInsteadOfComposing?: string[];
+  dangerouslyoverridehandlersinsteadofcomposing?: string[];
 }
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
@@ -105,7 +105,7 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
       if (
         slotPropValue &&
         childPropValue &&
-        !slotProps.dangerouslyOverrideHandlersInsteadOfComposing?.includes(propName)
+        !slotProps.dangerouslyoverridehandlersinsteadofcomposing?.includes(propName)
       ) {
         overrideProps[propName] = (...args: unknown[]) => {
           childPropValue(...args);

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -7,6 +7,7 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
 
 interface SlotProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
+  dangerouslyOverrideHandlersInsteadOfComposing?: string[];
 }
 
 const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
@@ -55,6 +56,7 @@ Slot.displayName = 'Slot';
 
 interface SlotCloneProps {
   children: React.ReactNode;
+  dangerouslyOverrideHandlersInsteadOfComposing?: string[];
 }
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
@@ -99,7 +101,12 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
     const isHandler = /^on[A-Z]/.test(propName);
     if (isHandler) {
       // if the handler exists on both, we compose them
-      if (slotPropValue && childPropValue) {
+      // unless the user has explicitly opted out of this behavior for this handler
+      if (
+        slotPropValue &&
+        childPropValue &&
+        !slotProps.dangerouslyOverrideHandlersInsteadOfComposing?.includes(propName)
+      ) {
         overrideProps[propName] = (...args: unknown[]) => {
           childPropValue(...args);
           slotPropValue(...args);


### PR DESCRIPTION
First off, thanks for the amazing work. Radix raised the bar for accessibility and set an example for composable components I strive to reach in my codebases.

### Description

This PR aims to enable more complex behavior composition through the use of the `Slot` component by allowing it to overwrite the child's handlers instead of merging. 

To be conservative, I implemented a new prop `dangerouslyoverridehandlersinsteadofcomposing` that requires the consumer to explicitly set which handlers it wants to be overwritten. eg:
```
<Slot
    {...props}
    dangerouslyoverridehandlersinsteadofcomposing={['onClick']}
    onClick={(event) => {
        // ... 
    }}
 />
``` 

The patterns that emerged from this remind me of React's HoC but through JSX instead of function wrappers.

A concrete use case for this would be providing useful feedback for "disabled" buttons; For example: when a user reaches the maximum amount of teams allowed by their license, don't disable the "new team" button, instead, show a modal with useful feedback and actions on click. This behavior is achievable without the changes to Slot, but they allow for creating simple abstractions that can be easily distributed. See: https://slot-overrides-examples.vercel.app/ ([source](https://github.com/bdsqqq/slot-overrides-examples)). 

Some immediate questions I have are:
- Do you see value in this feature?
- Would it be better exposed in another way?

Any feedback is welcome, and I hope to get this PR merged to enable a rich ecosystem of composable behavior components.