### PR TITLE
fix: Popover and Dialog trigger issue with shadow dom

### DIFF
--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -336,8 +336,11 @@ const DialogContentNonModal = React.forwardRef<DialogContentTypeElement, DialogC
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
           // cause it to close and immediately open.
-          const target = event.target as HTMLElement;
-          const targetIsTrigger = context.triggerRef.current?.contains(target);
+          const triggerEl = context.triggerRef.current;
+          const targetIsTrigger =
+            triggerEl &&
+            (event.composedPath().includes(triggerEl) ||
+              event.detail.originalEvent.composedPath().includes(triggerEl));
           if (targetIsTrigger) event.preventDefault();
 
           // On Safari if the trigger is inside a container with tabIndex={0}, when clicked

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -331,8 +331,11 @@ const PopoverContentNonModal = React.forwardRef<PopoverContentTypeElement, Popov
           // Prevent dismissing when clicking the trigger.
           // As the trigger is already setup to close, without doing so would
           // cause it to close and immediately open.
-          const target = event.target as HTMLElement;
-          const targetIsTrigger = context.triggerRef.current?.contains(target);
+          const triggerEl = context.triggerRef.current;
+          const targetIsTrigger =
+            triggerEl &&
+            (event.composedPath().includes(triggerEl) ||
+              event.detail.originalEvent.composedPath().includes(triggerEl));
           if (targetIsTrigger) event.preventDefault();
 
           // On Safari if the trigger is inside a container with tabIndex={0}, when clicked


### PR DESCRIPTION
### Description

Popover and Dialog currently rely on event.target to determine if a dismiss click was on the trigger element. However, when rendered inside shadow root, the dismiss event listener bound on document will always get the shadow host as event.target ([reference](https://javascript.info/shadow-dom-events)). This causes clicking on the target to close then immediately re-open the popover/dialog.

This commit fixes the issue by applying 2 changes:
1. Use event.composedPath() instead of event.target, this gives the full path of elements the event propagated through as long as the shadow mode is open.
2. Check not only the custom event but also the original event. This is because the custom event's composedPath starts from the shadow host.

### Testing

Check out this sandbox: https://codesandbox.io/s/radix-ui-popover-fixing-bug-with-shadow-dom-sqxyjs?file=/src/App.js

The local compiled copy of popover.js has this fix commit, and it works in shadow root.

The popover imported from npm has issue with shadow root.

Outside of shadow DOM both behave as expected.
