### PR TITLE
[NavigationMenu] Add NavigationMenu.Indicator translate values as css vars

### DIFF
--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -717,11 +717,13 @@ const NavigationMenuIndicatorImpl = React.forwardRef<
               left: 0,
               width: position.size + 'px',
               transform: `translateX(${position.offset}px)`,
+              '--radix-navigation-menu-indicator-translate-x': `${position.offset}px`,
             }
           : {
               top: 0,
               height: position.size + 'px',
               transform: `translateY(${position.offset}px)`,
+              '--radix-navigation-menu-indicator-translate-y': `${position.offset}px`,
             }),
         ...indicatorProps.style,
       }}


### PR DESCRIPTION
### Description
In issue #3005 it was requested that the translate values defined in `NavigationMenu.Indicator` be added as css variables so that this value can be used to make additional calculations.

This PR takes the `position.offset` defined in `NavigationMenu.Indicator` and assigns it to a css variable based on the if the menu is horizontal or vertical. 
