### PR TITLE
[Avatar] Fix flashing of broken image

### DIFF
--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -120,7 +120,7 @@ AvatarFallback.displayName = FALLBACK_NAME;
 function useImageLoadingStatus(src?: string) {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!src) {
       setLoadingStatus('error');
       return;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

`Avatar` has a visible flashing when `src` becomes falsy or broken. This PR fixes that.

**Before:**

https://github.com/radix-ui/primitives/assets/10157660/1d1ec1cc-3432-47a7-9035-97c82df4763f


**After:**

https://github.com/radix-ui/primitives/assets/10157660/e2345374-691a-452a-aca2-a9819595dcc0

| Before                                                                                                                       | After                                                                                                                        |
|------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot 2023-08-15 230102](https://github.com/radix-ui/primitives/assets/10157660/0cfba976-4333-4c6a-be90-4b5f356b2b2b) | ![Screenshot 2023-08-15 230229](https://github.com/radix-ui/primitives/assets/10157660/e92ca29e-01d6-4065-a8cc-56ce3a543a28) |
