### PR TITLE
[Popper] Add collision strategy option

### DIFF
--- a/.yarn/versions/60e659f9.yml
+++ b/.yarn/versions/60e659f9.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -445,6 +445,52 @@ export const Chromatic = () => {
 };
 Chromatic.parameters = { chromatic: { disable: false } };
 
+export const CollisionStrategy = () => {
+  const [flipOpen, setFlipOpen] = React.useState(false);
+  const [shiftOpen, setShiftOpen] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-around',
+        gap: '16px',
+        height: '200vh',
+      }}
+    >
+      <Popper.Root>
+        <Popper.Anchor className={anchorClass()} onClick={() => setFlipOpen(true)}>
+          open (flip)
+        </Popper.Anchor>
+
+        {flipOpen && (
+          <Portal asChild>
+            <Popper.Content className={contentClass()} sideOffset={5}>
+              <button onClick={() => setFlipOpen(false)}>close</button>
+              <Popper.Arrow className={arrowClass()} width={20} height={10} offset={25} />
+            </Popper.Content>
+          </Portal>
+        )}
+      </Popper.Root>
+      <Popper.Root>
+        <Popper.Anchor className={anchorClass()} onClick={() => setShiftOpen(true)}>
+          open (shift)
+        </Popper.Anchor>
+
+        {shiftOpen && (
+          <Portal asChild>
+            <Popper.Content className={contentClass()} sideOffset={5} collisionStrategy="shift">
+              <button onClick={() => setShiftOpen(false)}>close</button>
+              <Popper.Arrow className={arrowClass()} width={20} height={10} offset={25} />
+            </Popper.Content>
+          </Portal>
+        )}
+      </Popper.Root>
+    </div>
+  );
+};
+
 const Scrollable = (props: any) => (
   <div
     style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -120,6 +120,7 @@ interface PopperContentProps extends PrimitiveDivProps {
   avoidCollisions?: boolean;
   collisionBoundary?: Boundary | Boundary[];
   collisionPadding?: number | Partial<Record<Side, number>>;
+  collisionStrategy?: 'shift' | 'flip';
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
   updatePositionStrategy?: 'optimized' | 'always';
@@ -138,6 +139,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       avoidCollisions = true,
       collisionBoundary = [],
       collisionPadding: collisionPaddingProp = 0,
+      collisionStrategy = 'flip',
       sticky = 'partial',
       hideWhenDetached = false,
       updatePositionStrategy = 'optimized',
@@ -190,11 +192,11 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         avoidCollisions &&
           shift({
             mainAxis: true,
-            crossAxis: false,
+            crossAxis: collisionStrategy === 'shift',
             limiter: sticky === 'partial' ? limitShift() : undefined,
             ...detectOverflowOptions,
           }),
-        avoidCollisions && flip({ ...detectOverflowOptions }),
+        avoidCollisions && collisionStrategy === 'flip' && flip({ ...detectOverflowOptions }),
         size({
           ...detectOverflowOptions,
           apply: ({ elements, rects, availableWidth, availableHeight }) => {


### PR DESCRIPTION
### Description

Adds `collisionStrategy` prop to `Popper.Content` to control how the placement is done when it collides with a boundary. The two options are `'flip'` and `'shift'`. `'flip'` is how it is currently done, where it uses the `flip` middleware from Floating UI. The new option for `'shift'` will instead rely on the `shift` middleware, which is already used to avoid collisions for the alignment, but using this option also uses it for the side collision.

Fixes #2842 