### PR TITLE
Navigation menu - add prop to change default close delay

### DIFF
--- a/.yarn/versions/98967128.yml
+++ b/.yarn/versions/98967128.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-navigation-menu": minor

--- a/.yarn/versions/98967128.yml
+++ b/.yarn/versions/98967128.yml
@@ -1,2 +1,3 @@
 releases:
   "@radix-ui/react-navigation-menu": minor
+  primitives: minor

--- a/packages/react/navigation-menu/src/NavigationMenu.stories.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.stories.tsx
@@ -86,6 +86,16 @@ export const CustomDurations = () => {
 
       <h2>Custom (2000ms to move from one trigger to another)</h2>
       <DurationNavigation delayDuration={500} skipDelayDuration={2000} />
+
+      <h1 style={{ marginTop: 50 }}>Close delay duration</h1>
+      <h2>Default (150ms)</h2>
+      <DurationNavigation />
+
+      <h2>Custom (500ms)</h2>
+      <DurationNavigation closeDelayDuration={500} />
+
+      <h2>Custom (1000ms)</h2>
+      <DurationNavigation closeDelayDuration={1000} />
     </div>
   );
 };

--- a/packages/react/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react/navigation-menu/src/NavigationMenu.tsx
@@ -95,6 +95,11 @@ interface NavigationMenuProps
    * @defaultValue 300
    */
   skipDelayDuration?: number;
+  /**
+   * The delay before closing menu when the pointer leaves trigger or content area.
+   * @defaultValue 150
+   */
+  closeDelayDuration?: number;
 }
 
 const NavigationMenu = React.forwardRef<NavigationMenuElement, NavigationMenuProps>(
@@ -106,6 +111,7 @@ const NavigationMenu = React.forwardRef<NavigationMenuElement, NavigationMenuPro
       defaultValue,
       delayDuration = 200,
       skipDelayDuration = 300,
+      closeDelayDuration = 150,
       orientation = 'horizontal',
       dir,
       ...NavigationMenuProps
@@ -141,7 +147,7 @@ const NavigationMenu = React.forwardRef<NavigationMenuElement, NavigationMenuPro
 
     const startCloseTimer = React.useCallback(() => {
       window.clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = window.setTimeout(() => setValue(''), 150);
+      closeTimerRef.current = window.setTimeout(() => setValue(''), closeDelayDuration);
     }, [setValue]);
 
     const handleOpen = React.useCallback(


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

- Currently the NavigationMenu has a default close delay of 150ms.  When the user's pointer leaves the trigger or content area the menu will close in 150ms.
- This PR adds a prop `closeDelayDuration` with default value of 150ms that allows the user to change the close delay.
- Storybook updated with example.
- Release strategy added (minor release)

<!-- Describe the change you are introducing -->
