### PR TITLE
[RovingFocusGroup] Move only with single arrow keys

### DIFF
--- a/.yarn/versions/f4333956.yml
+++ b/.yarn/versions/f4333956.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
+
+declined:
+  - primitives

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -261,6 +261,7 @@ const RovingFocusGroupItem = React.forwardRef<RovingFocusItemElement, RovingFocu
             const focusIntent = getFocusIntent(event, context.orientation, context.dir);
 
             if (focusIntent !== undefined) {
+              if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
               event.preventDefault();
               const items = getItems().filter((item) => item.focusable);
               let candidateNodes = items.map((item) => item.ref.current!);


### PR DESCRIPTION
Fixes #2732