### PR TITLE
[Select] fix: onClick event propagation

### DIFF
--- a/.yarn/versions/04e78d65.yml
+++ b/.yarn/versions/04e78d65.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-select": patch

--- a/.yarn/versions/04e78d65.yml
+++ b/.yarn/versions/04e78d65.yml
@@ -1,5 +1,0 @@
-releases:
-  "@radix-ui/react-select": patch
-
-undecided:
-  - primitives

--- a/.yarn/versions/04e78d65.yml
+++ b/.yarn/versions/04e78d65.yml
@@ -1,2 +1,5 @@
 releases:
   "@radix-ui/react-select": patch
+
+undecided:
+  - primitives

--- a/.yarn/versions/59cd6502.yml
+++ b/.yarn/versions/59cd6502.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-select": patch

--- a/.yarn/versions/59cd6502.yml
+++ b/.yarn/versions/59cd6502.yml
@@ -1,2 +1,5 @@
 releases:
   "@radix-ui/react-select": patch
+
+undecided:
+  - primitives

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1272,7 +1272,8 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             ref={composedRefs}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
-            onClick={composeEventHandlers(itemProps.onClick, () => {
+            onClick={composeEventHandlers(itemProps.onClick, (event) => {
+              event.stopPropagation();
               // Open on click when using a touch or pen device
               if (pointerTypeRef.current !== 'mouse') handleSelect();
             })}

--- a/packages/react/select/src/Select.tsx
+++ b/packages/react/select/src/Select.tsx
@@ -1273,9 +1273,11 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
             onClick={composeEventHandlers(itemProps.onClick, (event) => {
-              event.stopPropagation();
               // Open on click when using a touch or pen device
-              if (pointerTypeRef.current !== 'mouse') handleSelect();
+              if (pointerTypeRef.current !== 'mouse') {
+                event.stopPropagation();
+                handleSelect();
+              }
             })}
             onPointerUp={composeEventHandlers(itemProps.onPointerUp, () => {
               // Using a mouse you should be able to do pointer down, move through


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Prevent Select.Root's onValueChange event to propagate to other event handlers.
