### PR TITLE
[Select] Added backspace key functionality for type-ahead accessibility

### DIFF
--- a/.yarn/versions/21ac240f.yml
+++ b/.yarn/versions/21ac240f.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": minor
+
+undecided:
+  - primitives

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -34,38 +34,52 @@ describe('Select', () => {
   describe('given a keyboard user', () => {
     it('should delete only the last character in typeahead on select content when backspace pressed', () => {
       cy.findByLabelText(/choose a size/).click();
-      cy.focused().type('sm');
-      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
-      cy.focused().type('{backspace}m');
-      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
+      typeIntoFocusedElement('sm');
+      assertOptionHighlighted(/small/i);
+      typeIntoFocusedElement('{backspace}m');
+      assertOptionHighlighted(/small/i);
     });
 
     it('should update typeahead correctly when backspace pressed on select content', () => {
       cy.findByLabelText(/choose a size/).click();
-      cy.focused().type('s');
-      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
-      cy.focused().type('{backspace}m');
-      cy.findByRole('option', { name: /medium/i }).should('have.attr', 'data-highlighted');
-      cy.focused().type('{backspace}l');
-      cy.findByRole('option', { name: /large/i }).should('have.attr', 'data-highlighted');
+      typeIntoFocusedElement('s');
+      assertOptionHighlighted(/small/i);
+      typeIntoFocusedElement('{backspace}m');
+      assertOptionHighlighted(/medium/i);
+      typeIntoFocusedElement('{backspace}l');
+      assertOptionHighlighted(/large/i);
     });
 
     it('should delete only the last character in typeahead on select trigger when backspace pressed', () => {
       cy.findByLabelText(/choose a size/).focus();
-      cy.focused().type('sm');
-      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
-      cy.focused().type('{backspace}m');
-      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
+      typeIntoFocusedElement('sm');
+      assertSelectTriggerText('Small');
+      typeIntoFocusedElement('{backspace}m');
+      assertSelectTriggerText('Small');
     });
 
     it('should update typeahead correctly when backspace pressed on select trigger', () => {
       cy.findByLabelText(/choose a size/).focus();
-      cy.focused().type('s');
-      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
-      cy.focused().type('{backspace}m');
-      cy.findByLabelText(/choose a size/).should('contain.text', 'Medium');
-      cy.focused().type('{backspace}l');
-      cy.findByLabelText(/choose a size/).should('contain.text', 'Large');
+      typeIntoFocusedElement('s');
+      assertSelectTriggerText('Small');
+      typeIntoFocusedElement('{backspace}m');
+      assertSelectTriggerText('Medium');
+      typeIntoFocusedElement('{backspace}l');
+      assertSelectTriggerText('Large');
     });
   });
+
+  /* ---------------------------------------------------------------------------------------------- */
+
+  function typeIntoFocusedElement(text: string) {
+    cy.focused().type(text);
+  }
+
+  function assertOptionHighlighted(textRegex: RegExp) {
+    cy.findByRole('option', { name: textRegex }).should('have.attr', 'data-highlighted');
+  }
+
+  function assertSelectTriggerText(text: string) {
+    cy.findByLabelText(/choose a size/).should('contain.text', text);
+  }
 });

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -32,39 +32,23 @@ describe('Select', () => {
   });
 
   describe('given a keyboard user', () => {
-    it('should delete only the last character in typeahead on select content when backspace pressed', () => {
-      cy.findByLabelText(/choose a size/).click();
-      typeIntoFocusedElement('sm');
-      assertOptionHighlighted(/small/i);
-      typeIntoFocusedElement('{backspace}m');
-      assertOptionHighlighted(/small/i);
-    });
-
     it('should update typeahead correctly when backspace pressed on select content', () => {
       cy.findByLabelText(/choose a size/).click();
-      typeIntoFocusedElement('s');
+      typeIntoFocusedElement('size');
       assertOptionHighlighted(/small/i);
-      typeIntoFocusedElement('{backspace}m');
+      typeIntoFocusedElement('{backspace}medium');
       assertOptionHighlighted(/medium/i);
-      typeIntoFocusedElement('{backspace}l');
+      typeIntoFocusedElement('{backspace}large');
       assertOptionHighlighted(/large/i);
-    });
-
-    it('should delete only the last character in typeahead on select trigger when backspace pressed', () => {
-      cy.findByLabelText(/choose a size/).focus();
-      typeIntoFocusedElement('sm');
-      assertSelectTriggerText('Small');
-      typeIntoFocusedElement('{backspace}m');
-      assertSelectTriggerText('Small');
     });
 
     it('should update typeahead correctly when backspace pressed on select trigger', () => {
       cy.findByLabelText(/choose a size/).focus();
-      typeIntoFocusedElement('s');
+      typeIntoFocusedElement('size');
       assertSelectTriggerText('Small');
-      typeIntoFocusedElement('{backspace}m');
+      typeIntoFocusedElement('{backspace}medium');
       assertSelectTriggerText('Medium');
-      typeIntoFocusedElement('{backspace}l');
+      typeIntoFocusedElement('{backspace}large');
       assertSelectTriggerText('Large');
     });
   });

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -30,4 +30,42 @@ describe('Select', () => {
       cy.findByText('…').should('exist');
     });
   });
+
+  describe('given a keyboard user', () => {
+    it('should delete only the last character in typeahead on select content when backspace pressed', () => {
+      cy.findByLabelText(/choose a size/).click();
+      cy.focused().type('sm');
+      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
+      cy.focused().type('{backspace}m');
+      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
+    });
+
+    it('should update typeahead correctly when backspace pressed on select content', () => {
+      cy.findByLabelText(/choose a size/).click();
+      cy.focused().type('s');
+      cy.findByRole('option', { name: /small/i }).should('have.attr', 'data-highlighted');
+      cy.focused().type('{backspace}m');
+      cy.findByRole('option', { name: /medium/i }).should('have.attr', 'data-highlighted');
+      cy.focused().type('{backspace}l');
+      cy.findByRole('option', { name: /large/i }).should('have.attr', 'data-highlighted');
+    });
+
+    it('should delete only the last character in typeahead on select trigger when backspace pressed', () => {
+      cy.findByLabelText(/choose a size/).focus();
+      cy.focused().type('sm');
+      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
+      cy.focused().type('{backspace}m');
+      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
+    });
+
+    it('should update typeahead correctly when backspace pressed on select trigger', () => {
+      cy.findByLabelText(/choose a size/).focus();
+      cy.focused().type('s');
+      cy.findByLabelText(/choose a size/).should('contain.text', 'Small');
+      cy.focused().type('{backspace}m');
+      cy.findByLabelText(/choose a size/).should('contain.text', 'Medium');
+      cy.focused().type('{backspace}l');
+      cy.findByLabelText(/choose a size/).should('contain.text', 'Large');
+    });
+  });
 });

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -286,7 +286,9 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
           onKeyDown={composeEventHandlers(triggerProps.onKeyDown, (event) => {
             const isTypingAhead = searchRef.current !== '';
             const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
-            if (!isModifierKey && event.key.length === 1) handleTypeaheadSearch(event.key);
+            if (!isModifierKey && (event.key.length === 1 || event.key === 'Backspace')) {
+              handleTypeaheadSearch(event.key);
+            }
             if (isTypingAhead && event.key === ' ') return;
             if (OPEN_KEYS.includes(event.key)) {
               handleOpen();
@@ -728,7 +730,9 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                   // select should not be navigated using tab key so we prevent it
                   if (event.key === 'Tab') event.preventDefault();
 
-                  if (!isModifierKey && event.key.length === 1) handleTypeaheadSearch(event.key);
+                  if (!isModifierKey && (event.key.length === 1 || event.key === 'Backspace')) {
+                    handleTypeaheadSearch(event.key);
+                  }
 
                   if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
                     const items = getItems().filter((item) => !item.disabled);
@@ -1602,7 +1606,7 @@ function useTypeaheadSearch(onSearchChange: (search: string) => void) {
 
   const handleTypeaheadSearch = React.useCallback(
     (key: string) => {
-      const search = searchRef.current + key;
+      const search = key === 'Backspace' ? searchRef.current.slice(0, -1) : searchRef.current + key;
       handleSearchChange(search);
 
       (function updateSearch(value: string) {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -286,7 +286,10 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
           onKeyDown={composeEventHandlers(triggerProps.onKeyDown, (event) => {
             const isTypingAhead = searchRef.current !== '';
             const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
-            if (!isModifierKey && (event.key.length === 1 || event.key === 'Backspace')) {
+            const isCharacterKey = event.key.length === 1;
+            const isBackspaceKey = event.key === 'Backspace';
+
+            if (!isModifierKey && (isCharacterKey || isBackspaceKey)) {
               handleTypeaheadSearch(event.key);
             }
             if (isTypingAhead && event.key === ' ') return;
@@ -730,7 +733,10 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                   // select should not be navigated using tab key so we prevent it
                   if (event.key === 'Tab') event.preventDefault();
 
-                  if (!isModifierKey && (event.key.length === 1 || event.key === 'Backspace')) {
+                  const isCharacterKey = event.key.length === 1;
+                  const isBackspaceKey = event.key === 'Backspace';
+
+                  if (!isModifierKey && (isCharacterKey || isBackspaceKey)) {
                     handleTypeaheadSearch(event.key);
                   }
 
@@ -1606,7 +1612,8 @@ function useTypeaheadSearch(onSearchChange: (search: string) => void) {
 
   const handleTypeaheadSearch = React.useCallback(
     (key: string) => {
-      const search = key === 'Backspace' ? searchRef.current.slice(0, -1) : searchRef.current + key;
+      const isBackspaceKey = key === 'Backspace';
+      const search = isBackspaceKey ? searchRef.current.slice(0, -1) : searchRef.current + key;
       handleSearchChange(search);
 
       (function updateSearch(value: string) {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1613,7 +1613,7 @@ function useTypeaheadSearch(onSearchChange: (search: string) => void) {
   const handleTypeaheadSearch = React.useCallback(
     (key: string) => {
       const isBackspaceKey = key === 'Backspace';
-      const search = isBackspaceKey ? searchRef.current.slice(0, -1) : searchRef.current + key;
+      const search = isBackspaceKey ? '' : searchRef.current + key;
       handleSearchChange(search);
 
       (function updateSearch(value: string) {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

closes https://github.com/radix-ui/primitives/issues/2636

### Description

<!-- Describe the change you are introducing -->

This pull request introduces an improvement to the type-ahead feature in the Radix Select component. The key enhancement is the implementation of backspace functionality for the Select component. 

When a user is utilizing typeahead to search through options in the select menu, pressing the backspace key will now delete characters from the input one by one. 

This change aligns the component's behavior more closely with standard input expectations and enhances the overall user experience by providing a more intuitive and efficient method for correcting typos or modifying search terms.

I have also thoroughly tested it and added integration tests for the typeahead backspace functionality in the Select component.

I added videos showing before and after. Sorry in advance for how quickly I am typing. It was necessary because otherwise the search gets reset after a second of no typing.

### After:
And here is the Select component with the new backspace key functionality 

https://github.com/radix-ui/primitives/assets/53095479/2ec8aaa7-7fac-4ca8-8265-1b670d945241

https://github.com/radix-ui/primitives/assets/53095479/febf0a56-dc5c-436d-bca9-aeda0b807ef0

(I typed **bl** which highlighted **blueberry**, then I pressed backspace (```search = "b"```) and it highlighted **broccoli**, pressed backspace again (```search = ""```) and  typed **pi** which highlighted **pineapple**, then pressed backspace twice (```search = ""```), then typed **carr** which highlighted **carrot**)


### Before:
Here is how the the Select component used to be without the backspace key functionality:

https://github.com/radix-ui/primitives/assets/53095479/7f5c62d8-748e-4d7b-933d-c1d0d41a31e9

https://github.com/radix-ui/primitives/assets/53095479/e385e465-2f67-4dd3-a1cc-e42454e8fcb3



