### PR TITLE
feat(Slot): allow customizing prop merging behavior with the new `propMergers` prop

### DIFF
--- a/.yarn/versions/63dd769c.yml
+++ b/.yarn/versions/63dd769c.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-slot": minor

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -4,4 +4,4 @@ export {
   //
   Root,
 } from './Slot';
-export type { SlotProps } from './Slot';
+export type { SlotProps, PropMergers, PropMerger, CustomizableMergingPropName } from './Slot';


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Closes #2631.

This PR adds a new prop `propMergers` to the `<Slot>` component that enables customizing the prop value merging behavior for each attribute.