### PR TITLE
[Checkbox] export type CheckedState

### DIFF
--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -227,4 +227,4 @@ export {
   Root,
   Indicator,
 };
-export type { CheckboxProps, CheckboxIndicatorProps };
+export type { CheckboxProps, CheckboxIndicatorProps, CheckedState };


### PR DESCRIPTION
### Description

Adds back the export for the type `CheckedState`, it was exported in 1.0.* and used by some to make typesafe APIs that interact with Checkbox. But this export was removed in 1.1, now consumers need a type like: `type CheckedState = Parameters<NonNullable<CheckboxProps['onCheckedChange']>>[0]` to keep their APIs in sync with the Radix internal types.