### PR TITLE
fix: index referring to scope?.[scopeName] being undefined

### DIFF
--- a/packages/react/context/src/createContext.tsx
+++ b/packages/react/context/src/createContext.tsx
@@ -56,7 +56,7 @@ function createContextScope(scopeName: string, createContextScopeDeps: CreateSco
       props: ContextValueType & { scope: Scope<ContextValueType>; children: React.ReactNode }
     ) {
       const { scope, children, ...context } = props;
-      const Context = scope?.[scopeName][index] || BaseContext;
+      const Context = scope?.[scopeName]?.[index] || BaseContext;
       // Only re-memoize when prop values change
       // eslint-disable-next-line react-hooks/exhaustive-deps
       const value = React.useMemo(() => context, Object.values(context)) as ContextValueType;
@@ -64,7 +64,7 @@ function createContextScope(scopeName: string, createContextScopeDeps: CreateSco
     }
 
     function useContext(consumerName: string, scope: Scope<ContextValueType | undefined>) {
-      const Context = scope?.[scopeName][index] || BaseContext;
+      const Context = scope?.[scopeName]?.[index] || BaseContext;
       const context = React.useContext(Context);
       if (context) return context;
       if (defaultContext !== undefined) return defaultContext;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Adding an additional optional chaining operator for `scope?.[scopeName]?.[index]`. We started seeing `scope?.[scopeName]` as `undefined` after switching to [esbuild](https://github.com/radix-ui/primitives/pull/2922) under specific conditions. 
Not sure whether such situation happens because a scope is not provided or there is incorrect scope composition. Adding an extra layer of safety ensures that both `scope?.[scopeName]` and `scope?.[scopeName]?.[index]` are properly checked.
