### PR TITLE
Allow empty string as value to Select.Item component

### DIFF
--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1202,12 +1202,6 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
       }
     };
 
-    if (value === '') {
-      throw new Error(
-        'A <Select.Item /> must have a value prop that is not an empty string. This is because the Select value can be set to an empty string to clear the selection and show the placeholder.'
-      );
-    }
-
     return (
       <SelectItemContextProvider
         scope={__scopeSelect}


### PR DESCRIPTION
In my opinion, disallowing the Select.Item to accept an empty string value eliminates the possibility of creating a custom item that clears the selection. The error handling for empty string values, in my view, generates more issues and unnecessary code.

