### PR TITLE
[Toast] Allow to disable toast hotkey

### DIFF
--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -129,14 +129,15 @@ type ToastViewportElement = React.ElementRef<typeof Primitive.ol>;
 type PrimitiveOrderedListProps = Radix.ComponentPropsWithoutRef<typeof Primitive.ol>;
 interface ToastViewportProps extends PrimitiveOrderedListProps {
   /**
-   * The keys to use as the keyboard shortcut that will move focus to the toast viewport.
+   * The keys to use as the keyboard shortcut that will move focus to the toast viewport. 
+   * You can pass `false` to disable the keyboard shortcut.
    * @defaultValue ['F8']
    */
-  hotkey?: string[];
+  hotkey?: string[] | false; 
   /**
    * An author-localized label for the toast viewport to provide context for screen reader users
    * when navigating page landmarks. The available `{hotkey}` placeholder will be replaced for you.
-   * @defaultValue 'Notifications ({hotkey})'
+   * @defaultValue 'Notifications ({hotkey})' if `hotkey` is not `false`, otherwise 'Notifications'
    */
   label?: string;
 }
@@ -146,7 +147,7 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
     const {
       __scopeToast,
       hotkey = VIEWPORT_DEFAULT_HOTKEY,
-      label = 'Notifications ({hotkey})',
+      label = props.hotkey === false ? "Notifications" : 'Notifications ({hotkey})',
       ...viewportProps
     } = props;
     const context = useToastProviderContext(VIEWPORT_NAME, __scopeToast);
@@ -156,10 +157,14 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
     const tailFocusProxyRef = React.useRef<FocusProxyElement>(null);
     const ref = React.useRef<ToastViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
-    const hotkeyLabel = hotkey.join('+').replace(/Key/g, '').replace(/Digit/g, '');
+    const hotkeyLabel = hotkey ? hotkey.join('+').replace(/Key/g, '').replace(/Digit/g, '') : ""
     const hasToasts = context.toastCount > 0;
 
     React.useEffect(() => {
+      if (!hotkey) {
+        return
+      }
+
       const handleKeyDown = (event: KeyboardEvent) => {
         // we use `event.code` as it is consistent regardless of meta keys that were pressed.
         // for example, `event.key` for `Control+Alt+t` is `†` and `t !== †`


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description


By default, Radix toast will use F8 to focus the toast viewport. However, F8 is also used in the Japanese input method. We should allow developers to disable the F8 hotkey here to prevent the toast viewport from being focused when the user is typing in Japanese.

Here is an example to show how F8 is used. I try to input "Hello world", where "Hello" is in Japanese and "world" is in English. 



https://github.com/radix-ui/primitives/assets/24715727/95e56f21-8f97-47c4-9faa-f503d2f57029


<!-- Describe the change you are introducing -->
