### PR TITLE
Fix checkbox missing name prop when is not inside a form

### DIFF
--- a/packages/react/checkbox/src/Checkbox.test.tsx
+++ b/packages/react/checkbox/src/Checkbox.test.tsx
@@ -20,18 +20,23 @@ global.ResizeObserver = class ResizeObserver {
 };
 
 describe('given a default Checkbox', () => {
+  const checkboxName = 'Primitive Checkbox';
   let rendered: RenderResult;
   let checkbox: HTMLElement;
   let indicator: HTMLElement | null;
 
   beforeEach(() => {
-    rendered = render(<CheckboxTest />);
+    rendered = render(<CheckboxTest name={checkboxName} />);
     checkbox = rendered.getByRole(CHECKBOX_ROLE);
     indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
   });
 
   it('should have no accessibility violations', async () => {
     expect(await axe(rendered.container)).toHaveNoViolations();
+  });
+
+  it('should have name prop on button when it not inside a form', async () => {
+    expect(checkbox).toHaveAttribute('name', checkboxName);
   });
 
   describe('when clicking the checkbox', () => {
@@ -117,6 +122,24 @@ describe('given a controlled `checked` Checkbox', () => {
     it('should call `onCheckedChange` prop', () => {
       expect(onCheckedChange).toHaveBeenCalled();
     });
+  });
+});
+
+describe('given a Checkbox inside a Form', () => {
+  let rendered: RenderResult;
+  let checkbox: HTMLElement;
+
+  beforeEach(() => {
+    rendered = render(
+      <form>
+        <CheckboxTest />
+      </form>
+    );
+    checkbox = rendered.getByRole(CHECKBOX_ROLE);
+  });
+
+  it('should have no name prop', async () => {
+    expect(checkbox).not.toHaveAttribute('name');
   });
 });
 

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -83,6 +83,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           value={value}
+          name={!isFormControl ? name : undefined}
           {...checkboxProps}
           ref={composedRefs}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This `primitive` uses a `button` and when inside a form adds a `input`. The name was destructured from the component and passed only to the input.

Fix:
- It was added the `name` prop to the button if the checkbox is `not` inside a form.

<!-- Describe the change you are introducing -->
