### PR TITLE
fix: Prevent infinite tabbing loop by checking for other active elements when tabbing out

### DIFF
--- a/packages/react/radio-group/src/RadioGroup.stories.tsx
+++ b/packages/react/radio-group/src/RadioGroup.stories.tsx
@@ -413,6 +413,36 @@ export const Chromatic = () => {
 };
 Chromatic.parameters = { chromatic: { disable: false } };
 
+export const WithLinks = () => (
+  <Label>
+    Favourite pet
+    <button>Random Focusable Element</button>
+    <RadioGroup.Root className={rootClass()} defaultValue="1" loop={false}>
+      <div className={withLinksItem()}>
+        <RadioGroup.Item className={itemClass()} value="1">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <Label>Dog</Label>
+        <a href="https://google.com">Dog Link</a>
+      </div>
+      <div className={withLinksItem()}>
+        <RadioGroup.Item className={itemClass()} value="2">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <Label>Cat</Label>
+        <a href="https://google.com">Cat Link</a>
+      </div>
+      <div className={withLinksItem()}>
+        <RadioGroup.Item className={itemClass()} value="3">
+          <RadioGroup.Indicator className={indicatorClass()} />
+        </RadioGroup.Item>
+        <Label>Rabbit</Label>
+        <a href="https://google.com">Rabbit Link</a>
+      </div>
+    </RadioGroup.Root>
+  </Label>
+);
+
 const Label = (props: any) => <LabelPrimitive {...props} style={RECOMMENDED_CSS__LABEL__ROOT} />;
 
 const rootClass = css({});
@@ -488,3 +518,9 @@ const styles = {
 const rootAttrClass = css(styles);
 const itemAttrClass = css(styles);
 const indicatorAttrClass = css(styles);
+
+const withLinksItem = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '5px',
+});

--- a/packages/react/roving-focus/src/RovingFocusGroup.tsx
+++ b/packages/react/roving-focus/src/RovingFocusGroup.tsx
@@ -188,7 +188,13 @@ const RovingFocusGroupImpl = React.forwardRef<
 
           isClickFocusRef.current = false;
         })}
-        onBlur={composeEventHandlers(props.onBlur, () => setIsTabbingBackOut(false))}
+        onBlur={composeEventHandlers(props.onBlur, () => {
+          // We are only shift+tabbing out if the currently active element is NOT
+          // not within the radio group. This can happen in cases where there is a link
+          // inside the radio group item label.
+          const hasActiveElement = ref.current?.contains(document.activeElement);
+          setIsTabbingBackOut(!hasActiveElement);
+        })}
       />
     </RovingFocusProvider>
   );


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
There is an issue with the radio group component that causes an infinite tabbing loop when it includes another focusable element.

In the following example, there is a link within the radio group. When the second radio group item is selected and a user tries to tab out (with `shift+tab`), the focus then goes to the Link element. After hitting `shift+tab` again, the focus goes back to the selected radio group item. And the user is stuck in a loop. 

https://github.com/radix-ui/primitives/assets/22824781/1bfc7a71-d8a8-425b-8294-c05fe7fcf305

This PR begins to only signify that the user is tabbing out as long as the active element is not contained within the radio group. This prevents auto-focusing to the selected radio group item and allows the user to tab out of the radio group.

https://github.com/radix-ui/primitives/assets/22824781/005f4e80-fcef-4ef7-843f-f081e73c9f78

