### PR TITLE
[Checkbox] Support form attribute

### DIFF
--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -83,6 +83,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
           data-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
+          form={form}
           value={value}
           {...checkboxProps}
           ref={composedRefs}

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -48,6 +48,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
       defaultChecked,
       required,
       disabled,
+      form,
       value = 'on',
       onCheckedChange,
       ...checkboxProps
@@ -56,7 +57,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) : true;
+    const isFormControl = button ? Boolean(button.form) : true;
     const [checked = false, setChecked] = useControllableState({
       prop: checkedProp,
       defaultProp: defaultChecked,
@@ -109,6 +110,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
             checked={checked}
             required={required}
             disabled={disabled}
+            form={form}
             // We transform because the input is absolutely positioned but we have
             // rendered it **after** the button. This pulls it back to sit on top
             // of the button.


### PR DESCRIPTION


<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This lets you associate the underlying native `<input>` element to a `<form>` anywhere in the document instead of requiring an ancestor `<form>` element.

Related change for Select: https://github.com/radix-ui/primitives/pull/2447