### PR TITLE
[Avatar] Adding support for Framework image

### DIFF
--- a/.yarn/versions/5ffaf749.yml
+++ b/.yarn/versions/5ffaf749.yml
@@ -1,0 +1,3 @@
+releases:
+  "@radix-ui/react-avatar": patch
+  primitives: patch

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -5,6 +5,7 @@ export default { title: 'Components/Avatar' };
 
 const src = 'https://picsum.photos/id/1005/400/400';
 const srcBroken = 'https://broken.link.com/broken-pic.jpg';
+const otherSrc = 'https://picsum.photos/id/1006/400/400';
 
 const FakeFrameworkImage = (props: any) => {
   console.log(props);
@@ -47,7 +48,7 @@ export const Styled = () => (
     <h1>With image framework component & with fallback</h1>
     <Avatar.Root className={rootClass()}>
       <Avatar.Image className={imageClass()} alt="John Smith" asChild>
-        <FakeFrameworkImage src={src} />
+        <FakeFrameworkImage src={otherSrc} />
       </Avatar.Image>
       <Avatar.Fallback delayMs={300} className={fallbackClass()}>
         JS

--- a/packages/react/avatar/src/Avatar.stories.tsx
+++ b/packages/react/avatar/src/Avatar.stories.tsx
@@ -6,6 +6,16 @@ export default { title: 'Components/Avatar' };
 const src = 'https://picsum.photos/id/1005/400/400';
 const srcBroken = 'https://broken.link.com/broken-pic.jpg';
 
+const FakeFrameworkImage = (props: any) => {
+  console.log(props);
+
+  return (
+    <div>
+      <img {...props} alt="framework test" data-testid="framework-image-component" />
+    </div>
+  );
+};
+
 export const Styled = () => (
   <>
     <h1>Without image & with fallback</h1>
@@ -30,6 +40,31 @@ export const Styled = () => (
         onLoadingStatusChange={console.log}
       />
       <Avatar.Fallback className={fallbackClass()}>
+        <AvatarIcon />
+      </Avatar.Fallback>
+    </Avatar.Root>
+
+    <h1>With image framework component & with fallback</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image className={imageClass()} alt="John Smith" asChild>
+        <FakeFrameworkImage src={src} />
+      </Avatar.Image>
+      <Avatar.Fallback delayMs={300} className={fallbackClass()}>
+        JS
+      </Avatar.Fallback>
+    </Avatar.Root>
+
+    <h1>With image framework component & with fallback (but broken src)</h1>
+    <Avatar.Root className={rootClass()}>
+      <Avatar.Image
+        className={imageClass()}
+        alt="John Smith"
+        onLoadingStatusChange={console.log}
+        asChild
+      >
+        <FakeFrameworkImage src={srcBroken} />
+      </Avatar.Image>
+      <Avatar.Fallback delayMs={300} className={fallbackClass()}>
         <AvatarIcon />
       </Avatar.Fallback>
     </Avatar.Root>


### PR DESCRIPTION
### Description
Hi Team,

I'm proposing a new suggestion to address issue #2230 on top of existing PR #2999 

I've implemented this solution by removing the prefetch image which helps to determine the image loading error.

Since `Primitive.img` already handles `OnLoad` and `OnError` events, it makes sense to leverage these callbacks for handling image load failures in a single fetch.


<!-- Describe the change you are introducing -->
## Changes Introduced
- On the first render, `Primitive.img` is displayed, and its `OnLoad` and `OnError` callbacks are subscribed through an intermediate handler:
    - **Loading:** The image’s `style.display` is set to `none`.
    - **Success:** The `display` property is updated to the user-specified value.
    - **Failure:** The component re-renders, returning `null` to display the fallback.
- Removed the `useImageLoadingStatus` custom hook, simplifying the image loading process: https://github.com/radix-ui/primitives/blob/6469d41dcc6e84fe41d70a2703924338e7562dd1/packages/react/avatar/src/Avatar.tsx#L119

NOTE: I don't find any other use-case of `useImageLoadingStatus` hook, other than tracking image loading status

## What This Solves
- Enables better integration with framework-specific optimizations (e.g., Next.js’s Image component).

## Visual Comparison
**Before:**

https://github.com/user-attachments/assets/0c0bada4-cbfe-4542-bd8d-a559c60e7ea3

**After:**

https://github.com/user-attachments/assets/f0f8022d-9a1d-4177-96b1-9a836489f4f2

**EDIT:**
*Upon toggling `Disable Cache` off It makes only one request*
