### PR TITLE
feat: make `data-state` more explicit

### DIFF
--- a/packages/react/accordion/src/Accordion.tsx
+++ b/packages/react/accordion/src/Accordion.tsx
@@ -391,6 +391,7 @@ const AccordionItem = React.forwardRef<AccordionItemElement, AccordionItemProps>
         <CollapsiblePrimitive.Root
           data-orientation={accordionContext.orientation}
           data-state={getState(open)}
+          data-accordion-state={getState(open)}
           {...collapsibleScope}
           {...accordionItemProps}
           ref={forwardedRef}
@@ -434,6 +435,7 @@ const AccordionHeader = React.forwardRef<AccordionHeaderElement, AccordionHeader
       <Primitive.h3
         data-orientation={accordionContext.orientation}
         data-state={getState(itemContext.open)}
+        data-accordion-state={getState(itemContext.open)}
         data-disabled={itemContext.disabled ? '' : undefined}
         {...headerProps}
         ref={forwardedRef}

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -80,6 +80,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
           aria-checked={isIndeterminate(checked) ? 'mixed' : checked}
           aria-required={required}
           data-state={getState(checked)}
+          data-checkbox-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           value={value}
@@ -146,6 +147,7 @@ const CheckboxIndicator = React.forwardRef<CheckboxIndicatorElement, CheckboxInd
       <Presence present={forceMount || isIndeterminate(context.state) || context.state === true}>
         <Primitive.span
           data-state={getState(context.state)}
+          data-checkbox-state={getState(context.state)}
           data-disabled={context.disabled ? '' : undefined}
           {...indicatorProps}
           ref={forwardedRef}

--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -66,6 +66,7 @@ const Collapsible = React.forwardRef<CollapsibleElement, CollapsibleProps>(
       >
         <Primitive.div
           data-state={getState(open)}
+          data-collapsible-state={getState(open)}
           data-disabled={disabled ? '' : undefined}
           {...collapsibleProps}
           ref={forwardedRef}
@@ -97,6 +98,7 @@ const CollapsibleTrigger = React.forwardRef<CollapsibleTriggerElement, Collapsib
         aria-controls={context.contentId}
         aria-expanded={context.open || false}
         data-state={getState(context.open)}
+        data-collapsible-state={getState(context.open)}
         data-disabled={context.disabled ? '' : undefined}
         disabled={context.disabled}
         {...triggerProps}
@@ -206,6 +208,7 @@ const CollapsibleContentImpl = React.forwardRef<
   return (
     <Primitive.div
       data-state={getState(context.open)}
+      data-collapsible-state={getState(context.open)}
       data-disabled={context.disabled ? '' : undefined}
       id={context.contentId}
       hidden={!isOpen}

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -116,6 +116,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
         <MenuPrimitive.Anchor {...menuScope} virtualRef={virtualRef} />
         <Primitive.span
           data-state={context.open ? 'open' : 'closed'}
+          data-context-menu-state={context.open ? 'open' : 'closed'}
           data-disabled={disabled ? '' : undefined}
           {...triggerProps}
           ref={forwardedRef}

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -107,6 +107,7 @@ const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>
         aria-expanded={context.open}
         aria-controls={context.contentId}
         data-state={getState(context.open)}
+        data-dialog-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}
         onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
@@ -204,6 +205,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
       <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
         <Primitive.div
           data-state={getState(context.open)}
+          data-dialog-state={getState(context.open)}
           {...overlayProps}
           ref={forwardedRef}
           // We re-enable pointer-events prevented by `Dialog.Content` to allow scrolling the overlay.
@@ -405,6 +407,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
             aria-describedby={context.descriptionId}
             aria-labelledby={context.titleId}
             data-state={getState(context.open)}
+            data-dialog-state={getState(context.open)}
             {...contentProps}
             ref={composedRefs}
             onDismiss={() => context.onOpenChange(false)}

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -110,6 +110,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           aria-expanded={context.open}
           aria-controls={context.open ? context.contentId : undefined}
           data-state={context.open ? 'open' : 'closed'}
+          data-dropdown-state={context.open ? 'open' : 'closed'}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           {...triggerProps}

--- a/packages/react/hover-card/src/HoverCard.tsx
+++ b/packages/react/hover-card/src/HoverCard.tsx
@@ -130,6 +130,7 @@ const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTrig
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.a
           data-state={context.open ? 'open' : 'closed'}
+          data-hover-card-state={context.open ? 'open' : 'closed'}
           {...triggerProps}
           ref={forwardedRef}
           onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
@@ -213,6 +214,7 @@ const HoverCardContent = React.forwardRef<HoverCardContentElement, HoverCardCont
       <Presence present={forceMount || context.open}>
         <HoverCardContentImpl
           data-state={context.open ? 'open' : 'closed'}
+          data-hover-card-state={context.open ? 'open' : 'closed'}
           {...contentProps}
           onPointerEnter={composeEventHandlers(props.onPointerEnter, excludeTouch(context.onOpen))}
           onPointerLeave={composeEventHandlers(props.onPointerLeave, excludeTouch(context.onClose))}

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -498,6 +498,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                   role="menu"
                   aria-orientation="vertical"
                   data-state={getOpenState(context.open)}
+                  data-menu-state={getOpenState(context.open)}
                   data-radix-menu-content=""
                   dir={rootContext.dir}
                   {...popperScope}
@@ -774,6 +775,7 @@ const MenuCheckboxItem = React.forwardRef<MenuCheckboxItemElement, MenuCheckboxI
           {...checkboxItemProps}
           ref={forwardedRef}
           data-state={getCheckedState(checked)}
+          data-menu-state={getCheckedState(checked)}
           onSelect={composeEventHandlers(
             checkboxItemProps.onSelect,
             () => onCheckedChange?.(isIndeterminate(checked) ? true : !checked),
@@ -842,6 +844,7 @@ const MenuRadioItem = React.forwardRef<MenuRadioItemElement, MenuRadioItemProps>
           {...radioItemProps}
           ref={forwardedRef}
           data-state={getCheckedState(checked)}
+          data-menu-state={getCheckedState(checked)}
           onSelect={composeEventHandlers(
             radioItemProps.onSelect,
             () => context.onValueChange?.(value),
@@ -894,6 +897,7 @@ const MenuItemIndicator = React.forwardRef<MenuItemIndicatorElement, MenuItemInd
           {...itemIndicatorProps}
           ref={forwardedRef}
           data-state={getCheckedState(indicatorContext.checked)}
+          data-menu-state={getCheckedState(indicatorContext.checked)}
         />
       </Presence>
     );
@@ -1049,6 +1053,7 @@ const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, MenuSubTriggerPro
           aria-expanded={context.open}
           aria-controls={subContext.contentId}
           data-state={getOpenState(context.open)}
+          data-menu-state={getOpenState(context.open)}
           {...props}
           ref={composeRefs(forwardedRef, subContext.onTriggerChange)}
           // This is redundant for mouse users but we cannot determine pointer type from

--- a/packages/react/menubar/src/Menubar.tsx
+++ b/packages/react/menubar/src/Menubar.tsx
@@ -236,6 +236,7 @@ const MenubarTrigger = React.forwardRef<MenubarTriggerElement, MenubarTriggerPro
               aria-controls={open ? menuContext.contentId : undefined}
               data-highlighted={isFocused ? '' : undefined}
               data-state={open ? 'open' : 'closed'}
+              data-menubar-state={open ? 'open' : 'closed'}
               data-disabled={disabled ? '' : undefined}
               disabled={disabled}
               {...triggerProps}

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -498,6 +498,7 @@ const NavigationMenuTrigger = React.forwardRef<
             disabled={disabled}
             data-disabled={disabled ? '' : undefined}
             data-state={getOpenState(open)}
+            data-navigation-menu-state={getOpenState(open)}
             aria-expanded={open}
             aria-controls={contentId}
             {...triggerProps}
@@ -708,6 +709,7 @@ const NavigationMenuIndicatorImpl = React.forwardRef<
     <Primitive.div
       aria-hidden
       data-state={isVisible ? 'visible' : 'hidden'}
+      data-navigation-state={isVisible ? 'visible' : 'hidden'}
       data-orientation={context.orientation}
       {...indicatorProps}
       ref={forwardedRef}
@@ -770,6 +772,7 @@ const NavigationMenuContent = React.forwardRef<
     <Presence present={forceMount || open}>
       <NavigationMenuContentImpl
         data-state={getOpenState(open)}
+        data-navigation-state={getOpenState(open)}
         {...commonProps}
         ref={composedRefs}
         onPointerEnter={composeEventHandlers(props.onPointerEnter, context.onContentEnter)}
@@ -1046,6 +1049,7 @@ const NavigationMenuViewportImpl = React.forwardRef<
   return (
     <Primitive.div
       data-state={getOpenState(open)}
+      data-navigation-state={getOpenState(open)}
       data-orientation={context.orientation}
       {...viewportImplProps}
       ref={composedRefs}

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -146,6 +146,7 @@ const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerPro
         aria-expanded={context.open}
         aria-controls={context.contentId}
         data-state={getState(context.open)}
+        data-popover-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}
         onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
@@ -416,6 +417,7 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
         >
           <PopperPrimitive.Content
             data-state={getState(context.open)}
+            data-popover-state={getState(context.open)}
             role="dialog"
             id={context.contentId}
             {...popperScope}

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -51,6 +51,7 @@ const Progress = React.forwardRef<ProgressElement, ProgressProps>(
           aria-valuetext={valueLabel}
           role="progressbar"
           data-state={getProgressState(value, max)}
+          data-progress-state={getProgressState(value, max)}
           data-value={value ?? undefined}
           data-max={max}
           {...progressProps}
@@ -99,6 +100,7 @@ const ProgressIndicator = React.forwardRef<ProgressIndicatorElement, ProgressInd
     return (
       <Primitive.div
         data-state={getProgressState(context.value, context.max)}
+        data-progress-state={getProgressState(context.value, context.max)}
         data-value={context.value ?? undefined}
         data-max={context.max}
         {...indicatorProps}

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -55,6 +55,7 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
           role="radio"
           aria-checked={checked}
           data-state={getState(checked)}
+          data-radio-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           value={value}
@@ -118,6 +119,7 @@ const RadioIndicator = React.forwardRef<RadioIndicatorElement, RadioIndicatorPro
       <Presence present={forceMount || context.checked}>
         <Primitive.span
           data-state={getState(context.checked)}
+          data-radio-state={getState(context.checked)}
           data-disabled={context.disabled ? '' : undefined}
           {...indicatorProps}
           ref={forwardedRef}

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -270,6 +270,7 @@ const ScrollAreaScrollbarHover = React.forwardRef<
     <Presence present={forceMount || visible}>
       <ScrollAreaScrollbarAuto
         data-state={visible ? 'visible' : 'hidden'}
+        data-scroll-area-state={visible ? 'visible' : 'hidden'}
         {...scrollbarProps}
         ref={forwardedRef}
       />
@@ -340,6 +341,7 @@ const ScrollAreaScrollbarScroll = React.forwardRef<
     <Presence present={forceMount || state !== 'hidden'}>
       <ScrollAreaScrollbarVisible
         data-state={state === 'hidden' ? 'hidden' : 'visible'}
+        data-scroll-area-state={state === 'hidden' ? 'hidden' : 'visible'}
         {...scrollbarProps}
         ref={forwardedRef}
         onPointerEnter={composeEventHandlers(props.onPointerEnter, () => send('POINTER_ENTER'))}
@@ -377,6 +379,7 @@ const ScrollAreaScrollbarAuto = React.forwardRef<
     <Presence present={forceMount || visible}>
       <ScrollAreaScrollbarVisible
         data-state={visible ? 'visible' : 'hidden'}
+        data-scroll-area-state={visible ? 'visible' : 'hidden'}
         {...scrollbarProps}
         ref={forwardedRef}
       />
@@ -808,6 +811,7 @@ const ScrollAreaThumbImpl = React.forwardRef<ScrollAreaThumbImplElement, ScrollA
     return (
       <Primitive.div
         data-state={scrollbarContext.hasThumb ? 'visible' : 'hidden'}
+        data-scroll-area-state={scrollbarContext.hasThumb ? 'visible' : 'hidden'}
         {...thumbProps}
         ref={composedRef}
         style={{

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -249,6 +249,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
           aria-autocomplete="none"
           dir={context.dir}
           data-state={context.open ? 'open' : 'closed'}
+          data-select-state={context.open ? 'open' : 'closed'}
           disabled={isDisabled}
           data-disabled={isDisabled ? '' : undefined}
           data-placeholder={shouldShowPlaceholder(context.value) ? '' : undefined}
@@ -708,6 +709,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
                 role="listbox"
                 id={context.contentId}
                 data-state={context.open ? 'open' : 'closed'}
+                data-select-state={context.open ? 'open' : 'closed'}
                 dir={context.dir}
                 onContextMenu={(event) => event.preventDefault()}
                 {...contentProps}
@@ -1232,6 +1234,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             // `isFocused` caveat fixes stuttering in VoiceOver
             aria-selected={isSelected && isFocused}
             data-state={isSelected ? 'checked' : 'unchecked'}
+            data-select-state={isSelected ? 'checked' : 'unchecked'}
             aria-disabled={disabled || undefined}
             data-disabled={disabled ? '' : undefined}
             tabIndex={disabled ? undefined : -1}

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -63,6 +63,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
           aria-checked={checked}
           aria-required={required}
           data-state={getState(checked)}
+          data-switch-state={getState(checked)}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           value={value}
@@ -118,6 +119,7 @@ const SwitchThumb = React.forwardRef<SwitchThumbElement, SwitchThumbProps>(
     return (
       <Primitive.span
         data-state={getState(context.checked)}
+        data-switch-state={getState(context.checked)}
         data-disabled={context.disabled ? '' : undefined}
         {...thumbProps}
         ref={forwardedRef}

--- a/packages/react/tabs/src/Tabs.tsx
+++ b/packages/react/tabs/src/Tabs.tsx
@@ -173,7 +173,7 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
           role="tab"
           aria-selected={isSelected}
           aria-controls={contentId}
-          data-state={isSelected ? 'active' : 'inactive'}
+          data-tab-state={isSelected ? 'active' : 'inactive'}
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           id={triggerId}
@@ -244,6 +244,7 @@ const TabsContent = React.forwardRef<TabsContentElement, TabsContentProps>(
         {({ present }) => (
           <Primitive.div
             data-state={isSelected ? 'active' : 'inactive'}
+            data-tab-state={isSelected ? 'active' : 'inactive'}
             data-orientation={context.orientation}
             role="tabpanel"
             aria-labelledby={triggerId}

--- a/packages/react/toast/src/Toast.tsx
+++ b/packages/react/toast/src/Toast.tsx
@@ -580,6 +580,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                   aria-atomic
                   tabIndex={0}
                   data-state={open ? 'open' : 'closed'}
+                  data-toast-state={open ? 'open' : 'closed'}
                   data-swipe-direction={context.swipeDirection}
                   {...toastProps}
                   ref={composedRefs}

--- a/packages/react/toggle/src/Toggle.tsx
+++ b/packages/react/toggle/src/Toggle.tsx
@@ -44,6 +44,7 @@ const Toggle = React.forwardRef<ToggleElement, ToggleProps>((props, forwardedRef
       type="button"
       aria-pressed={pressed}
       data-state={pressed ? 'on' : 'off'}
+      data-toast-state={pressed ? 'on' : 'off'}
       data-disabled={props.disabled ? '' : undefined}
       {...buttonProps}
       ref={forwardedRef}

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -278,6 +278,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
           // commonly anchors and the anchor `type` attribute signifies MIME type.
           aria-describedby={context.open ? context.contentId : undefined}
           data-state={context.stateAttribute}
+          data-tooltip-state={context.stateAttribute}
           {...triggerProps}
           ref={composedRefs}
           onPointerMove={composeEventHandlers(props.onPointerMove, (event) => {
@@ -533,6 +534,7 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
       >
         <PopperPrimitive.Content
           data-state={context.stateAttribute}
+          data-tooltip-state={context.stateAttribute}
           {...popperScope}
           {...contentProps}
           ref={forwardedRef}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

- fixes https://github.com/radix-ui/primitives/issues/602
- ref https://github.com/radix-ui/primitives/discussions/560#discussioncomment-3115606

Reading the comments from the discussion, I made the `date-state` more explicit by adding the name of the radix component. This feature will help the namespace of `data-state` be more clean.

I think leaving the `data-state` as a legacy and adding `data-[component]-state` will be good for now. For next major update, we can drop the support for the `data-state`.

If the maintainers agree on this approach, I can update all the storybook examples to new `data-state` representation as well. Please, any feedback is appreciated!!!