### PR TITLE
[Select] add new prop to SelectContent to account for shadow dom rendering

### DIFF
--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -4,57 +4,133 @@ import * as Select from '@radix-ui/react-select';
 import { Label } from '@radix-ui/react-label';
 import * as Dialog from '@radix-ui/react-dialog';
 import { foodGroups } from '../../../../test-data/foods';
+import { Portal } from '@radix-ui/react-portal';
 
 export default { title: 'Components/Select' };
 
 const POSITIONS = ['item-aligned', 'popper'] as const;
 
-export const Styled = () => (
-  <div style={{ display: 'flex', gap: 20, padding: 50 }}>
-    {POSITIONS.map((position) => (
-      <Label key={position}>
-        Choose a number:
-        <Select.Root defaultValue="two">
-          <Select.Trigger className={triggerClass()}>
-            <Select.Value />
-            <Select.Icon />
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Content className={contentClass()} position={position} sideOffset={5}>
-              <Select.Viewport className={viewportClass()}>
-                <Select.Item className={itemClass()} value="one">
-                  <Select.ItemText>
-                    One<span aria-hidden> 👍</span>
-                  </Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-                <Select.Item className={itemClass()} value="two">
-                  <Select.ItemText>
-                    Two<span aria-hidden> 👌</span>
-                  </Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-                <Select.Item className={itemClass()} value="three">
-                  <Select.ItemText>
-                    Three<span aria-hidden> 🤘</span>
-                  </Select.ItemText>
-                  <Select.ItemIndicator className={indicatorClass()}>
-                    <TickIcon />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              </Select.Viewport>
-              <Select.Arrow />
-            </Select.Content>
-          </Select.Portal>
-        </Select.Root>
-      </Label>
-    ))}
-  </div>
-);
+export const Styled = () => {
+  const appendShadowRootToBody = () => {
+    const SHADOW_HOST = 'SHADOW_HOST';
+    const REACT_ROOT = 'REACT_ROOT';
+
+    const prevShadowHost = document.querySelector(`#${SHADOW_HOST}`);
+    if (prevShadowHost) return prevShadowHost;
+    const shadowHost = document.createElement('div');
+    shadowHost.setAttribute('id', SHADOW_HOST);
+
+    const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = `
+         <div id=${REACT_ROOT} />
+         `;
+    document.body.appendChild(shadowHost);
+
+    return shadowRoot;
+  };
+
+  appendShadowRootToBody();
+
+  const shadow = document.querySelector(`#SHADOW_HOST`)?.shadowRoot;
+  const reactRoot = shadow?.querySelector(`#REACT_ROOT`);
+
+  return (
+    <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+      {POSITIONS.map((position) => (
+        <Label key={position}>
+          Choose a number:
+          <Select.Root defaultValue="two">
+            <Select.Trigger className={triggerClass()}>
+              <Select.Value />
+              <Select.Icon />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content className={contentClass()} position={position} sideOffset={5}>
+                <Select.Viewport className={viewportClass()}>
+                  <Select.Item className={itemClass()} value="one">
+                    <Select.ItemText>
+                      One<span aria-hidden> 👍</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={itemClass()} value="two">
+                    <Select.ItemText>
+                      Two<span aria-hidden> 👌</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={itemClass()} value="three">
+                    <Select.ItemText>
+                      Three<span aria-hidden> 🤘</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={indicatorClass()}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                </Select.Viewport>
+                <Select.Arrow />
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
+        </Label>
+      ))}
+
+      {POSITIONS.map((position) => (
+        <Portal container={(reactRoot as HTMLElement) || document.body}>
+          <Label key={position}>
+            Choose a number (rendered in shadow dom):
+            <Select.Root defaultValue="two">
+              <Select.Trigger className={triggerClass()}>
+                <Select.Value />
+                <Select.Icon />
+              </Select.Trigger>
+              <Select.Portal container={(reactRoot as HTMLElement) || document.body}>
+                <Select.Content
+                  className={contentClass()}
+                  position={position}
+                  sideOffset={5}
+                  shadowRoot={shadow as ShadowRoot}
+                >
+                  <Select.Viewport className={viewportClass()}>
+                    <Select.Item className={itemClass()} value="one">
+                      <Select.ItemText>
+                        One<span aria-hidden> 👍</span>
+                      </Select.ItemText>
+                      <Select.ItemIndicator className={indicatorClass()}>
+                        <TickIcon />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                    <Select.Item className={itemClass()} value="two">
+                      <Select.ItemText>
+                        Two<span aria-hidden> 👌</span>
+                      </Select.ItemText>
+                      <Select.ItemIndicator className={indicatorClass()}>
+                        <TickIcon />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                    <Select.Item className={itemClass()} value="three">
+                      <Select.ItemText>
+                        Three<span aria-hidden> 🤘</span>
+                      </Select.ItemText>
+                      <Select.ItemIndicator className={indicatorClass()}>
+                        <TickIcon />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                  </Select.Viewport>
+                  <Select.Arrow />
+                </Select.Content>
+              </Select.Portal>
+            </Select.Root>
+          </Label>
+        </Portal>
+      ))}
+    </div>
+  );
+};
 
 export const Controlled = () => {
   const [value, setValue] = React.useState('uk');

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -480,6 +480,7 @@ interface SelectContentImplProps
   onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
 
   position?: 'item-aligned' | 'popper';
+  shadowRoot?: ShadowRoot;
 }
 
 const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectContentImplProps>(
@@ -516,6 +517,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const getItems = useCollection(__scopeSelect);
     const [isPositioned, setIsPositioned] = React.useState(false);
     const firstValidItemFoundRef = React.useRef(false);
+    const activeElement = props.shadowRoot?.activeElement || document.activeElement;
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
     React.useEffect(() => {
@@ -531,7 +533,8 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
         const [firstItem, ...restItems] = getItems().map((item) => item.ref.current);
         const [lastItem] = restItems.slice(-1);
 
-        const PREVIOUSLY_FOCUSED_ELEMENT = document.activeElement;
+        const PREVIOUSLY_FOCUSED_ELEMENT = activeElement;
+
         for (const candidate of candidates) {
           // if focus is already where we want to go, we don't want to keep going through the candidates
           if (candidate === PREVIOUSLY_FOCUSED_ELEMENT) return;
@@ -610,7 +613,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
 
     const [searchRef, handleTypeaheadSearch] = useTypeaheadSearch((search) => {
       const enabledItems = getItems().filter((item) => !item.disabled);
-      const currentItem = enabledItems.find((item) => item.ref.current === document.activeElement);
+      const currentItem = enabledItems.find((item) => item.ref.current === activeElement);
       const nextItem = findNextItem(enabledItems, search, currentItem);
       if (nextItem) {
         /**
@@ -733,7 +736,6 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                   if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
                     const items = getItems().filter((item) => !item.disabled);
                     let candidateNodes = items.map((item) => item.ref.current!);
-
                     if (['ArrowUp', 'End'].includes(event.key)) {
                       candidateNodes = candidateNodes.slice().reverse();
                     }


### PR DESCRIPTION
### Description

Fix for https://github.com/radix-ui/primitives/issues/2606 .
Select arrow navigation depends on `document.activeElement`. But if the select is rendered in shadow dom, `document.activeElement` returns top level element in the shadow dom. This breaks the keyboard navigation. 

I edited the keyboard handler to check if select is in shadow dom then get the active element from it.
B