### PR TITLE
[Menu] Added backspace key functionality for type-ahead accessibility

### DIFF
--- a/.yarn/versions/1c300419.yml
+++ b/.yarn/versions/1c300419.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": minor
+  "@radix-ui/react-dropdown-menu": minor
+  "@radix-ui/react-menu": minor
+  "@radix-ui/react-menubar": minor
+
+undecided:
+  - primitives

--- a/cypress/integration/Menu.spec.ts
+++ b/cypress/integration/Menu.spec.ts
@@ -1,0 +1,33 @@
+describe('Menu', () => {
+  beforeEach(() => {
+    cy.visitUtilityStory('menu--cypress');
+  });
+
+  describe('given a keyboard user', () => {
+    it('should delete only the last character in typeahead on menu content when backspace pressed', () => {
+      typeIntoMenu('cu');
+      assertMenuItemHighlighted('Cut');
+      typeIntoMenu('{backspace}u');
+      assertMenuItemHighlighted('Cut');
+    });
+
+    it('should update typeahead correctly when backspace pressed on menu content', () => {
+      typeIntoMenu('u');
+      assertMenuItemHighlighted('Undo');
+      typeIntoMenu('{backspace}r');
+      assertMenuItemHighlighted('Redo');
+      typeIntoMenu('{backspace}c');
+      assertMenuItemHighlighted('Cut');
+    });
+  });
+
+  /* ---------------------------------------------------------------------------------------------- */
+
+  function typeIntoMenu(text: string) {
+    cy.findByRole('menu').type(text);
+  }
+
+  function assertMenuItemHighlighted(text: string) {
+    cy.findByRole('menuitem', { name: text }).should('have.attr', 'data-highlighted');
+  }
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,3 +28,8 @@ Cypress.Commands.add('visitStory', (storyName, options) => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   return cy.visit(`iframe.html?id=components-${storyName}`, options).wait(0);
 });
+
+Cypress.Commands.add('visitUtilityStory', (storyName, options) => {
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  return cy.visit(`iframe.html?id=utilities-${storyName}`, options).wait(0);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
     visitStory(storyName: string, options?: Partial<Cypress.VisitOptions>): Chainable<any>;
+    visitUtilityStory(storyName: string, options?: Partial<Cypress.VisitOptions>): Chainable<any>;
   }
 }

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -360,6 +360,21 @@ export const Animated = () => {
   );
 };
 
+export const Cypress = () => (
+  <MenuWithAnchor>
+    <Menu.Item className={itemClass()} onSelect={() => window.alert('undo')}>
+      Undo
+    </Menu.Item>
+    <Menu.Item className={itemClass()} onSelect={() => window.alert('redo')}>
+      Redo
+    </Menu.Item>
+    <Menu.Separator className={separatorClass()} />
+    <Menu.Item className={itemClass()} onSelect={() => window.alert('cut')}>
+      Cut
+    </Menu.Item>
+  </MenuWithAnchor>
+);
+
 type MenuProps = Omit<
   React.ComponentProps<typeof Menu.Root> & React.ComponentProps<typeof Menu.Content>,
   'trapFocus' | 'onCloseAutoFocus' | 'disableOutsidePointerEvents' | 'disableOutsideScroll'

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -394,7 +394,8 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
       : undefined;
 
     const handleTypeaheadSearch = (key: string) => {
-      const search = searchRef.current + key;
+      const isBackspaceKey = key === 'Backspace';
+      const search = isBackspaceKey ? searchRef.current.slice(0, -1) : searchRef.current + key;
       const items = getItems().filter((item) => !item.disabled);
       const currentItem = document.activeElement;
       const currentMatch = items.find((item) => item.ref.current === currentItem)?.textValue;
@@ -511,10 +512,12 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                       target.closest('[data-radix-menu-content]') === event.currentTarget;
                     const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
                     const isCharacterKey = event.key.length === 1;
+                    const isBackspaceKey = event.key === 'Backspace';
                     if (isKeyDownInside) {
                       // menus should not be navigated using tab key so we prevent it
                       if (event.key === 'Tab') event.preventDefault();
-                      if (!isModifierKey && isCharacterKey) handleTypeaheadSearch(event.key);
+                      if (!isModifierKey && (isCharacterKey || isBackspaceKey))
+                        handleTypeaheadSearch(event.key);
                     }
                     // focus first/last item based on key pressed
                     const content = contentRef.current;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

closes https://github.com/radix-ui/primitives/issues/2636

### Description

<!-- Describe the change you are introducing -->

This pull request introduces an improvement to the type-ahead feature in the Radix Menu component. The key enhancement is the implementation of backspace functionality. 

When a user is utilizing typeahead to search through options in the menu, pressing the backspace key will now delete characters from the input one by one. 

This change aligns the component's behavior more closely with standard input expectations and enhances the overall user experience by providing a more intuitive and efficient method for correcting typos or modifying search terms. 

I have also thoroughly tested it and added integration tests for the typeahead backspace functionality. 

Also, since the Menu component is under the Utilities section in Storybook, I had to add a new cypress command ```cy.visitUtilityStory``` to be able to visit pages under the Utilities section in Storyboard and be able to write tests for those pages.

### After

Here is the Menu component with the new backspace key functionality 

https://github.com/radix-ui/primitives/assets/53095479/9353bfed-d76f-47b3-9cf8-5c69c41e2f13

https://github.com/radix-ui/primitives/assets/53095479/8a09c889-79e1-4b6f-aa32-4279ae0e022b

### Before

Here is how the the Menu component used to be without the backspace key functionality:

https://github.com/radix-ui/primitives/assets/53095479/d284c270-3556-4ba7-9782-f25e311bffc0

https://github.com/radix-ui/primitives/assets/53095479/a5e7ac40-fe62-4fc2-89d0-a9d41dc6dfa3




