### PR TITLE
[Select] Missing className in the SelectValue component

### DIFF
--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -340,6 +340,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
     return (
       <Primitive.span
         {...valueProps}
+        className={className}
         ref={composedRefs}
         // we don't want events from the portalled `SelectValue` children to bubble
         // through the item they came from


### PR DESCRIPTION
### Description

The `SelectValue` component was missing the `className` property, which caused issues when attempting to customize the element's appearance.
