### PR TITLE
feat: Tooltip - Performance - avoid calling clearTimeout on unmount if timeout id is 0

### DIFF
--- a/.yarn/versions/ae1744f4.yml
+++ b/.yarn/versions/ae1744f4.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -190,12 +190,14 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
 
   const handleOpen = React.useCallback(() => {
     window.clearTimeout(openTimerRef.current);
+    openTimerRef.current = 0;
     wasOpenDelayedRef.current = false;
     setOpen(true);
   }, [setOpen]);
 
   const handleClose = React.useCallback(() => {
     window.clearTimeout(openTimerRef.current);
+    openTimerRef.current = 0;
     setOpen(false);
   }, [setOpen]);
 
@@ -204,11 +206,17 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
     openTimerRef.current = window.setTimeout(() => {
       wasOpenDelayedRef.current = true;
       setOpen(true);
+      openTimerRef.current = 0;
     }, delayDuration);
   }, [delayDuration, setOpen]);
 
   React.useEffect(() => {
-    return () => window.clearTimeout(openTimerRef.current);
+    return () => {
+      if (openTimerRef.current) {
+        window.clearTimeout(openTimerRef.current);
+        openTimerRef.current = 0;
+      }
+    };
   }, []);
 
   return (
@@ -230,6 +238,7 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
           } else {
             // Clear the timer in case the pointer leaves the trigger before the tooltip is opened.
             window.clearTimeout(openTimerRef.current);
+            openTimerRef.current = 0;
           }
         }, [handleClose, disableHoverableContent])}
         onOpen={handleOpen}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

#### Context:
We have a product list page with products with multiple color variants. These color variants have the Tooltip component to display the color name on hover.

#### Issue:
We have noticed a significant amount of `clearTimeout` calls when the component with the Tooltips _unmounts_. That's interesting because it happens even when we don't trigger any of the Tooltips in the page.

![6f5c359a-9b20-4739-82e8-41b2c0e2a1d8](https://github.com/user-attachments/assets/18f43ea5-7784-4957-b993-0e37b43a9c11)

After some investigation, we noticed this is caused by a `window.clearTimeout` that's happening in the component unmount.

#### Fix:
The fix proposed is quite simple. I'm checking `openTimerRef.current` and only calling this if it's not `0`. I'm also resetting `openTimerRef.current` to `0` after each `clearTimeout()`. We have noticed a reduction in the number of `clearTimeout` calls in the unmount of this component. This means a significant performance improvement in our scenario given we have dozens of Tooltips in some of our pages.

![4ef24b80-ef0b-4659-a354-bec155e0e8cc](https://github.com/user-attachments/assets/acd80fb8-48d1-4203-82f3-c6e7a29c26b0)

<!-- Describe the change you are introducing -->
