### PR TITLE
fix: using forceMount breaks escape behavior for native dialogs

### DIFF
--- a/packages/react/dismissable-layer/src/DismissableLayer.tsx
+++ b/packages/react/dismissable-layer/src/DismissableLayer.tsx
@@ -106,6 +106,9 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
       if (!isHighestLayer) return;
       onEscapeKeyDown?.(event);
       if (!event.defaultPrevented && onDismiss) {
+        const isTargetDialog = (event.target as HTMLElement).tagName === 'DIALOG';
+        if (isTargetDialog) return;
+
         event.preventDefault();
         onDismiss();
       }


### PR DESCRIPTION
This pull request addresses a bug where the use of the forceMount feature disrupts the escape behavior of native dialogs. Currently, when forceMount is used, unexpected behavior occurs when users attempt to dismiss native dialogs (e.g., confirmation dialogs for exiting the application).

This PR includes the following changes to resolve this problem:
Mitigation of the conflict with forceMount to fix the escape behavior of dialogs. (Fixes #2476)

Thank you!