### PR TITLE
Remove unnecessary useEffect in React Primitive component

### DIFF
--- a/packages/react/primitive/src/Primitive.tsx
+++ b/packages/react/primitive/src/Primitive.tsx
@@ -46,10 +46,6 @@ const Primitive = NODES.reduce((primitive, node) => {
     const { asChild, ...primitiveProps } = props;
     const Comp: any = asChild ? Slot : node;
 
-    React.useEffect(() => {
-      (window as any)[Symbol.for('radix-ui')] = true;
-    }, []);
-
     return <Comp {...primitiveProps} ref={forwardedRef} />;
   });
 


### PR DESCRIPTION
### Description

This PR removes what seems to be an unnecessary `useEffect` in React Primitive component. Usage of `useEffect` breaks compatibility with RSC (React Server Components). Because this is used in such a low lever primitive/component, all `radix-ui` components become unusable in RSC.
