### PR TITLE
refactor(useControllableState): merge useUncontolledState in useControllableState

### DIFF
--- a/.yarn/versions/261b859b.yml
+++ b/.yarn/versions/261b859b.yml
@@ -1,0 +1,25 @@
+releases:
+  "@radix-ui/react-use-controllable-state": patch
+
+declined:
+  - primitives
+  - "@radix-ui/react-accordion"
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-collapsible"
+  - "@radix-ui/react-context-menu"
+  - "@radix-ui/react-dialog"
+  - "@radix-ui/react-dropdown-menu"
+  - "@radix-ui/react-hover-card"
+  - "@radix-ui/react-menubar"
+  - "@radix-ui/react-navigation-menu"
+  - "@radix-ui/react-popover"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-roving-focus"
+  - "@radix-ui/react-select"
+  - "@radix-ui/react-slider"
+  - "@radix-ui/react-switch"
+  - "@radix-ui/react-tabs"
+  - "@radix-ui/react-toast"
+  - "@radix-ui/react-toggle"
+  - "@radix-ui/react-toggle-group"
+  - "@radix-ui/react-tooltip"

--- a/packages/react/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react/use-controllable-state/src/useControllableState.tsx
@@ -30,7 +30,7 @@ function useControllableState<T>({
 
       handleChange(nextValue as T);
     },
-    [isControlled, value, setUncontrolledProp, handleChange]
+    [isControlled, value, handleChange]
   );
 
   return [value, setValue] as const;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Test

![image](https://github.com/user-attachments/assets/aeb2cd6f-ac41-4960-85ea-b946ac8f44ad)

* test is successful!

### Description

* handleChage always run both(useControllableState, useUncontrolledState), we can merge.
* both always use nextValue (which is executed function case or not), so we dont need to seperate it. in useUncontrolledState, run useEffect when useUncontrolledState's value changed. but if merge, it does not need to use useEffect.
* in both, compare prevValue and nextValue if they are same or not, this case also we can merge.

<!-- Describe the change you are introducing -->
