### PR TITLE
[NavigationMenu] Allow `children` in `Viewport` types

### DIFF
--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -982,7 +982,7 @@ const VIEWPORT_NAME = 'NavigationMenuViewport';
 
 type NavigationMenuViewportElement = NavigationMenuViewportImplElement;
 interface NavigationMenuViewportProps
-  extends Omit<NavigationMenuViewportImplProps, 'children' | 'activeContentValue'> {
+  extends Omit<NavigationMenuViewportImplProps, 'activeContentValue'> {
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with React animation libraries.


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This is the same change as in #1300, but for NavigationMenu. The change allows us to pass children to  `NavigationMenu.Viewport` when using the `asChild` prop.

Referenced issue: https://github.com/radix-ui/primitives/issues/1284.

Thanks ✌️
