### PR TITLE
Use obfusctaed reference to React.useId

### DIFF
--- a/packages/react/id/src/id.tsx
+++ b/packages/react/id/src/id.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
-// We `toString()` to prevent bundlers from trying to `import { useId } from 'react';`
-const useReactId = (React as any)['useId'.toString()] || (() => undefined);
+// We spaces with `.trim().toString()` to prevent bundlers from trying to `import { useId } from 'react';`
+const useReactId = (React as any)[' useId '.trim().toString()] || (() => undefined);
 let count = 0;
 
 function useId(deterministicId?: string): string {


### PR DESCRIPTION
allows radix to use React.useId on react v18+ and custom implementation on react@17.

proposed fix for https://github.com/radix-ui/primitives/issues/2796