### PR TITLE
fix: Stop ignoring RadioGroup.Item onKeyDown prop

### DIFF
--- a/.yarn/versions/30279e97.yml
+++ b/.yarn/versions/30279e97.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-radio-group": patch
+
+undecided:
+  - primitives

--- a/packages/react/radio-group/src/RadioGroup.tsx
+++ b/packages/react/radio-group/src/RadioGroup.tsx
@@ -163,7 +163,7 @@ const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemPro
           name={context.name}
           ref={composedRefs}
           onCheck={() => context.onValueChange(itemProps.value)}
-          onKeyDown={composeEventHandlers((event) => {
+          onKeyDown={composeEventHandlers(itemProps.onKeyDown, (event) => {
             // According to WAI ARIA, radio groups don't activate items on enter keypress
             if (event.key === 'Enter') event.preventDefault();
           })}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

`RadioGroup.Item` ignores the `onKeyDown` prop.
This change fixes that.
