### PR TITLE
[Slot] Make children prop optional in SlotCloneProps interface

### DIFF
--- a/packages/react/slot/src/Slot.tsx
+++ b/packages/react/slot/src/Slot.tsx
@@ -54,7 +54,7 @@ Slot.displayName = 'Slot';
  * -----------------------------------------------------------------------------------------------*/
 
 interface SlotCloneProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {

--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -29,6 +29,8 @@ const VisuallyHidden = React.forwardRef<VisuallyHiddenElement, VisuallyHiddenPro
           clip: 'rect(0, 0, 0, 0)',
           whiteSpace: 'nowrap',
           wordWrap: 'normal',
+          top: 0,
+          left:0,
           ...props.style,
         }}
       />


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

I guess it was a mistake that the children prop is optional in SlotProps but not in SlotCloneProps