### PR TITLE
scroll-area: Restrict the Wheel Event Listener's Scope

### DIFF
--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -40,6 +40,9 @@ export const Basic = () => {
           <label>
             scrollHideDelay: <input type="number" name="scrollHideDelay" />
           </label>
+          <label>
+            <input type="checkbox" name="draggable" /> draggable items
+          </label>
         </form>
       </div>
 
@@ -49,7 +52,11 @@ export const Basic = () => {
         style={{ width: 800, height: 800, margin: '30px auto' }}
       >
         {Array.from({ length: 30 }).map((_, index) => (
-          <Copy key={index} />
+          <Copy
+            key={index}
+            style={{ cursor: props.draggable === 'on' ? 'move' : 'unset' }}
+            isDraggable={props.draggable === 'on'}
+          />
         ))}
       </ScrollAreaStory>
     </>
@@ -393,7 +400,7 @@ const ScrollAreaStory = ({
 );
 
 const Copy = (props: any) => (
-  <p style={{ width: 4000, marginTop: 0, ...props.style }}>
+  <p style={{ width: 4000, marginTop: 0, ...props.style }} draggable={props.isDraggable}>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sit amet eros iaculis, bibendum
     tellus ac, lobortis odio. Aliquam bibendum elit est, in iaculis est commodo id. Donec pulvinar
     est libero. Proin consectetur pellentesque molestie. Fusce mi ante, ullamcorper eu ante finibus,

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -523,10 +523,6 @@ const ScrollAreaScrollbarX = React.forwardRef<
         if (context.viewport) {
           const scrollPos = context.viewport.scrollLeft + event.deltaX;
           props.onWheelScroll(scrollPos);
-          // prevent window scroll when wheeling on scrollbar
-          if (isScrollingWithinScrollbarBounds(scrollPos, maxScrollPos)) {
-            event.preventDefault();
-          }
         }
       }}
       onResize={() => {
@@ -580,10 +576,6 @@ const ScrollAreaScrollbarY = React.forwardRef<
         if (context.viewport) {
           const scrollPos = context.viewport.scrollTop + event.deltaY;
           props.onWheelScroll(scrollPos);
-          // prevent window scroll when wheeling on scrollbar
-          if (isScrollingWithinScrollbarBounds(scrollPos, maxScrollPos)) {
-            event.preventDefault();
-          }
         }
       }}
       onResize={() => {
@@ -671,16 +663,16 @@ const ScrollAreaScrollbarImpl = React.forwardRef<
 
   /**
    * We bind wheel event imperatively so we can switch off passive
-   * mode for document wheel event to allow it to be prevented
+   * mode for scrollbar wheel event to allow it to be prevented.
    */
   React.useEffect(() => {
     const handleWheel = (event: WheelEvent) => {
-      const element = event.target as HTMLElement;
-      const isScrollbarWheel = scrollbar?.contains(element);
-      if (isScrollbarWheel) handleWheelScroll(event, maxScrollPos);
+      event.preventDefault();
+      handleWheelScroll(event, maxScrollPos);
     };
-    document.addEventListener('wheel', handleWheel, { passive: false });
-    return () => document.removeEventListener('wheel', handleWheel, { passive: false } as any);
+
+    scrollbar?.addEventListener('wheel', handleWheel, { passive: false });
+    return () => scrollbar?.removeEventListener('wheel', handleWheel, { passive: false } as any);
   }, [viewport, scrollbar, maxScrollPos, handleWheelScroll]);
 
   /**
@@ -950,10 +942,6 @@ function linearScale(input: readonly [number, number], output: readonly [number,
     const ratio = (output[1] - output[0]) / (input[1] - input[0]);
     return output[0] + ratio * (value - input[0]);
   };
-}
-
-function isScrollingWithinScrollbarBounds(scrollPos: number, maxScrollPos: number) {
-  return scrollPos > 0 && scrollPos < maxScrollPos;
 }
 
 // Custom scroll handler to avoid scroll-linked effects


### PR DESCRIPTION
### Description

This PR restricts the Wheel Event Listener's Scope to the scrollbar elements themselves rather than the entire document.

This limits the scope of custom logic and reduces the potential for unintended side effects.

Furthermore this improvements allows user to have draggable items inside their ScrollArea viewport.

### Screenshots

##### Before

https://github.com/radix-ui/primitives/assets/512958/c4af574a-99a3-4912-8c13-0b4567ef3779

##### After


https://github.com/radix-ui/primitives/assets/512958/8b8553eb-1526-48a3-80b3-78c173cddeb7

