### PR TITLE
[Select] Fix select portal by using Presence component

### DIFF
--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -370,6 +370,11 @@ SelectIcon.displayName = ICON_NAME;
 
 const PORTAL_NAME = 'SelectPortal';
 
+type PortalContextValue = { forceMount?: true };
+const [PortalProvider, usePortalContext] = createSelectContext<PortalContextValue>(PORTAL_NAME, {
+  forceMount: undefined,
+});
+
 type PortalProps = React.ComponentPropsWithoutRef<typeof PortalPrimitive>;
 interface SelectPortalProps {
   children?: React.ReactNode;
@@ -377,10 +382,25 @@ interface SelectPortalProps {
    * Specify a container element to portal the content into.
    */
   container?: PortalProps['container'];
+  /**
+   * Used to force mounting when more control is needed. Useful when
+   * controlling animation with React animation libraries.
+   */
+  forceMount?: true;
 }
 
 const SelectPortal: React.FC<SelectPortalProps> = (props: ScopedProps<SelectPortalProps>) => {
-  return <PortalPrimitive asChild {...props} />;
+  const { __scopeSelect, forceMount, children, container } = props;
+  const context = useSelectContext(PORTAL_NAME, __scopeSelect);
+  return (
+    <PortalProvider scope={__scopeSelect} forceMount={forceMount}>
+      <Presence present={forceMount || context.open}>
+        <PortalPrimitive asChild container={container}>
+          {children}
+        </PortalPrimitive>
+      </Presence>
+    </PortalProvider>
+  );
 };
 
 SelectPortal.displayName = PORTAL_NAME;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
When Select with portal was used inside a component like Dialog, Popover, etc., it was being rendered before the portal of the parent element, causing it to be shown behind it because of stacking context HTML tag order priority
<!-- Describe the change you are introducing -->

With this change, it will be possible to control the mount of Select.Portal, solving the stacking problem and also allowing to be controlled by js animation libraries
