### PR TITLE
[Select] add form prop (#2975)

### DIFF
--- a/.yarn/versions/79af2124.yml
+++ b/.yarn/versions/79af2124.yml
@@ -1,0 +1,6 @@
+releases:
+  "@radix-ui/react-select": minor
+
+declined:
+  - primitives
+  - ssr-testing

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -30,4 +30,18 @@ describe('Select', () => {
       cy.findByText('…').should('exist');
     });
   });
+
+  describe('given a select with a form attribute outside of a form', () => {
+    it('should include the select value when submitting the form', () => {
+      // submit without change
+      cy.findByText('go to').click();
+      cy.findByText(/You are going to/).should('include.text', 'Earth');
+
+      // react to changes
+      cy.findByLabelText(/choose a planet/).click();
+      cy.findByRole('option', { name: /Jupiter/i }).click();
+      cy.findByText('go to').click();
+      cy.findByText(/You are going to/).should('include.text', 'Jupiter');
+    });
+  });
 });

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -637,6 +637,72 @@ export const RequiredWithinForm = () => {
   );
 };
 
+export const LinkedToForm = () => {
+  const [data, setData] = React.useState({});
+
+  function handleChange(event: React.FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    setData(Object.fromEntries((formData as any).entries()));
+  }
+
+  const formId = React.useId();
+
+  return (
+    <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+      <Label style={{ display: 'block' }}>
+        Country
+        <Select.Root name="country" autoComplete="country" defaultValue="fr" form={formId}>
+          <Select.Trigger className={triggerClass()}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={contentClass()}>
+              <Select.Viewport className={viewportClass()}>
+                <Select.Item className={itemClass()} value="fr">
+                  <Select.ItemText>France</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="uk">
+                  <Select.ItemText>United Kingdom</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={itemClass()} value="es">
+                  <Select.ItemText>Spain</Select.ItemText>
+                  <Select.ItemIndicator className={indicatorClass()}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+      <form
+        id={formId}
+        onSubmit={(event) => {
+          handleChange(event);
+          event.preventDefault();
+        }}
+        onChange={handleChange}
+      >
+        <Label style={{ display: 'block' }}>
+          Name
+          <input name="name" autoComplete="name" style={{ display: 'block' }} />
+        </Label>
+        <br />
+        <button type="submit">Submit</button>
+        <br />
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+      </form>
+    </div>
+  );
+};
+
 export const WithinDialog = () => (
   <div style={{ height: '120vh' }}>
     <Dialog.Root>
@@ -780,10 +846,20 @@ ChromaticNoDefaultValue.parameters = { chromatic: { disable: false } };
 export const Cypress = () => {
   const [data, setData] = React.useState<{ size?: 'S' | 'M' | 'L' }>({});
   const [model, setModel] = React.useState<string | undefined>('');
+  const planets = React.useMemo(
+    () => ['Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune'] as const,
+    []
+  );
+  const [planetData, setPlanetData] = React.useState<{ planet?: (typeof planets)[number] }>({});
 
   function handleChange(event: React.FormEvent<HTMLFormElement>) {
     const formData = new FormData(event.currentTarget);
     setData(Object.fromEntries((formData as any).entries()));
+  }
+
+  function handlePlanetChange(event: React.FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    setPlanetData(Object.fromEntries(formData.entries()));
   }
 
   return (
@@ -881,6 +957,47 @@ export const Cypress = () => {
         <button type="button" style={{ width: 100, height: 50 }} onClick={() => setModel('')}>
           unset
         </button>
+      </div>
+
+      <hr />
+
+      <div style={{ padding: 50 }}>
+        <Label>
+          choose a planet:
+          <Select.Root defaultValue="Earth" name="planet" form="planetForm">
+            <Select.Trigger className={triggerClass()}>
+              <Select.Value />
+              <Select.Icon />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content className={contentClass()}>
+                <Select.Viewport className={viewportClass()}>
+                  {planets.map((planet) => (
+                    <Select.Item key={planet} className={itemClass()} value={planet}>
+                      <Select.ItemText>{planet}</Select.ItemText>
+                      <Select.ItemIndicator className={indicatorClass()}>
+                        <TickIcon />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                  ))}
+                </Select.Viewport>
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
+        </Label>
+        <form
+          id="planetForm"
+          onSubmit={(event) => {
+            handlePlanetChange(event);
+            event.preventDefault();
+          }}
+          onChange={handlePlanetChange}
+        >
+          <button type="submit" style={{ width: 100, height: 50 }}>
+            go to
+          </button>
+          {planetData.planet ? <p>You are going to {planetData.planet}</p> : null}
+        </form>
       </div>
     </>
   );

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -65,6 +65,7 @@ type SelectContextValue = {
   dir: SelectProps['dir'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
   disabled?: boolean;
+  form?: string;
 };
 
 const [SelectProvider, useSelectContext] = createSelectContext<SelectContextValue>(SELECT_NAME);
@@ -91,6 +92,7 @@ interface SelectProps {
   autoComplete?: string;
   disabled?: boolean;
   required?: boolean;
+  form?: string;
 }
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
@@ -108,6 +110,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     autoComplete,
     disabled,
     required,
+    form,
   } = props;
   const popperScope = usePopperScope(__scopeSelect);
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
@@ -127,7 +130,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const triggerPointerDownPosRef = React.useRef<{ x: number; y: number } | null>(null);
 
   // We set this to true by default so that events bubble to forms without JS (SSR)
-  const isFormControl = trigger ? Boolean(trigger.closest('form')) : true;
+  const isFormControl = trigger ? Boolean(trigger.form) : true;
   const [nativeOptionsSet, setNativeOptionsSet] = React.useState(new Set<NativeOption>());
 
   // The native `select` only associates the correct default value if the corresponding
@@ -158,6 +161,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
         dir={direction}
         triggerPointerDownPosRef={triggerPointerDownPosRef}
         disabled={disabled}
+        form={form}
       >
         <Collection.Provider scope={__scopeSelect}>
           <SelectNativeOptionsProvider
@@ -189,6 +193,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             // enable form autofill
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
+            form={form}
           >
             {value === undefined ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}
@@ -250,6 +255,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
         <Primitive.button
           type="button"
           role="combobox"
+          form={context.form}
           aria-controls={context.contentId}
           aria-expanded={context.open}
           aria-required={context.required}

--- a/ssr-testing/app/select/page.tsx
+++ b/ssr-testing/app/select/page.tsx
@@ -59,6 +59,38 @@ export default function Page() {
           </Select.Portal>
         </Select.Root>
       </form>
+
+      <form id="selectForm">
+        <button type="submit" value="submit">
+          Submit
+        </button>
+      </form>
+      <Select.Root form="selectForm" name="select" defaultValue="1">
+        <Select.Trigger>
+          <Select.Value placeholder="Pick an option" />
+          <Select.Icon>▼</Select.Icon>
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content>
+            <Select.ScrollUpButton>▲</Select.ScrollUpButton>
+            <Select.Viewport>
+              <Select.Item value="1">
+                <Select.ItemText>Item 1</Select.ItemText>
+                <Select.ItemIndicator>✔</Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item value="2">
+                <Select.ItemText>Item 2</Select.ItemText>
+                <Select.ItemIndicator>✔</Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item value="3">
+                <Select.ItemText>Item 3</Select.ItemText>
+                <Select.ItemIndicator>✔</Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+            <Select.ScrollDownButton>▼</Select.ScrollDownButton>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
     </>
   );
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

This PR adds a new `form` prop to the Select.Root primitive which serves the same purpose as the `form` attribute on a normal HTML `<select>` element.
This allows us to use radix Select elements outside of a form's markup and still have its value included in that form's submissions.

Apart from adding the `form` prop to the `Select.Root` primitive, this PR also changes how `isFormControl` is determined. Instead of using `element.closest('form')`, it now uses `element.form`. This shouldn't have an impact to controls that are located inside a `<form>` already, because the `form` attribute is automatically set to the parent form element. For elements outside a form, this attribute is unset, so it should be functionally the same as the previous behavior, with the added benefit of supporting overriding the associated form using the `form` attribute passed to the element.

There's more details in my original feature request #2975.