### PR TITLE
[Select] Added backspace key functionality for type-ahead accessibility

### DIFF
--- a/.yarn/versions/68e9e3c8.yml
+++ b/.yarn/versions/68e9e3c8.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": minor
+
+undecided:
+  - primitives

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -30,4 +30,40 @@ describe('Select', () => {
       cy.findByText('…').should('exist');
     });
   });
+
+  describe('given a keyboard user', () => {
+    it('should update typeahead correctly when backspace pressed on select content', () => {
+      cy.findByLabelText(/choose a size/).click();
+      typeIntoFocusedElement('size');
+      assertOptionHighlighted(/small/i);
+      typeIntoFocusedElement('{backspace}medium');
+      assertOptionHighlighted(/medium/i);
+      typeIntoFocusedElement('{backspace}large');
+      assertOptionHighlighted(/large/i);
+    });
+
+    it('should update typeahead correctly when backspace pressed on select trigger', () => {
+      cy.findByLabelText(/choose a size/).focus();
+      typeIntoFocusedElement('size');
+      assertSelectTriggerText('Small');
+      typeIntoFocusedElement('{backspace}medium');
+      assertSelectTriggerText('Medium');
+      typeIntoFocusedElement('{backspace}large');
+      assertSelectTriggerText('Large');
+    });
+  });
+
+  /* ---------------------------------------------------------------------------------------------- */
+
+  function typeIntoFocusedElement(text: string) {
+    cy.focused().type(text);
+  }
+
+  function assertOptionHighlighted(textRegex: RegExp) {
+    cy.findByRole('option', { name: textRegex }).should('have.attr', 'data-highlighted');
+  }
+
+  function assertSelectTriggerText(text: string) {
+    cy.findByLabelText(/choose a size/).should('contain.text', text);
+  }
 });

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -286,7 +286,12 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
           onKeyDown={composeEventHandlers(triggerProps.onKeyDown, (event) => {
             const isTypingAhead = searchRef.current !== '';
             const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
-            if (!isModifierKey && event.key.length === 1) handleTypeaheadSearch(event.key);
+            const isCharacterKey = event.key.length === 1;
+            const isBackspaceKey = event.key === 'Backspace';
+
+            if (!isModifierKey && (isCharacterKey || isBackspaceKey)) {
+              handleTypeaheadSearch(event.key);
+            }
             if (isTypingAhead && event.key === ' ') return;
             if (OPEN_KEYS.includes(event.key)) {
               handleOpen();
@@ -728,7 +733,12 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                   // select should not be navigated using tab key so we prevent it
                   if (event.key === 'Tab') event.preventDefault();
 
-                  if (!isModifierKey && event.key.length === 1) handleTypeaheadSearch(event.key);
+                  const isCharacterKey = event.key.length === 1;
+                  const isBackspaceKey = event.key === 'Backspace';
+
+                  if (!isModifierKey && (isCharacterKey || isBackspaceKey)) {
+                    handleTypeaheadSearch(event.key);
+                  }
 
                   if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
                     const items = getItems().filter((item) => !item.disabled);
@@ -1602,7 +1612,8 @@ function useTypeaheadSearch(onSearchChange: (search: string) => void) {
 
   const handleTypeaheadSearch = React.useCallback(
     (key: string) => {
-      const search = searchRef.current + key;
+      const isBackspaceKey = key === 'Backspace';
+      const search = isBackspaceKey ? '' : searchRef.current + key;
       handleSearchChange(search);
 
       (function updateSearch(value: string) {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

closes https://github.com/radix-ui/primitives/issues/2636

### Description

<!-- Describe the change you are introducing -->

This pull request introduces an improvement to the type-ahead feature in the Radix Select component. The key enhancement is the implementation of backspace functionality for the Select component. 

When a user is utilizing typeahead to search through options in the select menu, pressing the backspace key will now reset the typeahead input.

This change aligns the component's behavior more closely with standard input expectations and enhances the overall user experience by providing a more intuitive and efficient method for correcting typos or modifying search terms.

I have also thoroughly tested it and added integration tests for the typeahead backspace functionality in the Select component.

I added videos showing the native macOS select backspace functionality, the backspace functionality proposed to the Radix Select component, and the current Select component not responding to backspaces.

### backspace functionality on macOS using Chrome:

https://github.com/radix-ui/primitives/assets/53095479/0691ca12-0db5-4a4b-ab8a-93e46bd233fb

### New backspace functionality with Radix Select

https://github.com/radix-ui/primitives/assets/53095479/a7d80ede-c446-46fd-b34f-e0748352b414

### Previous non-implemented backspace functionality with Radix Select

https://github.com/radix-ui/primitives/assets/53095479/d4987443-3dde-4b4c-bfbf-459251283321

