### PR TITLE
refactor(useControllableState): add usePrevious instead useRef

### DIFF
--- a/.yarn/versions/b84c2e18.yml
+++ b/.yarn/versions/b84c2e18.yml
@@ -1,0 +1,25 @@
+releases:
+  "@radix-ui/react-use-controllable-state": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-context-menu"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-dropdown-menu"
+  - "@radix-ui/react-hover-card"
+  - "@radix-ui/react-menubar"
+  - "@radix-ui/react-navigation-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-select"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toast"
+  - "@radix-ui/react-toggle"
+  - "@radix-ui/react-toggle-group"
+  - "@radix-ui/react-tooltip"

--- a/packages/react/use-controllable-state/package.json
+++ b/packages/react/use-controllable-state/package.json
@@ -28,7 +28,8 @@
     "version": "yarn version"
   },
   "dependencies": {
-    "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-previous": "workspace:*"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react/use-controllable-state/src/useControllableState.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+import { usePrevious } from '@radix-ui/react-use-previous';
 
 type UseControllableStateParams<T> = {
   prop?: T | undefined;
@@ -41,15 +42,14 @@ function useUncontrolledState<T>({
 }: Omit<UseControllableStateParams<T>, 'prop'>) {
   const uncontrolledState = React.useState<T | undefined>(defaultProp);
   const [value] = uncontrolledState;
-  const prevValueRef = React.useRef(value);
+  const prevValue = usePrevious(value);
   const handleChange = useCallbackRef(onChange);
 
   React.useEffect(() => {
-    if (prevValueRef.current !== value) {
+    if (prevValue !== value) {
       handleChange(value as T);
-      prevValueRef.current = value;
     }
-  }, [value, prevValueRef, handleChange]);
+  }, [value, prevValue, handleChange]);
 
   return uncontrolledState;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,6 +4414,7 @@ __metadata:
   resolution: "@radix-ui/react-use-controllable-state@workspace:packages/react/use-controllable-state"
   dependencies:
     "@radix-ui/react-use-callback-ref": "workspace:*"
+    "@radix-ui/react-use-previous": "workspace:*"
   peerDependencies:
     "@types/react": "*"
     react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

<!-- Describe the change you are introducing -->

### Test

![image](https://github.com/user-attachments/assets/38ad1e26-6520-4a01-a140-939783ead2dd)
* test is successful! 👍

### Description

* we provide `usePrevious` custom hook in `radix-ui/primitives` so i add our `usePrevious` hook instead react's useRef in `useControllableState`. 
* i think using our product(`usePrevious`) is more pretty and cool! 🤗. 
