### PR TITLE
fix: :bug: fill height of parent container scroll area

### DIFF
--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -183,7 +183,10 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
            * widths that change. We'll wait to see what use-cases consumers come up with there
            * before trying to resolve it.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div
+            ref={context.onContentChange}
+            style={{ minWidth: '100%', display: 'table', height: '100%' }}
+          >
             {children}
           </div>
         </Primitive.div>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Ran into an issue, where the scroll area wouldn't take up the whole height of the parent container, only then did I notice there was an intermediate `div` being placed with display table. I get this is to match the height of the children, but this way I can't fill the height of the parent.

Here is an example where I need this:

In case the ScrollArea ViewPort does not overflow, I want a button to be at the bottom of the page, but in case the viewport gets bigger (scrolling gets enabled) I want the button to stay at the bottom of this child.

#### Before:

ScrollArea Content inherits the size from its children, so the button gets appended immediately after the cards (this would be the expected behaviour if we would've needed scrolling)

<img width="1259" alt="Screenshot 2024-04-24 at 19 30 30" src="https://github.com/radix-ui/primitives/assets/61006057/33552001-87b1-48c2-b22e-d0721b34e6e8">

#### After:

ScrollArea Content fills the whole page's height and thus the button can be at the very bottom of the page.

<img width="1259" alt="Screenshot 2024-04-24 at 19 16 49" src="https://github.com/radix-ui/primitives/assets/61006057/a278ed1e-c2e2-4aec-a84a-c84a7a4e2ff0">


> [!NOTE]
> I've tried around with lots of other css styles but ultimately only this ended up working, if anyone has other suggestions, feel free :)