### PR TITLE
[ScrollArea] Viewport fixes

### DIFF
--- a/.yarn/versions/a54ad5a9.yml
+++ b/.yarn/versions/a54ad5a9.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-scroll-area": minor
+
+declined:
+  - primitives
+  - ssr-testing

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -307,6 +307,85 @@ export const Chromatic = () => (
 );
 Chromatic.parameters = { chromatic: { disable: false } };
 
+const COPY_SHORT = `
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sit amet eros iaculis,
+  bibendum tellus ac, lobortis odio. Aliquam bibendum elit est, in iaculis est commodo id.
+  Donec pulvinar est libero. Proin consectetur pellentesque molestie.
+`;
+
+export const ChromaticFillParentHeight = () => (
+  <>
+    <h1>Parent has fixed height, short content</h1>
+    <div
+      style={{
+        display: 'flex',
+        width: 600,
+        height: 300,
+        overflow: 'hidden',
+      }}
+    >
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <div>{COPY_SHORT}</div>
+      </ScrollAreaStory>
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <div>{COPY_SHORT}</div>
+      </ScrollAreaStory>
+    </div>
+
+    <h1>Parent has fixed height, tall content</h1>
+    <div
+      style={{
+        display: 'flex',
+        width: 600,
+        height: 300,
+        overflow: 'hidden',
+      }}
+    >
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <div>{COPY_SHORT}</div>
+      </ScrollAreaStory>
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <Copy style={{ width: 'auto' }} />
+      </ScrollAreaStory>
+    </div>
+
+    <h1>Parent has max height</h1>
+    <div
+      style={{
+        display: 'flex',
+        width: 600,
+        maxHeight: 300,
+        overflow: 'hidden',
+      }}
+    >
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <div>{COPY_SHORT}</div>
+      </ScrollAreaStory>
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <Copy style={{ width: 'auto' }} />
+      </ScrollAreaStory>
+    </div>
+
+    <h1>Parent has auto height</h1>
+    <div
+      style={{
+        display: 'flex',
+        width: 600,
+        overflow: 'hidden',
+      }}
+    >
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <div>{COPY_SHORT}</div>
+      </ScrollAreaStory>
+      <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
+        <Copy style={{ width: 'auto' }} />
+      </ScrollAreaStory>
+    </div>
+
+    <div style={{ height: 200 }} />
+  </>
+);
+
 const DYNAMIC_CONTENT_DELAY = 2000;
 
 export const ChromaticDynamicContentBeforeLoaded = () => {
@@ -424,14 +503,7 @@ const scrollAreaClass = css({
   border: '1px solid black',
 });
 
-const RECOMMENDED_CSS__SCROLLAREA__VIEWPORT: any = {
-  width: '100%',
-  height: '100%',
-};
-
-const scrollAreaViewportClass = css({
-  ...RECOMMENDED_CSS__SCROLLAREA__VIEWPORT,
-});
+const scrollAreaViewportClass = css();
 
 const RECOMMENDED_CSS__SCROLLBAR__ROOT: any = {
   display: 'flex',

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -316,14 +316,7 @@ const COPY_SHORT = `
 export const ChromaticFillParentHeight = () => (
   <>
     <h1>Parent has fixed height, short content</h1>
-    <div
-      style={{
-        display: 'flex',
-        width: 600,
-        height: 300,
-        overflow: 'hidden',
-      }}
-    >
+    <div style={{ display: 'flex', width: 600, height: 300, overflow: 'hidden' }}>
       <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
         <div>{COPY_SHORT}</div>
       </ScrollAreaStory>
@@ -333,14 +326,7 @@ export const ChromaticFillParentHeight = () => (
     </div>
 
     <h1>Parent has fixed height, tall content</h1>
-    <div
-      style={{
-        display: 'flex',
-        width: 600,
-        height: 300,
-        overflow: 'hidden',
-      }}
-    >
+    <div style={{ display: 'flex', width: 600, height: 300, overflow: 'hidden' }}>
       <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
         <div>{COPY_SHORT}</div>
       </ScrollAreaStory>
@@ -350,14 +336,7 @@ export const ChromaticFillParentHeight = () => (
     </div>
 
     <h1>Parent has max height</h1>
-    <div
-      style={{
-        display: 'flex',
-        width: 600,
-        maxHeight: 300,
-        overflow: 'hidden',
-      }}
-    >
+    <div style={{ display: 'flex', width: 600, maxHeight: 300, overflow: 'hidden' }}>
       <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
         <div>{COPY_SHORT}</div>
       </ScrollAreaStory>
@@ -367,13 +346,7 @@ export const ChromaticFillParentHeight = () => (
     </div>
 
     <h1>Parent has auto height</h1>
-    <div
-      style={{
-        display: 'flex',
-        width: 600,
-        overflow: 'hidden',
-      }}
-    >
+    <div style={{ display: 'flex', width: 600, overflow: 'hidden' }}>
       <ScrollAreaStory type="always" vertical horizontal style={{ width: '50%', height: 'auto' }}>
         <div>{COPY_SHORT}</div>
       </ScrollAreaStory>

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -307,6 +307,41 @@ export const Chromatic = () => (
 );
 Chromatic.parameters = { chromatic: { disable: false } };
 
+export const ChromaticEllipsis = () => (
+  <>
+    <h1>Ellipsis at viewport width</h1>
+    <ScrollAreaStory type="always" horizontal={false} vertical>
+      {Array.from({ length: 10 }).map((_, index) => (
+        <Copy
+          key={index}
+          style={{
+            maxWidth: '100%',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        />
+      ))}
+    </ScrollAreaStory>
+
+    <h1>Ellipsis at content width</h1>
+    <ScrollAreaStory type="always" horizontal vertical>
+      {Array.from({ length: 10 }).map((_, index) => (
+        <Copy
+          key={index}
+          style={{
+            width: 500,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        />
+      ))}
+    </ScrollAreaStory>
+  </>
+);
+ChromaticEllipsis.parameters = { chromatic: { disable: false } };
+
 const COPY_SHORT = `
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sit amet eros iaculis,
   bibendum tellus ac, lobortis odio. Aliquam bibendum elit est, in iaculis est commodo id.

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -512,7 +512,14 @@ const scrollAreaClass = css({
   border: '1px solid black',
 });
 
-const scrollAreaViewportClass = css();
+const RECOMMENDED_CSS__SCROLLAREA__VIEWPORT: any = {
+  width: '100%',
+  height: '100%',
+};
+
+const scrollAreaViewportClass = css({
+  ...RECOMMENDED_CSS__SCROLLAREA__VIEWPORT,
+});
 
 const RECOMMENDED_CSS__SCROLLBAR__ROOT: any = {
   display: 'flex',

--- a/packages/react/scroll-area/src/ScrollArea.stories.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.stories.tsx
@@ -358,6 +358,7 @@ export const ChromaticFillParentHeight = () => (
     <div style={{ height: 200 }} />
   </>
 );
+ChromaticFillParentHeight.parameters = { chromatic: { disable: false } };
 
 const DYNAMIC_CONTENT_DELAY = 2000;
 

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -148,10 +148,29 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
     return (
       <>
-        {/* Hide scrollbars cross-browser and enable momentum scroll for touch devices */}
         <style
           dangerouslySetInnerHTML={{
-            __html: `[data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}`,
+            __html: `
+[data-radix-scroll-area-viewport] {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+[data-radix-scroll-area-viewport]::-webkit-scrollbar {
+  display: none;
+}
+:where([data-radix-scroll-area-viewport]) {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+:where([data-radix-scroll-area-content]) {
+  flex-grow: 1;
+  min-width: 100%;
+  width: fit-content;
+}
+`,
           }}
           nonce={nonce}
         />
@@ -176,14 +195,7 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
             ...props.style,
           }}
         >
-          {/**
-           * `display: table` ensures our content div will match the size of its children in both
-           * horizontal and vertical axis so we can determine if scroll width/height changed and
-           * recalculate thumb sizes. This doesn't account for children with *percentage*
-           * widths that change. We'll wait to see what use-cases consumers come up with there
-           * before trying to resolve it.
-           */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div data-radix-scroll-area-content="" ref={context.onContentChange}>
             {children}
           </div>
         </Primitive.div>

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -169,9 +169,6 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
 :where([data-radix-scroll-area-content]) {
   flex-grow: 1;
 }
-:where([data-radix-scroll-area-content-horitzontal]) {
-  flex-grow: 1;
-}
 `,
           }}
           nonce={nonce}

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -162,13 +162,15 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
 :where([data-radix-scroll-area-viewport]) {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   width: 100%;
   height: 100%;
 }
 :where([data-radix-scroll-area-content]) {
   flex-grow: 1;
-  min-width: 100%;
-  width: fit-content;
+}
+:where([data-radix-scroll-area-content-horitzontal]) {
+  flex-grow: 1;
 }
 `,
           }}
@@ -197,7 +199,18 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
           }}
         >
           {getSubtree({ asChild, children }, (children) => (
-            <div data-radix-scroll-area-content="" ref={context.onContentChange}>
+            <div
+              data-radix-scroll-area-content=""
+              ref={context.onContentChange}
+              /**
+               * When horizontal scrollbar is visible: this element should be at least
+               * as wide as its children for size calculations to work correctly.
+               *
+               * When horizontal scrollbar is NOT visible: this element's width should
+               * be constrained by the parent container to enable `text-overflow: ellipsis`
+               */
+              style={{ minWidth: context.scrollbarXEnabled ? 'fit-content' : undefined }}
+            >
               {children}
             </div>
           ))}

--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -163,8 +163,6 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  width: 100%;
-  height: 100%;
 }
 :where([data-radix-scroll-area-content]) {
   flex-grow: 1;

--- a/ssr-testing/app/scroll-area/page.tsx
+++ b/ssr-testing/app/scroll-area/page.tsx
@@ -9,29 +9,17 @@ import {
 
 export default function Page() {
   return (
-    <ScrollArea style={{ width: '400px', height: '400px' }}>
-      <Scrollbar orientation="vertical">
-        <ScrollAreaThumb />
-      </Scrollbar>
+    <div>
+      <ScrollArea>
+        <Scrollbar orientation="vertical">
+          <ScrollAreaThumb />
+        </Scrollbar>
 
-      <Scrollbar orientation="horizontal">
-        <ScrollAreaThumb />
-      </Scrollbar>
+        <Scrollbar orientation="horizontal">
+          <ScrollAreaThumb />
+        </Scrollbar>
 
-      <ScrollAreaViewport>
-        <div style={{ width: '2000px', padding: 20 }}>
-          <LongContent />
-          <LongContent />
-          <LongContent />
-          <LongContent />
-          <LongContent />
-          <LongContent />
-          <LongContent />
-        </div>
-      </ScrollAreaViewport>
-
-      <ScrollAreaViewport asChild>
-        <section style={{ border: '1px solid' }}>
+        <ScrollAreaViewport style={{ width: '400px', height: '400px' }}>
           <div style={{ width: '2000px', padding: 20 }}>
             <LongContent />
             <LongContent />
@@ -41,11 +29,37 @@ export default function Page() {
             <LongContent />
             <LongContent />
           </div>
-        </section>
-      </ScrollAreaViewport>
+        </ScrollAreaViewport>
 
-      <ScrollAreaCorner />
-    </ScrollArea>
+        <ScrollAreaCorner />
+      </ScrollArea>
+
+      <ScrollArea>
+        <Scrollbar orientation="vertical">
+          <ScrollAreaThumb />
+        </Scrollbar>
+
+        <Scrollbar orientation="horizontal">
+          <ScrollAreaThumb />
+        </Scrollbar>
+
+        <ScrollAreaViewport style={{ width: '400px', height: '400px' }} asChild>
+          <section style={{ border: '1px solid' }}>
+            <div style={{ width: '2000px', padding: 20 }}>
+              <LongContent />
+              <LongContent />
+              <LongContent />
+              <LongContent />
+              <LongContent />
+              <LongContent />
+              <LongContent />
+            </div>
+          </section>
+        </ScrollAreaViewport>
+
+        <ScrollAreaCorner />
+      </ScrollArea>
+    </div>
   );
 }
 

--- a/ssr-testing/app/scroll-area/page.tsx
+++ b/ssr-testing/app/scroll-area/page.tsx
@@ -18,14 +18,30 @@ export default function Page() {
         <ScrollAreaThumb />
       </Scrollbar>
 
-      <ScrollAreaViewport style={{ width: '2000px', padding: 20 }}>
-        <LongContent />
-        <LongContent />
-        <LongContent />
-        <LongContent />
-        <LongContent />
-        <LongContent />
-        <LongContent />
+      <ScrollAreaViewport>
+        <div style={{ width: '2000px', padding: 20 }}>
+          <LongContent />
+          <LongContent />
+          <LongContent />
+          <LongContent />
+          <LongContent />
+          <LongContent />
+          <LongContent />
+        </div>
+      </ScrollAreaViewport>
+
+      <ScrollAreaViewport asChild>
+        <section style={{ border: '1px solid' }}>
+          <div style={{ width: '2000px', padding: 20 }}>
+            <LongContent />
+            <LongContent />
+            <LongContent />
+            <LongContent />
+            <LongContent />
+            <LongContent />
+            <LongContent />
+          </div>
+        </section>
       </ScrollAreaViewport>
 
       <ScrollAreaCorner />


### PR DESCRIPTION
- Fix `asChild` prop not working as expected on the Viewport part
- Rework the inner content element styles on the Viewport part
  - Replace `display: table` with flex styles on the parent that allow the viewport to fill container height (based on the [Radix Themes implementation](https://github.com/radix-ui/themes/blob/main/packages/radix-ui-themes/src/components/scroll-area.css#L40))
  - Replace most related inline styles with 0,0,0 specificity styles for easier overrides via `[data-radix-scroll-area-content]`
  - Fix `text-overflow: ellipsis` not working when used with a vertical scrollbar

Closes #926 #1666