### PR TITLE
Fixed Dropdown Menu trigger to work only onClick

### DIFF
--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -114,7 +114,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+          onClick={composeEventHandlers(props.onClick, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
             if (!disabled && event.button === 0 && event.ctrlKey === false) {


### PR DESCRIPTION
### Description

Changed `onPointerDown` event to `onClick` event which triggers the dropdown only when you click and release the left mouse button. 

This was done because when you clicked without releasing the button, the dropdown opened, on pc this was not really an issue, but it was an annoying issue on mobile, where you could be scrolling down and unintentionally pressed any dropdown trigger, causing the menu to show even though it was not intended.

Further explanation can be found on this issue [#173](https://github.com/radix-ui/primitives/issues/2626) which is closed by this PR. Tests were performed to verify the new changes.