### PR TITLE
[FocusScope] Only reset focus to container if lastFocsedElementRef does not exist on container

### DIFF
--- a/packages/react/focus-scope/src/FocusScope.tsx
+++ b/packages/react/focus-scope/src/FocusScope.tsx
@@ -111,11 +111,8 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
       // back to the document.body. In this case, we move focus to the container
       // to keep focus trapped correctly.
       function handleMutations(mutations: MutationRecord[]) {
-        const focusedElement = document.activeElement as HTMLElement | null;
-        if (focusedElement !== document.body) return;
-        for (const mutation of mutations) {
-          if (mutation.removedNodes.length > 0) focus(container);
-        }
+        if (!mutations.some((m) => m.removedNodes.length)) return;
+        if (!container?.contains(lastFocusedElementRef.current)) focus(container);
       }
 
       document.addEventListener('focusin', handleFocusIn);


### PR DESCRIPTION
https://github.com/JedWatson/react-select/issues/5732
The current implementation of FocusScope falls short whenever the component that gains focus removes child nodes as they lose focus. `react-select` adds and removes spans for accessibility, causing `handleMutations` to trigger. It seems like tabbing through a `react-select` select causes two mutations, in which the first one the focus is on `document.body`. I don't really know why, but this seems to fix it.