### PR TITLE
Remove use of `cssText` in react-focus-guards

### DIFF
--- a/.yarn/versions/4c2c950e.yml
+++ b/.yarn/versions/4c2c950e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-focus-guards": minor

--- a/packages/react/focus-guards/src/FocusGuards.tsx
+++ b/packages/react/focus-guards/src/FocusGuards.tsx
@@ -32,7 +32,10 @@ function createFocusGuard() {
   const element = document.createElement('span');
   element.setAttribute('data-radix-focus-guard', '');
   element.tabIndex = 0;
-  element.style.cssText = 'outline: none; opacity: 0; position: fixed; pointer-events: none';
+  element.style.outline = 'none';
+  element.style.opacity = '0';
+  element.style.position = 'fixed';
+  element.style.pointerEvents = 'none';
   return element;
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

`createFocusGuard` creates a `<span>`, then applies CSS to it using `cssText`. This violates Content-Security-Policy unless `style-src: 'unsafe-inline'` is permitted. Setting the individual properties is acceptable under a strict CSP.