### PR TITLE
[Avatar] Fix flashing when image is already cached

### DIFF
--- a/.yarn/versions/4905f29b.yml
+++ b/.yarn/versions/4905f29b.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-avatar": patch
+
+declined:
+  - primitives

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -1,9 +1,11 @@
 import { css } from '../../../../stitches.config';
 import * as Avatar from '@radix-ui/react-avatar';
+import React from 'react';
 
 export default { title: 'Components/Avatar' };
 
 const src = 'https://picsum.photos/id/1005/400/400';
+const srcAlternative = 'https://picsum.photos/id/1006/400/400';
 const srcBroken = 'https://broken.link.com/broken-pic.jpg';
 
 export const Styled = () => (
@@ -33,6 +35,18 @@ export const Styled = () => (
         <AvatarIcon />
       </Avatar.Fallback>
     </Avatar.Root>
+
+    <h1>Changing image src</h1>
+    <SourceChanger sources={[src, srcAlternative, srcBroken]}>
+      {(src) => (
+        <Avatar.Root className={rootClass()}>
+          <Avatar.Image className={imageClass()} alt="John Smith" src={src} />
+          <Avatar.Fallback delayMs={300} className={fallbackClass()}>
+            JS
+          </Avatar.Fallback>
+        </Avatar.Root>
+      )}
+    </SourceChanger>
   </>
 );
 
@@ -58,6 +72,18 @@ export const Chromatic = () => (
         <AvatarIcon />
       </Avatar.Fallback>
     </Avatar.Root>
+
+    <h1>Changing image src</h1>
+    <SourceChanger sources={[src, srcAlternative, srcBroken]}>
+      {(src) => (
+        <Avatar.Root className={rootClass()}>
+          <Avatar.Image className={imageClass()} alt="John Smith" src={src} />
+          <Avatar.Fallback delayMs={300} className={fallbackClass()}>
+            JS
+          </Avatar.Fallback>
+        </Avatar.Root>
+      )}
+    </SourceChanger>
   </>
 );
 Chromatic.parameters = { chromatic: { disable: false, delay: 1000 } };
@@ -113,3 +139,21 @@ const AvatarIcon = () => (
     />
   </svg>
 );
+
+function SourceChanger({
+  sources,
+  children,
+}: {
+  sources: string[];
+  children: (src: string) => React.ReactElement;
+}) {
+  const [src, setSrc] = React.useState(sources[0]);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      const nextIndex = (sources.indexOf(src) + 1) % sources.length;
+      setSrc(sources[nextIndex]);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [sources, src]);
+  return children(src);
+}

--- a/packages/react/avatar/src/Avatar.test.tsx
+++ b/packages/react/avatar/src/Avatar.test.tsx
@@ -2,11 +2,13 @@ import { axe } from 'jest-axe';
 import type { RenderResult } from '@testing-library/react';
 import { render, waitFor } from '@testing-library/react';
 import * as Avatar from '@radix-ui/react-avatar';
+import { HTMLAttributeReferrerPolicy } from 'react';
 
 const ROOT_TEST_ID = 'avatar-root';
 const FALLBACK_TEXT = 'AB';
 const IMAGE_ALT_TEXT = 'Fake Avatar';
 const DELAY = 300;
+const cache = new Set<string>();
 
 describe('given an Avatar with fallback and no image', () => {
   let rendered: RenderResult;
@@ -27,32 +29,26 @@ describe('given an Avatar with fallback and no image', () => {
 describe('given an Avatar with fallback and a working image', () => {
   let rendered: RenderResult;
   let image: HTMLElement | null = null;
-  const orignalGlobalImage = window.Image;
+  const originalGlobalImage = window.Image;
+  const ui = (src?: string) => (
+    <Avatar.Root data-testid={ROOT_TEST_ID}>
+      <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
+      <Avatar.Image src={src} alt={IMAGE_ALT_TEXT} />
+    </Avatar.Root>
+  );
 
   beforeAll(() => {
-    (window.Image as any) = class MockImage {
-      onload: () => void = () => {};
-      src: string = '';
-      constructor() {
-        setTimeout(() => {
-          this.onload();
-        }, DELAY);
-        return this;
-      }
-    };
+    (window.Image as any) = MockImage;
   });
 
   afterAll(() => {
-    window.Image = orignalGlobalImage;
+    window.Image = originalGlobalImage;
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {
-    rendered = render(
-      <Avatar.Root data-testid={ROOT_TEST_ID}>
-        <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
-        <Avatar.Image src="/test.jpg" alt={IMAGE_ALT_TEXT} />
-      </Avatar.Root>
-    );
+    cache.clear();
+    rendered = render(ui('/test.png'));
   });
 
   it('should render the fallback initially', () => {
@@ -73,6 +69,65 @@ describe('given an Avatar with fallback and a working image', () => {
   it('should have alt text on the image', async () => {
     image = await rendered.findByAltText(IMAGE_ALT_TEXT);
     expect(image).toBeInTheDocument();
+  });
+
+  it('does not leak event listeners', async () => {
+    rendered.unmount();
+    const addEventListenerSpy = jest.spyOn(window.Image.prototype, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window.Image.prototype, 'removeEventListener');
+    rendered = render(ui('/test.png'));
+    rendered.unmount();
+    expect(addEventListenerSpy.mock.calls.length).toEqual(removeEventListenerSpy.mock.calls.length);
+  });
+
+  it('can handle changing src', async () => {
+    image = await rendered.findByRole('img');
+    expect(image).toBeInTheDocument();
+    rendered.rerender(ui('/test2.png'));
+    image = rendered.queryByRole('img');
+    expect(image).not.toBeInTheDocument();
+    image = await rendered.findByRole('img');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('should render the image immediately after it is cached', async () => {
+    image = await rendered.findByRole('img');
+    expect(image).toBeInTheDocument();
+
+    rendered.unmount();
+    rendered = render(ui('/test.png'));
+    image = rendered.queryByRole('img');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('should not render image with no src', async () => {
+    rendered.rerender(ui());
+    image = rendered.queryByRole('img');
+    expect(image).not.toBeInTheDocument();
+    rendered.unmount();
+    rendered = render(ui());
+    image = rendered.queryByRole('img');
+    expect(image).not.toBeInTheDocument();
+  });
+
+  it('should not render image with empty string as src', async () => {
+    rendered.rerender(ui(''));
+    image = rendered.queryByRole('img');
+    expect(image).not.toBeInTheDocument();
+    rendered.unmount();
+    rendered = render(ui(''));
+    image = rendered.queryByRole('img');
+    expect(image).not.toBeInTheDocument();
+  });
+
+  it('should show fallback if image has no data', async () => {
+    rendered.unmount();
+    const spy = jest.spyOn(window.Image.prototype, 'naturalWidth', 'get');
+    spy.mockReturnValue(0);
+    rendered = render(ui('/test.png'));
+    const fallback = rendered.queryByText(FALLBACK_TEXT);
+    expect(fallback).toBeInTheDocument();
+    spy.mockRestore();
   });
 });
 
@@ -103,39 +158,38 @@ describe('given an Avatar with fallback and delayed render', () => {
 
 describe('given an Avatar with an image that only works when referrerPolicy=no-referrer', () => {
   let rendered: RenderResult;
-  const orignalGlobalImage = window.Image;
+  const originalGlobalImage = window.Image;
+  const ui = (src?: string, referrerPolicy?: HTMLAttributeReferrerPolicy) => (
+    <Avatar.Root data-testid={ROOT_TEST_ID}>
+      <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
+      <Avatar.Image src={src} alt={IMAGE_ALT_TEXT} referrerPolicy={referrerPolicy} />
+    </Avatar.Root>
+  );
 
   beforeAll(() => {
-    (window.Image as any) = class MockImage {
-      onload: () => void = () => {};
-      onerror: () => void = () => {};
-      src: string = '';
+    (window.Image as any) = class MockNoReferrerImage extends MockImage {
       referrerPolicy: string | undefined;
-      constructor() {
+      onSrcChange() {
         setTimeout(() => {
           if (this.referrerPolicy === 'no-referrer') {
-            this.onload();
+            this.dispatchEvent(new Event('load'));
           } else {
-            this.onerror();
+            this.dispatchEvent(new Event('error'));
           }
         }, DELAY);
-        return this;
       }
     };
   });
 
   afterAll(() => {
-    window.Image = orignalGlobalImage;
+    window.Image = originalGlobalImage;
+    jest.restoreAllMocks();
   });
 
   describe('referrerPolicy=no-referrer', () => {
     beforeEach(() => {
-      rendered = render(
-        <Avatar.Root data-testid={ROOT_TEST_ID}>
-          <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
-          <Avatar.Image src="/test.jpg" alt={IMAGE_ALT_TEXT} referrerPolicy="no-referrer" />
-        </Avatar.Root>
-      );
+      cache.clear();
+      rendered = render(ui('/test.png', 'no-referrer'));
     });
 
     it('should render the fallback initially', () => {
@@ -161,12 +215,8 @@ describe('given an Avatar with an image that only works when referrerPolicy=no-r
 
   describe('referrerPolicy=origin', () => {
     beforeEach(() => {
-      rendered = render(
-        <Avatar.Root data-testid={ROOT_TEST_ID}>
-          <Avatar.Fallback>{FALLBACK_TEXT}</Avatar.Fallback>
-          <Avatar.Image src="/test.jpg" alt={IMAGE_ALT_TEXT} referrerPolicy="origin" />
-        </Avatar.Root>
-      );
+      cache.clear();
+      rendered = render(ui('/test.png', 'origin'));
     });
 
     it('should render the fallback initially', () => {
@@ -187,3 +237,40 @@ describe('given an Avatar with an image that only works when referrerPolicy=no-r
     });
   });
 });
+
+
+class MockImage extends EventTarget {
+  _src: string = '';
+
+  constructor() {
+    super();
+    return this;
+  }
+
+  get src() {
+    return this._src;
+  }
+
+  set src(src: string) {
+    if (!src) {
+      return;
+    }
+    this._src = src;
+    this.onSrcChange();
+  }
+
+  get complete() {
+    return !this.src || cache.has(this.src);
+  }
+
+  get naturalWidth() {
+    return this.complete ? 300 : 0;
+  }
+
+  onSrcChange() {
+    setTimeout(() => {
+      this.dispatchEvent(new Event('load'));
+      cache.add(this.src);
+    }, DELAY);
+  }
+}

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -131,7 +131,7 @@ function resolveLoadingStatus(image: HTMLImageElement | null, src?: string): Ima
 
 function useImageLoadingStatus(src?: string, referrerPolicy?: React.HTMLAttributeReferrerPolicy) {
   const isHydrated = useIsHydrated()
-  const image = React.useRef(isHydrated ? new window.Image() : null);
+  const image = React.useRef<HTMLImageElement | null>(null);
   const img = (() => {
     if (!isHydrated) return null;
     if (!image.current) {

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -116,7 +116,7 @@ AvatarFallback.displayName = FALLBACK_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function setImageSrcAndGetInitialState(image: HTMLImageElement, src?: string): ImageLoadingStatus {
+function resolveLoadingStatus(image: HTMLImageElement, src?: string): ImageLoadingStatus {
   if (!src) {
     return 'error';
   }
@@ -129,11 +129,11 @@ function setImageSrcAndGetInitialState(image: HTMLImageElement, src?: string): I
 function useImageLoadingStatus(src?: string, referrerPolicy?: React.HTMLAttributeReferrerPolicy) {
   const image = React.useRef(new window.Image());
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>(() =>
-    setImageSrcAndGetInitialState(image.current, src)
+    resolveLoadingStatus(image.current, src)
   );
 
   useLayoutEffect(() => {
-    setLoadingStatus(setImageSrcAndGetInitialState(image.current, src));
+    setLoadingStatus(resolveLoadingStatus(image.current, src));
   }, [src]);
 
   useLayoutEffect(() => {

--- a/ssr-testing/app/avatar/page.tsx
+++ b/ssr-testing/app/avatar/page.tsx
@@ -5,6 +5,7 @@ export default function Page() {
   return (
     <Avatar.Root>
       <Avatar.Fallback>A</Avatar.Fallback>
+      <Avatar.AvatarImage src="https://picsum.photos/id/1005/400/400" />
     </Avatar.Root>
   );
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Fixes https://github.com/radix-ui/primitives/issues/2044 by initializing loadingStatus with `loaded` if the [`image.complete`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/complete) is true, based on @lauri865 suggestion in the linked issue.

Based on MDN, `image.complete` will be true if:
- Neither the src nor the srcset attribute is specified.
- The srcset attribute is absent and the src attribute, while specified, is the empty string ("").
- The image resource has been fully fetched and has been queued for rendering/compositing.
- The image element has previously determined that the image is fully available and ready for use.
- The image is "broken;" that is, the image failed to load due to an error or because image loading is disabled.

I added test case for all the cases, although I imagine the last case might be different from browser to browser. In Chrome, when image loading is disabled the load event will never fire and `image.complete` will always be false. To be safe I added another check for `image.naturalWidth > 0` since image with no data will have naturalWidth = 0.

I also added test and story for the case when image src changing to make sure my change can handle the changing src.

Tests added:
    ✓ does not leak event listeners (7 ms)
    ✓ can handle changing src (627 ms)
    ✓ should render the image immediately after it is cached (327 ms)
    ✓ should not render image with no src (5 ms)
    ✓ should not render image with empty string as src (3 ms)
    ✓ should show fallback if image has no data (4 ms)

Storybook added:
- Changing image src

| Before | After |
|--------|--------|
| ![fix-flashing-avatar-before](https://github.com/radix-ui/primitives/assets/1536976/05b587b5-5193-4166-aea5-bce6de143eba) | ![fix-flashing-avatar-after](https://github.com/radix-ui/primitives/assets/1536976/c73ffa3b-c0a0-4cb7-b556-fb5239b8eef4) |
