### PR TITLE
[Select] Fix touch devices bugs

### DIFF
--- a/.yarn/versions/cc138cf5.yml
+++ b/.yarn/versions/cc138cf5.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -829,7 +829,9 @@ export const Cypress = () => {
             </Select.Portal>
           </Select.Root>
         </Label>
-        <button type="submit">buy</button>
+        <button type="submit" style={{ width: 100, height: 50 }}>
+          buy
+        </button>
         {data.size ? <p>You picked t-shirt size {data.size}</p> : null}
       </form>
 
@@ -876,7 +878,7 @@ export const Cypress = () => {
           </Select.Root>
         </Label>
 
-        <button type="button" onClick={() => setModel('')}>
+        <button type="button" style={{ width: 100, height: 50 }} onClick={() => setModel('')}>
           unset
         </button>
       </div>
@@ -1106,6 +1108,10 @@ const itemClass = css({
   ...itemStyles,
   position: 'relative',
   outline: 'none',
+
+  '&:active': {
+    backgroundColor: '$gray100',
+  },
 
   '&[data-highlighted]': {
     backgroundColor: '$black',

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -787,7 +787,7 @@ export const Cypress = () => {
   }
 
   return (
-    <div style={{ height: '200vh' }}>
+    <>
       <form
         style={{ padding: 50 }}
         onSubmit={(event) => {
@@ -882,7 +882,7 @@ export const Cypress = () => {
           unset
         </button>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -787,7 +787,7 @@ export const Cypress = () => {
   }
 
   return (
-    <>
+    <div style={{ height: '200vh' }}>
       <form
         style={{ padding: 50 }}
         onSubmit={(event) => {
@@ -882,7 +882,7 @@ export const Cypress = () => {
           unset
         </button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -220,6 +220,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
     const isDisabled = context.disabled || disabled;
     const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
     const getItems = useCollection(__scopeSelect);
+    const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const [searchRef, handleTypeaheadSearch, resetTypeahead] = useTypeaheadSearch((search) => {
       const enabledItems = getItems().filter((item) => !item.disabled);
@@ -230,11 +231,18 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
       }
     });
 
-    const handleOpen = () => {
+    const handleOpen = (pointerEvent?: React.MouseEvent | React.PointerEvent) => {
       if (!isDisabled) {
         context.onOpenChange(true);
         // reset typeahead when we open
         resetTypeahead();
+      }
+
+      if (pointerEvent) {
+        context.triggerPointerDownPosRef.current = {
+          x: Math.round(pointerEvent.pageX),
+          y: Math.round(pointerEvent.pageY),
+        };
       }
     };
 
@@ -262,8 +270,15 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
             // because we are preventing default in `onPointerDown` so effectively
             // this only runs for a label "click"
             event.currentTarget.focus();
+
+            // Open on click when using a touch or pen device
+            if (pointerTypeRef.current !== 'mouse') {
+              handleOpen(event);
+            }
           })}
           onPointerDown={composeEventHandlers(triggerProps.onPointerDown, (event) => {
+            pointerTypeRef.current = event.pointerType;
+
             // prevent implicit pointer capture
             // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
             const target = event.target as HTMLElement;
@@ -272,13 +287,10 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
             }
 
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
-            // but not when the control key is pressed (avoiding MacOS right click)
-            if (event.button === 0 && event.ctrlKey === false) {
-              handleOpen();
-              context.triggerPointerDownPosRef.current = {
-                x: Math.round(event.pageX),
-                y: Math.round(event.pageY),
-              };
+            // but not when the control key is pressed (avoiding MacOS right click); also not for touch
+            // devices because that would open the menu on scroll. (pen devices behave as touch on iOS).
+            if (event.button === 0 && event.ctrlKey === false && event.pointerType === 'mouse') {
+              handleOpen(event);
               // prevent trigger from stealing focus from the active item after opening.
               event.preventDefault();
             }
@@ -1197,6 +1209,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
       contentContext.itemRefCallback?.(node, value, disabled)
     );
     const textId = useId();
+    const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const handleSelect = () => {
       if (!disabled) {
@@ -1242,11 +1255,24 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             ref={composedRefs}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
-            onPointerUp={composeEventHandlers(itemProps.onPointerUp, handleSelect)}
+            onClick={composeEventHandlers(itemProps.onClick, () => {
+              // Open on click when using a touch or pen device
+              if (pointerTypeRef.current !== 'mouse') handleSelect();
+            })}
+            onPointerUp={composeEventHandlers(itemProps.onPointerUp, () => {
+              // Using a mouse you should be able to do pointer down, move through
+              // the list, and release the pointer over the item to select it.
+              if (pointerTypeRef.current === 'mouse') handleSelect();
+            })}
+            onPointerDown={composeEventHandlers(itemProps.onPointerDown, (event) => {
+              pointerTypeRef.current = event.pointerType;
+            })}
             onPointerMove={composeEventHandlers(itemProps.onPointerMove, (event) => {
+              // Remember pointer type when sliding over to this item from another one
+              pointerTypeRef.current = event.pointerType;
               if (disabled) {
                 contentContext.onItemLeave?.();
-              } else {
+              } else if (pointerTypeRef.current === 'mouse') {
                 // even though safari doesn't support this option, it's acceptable
                 // as it only means it might scroll a few pixels when using the pointer.
                 event.currentTarget.focus({ preventScroll: true });


### PR DESCRIPTION
- Fix an issue when clicking a Select Item would click an element behind it on Android touch devices (https://github.com/radix-ui/primitives/issues/1658)
  - Reproducible in Chrome’s touch device simulator
- Fix an issue when Select Trigger would open inadvertently on touch-based scroll (https://github.com/radix-ui/primitives/issues/1912) 
  - Reproducible on iOS and in Chrome’s touch device simulator
- Similarly to the above, but in an open menu, prevent touch-based scrolling over Select Items from yielding a weird half-working focus interactions, and change Select Items to active on "click" for touch devices instead

The dropdown menu and potentially a couple other primitives would need similar fixes up next (can be done separately)

Touch, before:

https://github.com/radix-ui/primitives/assets/8441036/238b0fc6-3b05-45fd-9e54-71011dcba752

Touch, after:

https://github.com/radix-ui/primitives/assets/8441036/678a8fd2-1e78-432f-b55c-f153f315f67b

Behaviour with mouse devices is preserved:

https://github.com/radix-ui/primitives/assets/8441036/8042f00d-5d7a-4609-9a8b-b784f08122a4

Tested on real devices as well

