### PR TITLE
fix(@radix-ui/react-menu): Dropdown Scrolling Issue (handle negative offsetY on onPointerMove)

### DIFF
--- a/.yarn/versions/ed675cf3.yml
+++ b/.yarn/versions/ed675cf3.yml
@@ -1,0 +1,8 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.tsx
+++ b/packages/react/menu/src/Menu.tsx
@@ -724,7 +724,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
             onPointerMove={composeEventHandlers(
               props.onPointerMove,
               whenMouse((event) => {
-                if (disabled) {
+                if (disabled || event.nativeEvent.offsetY < 0) {
                   contentContext.onItemLeave(event);
                 } else {
                   contentContext.onItemEnter(event);


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

#### **Issue with video**

This video shows a scrolling issue that occurs in dropdown with `max-height` and `overflow: scroll` set.

In this video, I never scrolled but only move the mouse pointer near the bottom edge of the dropdown.

https://github.com/radix-ui/primitives/assets/10149370/7ed39918-33dc-4148-873a-3ba4ee31f9e0

#### **Summary**

- In a dropdown with `max-height` and `overflow: scroll`, hovering over an item can trigger dropdown scrolling.
- However, when the pointer is at the bottom edge of the dropdown, an `onPointerMove` event is triggered for the next item that is out of view(with negative offsetY), causing focus to shift to that item and resulting in continuous scrolling.
- This issue means that the dropdown can be continuously scrolled with just pointer movement. This can lead users to click incorrectly or get confused.

#### **Solution**

- This PR fixes an issue where the `onPointerMove` handler in `MenuItemImpl` was treating `PointerEvent` with `offsetY < 0` as an `entering item`.
- It now treats `offsetY < 0` as a `leaving item` to prevent the dropdown scroll issue.

#### **Testing**

- Tested the fix in the scenario where the issue was reproducible and confirmed that it is resolved.
