### PR TITLE
Attribute checked has faulty types

### DIFF
--- a/.yarn/versions/1b559ed8.yml
+++ b/.yarn/versions/1b559ed8.yml
@@ -1,0 +1,4 @@
+undecided:
+  - "@radix-ui/react-checkbox"
+  - "@radix-ui/react-radio-group"
+  - "@radix-ui/react-switch"

--- a/.yarn/versions/1b559ed8.yml
+++ b/.yarn/versions/1b559ed8.yml
@@ -3,3 +3,5 @@ releases:
   "@radix-ui/react-radio-group": patch
   "@radix-ui/react-switch": patch
 
+declined:
+  - primitives

--- a/.yarn/versions/1b559ed8.yml
+++ b/.yarn/versions/1b559ed8.yml
@@ -1,4 +1,5 @@
-undecided:
-  - "@radix-ui/react-checkbox"
-  - "@radix-ui/react-radio-group"
-  - "@radix-ui/react-switch"
+releases:
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-switch": patch
+

--- a/packages/react/checkbox/src/Checkbox.stories.tsx
+++ b/packages/react/checkbox/src/Checkbox.stories.tsx
@@ -56,7 +56,7 @@ export const Styled = () => (
 );
 
 export const Controlled = () => {
-  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>(true);
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate' | undefined>(true);
 
   return (
     <>
@@ -75,7 +75,9 @@ export const Controlled = () => {
 };
 
 export const Indeterminate = () => {
-  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate' | undefined>(
+    'indeterminate'
+  );
 
   return (
     <>
@@ -101,7 +103,9 @@ export const Indeterminate = () => {
 
 export const WithinForm = () => {
   const [data, setData] = React.useState({ optional: false, required: false, stopprop: false });
-  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate' | undefined>(
+    'indeterminate'
+  );
 
   return (
     <form
@@ -173,7 +177,9 @@ export const WithinForm = () => {
 };
 
 export const Animated = () => {
-  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate' | undefined>(
+    'indeterminate'
+  );
 
   return (
     <>

--- a/packages/react/checkbox/src/Checkbox.tsx
+++ b/packages/react/checkbox/src/Checkbox.tsx
@@ -19,7 +19,7 @@ const CHECKBOX_NAME = 'Checkbox';
 type ScopedProps<P> = P & { __scopeCheckbox?: Scope };
 const [createCheckboxContext, createCheckboxScope] = createContextScope(CHECKBOX_NAME);
 
-type CheckedState = boolean | 'indeterminate';
+type CheckedState = boolean | 'indeterminate' | undefined;
 
 type CheckboxContextValue = {
   state: CheckedState;
@@ -105,7 +105,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
             bubbles={!hasConsumerStoppedPropagationRef.current}
             name={name}
             value={value}
-            checked={checked}
+            checked={checked ? true : undefined}
             required={required}
             disabled={disabled}
             // We transform because the input is absolutely positioned but we have

--- a/packages/react/radio-group/src/Radio.tsx
+++ b/packages/react/radio-group/src/Radio.tsx
@@ -24,7 +24,7 @@ const [RadioProvider, useRadioContext] = createRadioContext<RadioContextValue>(R
 type RadioElement = React.ElementRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
 interface RadioProps extends PrimitiveButtonProps {
-  checked?: boolean;
+  checked?: boolean | undefined;
   required?: boolean;
   onCheck?(): void;
 }
@@ -77,7 +77,7 @@ const Radio = React.forwardRef<RadioElement, RadioProps>(
             bubbles={!hasConsumerStoppedPropagationRef.current}
             name={name}
             value={value}
-            checked={checked}
+            checked={checked ? true : undefined}
             required={required}
             disabled={disabled}
             // We transform because the input is absolutely positioned but we have
@@ -132,7 +132,7 @@ RadioIndicator.displayName = INDICATOR_NAME;
 
 type InputProps = React.ComponentPropsWithoutRef<'input'>;
 interface BubbleInputProps extends Omit<InputProps, 'checked'> {
-  checked: boolean;
+  checked: boolean | undefined;
   control: HTMLElement | null;
   bubbles: boolean;
 }

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -24,7 +24,7 @@ const [SwitchProvider, useSwitchContext] = createSwitchContext<SwitchContextValu
 type SwitchElement = React.ElementRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
 interface SwitchProps extends PrimitiveButtonProps {
-  checked?: boolean;
+  checked?: boolean | undefined;
   defaultChecked?: boolean;
   required?: boolean;
   onCheckedChange?(checked: boolean): void;
@@ -84,7 +84,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
             bubbles={!hasConsumerStoppedPropagationRef.current}
             name={name}
             value={value}
-            checked={checked}
+            checked={checked ? true : undefined}
             required={required}
             disabled={disabled}
             // We transform because the input is absolutely positioned but we have
@@ -131,7 +131,7 @@ SwitchThumb.displayName = THUMB_NAME;
 
 type InputProps = React.ComponentPropsWithoutRef<'input'>;
 interface BubbleInputProps extends Omit<InputProps, 'checked'> {
-  checked: boolean;
+  checked: boolean | undefined;
   control: HTMLElement | null;
   bubbles: boolean;
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Possible solution for issue https://github.com/radix-ui/primitives/issues/3158

I added the type of undefined for the property checked in RadioItems, Checkboxes and switches to either set the html-attribute to true or undefined(to completely get rid of the attribute if set to false)