### PR TITLE
Fix isFormControl to check if form attribute is defined (checkbox, radio-group, select, slider, switch)

### DIFF
--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -50,13 +50,14 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
       disabled,
       value = 'on',
       onCheckedChange,
+      form,
       ...checkboxProps
     } = props;
     const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || form !== undefined : true;
     const [checked = false, setChecked] = useControllableState({
       prop: checkedProp,
       defaultProp: defaultChecked,
@@ -109,6 +110,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
             checked={checked}
             required={required}
             disabled={disabled}
+            form={form}
             // We transform because the input is absolutely positioned but we have
             // rendered it **after** the button. This pulls it back to sit on top
             // of the button.

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -56,7 +56,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
     const [checked = false, setChecked] = useControllableState({
       prop: checkedProp,
       defaultProp: defaultChecked,

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -40,13 +40,14 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
       disabled,
       value = 'on',
       onCheck,
+      form,
       ...radioProps
     } = props;
     const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || form !== undefined : true;
 
     return (
       <RadioProvider scope={__scopeRadio} checked={checked} disabled={disabled}>
@@ -81,6 +82,7 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
             checked={checked}
             required={required}
             disabled={disabled}
+            form={form}
             // We transform because the input is absolutely positioned but we have
             // rendered it **after** the button. This pulls it back to sit on top
             // of the button.

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -46,7 +46,7 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
 
     return (
       <RadioProvider scope={__scopeRadio} checked={checked} disabled={disabled}>

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -128,7 +128,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const triggerPointerDownPosRef = React.useRef<{ x: number; y: number } | null>(null);
 
   // We set this to true by default so that events bubble to forms without JS (SSR)
-  const isFormControl = trigger ? Boolean(trigger.closest('form')) : true;
+  const isFormControl = trigger ? Boolean(trigger.closest('form')) || Boolean(trigger.form) : true;
   const [nativeOptionsSet, setNativeOptionsSet] = React.useState(new Set<NativeOption>());
 
   // The native `select` only associates the correct default value if the corresponding

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -92,6 +92,7 @@ interface SelectProps {
   autoComplete?: string;
   disabled?: boolean;
   required?: boolean;
+  form?: string;
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -109,6 +110,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     autoComplete,
     disabled,
     required,
+    form,
   } = props;
   const popperScope = usePopperScope(__scopeSelect);
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
@@ -128,7 +130,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const triggerPointerDownPosRef = React.useRef<{ x: number; y: number } | null>(null);
 
   // We set this to true by default so that events bubble to forms without JS (SSR)
-  const isFormControl = trigger ? Boolean(trigger.closest('form')) || Boolean(trigger.form) : true;
+  const isFormControl = trigger ? Boolean(trigger.closest('form')) || form !== undefined : true;
   const [nativeOptionsSet, setNativeOptionsSet] = React.useState(new Set<NativeOption>());
 
   // The native `select` only associates the correct default value if the corresponding
@@ -190,6 +192,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             // enable form autofill
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
+            form={form}
           >
             {value === undefined ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -71,6 +71,7 @@ interface SliderProps
   onValueChange?(value: number[]): void;
   onValueCommit?(value: number[]): void;
   inverted?: boolean;
+  form?: string;
 }
 
 const Slider = React.forwardRef<SliderElement, SliderProps>(
@@ -88,6 +89,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
       onValueChange = () => {},
       onValueCommit = () => {},
       inverted = false,
+      form,
       ...sliderProps
     } = props;
     const [slider, setSlider] = React.useState<HTMLSpanElement | null>(null);
@@ -96,7 +98,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
     const valueIndexToChangeRef = React.useRef<number>(0);
     const isHorizontal = orientation === 'horizontal';
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = slider ? Boolean(slider.closest('form')) : true;
+    const isFormControl = slider ? Boolean(slider.closest('form')) || form !== undefined : true;
     const SliderOrientation = isHorizontal ? SliderHorizontal : SliderVertical;
 
     const [values = [], setValues] = useControllableState({
@@ -195,6 +197,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
               key={index}
               name={name ? name + (values.length > 1 ? '[]' : '') : undefined}
               value={value}
+              form={form}
             />
           ))}
       </SliderProvider>

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -48,7 +48,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
     const [checked = false, setChecked] = useControllableState({
       prop: checkedProp,
       defaultProp: defaultChecked,

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -42,13 +42,14 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
       disabled,
       value = 'on',
       onCheckedChange,
+      form,
       ...switchProps
     } = props;
     const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
     const hasConsumerStoppedPropagationRef = React.useRef(false);
     // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? Boolean(button.closest('form')) || Boolean(button.form) : true;
+    const isFormControl = button ? Boolean(button.closest('form')) || form !== undefined : true;
     const [checked = false, setChecked] = useControllableState({
       prop: checkedProp,
       defaultProp: defaultChecked,
@@ -88,6 +89,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
             checked={checked}
             required={required}
             disabled={disabled}
+            form={form}
             // We transform because the input is absolutely positioned but we have
             // rendered it **after** the button. This pulls it back to sit on top
             // of the button.


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

In some situations it is useful to render form inputs outside of a form. Inputs have a [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form) attribute where you can specify which form the input is associated with. This PR fixes the `isFormControl` check to not only check if the input is contained in a form but to also check if the form attribute has been specified. It also passes the form attribute to the hidden input so that it will be submitted correctly.

Fixes #2530 
