### PR TITLE
Add forward ref to react/select:Select

### DIFF
--- a/.yarn/versions/fd8c5361.yml
+++ b/.yarn/versions/fd8c5361.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Closes #2590 (More detail in issue description)

`Select` component needs to forward a ref to `BubbleSelect` to be compatible with `react-hook-form`'s `register()` function.
