### PR TITLE
[DropdownMenu] replace onPointerDown by onClick to avoid scroll prevention on mobile

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -114,7 +114,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+          onClick={composeEventHandlers(props.onClick, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {


### PR DESCRIPTION
### Description

Scrolling on mobile devices trigger DropdownMenu.Trigger even when not intended.
This is caused by using `onPointerDown`.

The problem is reported in issue https://github.com/radix-ui/primitives/issues/1912

Scrolling is prevented and the DropdownMenu opens, which is not intended by users in that case.
By using `onClick` everything seems to work normal while users can still scroll on mobile devices.

Since this is my first PR and I don't know the codebase of Radix UI well, I'm not sure, what implications or side-effects this change could have. In my tests, everything worked fine by just using `onClick`.