### PR TITLE
add ignoreThumbOffset option

### DIFF
--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -547,11 +547,12 @@ type SliderThumbImplElement = React.ElementRef<typeof Primitive.span>;
 interface SliderThumbImplProps extends PrimitiveSpanProps {
   index: number;
   name?: string;
+  ignoreThumbOffset?: boolean
 }
 
 const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImplProps>(
   (props: ScopedProps<SliderThumbImplProps>, forwardedRef) => {
-    const { __scopeSlider, index, name, ...thumbProps } = props;
+    const { __scopeSlider, index, name, ignoreThumbOffset = false, ...thumbProps } = props;
     const context = useSliderContext(THUMB_NAME, __scopeSlider);
     const orientation = useSliderOrientationContext(THUMB_NAME, __scopeSlider);
     const [thumb, setThumb] = React.useState<HTMLSpanElement | null>(null);
@@ -565,7 +566,7 @@ const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImpl
       value === undefined ? 0 : convertValueToPercentage(value, context.min, context.max);
     const label = getLabel(index, context.values.length);
     const orientationSize = size?.[orientation.size];
-    const thumbInBoundsOffset = orientationSize
+    const thumbInBoundsOffset = orientationSize && !ignoreThumbOffset
       ? getThumbInBoundsOffset(orientationSize, percent, orientation.direction)
       : 0;
 


### PR DESCRIPTION
## Feature request
I'm trying to implement the following design using the Slider component
![CleanShot 2024-06-10 at 15 52 02@2x](https://github.com/radix-ui/primitives/assets/235510/bff24f43-d469-4915-9350-d149c619bbb0)


### Overview
Using the following code
```tsx
<SliderPrimitive.Root
    [clip]
    defaultValue={[value]}
    max={steps}
    step={1}
>
    <SliderPrimitive.Thumb [clip]>
        <Bubble className="px-6 py-2 block">move me</Bubble>
    </SliderPrimitive.Thumb>
</SliderPrimitive.Root>
```

Which gives me the following result

https://github.com/radix-ui/primitives/assets/235510/8794f81b-d08c-4b55-b817-b459595d3ff6




The guilty is the `thumbInBoundsOffset` on https://github.com/radix-ui/primitives/blob/af1e3b41cb5c49d7b8c073d2aec34d5074c6dd17/packages/react/slider/src/Slider.tsx#L586C58-L586C77

By adding the option `ignoreThumbOffset` on the `<Thumb />`, we could refactor the code 
to be
```ts
const thumbInBoundsOffset = orientationSize && !ignoreThumbOffsfet
      ? getThumbInBoundsOffset(orientationSize, percent, orientation.direction)
      : 0;
```

And it would fix the issue

https://github.com/radix-ui/primitives/assets/235510/6b813774-544a-4bec-81e5-b9c1213c052a


