### PR TITLE
[Slot] Access ref from props else fallback to element.ref

### DIFF
--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -19,7 +19,10 @@ const Presence: React.FC<PresenceProps> = (props) => {
       : React.Children.only(children)
   ) as React.ReactElement;
 
-  const ref = useComposedRefs(presence.ref, (child as any).ref);
+  // Accessing the ref from props, else fallback to element.ref
+  // https://github.com/facebook/react/pull/28348
+  const childrenRef = child.props.ref ?? (child as any).ref;
+  const ref = useComposedRefs(presence.ref, childrenRef);
   const forceMount = typeof children === 'function';
   return forceMount || presence.isPresent ? React.cloneElement(child, { ref }) : null;
 };

--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -61,9 +61,12 @@ const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) =>
   const { children, ...slotProps } = props;
 
   if (React.isValidElement(children)) {
+    // Accessing the ref from props, else fallback to element.ref
+    // https://github.com/facebook/react/pull/28348
+    const childrenRef = children.props.ref ?? (children as any).ref;
     return React.cloneElement(children, {
       ...mergeProps(slotProps, children.props),
-      ref: forwardedRef ? composeRefs(forwardedRef, (children as any).ref) : (children as any).ref,
+      ref: forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef,
     });
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

fix #2769

Starting from the React 18.3.0 canary, accessing the ref via `element.ref` will throw a warning, and `element.ref` will be removed in the future React release.

Instead, we should access the ref from props. To maintain the backward compatibility, we can do `children.props.ref ?? children.ref`.