### PR TITLE
feat(react-select): create number type support for value

### DIFF
--- a/.yarn/versions/c0096325.yml
+++ b/.yarn/versions/c0096325.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-select": patch

--- a/.yarn/versions/c0096325.yml
+++ b/.yarn/versions/c0096325.yml
@@ -1,2 +1,3 @@
 releases:
   "@radix-ui/react-select": patch
+  primitives: patch

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -57,7 +57,7 @@ export const Styled = () => (
 );
 
 export const Controlled = () => {
-  const [value, setValue] = React.useState('uk');
+  const [value, setValue] = React.useState<string | number>('uk');
   return (
     <div style={{ display: 'flex', gap: 20, padding: 50 }}>
       {POSITIONS.map((position) => (
@@ -774,7 +774,7 @@ ChromaticNoDefaultValue.parameters = { chromatic: { disable: false } };
 
 export const Cypress = () => {
   const [data, setData] = React.useState<{ size?: 'S' | 'M' | 'L' }>({});
-  const [model, setModel] = React.useState<string | undefined>('');
+  const [model, setModel] = React.useState<string | number | undefined>('');
 
   function handleChange(event: React.FormEvent<HTMLFormElement>) {
     const formData = new FormData(event.currentTarget);

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -37,7 +37,7 @@ const SELECTION_KEYS = [' ', 'Enter'];
 
 const SELECT_NAME = 'Select';
 
-type ItemData = { value: string; disabled: boolean; textValue: string };
+type ItemData = { value: string | number; disabled: boolean; textValue: string };
 const [Collection, useCollection, createCollectionScope] = createCollection<
   SelectItemElement,
   ItemData
@@ -58,8 +58,8 @@ type SelectContextValue = {
   valueNodeHasChildren: boolean;
   onValueNodeHasChildrenChange(hasChildren: boolean): void;
   contentId: string;
-  value?: string;
-  onValueChange(value: string): void;
+  value?: string | number;
+  onValueChange(value: string | number): void;
   open: boolean;
   required?: boolean;
   onOpenChange(open: boolean): void;
@@ -77,15 +77,13 @@ type SelectNativeOptionsContextValue = {
   onNativeOptionRemove(option: NativeOption): void;
 };
 const [SelectNativeOptionsProvider, useSelectNativeOptionsContext] =
-createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
-
-type Item = string | number | object;
+  createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
 
 interface SelectProps {
   children?: React.ReactNode;
-  value?: Item;
-  defaultValue?: Item;
-  onValueChange?(value: Item): void;
+  value?: string | number;
+  defaultValue?: string | number;
+  onValueChange?(value: string | number): void;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
@@ -436,12 +434,16 @@ type SelectContentContextValue = {
   content?: SelectContentElement | null;
   viewport?: SelectViewportElement | null;
   onViewportChange?: (node: SelectViewportElement | null) => void;
-  itemRefCallback?: (node: SelectItemElement | null, value: string, disabled: boolean) => void;
+  itemRefCallback?: (
+    node: SelectItemElement | null,
+    value: string | number,
+    disabled: boolean
+  ) => void;
   selectedItem?: SelectItemElement | null;
   onItemLeave?: () => void;
   itemTextRefCallback?: (
     node: SelectItemTextElement | null,
-    value: string,
+    value: string | number,
     disabled: boolean
   ) => void;
   focusSelectedItem?: () => void;
@@ -624,7 +626,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     });
 
     const itemRefCallback = React.useCallback(
-      (node: SelectItemElement | null, value: string, disabled: boolean) => {
+      (node: SelectItemElement | null, value: string | number, disabled: boolean) => {
         const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
         if (isSelectedItem || isFirstValidItem) {
@@ -636,7 +638,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     );
     const handleItemLeave = React.useCallback(() => content?.focus(), [content]);
     const itemTextRefCallback = React.useCallback(
-      (node: SelectItemTextElement | null, value: string, disabled: boolean) => {
+      (node: SelectItemTextElement | null, value: string | number, disabled: boolean) => {
         const isFirstValidItem = !firstValidItemFoundRef.current && !disabled;
         const isSelectedItem = context.value !== undefined && context.value === value;
         if (isSelectedItem || isFirstValidItem) {
@@ -1161,7 +1163,7 @@ SelectLabel.displayName = LABEL_NAME;
 const ITEM_NAME = 'SelectItem';
 
 type SelectItemContextValue = {
-  value: string;
+  value: string | number;
   disabled: boolean;
   textId: string;
   isSelected: boolean;
@@ -1173,7 +1175,7 @@ const [SelectItemContextProvider, useSelectItemContext] =
 
 type SelectItemElement = React.ElementRef<typeof Primitive.div>;
 interface SelectItemProps extends PrimitiveDivProps {
-  value: Item;
+  value: string | number;
   disabled?: boolean;
   textValue?: string;
 }
@@ -1548,7 +1550,7 @@ SelectArrow.displayName = ARROW_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function shouldShowPlaceholder(value?: string) {
+function shouldShowPlaceholder(value?: string | number) {
   return value === '' || value === undefined;
 }
 

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -77,13 +77,15 @@ type SelectNativeOptionsContextValue = {
   onNativeOptionRemove(option: NativeOption): void;
 };
 const [SelectNativeOptionsProvider, useSelectNativeOptionsContext] =
-  createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
+createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
+
+type Item = string | number | object;
 
 interface SelectProps {
   children?: React.ReactNode;
-  value?: string;
-  defaultValue?: string;
-  onValueChange?(value: string): void;
+  value?: Item;
+  defaultValue?: Item;
+  onValueChange?(value: Item): void;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
@@ -1171,7 +1173,7 @@ const [SelectItemContextProvider, useSelectItemContext] =
 
 type SelectItemElement = React.ElementRef<typeof Primitive.div>;
 interface SelectItemProps extends PrimitiveDivProps {
-  value: string;
+  value: Item;
   disabled?: boolean;
   textValue?: string;
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

1. **Type Definition Updates**: The `ItemData` type, `SelectContextValue`, `SelectProps`, `SelectContentContextValue`, `SelectItemContextValue`, and `SelectItemProps` have all been updated so that the `value` property can accept both `string` and `number` types.

2. **Function and Callback Adjustments**: Functions and callbacks that previously accepted `value` as a string now accept it as `string | number`. This includes `itemRefCallback`, `itemTextRefCallback`, and `shouldShowPlaceholder`.

3. **Component Property Changes**: Various component properties that dealt with `value` have been updated to align with the new type definition. This includes changes in `SelectContentImpl`, `SelectLabel`, `SelectItem`, and other components where `value` is used.

4. **Consistency and Robustness**: These changes ensure that the usage of `value` is consistent throughout the codebase and that the components can handle both strings and numbers, increasing the robustness of the code.

These modifications are significant as they improve the flexibility and type safety of the components involved, allowing for a more versatile and error-resistant implementation. If you're looking for a specific analysis or have a specific question about these changes, feel free to ask!
<!-- Describe the change you are introducing -->
