### PR TITLE
[Select] fix: disabled select when fieldset has `disabled` attr

### DIFF
--- a/.yarn/versions/a4fe86bf.yml
+++ b/.yarn/versions/a4fe86bf.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-select": patch
+
+declined:
+  - primitives

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -288,10 +288,18 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
               target.releasePointerCapture(event.pointerId);
             }
 
+            const fieldset = target.closest('fieldset');
+            const fieldsetDisabled = fieldset ? fieldset.disabled : false;
+
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click); also not for touch
             // devices because that would open the menu on scroll. (pen devices behave as touch on iOS).
-            if (event.button === 0 && event.ctrlKey === false && event.pointerType === 'mouse') {
+            if (
+              event.button === 0 &&
+              event.ctrlKey === false &&
+              event.pointerType === 'mouse' &&
+              !fieldsetDisabled
+            ) {
               handleOpen(event);
               // prevent trigger from stealing focus from the active item after opening.
               event.preventDefault();


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

close #2417 
- When there is disabled `fieldset`, `Select` component does not be disabled.
- This is because [`Select.Trigger` has `onPointerDown` handler](https://github.com/radix-ui/primitives/blob/74b182b401c8ca0fa5b66a5a9a47f507bb3d5adc/packages/react/select/src/Select.tsx#L281) and even if button is disabled, that handler can be triggered.
- So I added the code that check if there is `fieldset` disabled.

#### AS-IS

https://github.com/user-attachments/assets/eb77a71e-9848-4070-8e6f-5f6ba98d092b

#### TO-BE

https://github.com/user-attachments/assets/632ab57c-4b5c-44dd-9a9a-19eb693918c4
