### PR TITLE
[Menu] Don’t scroll menus in response to hover

### DIFF
--- a/.yarn/versions/54d1ffa8.yml
+++ b/.yarn/versions/54d1ffa8.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -729,7 +729,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
                   contentContext.onItemEnter(event);
                   if (!event.defaultPrevented) {
                     const item = event.currentTarget;
-                    item.focus();
+                    item.focus({ preventScroll: true });
                   }
                 }
               })


### PR DESCRIPTION
<!--
- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.
-->

### Description
By default, when a menu item is focused, browsers will scroll it into view. Sometimes even into the centre of the view. This is good when using a keyboard, because the focused item is automatically visible, but when it was focused in response to mouse movement, it has the effect of moving the item out from underneath the pointer.

Fixes radix-ui/primitives#1566
