### PR TITLE
[ScrolAreaViewport] Add `data-radix` attribute to the content element

### DIFF
--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -183,7 +183,11 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
            * widths that change. We'll wait to see what use-cases consumers come up with there
            * before trying to resolve it.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div
+            ref={context.onContentChange}
+            data-radix-scroll-area-viewport-content=""
+            style={{ minWidth: '100%', display: 'table' }}
+          >
             {children}
           </div>
         </Primitive.div>


### PR DESCRIPTION
I need this data attribute to query the inner div element. Trying to avoid usage of `>div`-like queries.
