### PR TITLE
fix: (@radix-ui/react-tooltip) only allow content to be dismissed by trigger if visible

### DIFF
--- a/packages/react/tooltip/src/Tooltip.test.tsx
+++ b/packages/react/tooltip/src/Tooltip.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import userEvent from '@testing-library/user-event';
+
+describe('Tooltip', () => {
+    it('renders tooltip trigger', () => {
+        render(
+            <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                Tooltip Trigger
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content>
+                    Tooltip Content
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        );
+
+        expect(screen.getByText('Tooltip Trigger')).toBeInTheDocument();
+        expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+    });
+
+    it('renders tooltip content when trigger is hovered', async () => {
+        render(
+            <Tooltip.Provider>
+            <Tooltip.Root delayDuration={0}>
+              <Tooltip.Trigger>
+                Tooltip Trigger
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content>
+                    Tooltip Content
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        );
+
+        const trigger = screen.getByText('Tooltip Trigger');
+        expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+
+        userEvent.hover(trigger);
+        await waitFor(() => {
+            // Get the first instance of the tooltip content because the second is
+            // the visually hidden primitive.
+            expect(screen.queryAllByText('Tooltip Content')[0]).toBeVisible();
+        });
+    });
+
+    it('renders tooltip content is dismissed when trigger is clicked', async () => {
+        render(
+            <Tooltip.Provider>
+            <Tooltip.Root delayDuration={0}>
+              <Tooltip.Trigger>
+                Tooltip Trigger
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content>
+                    Tooltip Content
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        );
+
+        const trigger = screen.getByText('Tooltip Trigger');
+        expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+
+        userEvent.hover(trigger);
+        await waitFor(() => {
+            // Get the first instance of the tooltip content because the second is
+            // the visually hidden primitive.
+            expect(screen.queryAllByText('Tooltip Content')[0]).toBeVisible();
+        });
+
+        userEvent.click(trigger);
+        await waitFor(() => {
+            expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+        });
+    });
+
+    it('trigger click does not prevent tooltip content from initially appearing', async () => {
+        render(
+            <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                Tooltip Trigger
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content>
+                    Tooltip Content
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        );
+
+        const trigger = screen.getByText('Tooltip Trigger');
+        expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+
+        userEvent.click(trigger);
+        await waitFor(() => {
+            expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+        });
+
+        userEvent.hover(trigger);
+        await waitFor(() => {
+            // Get the first instance of the tooltip content because the second is
+            // the visually hidden primitive.
+            expect(screen.queryAllByText('Tooltip Content')[0]).toBeVisible();
+        }, {timeout: 1000});
+    });
+});

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -196,9 +196,11 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
   }, [setOpen]);
 
   const handleClose = React.useCallback(() => {
-    window.clearTimeout(openTimerRef.current);
-    setOpen(false);
-  }, [setOpen]);
+    if(open) {
+      window.clearTimeout(openTimerRef.current);
+      setOpen(false);
+    }
+  }, [open, setOpen]);
 
   const handleDelayedOpen = React.useCallback(() => {
     window.clearTimeout(openTimerRef.current);


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

When the tooltip trigger is clicked before the content appears, it prevents the content from ever appearing. The change in PR allows the content to be dismissed only after when the content is visible. Subsequent clicks will dismiss the content and it will not appear again. This way the content will be visible to a user before they are able to dismiss it. 

Behavior before change:
https://github.com/radix-ui/primitives/assets/17918553/0ce84391-36c5-441e-872b-db839509966b

Behavior after change:
https://github.com/radix-ui/primitives/assets/17918553/5affe843-9b18-4362-a54d-fe6abc26e654

Additionally, I have added unit tests for the `Tooltip` component. The last text case demonstrates the fix this PR addresses.
