### PR TITLE
[Label] Don't eagerly prevent double-click

### DIFF
--- a/.yarn/versions/ded3a040.yml
+++ b/.yarn/versions/ded3a040.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-form": patch
+  "@radix-ui/react-label": patch
+
+declined:
+  - primitives

--- a/packages/react/label/src/Label.stories.tsx
+++ b/packages/react/label/src/Label.stories.tsx
@@ -14,6 +14,13 @@ export const WithControl = () => {
         <Control className={controlClass()} /> Label
       </Label>
 
+      <br />
+
+      <Label>
+        <span>Name:</span>
+        <input type="number" />
+      </Label>
+
       <h1>Referencing control</h1>
       <Control id="control" className={controlClass()} />
       <Label htmlFor="control">Label</Label>

--- a/packages/react/label/src/Label.stories.tsx
+++ b/packages/react/label/src/Label.stories.tsx
@@ -14,17 +14,19 @@ export const WithControl = () => {
         <Control className={controlClass()} /> Label
       </Label>
 
-      <br />
-
-      <Label>
-        <span>Name:</span>
-        <input type="number" />
-      </Label>
-
       <h1>Referencing control</h1>
       <Control id="control" className={controlClass()} />
       <Label htmlFor="control">Label</Label>
     </>
+  );
+};
+
+export const WithInputNumber = (props: any) => {
+  return (
+    <Label>
+      <span>Name:</span>
+      <input type="number" />
+    </Label>
   );
 };
 

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -21,7 +21,7 @@ const Label = React.forwardRef<LabelElement, LabelProps>((props, forwardedRef) =
       onMouseDown={(event) => {
         // only prevent text selection if clicking inside the label itself
         const target = event.target as HTMLElement;
-        if (target.closest('input, button')) return;
+        if (target.closest('input, button, select')) return;
 
         props.onMouseDown?.(event);
         // prevent text selection when double clicking label

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -21,7 +21,7 @@ const Label = React.forwardRef<LabelElement, LabelProps>((props, forwardedRef) =
       onMouseDown={(event) => {
         // only prevent text selection if clicking inside the label itself
         const target = event.target as HTMLElement;
-        if (target.closest('input, button, select')) return;
+        if (target.closest('button, input, select, textarea')) return;
 
         props.onMouseDown?.(event);
         // prevent text selection when double clicking label

--- a/packages/react/label/src/Label.tsx
+++ b/packages/react/label/src/Label.tsx
@@ -19,6 +19,10 @@ const Label = React.forwardRef<LabelElement, LabelProps>((props, forwardedRef) =
       {...props}
       ref={forwardedRef}
       onMouseDown={(event) => {
+        // only prevent text selection if clicking inside the label itself
+        const target = event.target as HTMLElement;
+        if (target.closest('input, button')) return;
+
         props.onMouseDown?.(event);
         // prevent text selection when double clicking label
         if (!event.defaultPrevented && event.detail > 1) event.preventDefault();


### PR DESCRIPTION
We were a bit too eager with preventing double-click, causing issues with double-clicking on arrows in a number input for example.

Fixes  #2656