### PR TITLE
Bug fix matcher not triggering

### DIFF
--- a/.yarn/versions/93f8b8d7.yml
+++ b/.yarn/versions/93f8b8d7.yml
@@ -1,0 +1,3 @@
+releases:
+  "@radix-ui/react-form": patch
+  primitives: patch

--- a/cypress/integration/Form.spec.ts
+++ b/cypress/integration/Form.spec.ts
@@ -153,6 +153,28 @@ describe('Form', () => {
       cy.findByText(/not valid/).should('not.exist');
     });
 
+    it('should handle custom validity (sync custom validator) with untouched same previous value', () => {
+      cy.findByLabelText(/secret 1/i)
+        .as('control')
+        .focus()
+        .realType('secret');
+      cy.realPress('Tab');
+      cy.findByText(/not valid/).as('message');
+      checkControlMessageAssociation();
+
+      cy.findByLabelText(/secret 1/i)
+        .as('control')
+        .focus()
+        .realType('secret');
+      cy.realPress('Tab');
+      cy.findByText(/not valid/).as('message');
+      checkControlMessageAssociation();
+
+      cy.get('@control').focus().clear().realType('shush');
+      cy.realPress('Tab');
+      cy.findByText(/not valid/).should('not.exist');
+    });
+
     it('should handle custom validity (async custom validator)', () => {
       cy.findByLabelText(/secret 2/i)
         .as('control')

--- a/packages/react/form/src/Form.tsx
+++ b/packages/react/form/src/Form.tsx
@@ -371,6 +371,24 @@ const FormControl = React.forwardRef<FormControlElement, FormControlProps>(
       }
     }, [name, onFieldValiditionClear]);
 
+    React.useEffect(() => {
+      const control = ref.current;
+      if (control) {
+        // It emits a 'change' event on blur since this is an uncontrolled input.
+        // For cases when programatically `control.value` or same previous value is set on input,
+        // `change` event is not emitted, so the following manually emits on `blur`.
+        // It skips when value is "" so focus then blur on input doesn't trigger validation.
+        const handleBlur = () => {
+          if (control.value === '') {
+            return;
+          }
+          control.dispatchEvent(new Event('change'));
+        };
+        control.addEventListener('blur', handleBlur);
+        return () => control.removeEventListener('change', handleBlur);
+      }
+    }, []);
+
     // reset validity and errors when the form is reset
     React.useEffect(() => {
       const form = ref.current?.form;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

This PR intends to fix issue https://github.com/radix-ui/primitives/issues/2542

Why this issue occurs?

Since form input uses the native `change` event, programmatically updates doesn't emits.
Also if a validation error has already triggers and `input.value` gets updated with [same value](https://github.com/radix-ui/primitives/issues/2542) validation disappear, because input event doesn't detect a change hence event `change` not emits.
Currently this is happening for custom and non-custom matchers, i.e. `type="email"` inputs.

Before
https://github.com/radix-ui/primitives/assets/74157/d2be0df4-403c-491d-bf66-a1bec00e33d7

After
https://github.com/radix-ui/primitives/assets/74157/968d2091-fdd3-492d-b900-986a55707ae1