### PR TITLE
fix(Popper): use `visibility` to hide instead of `opacity`

### DIFF
--- a/.yarn/versions/5793010b.yml
+++ b/.yarn/versions/5793010b.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -268,7 +268,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
               // we prevent animations so that users's animation don't kick in too early referring wrong sides
               animation: !isPositioned ? 'none' : undefined,
               // hide the content if using the hide middleware and should be hidden
-              opacity: middlewareData.hide?.referenceHidden ? 0 : undefined,
+              visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible',
             }}
           />
         </PopperContentProvider>

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -268,7 +268,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
               // we prevent animations so that users's animation don't kick in too early referring wrong sides
               animation: !isPositioned ? 'none' : undefined,
               // hide the content if using the hide middleware and should be hidden
-              visibility: middlewareData.hide?.referenceHidden ? 'hidden' : 'visible',
+              visibility: middlewareData.hide?.referenceHidden ? 'hidden' : undefined,
             }}
           />
         </PopperContentProvider>


### PR DESCRIPTION
When using `hideWhenDetached`, the opacity is changed to 0 instead of the visibility. This lets users click items that they cannot see. This is generally a bad user experience.

This patch updates the `Popper` to set the `visibility` to `hidden` when `hideWhenDetached` is used. This ensures the user cannot interact with the hidden element.

This aligns with what is in the `@floating-ui/react-dom` documentation.

Ref: https://floating-ui.com/docs/hide#usage

Closes: https://github.com/radix-ui/primitives/issues/2743

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
