### PR TITLE
Add `useResizeObserver` and standardize usage

### DIFF
--- a/.yarn/versions/7349cd34.yml
+++ b/.yarn/versions/7349cd34.yml
@@ -1,0 +1,22 @@
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-navigation-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-scroll-area": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-slider": patch
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-use-size": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-use-debounce-callback"
+  - "@radix-ui/react-use-resize-observer"

--- a/packages/react/navigation-menu/package.json
+++ b/packages/react/navigation-menu/package.json
@@ -42,7 +42,11 @@
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*",
     "@radix-ui/react-use-previous": "workspace:*",
+    "@radix-ui/react-use-resize-observer": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/resize-observer-browser": "^0.1.4"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -12,9 +12,10 @@ import { Presence } from '@radix-ui/react-presence';
 import { useId } from '@radix-ui/react-id';
 import { createCollection } from '@radix-ui/react-collection';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
-import { usePrevious } from '@radix-ui/react-use-previous';
-import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
+import { usePrevious } from '@radix-ui/react-use-previous';
+import { useResizeObserver } from '@radix-ui/react-use-resize-observer';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
 import type * as Radix from '@radix-ui/react-primitive';
@@ -1195,31 +1196,6 @@ function removeFromTabOrder(candidates: HTMLElement[]) {
       candidate.setAttribute('tabindex', prevTabIndex);
     });
   };
-}
-
-function useResizeObserver(element: HTMLElement | null, onResize: () => void) {
-  const handleResize = useCallbackRef(onResize);
-  useLayoutEffect(() => {
-    let rAF = 0;
-    if (element) {
-      /**
-       * Resize Observer will throw an often benign error that says `ResizeObserver loop
-       * completed with undelivered notifications`. This means that ResizeObserver was not
-       * able to deliver all observations within a single animation frame, so we use
-       * `requestAnimationFrame` to ensure we don't deliver unnecessary observations.
-       * Further reading: https://github.com/WICG/resize-observer/issues/38
-       */
-      const resizeObserver = new ResizeObserver(() => {
-        cancelAnimationFrame(rAF);
-        rAF = window.requestAnimationFrame(handleResize);
-      });
-      resizeObserver.observe(element);
-      return () => {
-        window.cancelAnimationFrame(rAF);
-        resizeObserver.unobserve(element);
-      };
-    }
-  }, [element, handleResize]);
 }
 
 function getOpenState(open: boolean) {

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -37,7 +37,8 @@
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
-    "@radix-ui/react-use-layout-effect": "workspace:*"
+    "@radix-ui/react-use-debounce-callback": "workspace:*",
+    "@radix-ui/react-use-resize-observer": "workspace:*"
   },
   "devDependencies": {
     "@types/resize-observer-browser": "^0.1.4"

--- a/packages/react/use-debounce-callback/README.md
+++ b/packages/react/use-debounce-callback/README.md
@@ -1,0 +1,13 @@
+# `react-use-debounce-callback`
+
+## Installation
+
+```sh
+$ yarn add @radix-ui/react-use-debounce-callback
+# or
+$ npm install @radix-ui/react-use-debounce-callback
+```
+
+## Usage
+
+This is an internal utility, not intended for public usage.

--- a/packages/react/use-debounce-callback/package.json
+++ b/packages/react/use-debounce-callback/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@radix-ui/react-use-size",
-  "version": "1.0.1",
+  "name": "@radix-ui/react-use-debounce-callback",
+  "version": "1.0.0",
   "license": "MIT",
   "exports": {
     ".": {
@@ -29,9 +29,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/react-use-debounce-callback": "workspace:*",
-    "@radix-ui/react-use-layout-effect": "workspace:*",
-    "@radix-ui/react-use-resize-observer": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
     "@types/react": "*",
@@ -41,9 +40,6 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@types/resize-observer-browser": "^0.1.4"
   },
   "homepage": "https://radix-ui.com/primitives",
   "repository": {

--- a/packages/react/use-debounce-callback/src/index.ts
+++ b/packages/react/use-debounce-callback/src/index.ts
@@ -1,0 +1,1 @@
+export { useDebounceCallback } from './useDebounceCallback';

--- a/packages/react/use-debounce-callback/src/useDebounceCallback.ts
+++ b/packages/react/use-debounce-callback/src/useDebounceCallback.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+
+function useDebounceCallback(callback: (...args: any[]) => void, delay: number) {
+  const handleCallback = useCallbackRef(callback);
+  const debounceTimerRef = React.useRef(0);
+
+  React.useEffect(() => () => window.clearTimeout(debounceTimerRef.current), []);
+
+  return React.useCallback(
+    (...args: unknown[]) => {
+      window.clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = window.setTimeout(() => {
+        handleCallback(...args);
+      }, delay);
+    },
+    [handleCallback, delay]
+  );
+}
+
+export { useDebounceCallback };

--- a/packages/react/use-resize-observer/README.md
+++ b/packages/react/use-resize-observer/README.md
@@ -1,0 +1,13 @@
+# `react-use-resize-observer`
+
+## Installation
+
+```sh
+$ yarn add @radix-ui/react-use-resize-observer
+# or
+$ npm install @radix-ui/react-use-resize-observer
+```
+
+## Usage
+
+This is an internal utility, not intended for public usage.

--- a/packages/react/use-resize-observer/package.json
+++ b/packages/react/use-resize-observer/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@radix-ui/react-use-size",
-  "version": "1.0.1",
+  "name": "@radix-ui/react-use-resize-observer",
+  "version": "1.0.0",
   "license": "MIT",
   "exports": {
     ".": {
@@ -29,9 +29,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@radix-ui/react-use-debounce-callback": "workspace:*",
-    "@radix-ui/react-use-layout-effect": "workspace:*",
-    "@radix-ui/react-use-resize-observer": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/use-resize-observer/src/index.ts
+++ b/packages/react/use-resize-observer/src/index.ts
@@ -1,0 +1,1 @@
+export { useResizeObserver } from './useResizeObserver';

--- a/packages/react/use-resize-observer/src/useResizeObserver.ts
+++ b/packages/react/use-resize-observer/src/useResizeObserver.ts
@@ -1,0 +1,38 @@
+/// <reference types="resize-observer-browser" />
+
+import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
+
+function useResizeObserver(
+  element: HTMLElement | null,
+  onResize: (entries: ResizeObserverEntry[]) => void
+) {
+  const handleResize = useCallbackRef(onResize);
+  useLayoutEffect(() => {
+    let rAF = 0;
+    if (element) {
+      /**
+       * Resize Observer will throw an often benign error that says `ResizeObserver loop
+       * completed with undelivered notifications`. This means that ResizeObserver was not
+       * able to deliver all observations within a single animation frame, so we use
+       * `requestAnimationFrame` to ensure we don't deliver unnecessary observations.
+       * Further reading: https://github.com/WICG/resize-observer/issues/38
+       */
+      const resizeObserver = new ResizeObserver((entries) => {
+        cancelAnimationFrame(rAF);
+        rAF = window.requestAnimationFrame(() => {
+          handleResize(entries);
+        });
+      });
+
+      resizeObserver.observe(element);
+
+      return () => {
+        window.cancelAnimationFrame(rAF);
+        resizeObserver.unobserve(element);
+      };
+    }
+  }, [element, handleResize]);
+}
+
+export { useResizeObserver };

--- a/packages/react/use-size/src/useSize.tsx
+++ b/packages/react/use-size/src/useSize.tsx
@@ -1,7 +1,9 @@
 /// <reference types="resize-observer-browser" />
 
 import * as React from 'react';
+import { useDebounceCallback } from '@radix-ui/react-use-debounce-callback';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
+import { useResizeObserver } from '@radix-ui/react-use-resize-observer';
 
 function useSize(element: HTMLElement | null) {
   const [size, setSize] = React.useState<{ width: number; height: number } | undefined>(undefined);
@@ -10,47 +12,47 @@ function useSize(element: HTMLElement | null) {
     if (element) {
       // provide size as early as possible
       setSize({ width: element.offsetWidth, height: element.offsetHeight });
-
-      const resizeObserver = new ResizeObserver((entries) => {
-        if (!Array.isArray(entries)) {
-          return;
-        }
-
-        // Since we only observe the one element, we don't need to loop over the
-        // array
-        if (!entries.length) {
-          return;
-        }
-
-        const entry = entries[0];
-        let width: number;
-        let height: number;
-
-        if ('borderBoxSize' in entry) {
-          const borderSizeEntry = entry['borderBoxSize'];
-          // iron out differences between browsers
-          const borderSize = Array.isArray(borderSizeEntry) ? borderSizeEntry[0] : borderSizeEntry;
-          width = borderSize['inlineSize'];
-          height = borderSize['blockSize'];
-        } else {
-          // for browsers that don't support `borderBoxSize`
-          // we calculate it ourselves to get the correct border box.
-          width = element.offsetWidth;
-          height = element.offsetHeight;
-        }
-
-        setSize({ width, height });
-      });
-
-      resizeObserver.observe(element, { box: 'border-box' });
-
-      return () => resizeObserver.unobserve(element);
     } else {
       // We only want to reset to `undefined` when the element becomes `null`,
       // not if it changes to another element.
       setSize(undefined);
     }
   }, [element]);
+
+  const handleResize = useDebounceCallback((entries: ResizeObserverEntry[]) => {
+    if (element) {
+      if (!Array.isArray(entries)) {
+        return;
+      }
+
+      // Since we only observe the one element, we don't need to loop over the
+      // array
+      if (!entries.length) {
+        return;
+      }
+
+      const entry = entries[0];
+      let width: number;
+      let height: number;
+
+      if ('borderBoxSize' in entry) {
+        const borderSizeEntry = entry['borderBoxSize'];
+        // iron out differences between browsers
+        const borderSize = Array.isArray(borderSizeEntry) ? borderSizeEntry[0] : borderSizeEntry;
+        width = borderSize['inlineSize'];
+        height = borderSize['blockSize'];
+      } else {
+        // for browsers that don't support `borderBoxSize`
+        // we calculate it ourselves to get the correct border box.
+        width = element.offsetWidth;
+        height = element.offsetHeight;
+      }
+
+      setSize({ width, height });
+    }
+  }, 10);
+
+  useResizeObserver(element, handleResize);
 
   return size;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,10 +53,12 @@
       "@radix-ui/react-tooltip": ["./packages/react/tooltip/src"],
       "@radix-ui/react-use-callback-ref": ["./packages/react/use-callback-ref/src"],
       "@radix-ui/react-use-controllable-state": ["./packages/react/use-controllable-state/src"],
+      "@radix-ui/react-use-debounce-callback": ["./packages/react/use-debounce-callback/src"],
       "@radix-ui/react-use-escape-keydown": ["./packages/react/use-escape-keydown/src"],
       "@radix-ui/react-use-layout-effect": ["./packages/react/use-layout-effect/src"],
       "@radix-ui/react-use-previous": ["./packages/react/use-previous/src"],
       "@radix-ui/react-use-rect": ["./packages/react/use-rect/src"],
+      "@radix-ui/react-use-resize-observer": ["./packages/react/use-resize-observer/src"],
       "@radix-ui/react-use-size": ["./packages/react/use-size/src"],
       "@radix-ui/react-visually-hidden": ["./packages/react/visually-hidden/src"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3879,7 +3879,6 @@ __metadata:
     "@radix-ui/react-presence": "workspace:*"
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
-    "@radix-ui/react-use-layout-effect": "workspace:*"
     "@types/resize-observer-browser": ^0.1.4
   peerDependencies:
     "@types/react": "*"
@@ -4209,6 +4208,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@radix-ui/react-use-debounce-callback@workspace:*, @radix-ui/react-use-debounce-callback@workspace:packages/react/use-debounce-callback":
+  version: 0.0.0-use.local
+  resolution: "@radix-ui/react-use-debounce-callback@workspace:packages/react/use-debounce-callback"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-layout-effect": "workspace:*"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@radix-ui/react-use-escape-keydown@workspace:*, @radix-ui/react-use-escape-keydown@workspace:packages/react/use-escape-keydown":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-use-escape-keydown@workspace:packages/react/use-escape-keydown"
@@ -4267,12 +4282,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@radix-ui/react-use-resize-observer@workspace:*, @radix-ui/react-use-resize-observer@workspace:packages/react/use-resize-observer":
+  version: 0.0.0-use.local
+  resolution: "@radix-ui/react-use-resize-observer@workspace:packages/react/use-resize-observer"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-debounce-callback": "workspace:*"
+    "@radix-ui/react-use-layout-effect": "workspace:*"
+    "@types/resize-observer-browser": ^0.1.4
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@radix-ui/react-use-size@workspace:*, @radix-ui/react-use-size@workspace:packages/react/use-size":
   version: 0.0.0-use.local
   resolution: "@radix-ui/react-use-size@workspace:packages/react/use-size"
   dependencies:
     "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-debounce-callback": "workspace:*"
     "@radix-ui/react-use-layout-effect": "workspace:*"
+    "@radix-ui/react-use-resize-observer": "workspace:*"
     "@types/resize-observer-browser": ^0.1.4
   peerDependencies:
     "@types/react": "*"


### PR DESCRIPTION
Resolves #2313

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Adds 2 new private packages:
* `@radix-ui/react-use-resize-observer`
  * Extract `useResizeObserver` functionality from `NavigationMenu` and `ScrollArea` into reusable hook
* `@radix-ui/react-use-debounce-callback`
  * Extract `useDebounceCallback` functionality from `ScrollArea` into reusable hook

Use new hooks in `useSize`
Update instances of `useResizeObserver` and `useDebounceCallback` hooks in and `NavigationMenu` and `ScrollArea`

Package version changes affect all packages that use `useSize` or `useResizeObserver` internally

<!-- Describe the change you are introducing -->
