### PR TITLE
Adding support for framework image component in Radix Avatar

### DIFF
--- a/.yarn/versions/48669fbc.yml
+++ b/.yarn/versions/48669fbc.yml
@@ -1,2 +1,3 @@
 releases:
   "@radix-ui/react-avatar": minor
+  primitives: patch

--- a/.yarn/versions/48669fbc.yml
+++ b/.yarn/versions/48669fbc.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-avatar": minor

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -50,10 +50,11 @@ export const Styled = () => (
       <Avatar.Image
         className={imageClass()}
         alt="John Smith"
-        src={otherSrc}
         onLoadingStatusChange={console.log}
-        component={FakeFrameworkImage}
-      />
+        asChild
+      >
+        <FakeFrameworkImage src={otherSrc} />
+      </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>
@@ -61,13 +62,9 @@ export const Styled = () => (
 
     <h1>With image framework component & with fallback (but broken src)</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image
-        className={imageClass()}
-        alt="John Smith"
-        src={srcBroken}
-        onLoadingStatusChange={console.log}
-        component={FakeFrameworkImage}
-      />
+      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+        <FakeFrameworkImage src={srcBroken} />
+      </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>
@@ -100,13 +97,9 @@ export const Chromatic = () => (
 
     <h1>With image framework component</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image
-        className={imageClass()}
-        alt="John Smith"
-        src={otherSrc}
-        onLoadingStatusChange={console.log}
-        component={FakeFrameworkImage}
-      />
+      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+        <FakeFrameworkImage src={otherSrc} />
+      </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>
@@ -114,13 +107,9 @@ export const Chromatic = () => (
 
     <h1>With image framework component & with fallback (but broken src)</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image
-        className={imageClass()}
-        alt="John Smith"
-        src={srcBroken}
-        onLoadingStatusChange={console.log}
-        component={FakeFrameworkImage}
-      />
+      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+        <FakeFrameworkImage src={srcBroken} />
+      </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -4,7 +4,18 @@ import * as Avatar from '@radix-ui/react-avatar';
 export default { title: 'Components/Avatar' };
 
 const src = 'https://picsum.photos/id/1005/400/400';
+const otherSrc = 'https://picsum.photos/id/1006/400/400';
 const srcBroken = 'https://broken.link.com/broken-pic.jpg';
+
+const FakeFrameworkImage = (props: any) => {
+  console.log(props);
+
+  return (
+    <div>
+      <img {...props} alt="framework test" data-testid="framework-image-component" />
+    </div>
+  );
+};
 
 export const Styled = () => (
   <>
@@ -33,6 +44,34 @@ export const Styled = () => (
         <AvatarIcon />
       </Avatar.Fallback>
     </Avatar.Root>
+
+    <h1>With image framework component</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        src={otherSrc}
+        onLoadingStatusChange={console.log}
+        component={FakeFrameworkImage}
+      />
+      <Avatar.Fallback className={fallbackClass()}>
+        <AvatarIcon />
+      </Avatar.Fallback>
+    </Avatar.Root>
+
+    <h1>With image framework component & with fallback (but broken src)</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        src={srcBroken}
+        onLoadingStatusChange={console.log}
+        component={FakeFrameworkImage}
+      />
+      <Avatar.Fallback className={fallbackClass()}>
+        <AvatarIcon />
+      </Avatar.Fallback>
+    </Avatar.Root>
   </>
 );
 
@@ -54,6 +93,34 @@ export const Chromatic = () => (
     <h1>With image & with fallback (but broken src)</h1>
     <Avatar.Root className={rootClass()}>
       <Avatar.Image className={imageClass()} alt="John Smith" src={srcBroken} />
+      <Avatar.Fallback className={fallbackClass()}>
+        <AvatarIcon />
+      </Avatar.Fallback>
+    </Avatar.Root>
+
+    <h1>With image framework component</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        src={otherSrc}
+        onLoadingStatusChange={console.log}
+        component={FakeFrameworkImage}
+      />
+      <Avatar.Fallback className={fallbackClass()}>
+        <AvatarIcon />
+      </Avatar.Fallback>
+    </Avatar.Root>
+
+    <h1>With image framework component & with fallback (but broken src)</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        src={srcBroken}
+        onLoadingStatusChange={console.log}
+        component={FakeFrameworkImage}
+      />
       <Avatar.Fallback className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -62,7 +62,12 @@ export const Styled = () => (
 
     <h1>With image framework component & with fallback (but broken src)</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        onLoadingStatusChange={console.log}
+        asChild
+      >
         <FakeFrameworkImage src={srcBroken} />
       </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
@@ -97,7 +102,12 @@ export const Chromatic = () => (
 
     <h1>With image framework component</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        onLoadingStatusChange={console.log}
+        asChild
+      >
         <FakeFrameworkImage src={otherSrc} />
       </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>
@@ -107,7 +117,12 @@ export const Chromatic = () => (
 
     <h1>With image framework component & with fallback (but broken src)</h1>
     <Avatar.Root className={rootClass()}>
-      <Avatar.Image className={imageClass()} alt="John Smith" onLoadingStatusChange={console.log}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        onLoadingStatusChange={console.log}
+        asChild
+      >
         <FakeFrameworkImage src={srcBroken} />
       </Avatar.Image>
       <Avatar.Fallback className={fallbackClass()}>

--- a/packages/react/avatar/src/Avatar.test.tsx
+++ b/packages/react/avatar/src/Avatar.test.tsx
@@ -1,12 +1,14 @@
 import { axe } from 'jest-axe';
 import type { RenderResult } from '@testing-library/react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import * as Avatar from '@radix-ui/react-avatar';
 
 const ROOT_TEST_ID = 'avatar-root';
 const FALLBACK_TEXT = 'AB';
 const IMAGE_ALT_TEXT = 'Fake Avatar';
 const DELAY = 300;
+const FRAMEWORK_IMAGE_TEST_ID = 'framework-image-component';
+const FRAMEWORK_IMAGE_ALT_TEXT = 'framework test';
 
 describe('given an Avatar with fallback and no image', () => {
   let rendered: RenderResult;
@@ -27,6 +29,25 @@ describe('given an Avatar with fallback and no image', () => {
 describe('given an Avatar with fallback and a working image', () => {
   let rendered: RenderResult;
   let image: HTMLElement | null = null;
+  const orignalGlobalImage = window.Image;
+
+  beforeAll(() => {
+    (window.Image as any) = class MockImage {
+      onload: () => void = () => {};
+      src: string = '';
+
+      constructor() {
+        setTimeout(() => {
+          this.onload();
+        }, DELAY);
+        return this;
+      }
+    };
+  });
+
+  afterAll(() => {
+    window.Image = orignalGlobalImage;
+  });
 
   beforeEach(() => {
     rendered = render(
@@ -48,7 +69,6 @@ describe('given an Avatar with fallback and a working image', () => {
   });
 
   it('should render the image after it has loaded', async () => {
-    fireEvent.load(rendered.getByRole('img', { hidden: true }));
     image = await rendered.findByRole('img');
     expect(image).toBeInTheDocument();
   });
@@ -81,5 +101,65 @@ describe('given an Avatar with fallback and delayed render', () => {
     expect(fallback).not.toBeInTheDocument();
     fallback = await rendered.findByText(FALLBACK_TEXT);
     expect(fallback).toBeInTheDocument();
+  });
+});
+
+describe('given an Avatar with fallback and child image', () => {
+  let rendered: RenderResult;
+  let image: HTMLElement | null = null;
+  const orignalGlobalImage = window.Image;
+
+  beforeAll(() => {
+    (window.Image as any) = class MockImage {
+      onload: () => void = () => {};
+      src: string = '';
+
+      constructor() {
+        setTimeout(() => {
+          this.onload();
+        }, DELAY);
+        return this;
+      }
+    };
+  });
+
+  afterAll(() => {
+    window.Image = orignalGlobalImage;
+  });
+
+  beforeEach(() => {
+    rendered = render(
+      <Avatar.Root data-testid={ROOT_TEST_ID}>
+        <Avatar.Image asChild>
+          <img
+            src="/test.jpg"
+            data-testid={FRAMEWORK_IMAGE_TEST_ID}
+            alt={FRAMEWORK_IMAGE_ALT_TEXT}
+          />
+        </Avatar.Image>
+        <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
+      </Avatar.Root>
+    );
+    console.log(rendered);
+  });
+
+  it('should render the image after it has loaded', async () => {
+    image = await rendered.findByRole('img');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('should have alt text on the image', async () => {
+    image = await rendered.findByAltText(FRAMEWORK_IMAGE_ALT_TEXT);
+    expect(image).toBeInTheDocument();
+  });
+
+  it('should render the fallback initially', () => {
+    const fallback = rendered.queryByText(FALLBACK_TEXT);
+    expect(fallback).toBeInTheDocument();
+  });
+
+  it('should render the image framework component', () => {
+    const frameworkImage = rendered.queryByTestId(FRAMEWORK_IMAGE_TEST_ID);
+    expect(frameworkImage).toBeInTheDocument();
   });
 });

--- a/packages/react/avatar/src/Avatar.test.tsx
+++ b/packages/react/avatar/src/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import { axe } from 'jest-axe';
 import type { RenderResult } from '@testing-library/react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import * as Avatar from '@radix-ui/react-avatar';
 
 const ROOT_TEST_ID = 'avatar-root';

--- a/packages/react/avatar/src/Avatar.test.tsx
+++ b/packages/react/avatar/src/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import { axe } from 'jest-axe';
 import type { RenderResult } from '@testing-library/react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import * as Avatar from '@radix-ui/react-avatar';
 
 const ROOT_TEST_ID = 'avatar-root';
@@ -27,24 +27,6 @@ describe('given an Avatar with fallback and no image', () => {
 describe('given an Avatar with fallback and a working image', () => {
   let rendered: RenderResult;
   let image: HTMLElement | null = null;
-  const orignalGlobalImage = window.Image;
-
-  beforeAll(() => {
-    (window.Image as any) = class MockImage {
-      onload: () => void = () => {};
-      src: string = '';
-      constructor() {
-        setTimeout(() => {
-          this.onload();
-        }, DELAY);
-        return this;
-      }
-    };
-  });
-
-  afterAll(() => {
-    window.Image = orignalGlobalImage;
-  });
 
   beforeEach(() => {
     rendered = render(
@@ -66,6 +48,7 @@ describe('given an Avatar with fallback and a working image', () => {
   });
 
   it('should render the image after it has loaded', async () => {
+    fireEvent.load(rendered.getByRole('img', { hidden: true }));
     image = await rendered.findByRole('img');
     expect(image).toBeInTheDocument();
   });

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import type { Scope } from '@radix-ui/react-context';
 import { createContextScope } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { Primitive } from '@radix-ui/react-primitive';
+
+import type { Scope } from '@radix-ui/react-context';
 
 /* -------------------------------------------------------------------------------------------------
  * Avatar
@@ -25,7 +26,6 @@ const [AvatarProvider, useAvatarContext] = createAvatarContext<AvatarContextValu
 
 type AvatarElement = React.ElementRef<typeof Primitive.span>;
 type PrimitiveSpanProps = React.ComponentPropsWithoutRef<typeof Primitive.span>;
-
 interface AvatarProps extends PrimitiveSpanProps {}
 
 const Avatar = React.forwardRef<AvatarElement, AvatarProps>(
@@ -54,7 +54,6 @@ const IMAGE_NAME = 'AvatarImage';
 
 type AvatarImageElement = React.ElementRef<typeof Primitive.img>;
 type PrimitiveImageProps = React.ComponentPropsWithoutRef<typeof Primitive.img>;
-
 interface AvatarImageProps extends PrimitiveImageProps {
   onLoadingStatusChange?: (status: ImageLoadingStatus) => void;
 }
@@ -62,24 +61,29 @@ interface AvatarImageProps extends PrimitiveImageProps {
 const AvatarImage = React.forwardRef<AvatarImageElement, AvatarImageProps>(
   (props: ScopedProps<AvatarImageProps>, forwardedRef) => {
     const { __scopeAvatar, src, onLoadingStatusChange = () => {}, ...imageProps } = props;
-
     const context = useAvatarContext(IMAGE_NAME, __scopeAvatar);
-    const imageLoadingStatus = useImageLoadingStatus(src, props.asChild, imageProps.referrerPolicy);
+    const { loadingStatus: imageLoadingStatus, setLoadingStatus } = useImageLoadingStatus(
+      src,
+      props.asChild,
+      imageProps.referrerPolicy
+    );
     const handleLoadingStatusChange = useCallbackRef((status: ImageLoadingStatus) => {
+      setLoadingStatus(status);
       onLoadingStatusChange(status);
       context.onImageLoadingStatusChange(status);
     });
 
     useLayoutEffect(() => {
-      if (!src) {
-        handleLoadingStatusChange('error');
-        return;
+      if (imageLoadingStatus !== 'idle') {
+        handleLoadingStatusChange(imageLoadingStatus);
       }
-
-      handleLoadingStatusChange('loading');
-    }, [handleLoadingStatusChange, src]);
+    }, [imageLoadingStatus, handleLoadingStatusChange]);
 
     if (props.asChild && props.children) {
+      if (imageLoadingStatus === 'error') {
+        return null;
+      }
+
       // Ensure children is a valid React element
       const child = React.Children.only(props.children) as React.ReactElement;
 
@@ -147,7 +151,11 @@ AvatarFallback.displayName = FALLBACK_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function useImageLoadingStatus(src?: string, bypass?: boolean, referrerPolicy?: React.HTMLAttributeReferrerPolicy) {
+function useImageLoadingStatus(
+  src?: string,
+  bypass?: boolean,
+  referrerPolicy?: React.HTMLAttributeReferrerPolicy
+) {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
   useLayoutEffect(() => {
@@ -181,9 +189,8 @@ function useImageLoadingStatus(src?: string, bypass?: boolean, referrerPolicy?: 
     };
   }, [src, bypass, referrerPolicy]);
 
-  return loadingStatus;
+  return { loadingStatus, setLoadingStatus };
 }
-
 const Root = Avatar;
 const Image = AvatarImage;
 const Fallback = AvatarFallback;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Hello there, how you guys doing?

As discussed in issue #2230, we would love to enhance image optimization by integrating the Next.js Image component. I've implemented a solution that allows us to utilize the Next.js Image component while maintaining the existing functionality.

In this update, I've removed the image load logic from useLayoutEffect and delegated it directly to the respective components. This means that Primitive.img will handle image loading as usual, while the Next.js Image component will load images with its optimizations.

I would greatly appreciate your feedback on this solution. Let's collaborate to refine this feature and ensure it meets our needs.