### PR TITLE
[Dialog] Align disableOutsidePointerEvents to trapFocus prop

### DIFF
--- a/.yarn/versions/ff2592d9.yml
+++ b/.yarn/versions/ff2592d9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-dialog": patch

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -273,7 +273,7 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
         // we make sure focus isn't trapped once `DialogContent` has been closed
         // (closed !== unmounted when animating out)
         trapFocus={context.open}
-        disableOutsidePointerEvents
+        disableOutsidePointerEvents={context.open}
         onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
           event.preventDefault();
           context.triggerRef.current?.focus();


### PR DESCRIPTION
### Description

We were trying to use `forceMount` on our Dialog implementation of the component. Our idea is to have the modals be in the DOM but not visible until the Trigger is clicked.

Doing this, we noticed that the `trapFocus` worked correctly but the `disableOutsidePointerEvents` prop was adding `pointer-events: none` to a lot of elements so you couldn't interact with the page. 

By aligning this behavior with `trapFocus`, everything works as intended and the pointer event styles aren't added if the modal is closed.
