### PR TITLE
fix: removes redundent isOpen check in collapsable menu that is preventing users from customizing behaviour

### DIFF
--- a/packages/react/collapsible/src/Collapsible.tsx
+++ b/packages/react/collapsible/src/Collapsible.tsx
@@ -217,7 +217,7 @@ const CollapsibleContentImpl = React.forwardRef<
         ...props.style,
       }}
     >
-      {isOpen && children}
+      {children}
     </Primitive.div>
   );
 });


### PR DESCRIPTION
### Description

The current implementation has both:
`hidden={!isOpen}`
`{isOpen && children}`

Not being able to control how collapsable content is shown, can cause issues when combining it with forms.
If you have form fields inside a collapsable element, the fields can end up not being mounted to the dom when the form is submitted, causing the fields not to be included in `form data`.

I dont think this is a very common use case so I dont think this needs a custom solution, but allowing the user to control the behaviour by targeting the `data-state` attribute, would be a good middleground.