### PR TITLE
[Slider] Add ability to pass a ref prop for input element through SliderThumb

### DIFF
--- a/packages/react/slider/src/Slider.stories.tsx
+++ b/packages/react/slider/src/Slider.stories.tsx
@@ -3,6 +3,7 @@ import { DirectionProvider } from '@radix-ui/react-direction';
 import { css } from '../../../../stitches.config';
 import serialize from 'form-serialize';
 import * as Slider from '@radix-ui/react-slider';
+import { Primitive } from '@radix-ui/react-primitive';
 
 export default { title: 'Components/Slider' };
 
@@ -264,12 +265,16 @@ export const SmallSteps = () => {
 export const WithinForm = () => {
   const [data, setData] = React.useState({
     single: [0],
+    input: [0],
     multiple: [10, 15, 20, 80],
     price: {
       min: 30,
       max: 70,
     },
   });
+
+  const inputRef = React.useRef<React.ElementRef<typeof Primitive.input>>(null);
+
   return (
     <form
       onSubmit={(event) => {
@@ -278,6 +283,9 @@ export const WithinForm = () => {
       }}
       onChange={(event) => {
         const formData = serialize(event.currentTarget, { hash: true });
+        if (event.target !== inputRef.current) {
+          console.log("This is the event from our input reference");
+        }
         setData(formData as any);
       }}
     >
@@ -288,6 +296,19 @@ export const WithinForm = () => {
             <Slider.Range className={rangeClass()} />
           </Slider.Track>
           <Slider.Thumb className={thumbClass()} />
+        </Slider.Root>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>Input Ref value: {String(inputRef.current?.value)}</legend>
+        <Slider.Root name="input" defaultValue={data.single} className={rootClass()}>
+          <Slider.Track className={trackClass()}>
+            <Slider.Range className={rangeClass()} />
+          </Slider.Track>
+          <Slider.Thumb className={thumbClass()} inputRef={inputRef} />
         </Slider.Root>
       </fieldset>
 

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -545,12 +545,13 @@ const SliderThumb = React.forwardRef<SliderThumbElement, SliderThumbProps>(
 type SliderThumbImplElement = React.ElementRef<typeof Primitive.span>;
 interface SliderThumbImplProps extends PrimitiveSpanProps {
   index: number;
+  inputRef?: React.RefObject<BubbleInputElement> | undefined;
   name?: string;
 }
 
 const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImplProps>(
   (props: ScopedProps<SliderThumbImplProps>, forwardedRef) => {
-    const { __scopeSlider, index, name, ...thumbProps } = props;
+    const { __scopeSlider, index, inputRef, name, ...thumbProps } = props;
     const context = useSliderContext(THUMB_NAME, __scopeSlider);
     const orientation = useSliderOrientationContext(THUMB_NAME, __scopeSlider);
     const [thumb, setThumb] = React.useState<HTMLSpanElement | null>(null);
@@ -618,6 +619,7 @@ const SliderThumbImpl = React.forwardRef<SliderThumbImplElement, SliderThumbImpl
               name ??
               (context.name ? context.name + (context.values.length > 1 ? '[]' : '') : undefined)
             }
+            inputRef={inputRef}
             value={value}
           />
         )}
@@ -630,10 +632,17 @@ SliderThumb.displayName = THUMB_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const BubbleInput = (props: React.ComponentPropsWithoutRef<'input'>) => {
-  const { value, ...inputProps } = props;
-  const ref = React.useRef<HTMLInputElement>(null);
+type BubbleInputElement = React.ElementRef<typeof Primitive.input>
+
+interface BubbleInputProps extends React.ComponentPropsWithoutRef<'input'> {
+  inputRef?: React.RefObject<BubbleInputElement> | undefined;
+}
+
+const BubbleInput = (props: BubbleInputProps) => {
+  const { value, inputRef, ...inputProps } = props;
   const prevValue = usePrevious(value);
+  let ref = React.useRef<BubbleInputElement>(null);
+  if (inputRef) ref = inputRef;  
 
   // Bubble value change to parents (e.g form change event)
   React.useEffect(() => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Hello :wave: 

Thank you for reading my PR.  🙏 

I've found a use case where we're not able to interact with the input element in the Slider thumb. While you try to take care of this with the BubbleInput it's still limiting for consumers who want to do more e.g. pass more attributes or just have context of the input element itself. 

With this change, it enables consumers to set an accessable ref on the input element. Allowing the consumer to set attributes like `form` or `id` (for related label elements). 
Consumers can also add their own _onEventListeners_ directly to the `<input>`.

### Changes
- Added inputRef Prop for SliderThumb and BubbleInput
- Updated Slider Storybook with inputRef example.


If there is anything you are unsure about please do comment quesitons, suggestions the lot. 

Best Wishes
