### PR TITLE
Storybook (preview.ts) order option uncommented (Order now working)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,14 +2,11 @@ import type { Preview } from '@storybook/react';
 
 const preview: Preview = {
   parameters: {
-    // This should work after upgrading to Storybook 7.6 but doesn't.
-    // I am leaving it commented out here so we can fix it one day.
-    //
-    // options: {
-    //   storySort: {
-    //     order: ['Components', 'Utilities'],
-    //   },
-    // },
+    options: {
+      storySort: {
+        order: ['Components', 'Utilities'],
+      },
+    },
 
     // disables Chromatic on a global level
     chromatic: { disable: true },


### PR DESCRIPTION
 Storybook sort order was comment out, as it wasn't working.
 Not sure which update of Storybook 7.6 resolved this but it is now working.
 
 // This should work after upgrading to Storybook 7.6 but doesn't.
 // I am leaving it commented out here so we can fix it one day.
