### PR TITLE
[Select] Select scroll speed addition

### DIFF
--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1382,10 +1382,7 @@ SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
 const SCROLL_UP_BUTTON_NAME = 'SelectScrollUpButton';
 
 type SelectScrollUpButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
-  scrollFactor?: number;
-  applyScrollFactorOnMobile?: boolean;
-}
+interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
 
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
@@ -1416,9 +1413,7 @@ const SelectScrollUpButton = React.forwardRef<
       onAutoScroll={() => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          const isMobile = navigator.maxTouchPoints > 0;
-          const factor = isMobile && !props.applyScrollFactorOnMobile ? 1 : props.scrollFactor ?? 1;
-          viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight * Math.abs(factor);
+          viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight;
         }
       }}
     />
@@ -1434,10 +1429,7 @@ SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 const SCROLL_DOWN_BUTTON_NAME = 'SelectScrollDownButton';
 
 type SelectScrollDownButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
-  scrollFactor?: number;
-  applyScrollFactorOnMobile?: boolean;
-}
+interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
@@ -1471,9 +1463,7 @@ const SelectScrollDownButton = React.forwardRef<
       onAutoScroll={() => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          const isMobile = navigator.maxTouchPoints > 0;
-          const factor = isMobile && !props.applyScrollFactorOnMobile ? 1 : props.scrollFactor ?? 1;
-          viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight * Math.abs(factor);
+          viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight;
         }
       }}
     />

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1390,42 +1390,46 @@ interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'o
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
   SelectScrollUpButtonProps
->((props: ScopedProps<SelectScrollUpButtonProps>, forwardedRef) => {
-  const contentContext = useSelectContentContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
-  const viewportContext = useSelectViewportContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
-  const [canScrollUp, setCanScrollUp] = React.useState(false);
-  const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
+>(
+  (
+    { hoverScrollFactor, touchScrollFactor, ...props }: ScopedProps<SelectScrollUpButtonProps>,
+    forwardedRef
+  ) => {
+    const contentContext = useSelectContentContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
+    const viewportContext = useSelectViewportContext(SCROLL_UP_BUTTON_NAME, props.__scopeSelect);
+    const [canScrollUp, setCanScrollUp] = React.useState(false);
+    const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
 
-  useLayoutEffect(() => {
-    if (contentContext.viewport && contentContext.isPositioned) {
-      const viewport = contentContext.viewport;
-      function handleScroll() {
-        const canScrollUp = viewport.scrollTop > 0;
-        setCanScrollUp(canScrollUp);
-      }
-      handleScroll();
-      viewport.addEventListener('scroll', handleScroll);
-      return () => viewport.removeEventListener('scroll', handleScroll);
-    }
-  }, [contentContext.viewport, contentContext.isPositioned]);
-
-  return canScrollUp ? (
-    <SelectScrollButtonImpl
-      {...props}
-      ref={composedRefs}
-      onAutoScroll={(pointerAction?: 'move' | 'down') => {
-        const { viewport, selectedItem } = contentContext;
-        if (viewport && selectedItem) {
-          const factor =
-            pointerAction &&
-            (pointerAction === 'move' ? props.hoverScrollFactor : props.touchScrollFactor);
-          viewport.scrollTop =
-            viewport.scrollTop - selectedItem.offsetHeight * Math.abs(factor ?? 1);
+    useLayoutEffect(() => {
+      if (contentContext.viewport && contentContext.isPositioned) {
+        const viewport = contentContext.viewport;
+        function handleScroll() {
+          const canScrollUp = viewport.scrollTop > 0;
+          setCanScrollUp(canScrollUp);
         }
-      }}
-    />
-  ) : null;
-});
+        handleScroll();
+        viewport.addEventListener('scroll', handleScroll);
+        return () => viewport.removeEventListener('scroll', handleScroll);
+      }
+    }, [contentContext.viewport, contentContext.isPositioned]);
+
+    return canScrollUp ? (
+      <SelectScrollButtonImpl
+        {...props}
+        ref={composedRefs}
+        onAutoScroll={(pointerAction?: 'move' | 'down') => {
+          const { viewport, selectedItem } = contentContext;
+          if (viewport && selectedItem) {
+            const factor =
+              pointerAction && (pointerAction === 'move' ? hoverScrollFactor : touchScrollFactor);
+            viewport.scrollTop =
+              viewport.scrollTop - selectedItem.offsetHeight * Math.abs(factor ?? 1);
+          }
+        }}
+      />
+    ) : null;
+  }
+);
 
 SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 
@@ -1444,45 +1448,49 @@ interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
   SelectScrollDownButtonProps
->((props: ScopedProps<SelectScrollDownButtonProps>, forwardedRef) => {
-  const contentContext = useSelectContentContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
-  const viewportContext = useSelectViewportContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
-  const [canScrollDown, setCanScrollDown] = React.useState(false);
-  const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
+>(
+  (
+    { hoverScrollFactor, touchScrollFactor, ...props }: ScopedProps<SelectScrollDownButtonProps>,
+    forwardedRef
+  ) => {
+    const contentContext = useSelectContentContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
+    const viewportContext = useSelectViewportContext(SCROLL_DOWN_BUTTON_NAME, props.__scopeSelect);
+    const [canScrollDown, setCanScrollDown] = React.useState(false);
+    const composedRefs = useComposedRefs(forwardedRef, viewportContext.onScrollButtonChange);
 
-  useLayoutEffect(() => {
-    if (contentContext.viewport && contentContext.isPositioned) {
-      const viewport = contentContext.viewport;
-      function handleScroll() {
-        const maxScroll = viewport.scrollHeight - viewport.clientHeight;
-        // we use Math.ceil here because if the UI is zoomed-in
-        // `scrollTop` is not always reported as an integer
-        const canScrollDown = Math.ceil(viewport.scrollTop) < maxScroll;
-        setCanScrollDown(canScrollDown);
-      }
-      handleScroll();
-      viewport.addEventListener('scroll', handleScroll);
-      return () => viewport.removeEventListener('scroll', handleScroll);
-    }
-  }, [contentContext.viewport, contentContext.isPositioned]);
-
-  return canScrollDown ? (
-    <SelectScrollButtonImpl
-      {...props}
-      ref={composedRefs}
-      onAutoScroll={(pointerAction?: 'move' | 'down') => {
-        const { viewport, selectedItem } = contentContext;
-        if (viewport && selectedItem) {
-          const factor =
-            pointerAction &&
-            (pointerAction === 'move' ? props.hoverScrollFactor : props.touchScrollFactor);
-          viewport.scrollTop =
-            viewport.scrollTop + selectedItem.offsetHeight * Math.abs(factor ?? 1);
+    useLayoutEffect(() => {
+      if (contentContext.viewport && contentContext.isPositioned) {
+        const viewport = contentContext.viewport;
+        function handleScroll() {
+          const maxScroll = viewport.scrollHeight - viewport.clientHeight;
+          // we use Math.ceil here because if the UI is zoomed-in
+          // `scrollTop` is not always reported as an integer
+          const canScrollDown = Math.ceil(viewport.scrollTop) < maxScroll;
+          setCanScrollDown(canScrollDown);
         }
-      }}
-    />
-  ) : null;
-});
+        handleScroll();
+        viewport.addEventListener('scroll', handleScroll);
+        return () => viewport.removeEventListener('scroll', handleScroll);
+      }
+    }, [contentContext.viewport, contentContext.isPositioned]);
+
+    return canScrollDown ? (
+      <SelectScrollButtonImpl
+        {...props}
+        ref={composedRefs}
+        onAutoScroll={(pointerAction?: 'move' | 'down') => {
+          const { viewport, selectedItem } = contentContext;
+          if (viewport && selectedItem) {
+            const factor =
+              pointerAction && (pointerAction === 'move' ? hoverScrollFactor : touchScrollFactor);
+            viewport.scrollTop =
+              viewport.scrollTop + selectedItem.offsetHeight * Math.abs(factor ?? 1);
+          }
+        }}
+      />
+    ) : null;
+  }
+);
 
 SelectScrollDownButton.displayName = SCROLL_DOWN_BUTTON_NAME;
 

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1382,7 +1382,10 @@ SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
 const SCROLL_UP_BUTTON_NAME = 'SelectScrollUpButton';
 
 type SelectScrollUpButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
+  hoverScrollFactor?: number;
+  touchScrollFactor?: number;
+}
 
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
@@ -1410,10 +1413,14 @@ const SelectScrollUpButton = React.forwardRef<
     <SelectScrollButtonImpl
       {...props}
       ref={composedRefs}
-      onAutoScroll={() => {
+      onAutoScroll={(pointerAction?: 'move' | 'down') => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight;
+          const factor =
+            pointerAction &&
+            (pointerAction === 'move' ? props.hoverScrollFactor : props.touchScrollFactor);
+          viewport.scrollTop =
+            viewport.scrollTop - selectedItem.offsetHeight * Math.abs(factor ?? 1);
         }
       }}
     />
@@ -1429,7 +1436,10 @@ SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 const SCROLL_DOWN_BUTTON_NAME = 'SelectScrollDownButton';
 
 type SelectScrollDownButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
+  hoverScrollFactor?: number;
+  touchScrollFactor?: number;
+}
 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
@@ -1460,10 +1470,14 @@ const SelectScrollDownButton = React.forwardRef<
     <SelectScrollButtonImpl
       {...props}
       ref={composedRefs}
-      onAutoScroll={() => {
+      onAutoScroll={(pointerAction?: 'move' | 'down') => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight;
+          const factor =
+            pointerAction &&
+            (pointerAction === 'move' ? props.hoverScrollFactor : props.touchScrollFactor);
+          viewport.scrollTop =
+            viewport.scrollTop + selectedItem.offsetHeight * Math.abs(factor ?? 1);
         }
       }}
     />
@@ -1474,7 +1488,7 @@ SelectScrollDownButton.displayName = SCROLL_DOWN_BUTTON_NAME;
 
 type SelectScrollButtonImplElement = React.ElementRef<typeof Primitive.div>;
 interface SelectScrollButtonImplProps extends PrimitiveDivProps {
-  onAutoScroll(): void;
+  onAutoScroll(pointerAction?: 'move' | 'down'): void;
 }
 
 const SelectScrollButtonImpl = React.forwardRef<
@@ -1514,13 +1528,13 @@ const SelectScrollButtonImpl = React.forwardRef<
       style={{ flexShrink: 0, ...scrollIndicatorProps.style }}
       onPointerDown={composeEventHandlers(scrollIndicatorProps.onPointerDown, () => {
         if (autoScrollTimerRef.current === null) {
-          autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
+          autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50, 'down');
         }
       })}
       onPointerMove={composeEventHandlers(scrollIndicatorProps.onPointerMove, () => {
         contentContext.onItemLeave?.();
         if (autoScrollTimerRef.current === null) {
-          autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50);
+          autoScrollTimerRef.current = window.setInterval(onAutoScroll, 50, 'move');
         }
       })}
       onPointerLeave={composeEventHandlers(scrollIndicatorProps.onPointerLeave, () => {

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1382,7 +1382,10 @@ SelectItemIndicator.displayName = ITEM_INDICATOR_NAME;
 const SCROLL_UP_BUTTON_NAME = 'SelectScrollUpButton';
 
 type SelectScrollUpButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollUpButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
+  scrollFactor?: number;
+  applyScrollFactorOnMobile?: boolean;
+}
 
 const SelectScrollUpButton = React.forwardRef<
   SelectScrollUpButtonElement,
@@ -1413,7 +1416,9 @@ const SelectScrollUpButton = React.forwardRef<
       onAutoScroll={() => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight;
+          const isMobile = navigator.maxTouchPoints > 0;
+          const factor = isMobile && !props.applyScrollFactorOnMobile ? 1 : props.scrollFactor ?? 1;
+          viewport.scrollTop = viewport.scrollTop - selectedItem.offsetHeight * Math.abs(factor);
         }
       }}
     />
@@ -1429,7 +1434,10 @@ SelectScrollUpButton.displayName = SCROLL_UP_BUTTON_NAME;
 const SCROLL_DOWN_BUTTON_NAME = 'SelectScrollDownButton';
 
 type SelectScrollDownButtonElement = SelectScrollButtonImplElement;
-interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {}
+interface SelectScrollDownButtonProps extends Omit<SelectScrollButtonImplProps, 'onAutoScroll'> {
+  scrollFactor?: number;
+  applyScrollFactorOnMobile?: boolean;
+}
 
 const SelectScrollDownButton = React.forwardRef<
   SelectScrollDownButtonElement,
@@ -1463,7 +1471,9 @@ const SelectScrollDownButton = React.forwardRef<
       onAutoScroll={() => {
         const { viewport, selectedItem } = contentContext;
         if (viewport && selectedItem) {
-          viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight;
+          const isMobile = navigator.maxTouchPoints > 0;
+          const factor = isMobile && !props.applyScrollFactorOnMobile ? 1 : props.scrollFactor ?? 1;
+          viewport.scrollTop = viewport.scrollTop + selectedItem.offsetHeight * Math.abs(factor);
         }
       }}
     />


### PR DESCRIPTION
Added the following props to `SelectScrollUpButtonProps` and `SelectScrollDownButtonProps` to be able to control the scroll speed when hovering or clicking on those buttons.

Props added
```
  hoverScrollFactor?: number;
  touchScrollFactor?: number;
```

I made the decision to supply two separate props because the functionality and the use case might be very different. On web when hovering over the buttons, in some scenarios scroll is too fast so we might put a value of `hoverScrollFactor={0.3}` for example to slow it down. At the same time on mobile we might want to increase how much the list scrolls on press so we will set `touchScrollFactor={2}` for example.

Tested on web with various browsers as well as on Android and iOS real devices.