### PR TITLE
Correctly concatenate aria-describedby in a slot

### DIFF
--- a/packages/react/slot/src/Slot.test.tsx
+++ b/packages/react/slot/src/Slot.test.tsx
@@ -106,6 +106,66 @@ describe('given a slotted Trigger', () => {
       expect(handleChildClick).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('with aria-describedby on itself', () => {
+    beforeEach(() => {
+      render(
+        <Trigger as={Slot} aria-describedby="description">
+          <button type="button">Click me</button>
+        </Trigger>
+      );
+    });
+
+    it('should set aria-describedby on the child', async () => {
+      expect(screen.getByRole('button')).toHaveAttribute('aria-describedby', 'description');
+    });
+  });
+  describe('with aria-describedby on the child', () => {
+    beforeEach(() => {
+      render(
+        <Trigger as={Slot}>
+          <button type="button" aria-describedby="description">
+            Click me
+          </button>
+        </Trigger>
+      );
+    });
+
+    it('should set aria-describedby on the child', async () => {
+      expect(screen.getByRole('button')).toHaveAttribute('aria-describedby', 'description');
+    });
+  });
+  describe('with aria-describedby on itself AND the child', () => {
+    beforeEach(() => {
+      render(
+        <Trigger as={Slot} aria-describedby="description1">
+          <button type="button" aria-describedby="description2">
+            Click me
+          </button>
+        </Trigger>
+      );
+    });
+
+    it('should concatenate both aria-describedby on the child', async () => {
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-describedby',
+        'description1 description2'
+      );
+    });
+  });
+  describe('with undefined aria-describedby on itself AND aria-describedby on the child', () => {
+    beforeEach(() => {
+      render(
+        <Trigger as={Slot}>
+          <button type="button">Click me</button>
+        </Trigger>
+      );
+    });
+
+    it('should set aria-describedby on the child', async () => {
+      expect(screen.getByRole('button')).not.toHaveAttribute('aria-describedby');
+    });
+  });
 });
 
 describe('given a Button with Slottable', () => {

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -111,10 +111,17 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
       }
     }
     // if it's `style`, we merge them
-    else if (propName === 'style') {
-      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
-    } else if (propName === 'className') {
-      overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+    else {
+      switch (propName) {
+        case 'style':
+          overrideProps[propName] = { ...slotPropValue, ...childPropValue };
+          break;
+
+        case 'className':
+        case 'aria-describedby':
+          overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
### Description

aria-describedby is technically a list of ids and should be concatenated kind of like className.

This pr fixes [my own issue](https://github.com/radix-ui/primitives/issues/2598) where this is described

Tests are included