### PR TITLE
fix(select): select click event passthrough underneath

### DIFF
--- a/.yarn/versions/fa26f69d.yml
+++ b/.yarn/versions/fa26f69d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-select": patch

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1190,15 +1190,23 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     const isSelected = context.value === value;
     const [textValue, setTextValue] = React.useState(textValueProp ?? '');
     const [isFocused, setIsFocused] = React.useState(false);
+    const [isClicked, setIsClicked] = React.useState(false);
+    const [isDoneSelection, setIsDoneSelection] = React.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, (node) =>
       contentContext.itemRefCallback?.(node, value, disabled)
     );
     const textId = useId();
 
-    const handleSelect = () => {
-      if (!disabled) {
+    React.useEffect(() => {
+      if (isDoneSelection && isClicked) {
         context.onValueChange(value);
         context.onOpenChange(false);
+      }
+    }, [isDoneSelection, isClicked, value, context]);
+
+    const handleSelect = () => {
+      if (!disabled) {
+        setIsDoneSelection(true);
       }
     };
 
@@ -1237,6 +1245,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             tabIndex={disabled ? undefined : -1}
             {...itemProps}
             ref={composedRefs}
+            onClick={composeEventHandlers(itemProps.onClick, () => setIsClicked(true))}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
             onPointerUp={composeEventHandlers(itemProps.onPointerUp, handleSelect)}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

close #1658 

### Description

The `select` component has this behaviour when using mobile browsers, or in Chrome mobile simulator. The tapping of an item to select will close the select content wrapper and then trigger `onClick` event of the element underneath the select content wrapper.

I have experimented it in the storybook as shown in following screenshot:

<img width="318" alt="1" src="https://github.com/radix-ui/primitives/assets/44829092/5984f42f-62f3-4190-b971-46ea529960ed">

![2](https://github.com/radix-ui/primitives/assets/44829092/c44ad3f7-4fa2-48be-a9c8-0209c079e9af)

As seen from screenshot, I put a button covering the entire view underneath the select component, in the second GIF recording, we can see that the button underneath is clicked when we try to tap to select an item (reflected by the increasing of the counter value).

### Hypothesis

In the original `handleSelect` event listener when an item is selected, the `context.onOpenChange(false)` was called before the `onClick` event was triggered. This is because the `handleSelect` event listener is listening to the `onPointerUp` event, which will be fired first before `onClick` event gets fired. Therefore, this results in our select content wrapper being **closed** before `onClick` event is fired, causing the `onClick` event to **pass through** to the component underneath.

### Solution

My proposed solution in this PR is to **make sure that `onClick` event is captured by the select item before the `onOpenChange(false)` is called which closes the select content wrapper**. This can be done by set up two states, one will get updated when `onClick` on the select item is captured, the other will be updated when `onPointerUp` on the select item is captured.

Then we just listen to the two states with a `useEffect` that will handle the effects caused by the changing two states. Once we get both states to be `true`, basically means our select item has both `onPointerUp` and `onClick` event received, then we can safely call `onOpenChange(false)` to close the select content wrapper.

### Result

The result is the `onClick` event no longer pass through to the component below, as shown in below GIF image:

![3](https://github.com/radix-ui/primitives/assets/44829092/e68980c0-f5aa-4535-bab0-4091945ec7e2)


### Unit Test ✅

<!-- Describe the change you are introducing -->
