### PR TITLE
[DropdownMenu][ContextMenu][Menu] Only register a single set of event listeners for the entire document

### DIFF
--- a/packages/react/menu/src/useIsUsingKeyboard.tsx
+++ b/packages/react/menu/src/useIsUsingKeyboard.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+let isUsingKeyboard = false;
+let isUsingKeyboardSubscriberCount = 0;
+
+function handleKeydown() {
+  isUsingKeyboard = true;
+}
+
+function handlePointer() {
+  isUsingKeyboard = false;
+}
+
+function getIsUsingKeyboard() {
+  return isUsingKeyboard;
+}
+
+function subscribeShared() {
+  if (isUsingKeyboardSubscriberCount++ === 0) {
+    // Capture phase ensures we set the boolean before any side effects execute
+    // in response to the key or pointer event as they might depend on this value.
+    document.addEventListener('keydown', handleKeydown, { capture: true });
+    document.addEventListener('pointerdown', handlePointer, { capture: true });
+    document.addEventListener('pointermove', handlePointer, { capture: true });
+  }
+}
+
+function unsubscribeShared() {
+  if (--isUsingKeyboardSubscriberCount === 0) {
+    document.removeEventListener('keydown', handleKeydown, { capture: true });
+    document.removeEventListener('pointerdown', handlePointer, { capture: true });
+    document.removeEventListener('pointermove', handlePointer, { capture: true });
+  }
+}
+
+/**
+ * Starts tracking whether the user is using a keyboard or a mouse.
+ * This implementation keeps track of how many subscribers it has and makes sure
+ * only one set of listeners is attached to the document to improve performance and
+ * prevent memory leaks.
+ */
+export function useIsUsingKeyboard() {
+  React.useEffect(() => {
+    subscribeShared();
+    return unsubscribeShared;
+  }, []);
+
+  return getIsUsingKeyboard;
+}


### PR DESCRIPTION
### Description

Make `Menu` components more efficient when used in large numbers by only registering a single set of event listeners on the `document` to track whether a user is using a keyboard or a mouse.

This properly fixes https://github.com/radix-ui/primitives/issues/1239 and https://github.com/radix-ui/primitives/issues/1139.

I also saw that a similar change was attempted in https://github.com/radix-ui/primitives/pull/1252, but I'm proposing a much simpler implementation here. 

P.S. I did read through the discussion in https://github.com/radix-ui/primitives/issues/1239, but we unfortunately do seem to be running into some performance issues due to having a huge number of React components including Menus on the page. While I agree that this is an issue in and of itself, I also think that it's great for UI libraries to be efficient and be able to scale well with a large number of component instances.
