### PR TITLE
fix: dropdown menu immediately closes on Android Firefox mobile

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -124,6 +124,9 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
               if (!context.open) event.preventDefault();
             }
           })}
+          onFocusCapture={(event)=>{
+            event.stopPropagation();  
+          }}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
             if (['Enter', ' '].includes(event.key)) context.onOpenToggle();


### PR DESCRIPTION
### Description
Fix #2565 

[onFocusCapture](https://github.com/tvankith/primitives/blob/8b2e59a2227d7d2eb66afee2fc88a09fd9ea3cb0/packages/react/dismissable-layer/src/DismissableLayer.tsx#L168) is triggered while clicking on dropdown trigger.This prevented by stopping propogation of focus event from DropdownMenuTrigger component
