### PR TITLE
[react/form] Fix Form.Message not being able to be used outside a Form.Field

### DIFF
--- a/.yarn/versions/52f80f42.yml
+++ b/.yarn/versions/52f80f42.yml
@@ -1,0 +1,33 @@
+releases:
+  "@radix-ui/react-context": patch
+  "@radix-ui/react-form": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-alert-dialog"
+  - "@radix-ui/react-avatar"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-collection"
+  - "@radix-ui/react-context-menu"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-dropdown-menu"
+  - "@radix-ui/react-hover-card"
+  - "@radix-ui/react-menu"
+  - "@radix-ui/react-menubar"
+  - "@radix-ui/react-navigation-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-popper"
+  - "@radix-ui/react-progress"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-scroll-area"
+  - "@radix-ui/react-select"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toast"
+  - "@radix-ui/react-toggle-group"
+  - "@radix-ui/react-toolbar"
+  - "@radix-ui/react-tooltip"

--- a/packages/react/context/src/createContext.tsx
+++ b/packages/react/context/src/createContext.tsx
@@ -63,12 +63,18 @@ function createContextScope(scopeName: string, createContextScopeDeps: CreateSco
       return <Context.Provider value={value}>{children}</Context.Provider>;
     }
 
-    function useContext(consumerName: string, scope: Scope<ContextValueType | undefined>) {
+    function useContext(
+      consumerName: string,
+      scope: Scope<ContextValueType | undefined>,
+      options: { isOptional?: boolean } = {}
+    ) {
       const Context = scope?.[scopeName][index] || BaseContext;
       const context = React.useContext(Context);
+      const { isOptional } = options;
+      if (isOptional) return {} as ContextValueType;
       if (context) return context;
       if (defaultContext !== undefined) return defaultContext;
-      // if a defaultContext wasn't specified, it's a required context.
+      // if a defaultContext wasn't specified and isOptional is false, it's a required context.
       throw new Error(`\`${consumerName}\` must be used within \`${rootComponentName}\``);
     }
 

--- a/packages/react/form/src/Form.stories.tsx
+++ b/packages/react/form/src/Form.stories.tsx
@@ -107,10 +107,11 @@ export const Cypress = () => {
         <Form.Field name="name">
           <Form.Label>Name (required)</Form.Label>
           <Form.Control type="text" required />
-          <Form.Message match="valueMissing" />
           <Form.Message match="valid">valid!</Form.Message>
         </Form.Field>
 
+        {/* This Form.Message is used out of the Form.Field context */}
+        <Form.Message match="valueMissing" name="name" />
         <Form.Field name="age">
           <Form.Label>Age (0-99)</Form.Label>
           <Form.Control type="number" min="0" max="99" step="1" />

--- a/packages/react/form/src/Form.tsx
+++ b/packages/react/form/src/Form.tsx
@@ -462,8 +462,16 @@ interface FormMessageProps extends Omit<FormMessageImplProps, 'name'> {
 const FormMessage = React.forwardRef<FormMessageElement, FormMessageProps>(
   (props: ScopedProps<FormMessageProps>, forwardedRef) => {
     const { match, name: nameProp, ...messageProps } = props;
-    const fieldContext = useFormFieldContext(MESSAGE_NAME, props.__scopeForm);
+    const fieldContext = useFormFieldContext(MESSAGE_NAME, props.__scopeForm, {
+      isOptional: !!nameProp,
+    });
     const name = nameProp ?? fieldContext.name;
+
+    if (!nameProp && !fieldContext?.name) {
+      throw new Error(
+        `\`${MESSAGE_NAME}\` must be used within \`${FIELD_NAME}\` or specify the \`name\` prop`
+      );
+    }
 
     if (match === undefined) {
       return (


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
Closes: #2279 

This PR regards an issue where users receive an error when using `Form.Message` outside of a `Form.Field`, even when following the [documentation](https://www.radix-ui.com/primitives/docs/components/form#message) and specifying the `name` prop.

#### The Problem
The root cause is in the `useContext` hook within `createContext.tsx`, which throws an error immediately upon detecting a missing context.

#### The Changes
This PR introduces the following changes to try and solve that:

- Enhances the `useContext` hook in `createContext.tsx`:
     - Adds an `options` object parameter with an `isOptional` prop
     - Checks if the context is optional and returns an empty object if so, preventing unintended errors
     
- Improves `FormMessage` implementation:
     - Prioritizes using the name prop to link `Field.Message` to a `Form.Field` when available
     - Falls back to using the form context if name is not provided
     - Throws an appropriate error when both `Form.Field` context and name prop are absent.

- Updates Form.stories.tsx:
    - Modifies a `Form.Message` usage to be out of context, enabling Cypress tests to also check for this scenario.
