### PR TITLE
[Tooltip] Export type tooltip provider props

### DIFF
--- a/.yarn/versions/6945cc14.yml
+++ b/.yarn/versions/6945cc14.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -754,6 +754,7 @@ export {
   Arrow,
 };
 export type {
+  TooltipProviderProps,
   TooltipProps,
   TooltipTriggerProps,
   TooltipPortalProps,

--- a/packages/react/tooltip/src/index.ts
+++ b/packages/react/tooltip/src/index.ts
@@ -17,6 +17,7 @@ export {
   Arrow,
 } from './Tooltip';
 export type {
+  TooltipProviderProps,
   TooltipProps,
   TooltipTriggerProps,
   TooltipPortalProps,


### PR DESCRIPTION
### Description

Exports back previously exported type. It's also used when generating [shadcn-ui/tooltip](https://ui.shadcn.com/docs/components/tooltip).
Fixes [#2978](https://github.com/radix-ui/primitives/issues/2978)
Similar to [#2968](https://github.com/radix-ui/primitives/pull/2968), but for Tooltip.
