### PR TITLE
[Progress] Assume indeterminate value

### DIFF
--- a/.yarn/versions/c9fc51b8.yml
+++ b/.yarn/versions/c9fc51b8.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-progress": minor
+
+declined:
+  - primitives

--- a/packages/react/progress/src/Progress.stories.tsx
+++ b/packages/react/progress/src/Progress.stories.tsx
@@ -38,7 +38,7 @@ export const Chromatic = () => (
     </Progress.Root>
 
     <h1>Indeterminate</h1>
-    <Progress.Root className={rootClass()} value={null}>
+    <Progress.Root className={rootClass()}>
       <Progress.Indicator className={chromaticIndicatorClass()}>/</Progress.Indicator>
     </Progress.Root>
 
@@ -54,7 +54,7 @@ export const Chromatic = () => (
     </Progress.Root>
 
     <h2>Indeterminate</h2>
-    <Progress.Root className={rootAttrClass()} value={null}>
+    <Progress.Root className={rootAttrClass()}>
       <Progress.Indicator className={indicatorAttrClass()}>/</Progress.Indicator>
     </Progress.Root>
 

--- a/packages/react/progress/src/Progress.tsx
+++ b/packages/react/progress/src/Progress.tsx
@@ -31,7 +31,7 @@ const Progress = React.forwardRef<ProgressElement, ProgressProps>(
   (props: ScopedProps<ProgressProps>, forwardedRef) => {
     const {
       __scopeProgress,
-      value: valueProp,
+      value: valueProp = null,
       max: maxProp,
       getValueLabel = defaultGetValueLabel,
       ...progressProps
@@ -140,7 +140,7 @@ function getInvalidValueError(propValue: string, componentName: string) {
   return `Invalid prop \`value\` of value \`${propValue}\` supplied to \`${componentName}\`. The \`value\` prop must be:
   - a positive number
   - less than the value passed to \`max\` (or ${DEFAULT_MAX} if no \`max\` prop is set)
-  - \`null\` if the progress is indeterminate.
+  - \`null\` or \`undefined\` if the progress is indeterminate.
 
 Defaulting to \`null\`.`;
 }


### PR DESCRIPTION
I've discovered new errors in the console for undefined Progress values in the recent RC:

<img src="https://github.com/radix-ui/primitives/assets/8441036/c6f37c22-1542-4a90-b571-f21499305623" width='500' />

***

Digging in, in #2934, a [loose null comparison](https://github.com/radix-ui/primitives/pull/2934/files#diff-44b69285a9a3964d445cfdbd921ebadc4140b249f1002db2cd3eeae31b2fed59L79) for `valueProp != null` was [changed](https://github.com/radix-ui/primitives/pull/2934/files#diff-44b69285a9a3964d445cfdbd921ebadc4140b249f1002db2cd3eeae31b2fed59R46) to a strict `valueProp !== null` as that seemed to reflect the intention of the code better given the related error message that it rendered.

This restores the previous behaviour of undefined value considered valid for forward compatibility 



