### PR TITLE
feature: use onBlur instead of native change event on FormControl change (Form package)

### DIFF
--- a/packages/react/form/src/Form.tsx
+++ b/packages/react/form/src/Form.tsx
@@ -352,17 +352,6 @@ const FormControl = React.forwardRef<FormControlElement, FormControlProps>(
       [customMatcherEntries, name, onFieldCustomErrorsChange, onFieldValidityChange]
     );
 
-    React.useEffect(() => {
-      const control = ref.current;
-      if (control) {
-        // We only want validate on change (native `change` event, not React's `onChange`). This is primarily
-        // a UX decision, we don't want to validate on every keystroke and React's `onChange` is the `input` event.
-        const handleChange = () => updateControlValidity(control);
-        control.addEventListener('change', handleChange);
-        return () => control.removeEventListener('change', handleChange);
-      }
-    }, [updateControlValidity]);
-
     const resetControlValidity = React.useCallback(() => {
       const control = ref.current;
       if (control) {
@@ -411,6 +400,10 @@ const FormControl = React.forwardRef<FormControlElement, FormControlProps>(
         onChange={composeEventHandlers(props.onChange, (event) => {
           // reset validity when user changes value
           resetControlValidity();
+        })}
+        onBlur={composeEventHandlers(props.onBlur, (event) => {
+          const control = event.currentTarget;
+          updateControlValidity(control);
         })}
       />
     );


### PR DESCRIPTION
### Description
I think using React's onBlur event is a better choice here for a few reasons:
1) Imagine a hypothetical situation when user types incorrect input, he then clicks outside and input loose focus. Now the native onChange event is fired and the field is correctly marked as invalid. So the user goes back, fixes the input, field is marked as valid because of the `resetControlValidity();` call on line 402. So far so good, but the user types again and unfortunately makes the same mistake as before and ends up with the same incorrect value in the input. If he now clicks outside and the input loses focus, the native onChange event is not fired at all because the value is the same as before. So the user is left with an incorrectly filled input without even realising it.
2) It's less code, and you don't have to escape from the React event system to native events.
