### PR TITLE
[Tooltip] fix focusing on a tooltip trigger outside of viewport

### DIFF
--- a/.yarn/versions/47aa1bb6.yml
+++ b/.yarn/versions/47aa1bb6.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -502,7 +502,32 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
     } = props;
     const context = useTooltipContext(CONTENT_NAME, __scopeTooltip);
     const popperScope = usePopperScope(__scopeTooltip);
+    const [hasIntersectedOnce, setHasIntersectedOnce] = React.useState(false);
     const { onClose } = context;
+
+    // track if the trigger has intersected with the viewport once
+    React.useEffect(() => {
+      if (context.trigger) {
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (entry.isIntersecting) {
+              setHasIntersectedOnce(true);
+            }
+          },
+          {
+            root: null,
+            rootMargin: '0px',
+            threshold: 0.1,
+          }
+        );
+
+        observer.observe(context.trigger);
+
+        return () => {
+          observer.disconnect();
+        };
+      }
+    }, [context.trigger]);
 
     // Close this tooltip if another one opens
     React.useEffect(() => {
@@ -510,17 +535,17 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
       return () => document.removeEventListener(TOOLTIP_OPEN, onClose);
     }, [onClose]);
 
-    // Close the tooltip if the trigger is scrolled
+    // Close the tooltip if the trigger is scrolled and it's already intersected with viewport once
     React.useEffect(() => {
       if (context.trigger) {
         const handleScroll = (event: Event) => {
           const target = event.target as HTMLElement;
-          if (target?.contains(context.trigger)) onClose();
+          if (target?.contains(context.trigger) && hasIntersectedOnce) onClose();
         };
         window.addEventListener('scroll', handleScroll, { capture: true });
         return () => window.removeEventListener('scroll', handleScroll, { capture: true });
       }
-    }, [context.trigger, onClose]);
+    }, [context.trigger, onClose, hasIntersectedOnce]);
 
     return (
       <DismissableLayer


### PR DESCRIPTION
fixes issue #1944 

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Currently if you focus on a tooltip trigger that is outside of the viewport (by tabbing with the keyboard), the tooltip does not open because `onClose()` is called when the trigger is scrolled.

My change introduces a piece of state `hasIntersectedOnce` that tracks if the tooltip trigger has intersected with the viewport once.  If it has, then it's safe to close the tooltip on scroll.  Otherwise, don't close it and keep it open.  

This seems to work pretty well, but let me know if you have any suggestions
