### PR TITLE
[Dialog] Log error instead of throwing for missing titles

### DIFF
--- a/.yarn/versions/261663d9.yml
+++ b/.yarn/versions/261663d9.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-dialog": patch
+
+declined:
+  - primitives

--- a/packages/react/dialog/src/Dialog.test.tsx
+++ b/packages/react/dialog/src/Dialog.test.tsx
@@ -49,6 +49,8 @@ describe('given a default Dialog', () => {
   let closeButton: HTMLElement;
   let consoleWarnMock: jest.SpyInstance;
   let consoleWarnMockFunction: jest.Mock;
+  let consoleErrorMock: jest.SpyInstance;
+  let consoleErrorMockFunction: jest.Mock;
 
   beforeEach(() => {
     // This surpresses React error boundary logs for testing intentionally
@@ -56,6 +58,8 @@ describe('given a default Dialog', () => {
     // this here: https://github.com/facebook/react/issues/11098
     consoleWarnMockFunction = jest.fn();
     consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(consoleWarnMockFunction);
+    consoleErrorMockFunction = jest.fn();
+    consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(consoleErrorMockFunction);
 
     rendered = render(<DialogTest />);
     trigger = rendered.getByText(OPEN_TEXT);
@@ -64,6 +68,8 @@ describe('given a default Dialog', () => {
   afterEach(() => {
     consoleWarnMock.mockRestore();
     consoleWarnMockFunction.mockClear();
+    consoleErrorMock.mockRestore();
+    consoleErrorMockFunction.mockClear();
   });
 
   it('should have no accessibility violations in default state', async () => {
@@ -83,10 +89,15 @@ describe('given a default Dialog', () => {
     });
 
     describe('when no title has been provided', () => {
-      it('should throw an error', () =>
-        expect(() => {
-          renderAndClickDialogTrigger(<NoLabelDialogTest />);
-        }).toThrowError());
+      beforeEach(() => {
+        cleanup();
+      });
+      it('should display an error in the console', () => {
+        consoleErrorMockFunction.mockClear();
+
+        renderAndClickDialogTrigger(<NoLabelDialogTest />);
+        expect(consoleErrorMockFunction).toHaveBeenCalled();
+      });
     });
 
     describe('when aria-describedby is set to undefined', () => {

--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -514,7 +514,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
   React.useEffect(() => {
     if (titleId) {
       const hasTitle = document.getElementById(titleId);
-      if (!hasTitle) throw new Error(MESSAGE);
+      if (!hasTitle) console.error(MESSAGE);
     }
   }, [MESSAGE, titleId]);
 


### PR DESCRIPTION
- Dialog primitive was supposed to throw errors when there was a missing title because that’s an A11Y violation; also it was supposed to show a console warning for missing descriptions
- However, that didn’t actually work in practice—I confirmed that in CodeSandbox for different primitive versions (tested 0.1.7, 1.0.0, and a bunch of versions leading up to 1.1.0-rc.3) and different React versions
- The above code started working after the [changes to the build process](https://github.com/radix-ui/primitives/pull/2922)
- The build changes “fixed” errors not being thrown, but that now breaks your app when upgrading if you missed the title
- For forward compatibility, I'm changing the thrown errors to `console.error` to avoid new runtime failures after upgrades