### PR TITLE
[Slider] Fix slider focus in scrollable context

### DIFF
--- a/.changeset/empty-hounds-sit.md
+++ b/.changeset/empty-hounds-sit.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+Fix slider focus in scrollable context

--- a/apps/storybook/stories/slider.stories.tsx
+++ b/apps/storybook/stories/slider.stories.tsx
@@ -345,6 +345,26 @@ export const Strict = () => (
   </React.StrictMode>
 );
 
+export const InScrollableContext = () => {
+  const [value, setValue] = React.useState(0);
+
+  return (
+    <div style={{ width: '40vw', overflowX: 'scroll', border: '1px' }}>
+      <Slider.Root
+        className={rootClass()}
+        style={{ width: '100vw' }}
+        value={[value]}
+        onValueChange={([newValue]: [number]) => setValue(newValue)}
+      >
+        <Slider.Track className={trackClass()}>
+          <Slider.Range className={rangeClass()} />
+        </Slider.Track>
+        <Slider.Thumb className={thumbClass()} />
+      </Slider.Root>
+    </div>
+  );
+};
+
 export const Chromatic = () => (
   <>
     <h1>Uncontrolled</h1>

--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -103,7 +103,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
       defaultProp: defaultValue,
       onChange: (value) => {
         const thumbs = [...thumbRefs.current];
-        thumbs[valueIndexToChangeRef.current]?.focus();
+        thumbs[valueIndexToChangeRef.current]?.focus({ preventScroll: true });
         onValueChange(value);
       },
     });
@@ -435,7 +435,7 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
           // Touch devices have a delay before focusing so won't focus if touch immediately moves
           // away from target (sliding). We want thumb to focus regardless.
           if (context.thumbs.has(target)) {
-            target.focus();
+            target.focus({ preventScroll: true });
           } else {
             onSlideStart(event);
           }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Previously if a Slider was used in a context where one has to scroll to view the entire range of the Slider, and the Slider was used in conjunction with a backed value (i.e. `Value` and `onValueChange` props are provided) then unexpected scrolling would occur with the following steps.

1. Have the slider at a position near the start value.
2. Scroll towards the end of the slider (make sure the Slider thumb is no longer visible in the scroll container).
3. Click somewhere else to ensure the Slider thumb is currently not the focused element
4. Click on the slider track to change the value

Then the `.focus()` in the `onChange` handler would scroll back to the last location of the Slider thumb, and then the value would be updated. Thus the Slider thumb would be at the location you scrolled to, while the user would be at the location where the slider thumb was before.
See video for short demo.

https://github.com/user-attachments/assets/f76ba805-c9c5-4168-bcd8-9582649486cd

This fix prevents scrolling when focusing the Slider Thumb so the location in the scroll context remains stable.

Current behavior can be observed in the following Codesandbox  https://codesandbox.io/p/devbox/damp-microservice-n4hz7x
I also included a story in Storybook where the Slider is placed in a scroll container where the fixed behavior can be observed.

#### Motivation

One might wonder why you would have a Slider so wide that you need to scroll. I am currently building a diagram where the x axis represents time and in that context it is quite likely that the whole diagram represents 24 hours, but the user only sees 2~3 hours on their screen at a time in order to observe the necessary details.

<!-- Describe the change you are introducing -->
