### PR TITLE
Popover: Feature: Allow an additional prop to be passed that changes trigger behavior from toggle to always open

### DIFF
--- a/.yarn/versions/08415281.yml
+++ b/.yarn/versions/08415281.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-popover": patch
+
+declined:
+  - primitives

--- a/packages/react/popover/src/Popover.stories.tsx
+++ b/packages/react/popover/src/Popover.stories.tsx
@@ -280,6 +280,25 @@ export const WithSlottedTrigger = () => {
   );
 };
 
+export const TriggerDoesntToggleClose = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}
+    >
+      <Popover.Root toggleOpen={false}>
+        <Popover.Trigger className={triggerClass()}>open</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content className={contentClass()} sideOffset={5}>
+            <Popover.Close className={closeClass()}>close</Popover.Close>
+            <Popover.Arrow className={arrowClass()} width={20} height={10} />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+      <input />
+    </div>
+  );
+};
+
 // change order slightly for more pleasing visual
 const SIDES = SIDE_OPTIONS.filter((side) => side !== 'bottom').concat(['bottom']);
 

--- a/packages/react/popover/src/Popover.tsx
+++ b/packages/react/popover/src/Popover.tsx
@@ -49,6 +49,7 @@ interface PopoverProps {
   children?: React.ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
+  toggleOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   modal?: boolean;
 }
@@ -59,6 +60,7 @@ const Popover: React.FC<PopoverProps> = (props: ScopedProps<PopoverProps>) => {
     children,
     open: openProp,
     defaultOpen,
+    toggleOpen = true,
     onOpenChange,
     modal = false,
   } = props;
@@ -79,7 +81,10 @@ const Popover: React.FC<PopoverProps> = (props: ScopedProps<PopoverProps>) => {
         triggerRef={triggerRef}
         open={open}
         onOpenChange={setOpen}
-        onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
+        onOpenToggle={React.useCallback(
+          () => (toggleOpen ? setOpen((prevOpen) => !prevOpen) : setOpen(true)),
+          [setOpen, toggleOpen]
+        )}
         hasCustomAnchor={hasCustomAnchor}
         onCustomAnchorAdd={React.useCallback(() => setHasCustomAnchor(true), [])}
         onCustomAnchorRemove={React.useCallback(() => setHasCustomAnchor(false), [])}


### PR DESCRIPTION
### Description

Adding a boolean prop that allows the user to change the behavior of the Popover's toggling open. Defaulting to true, if set to false then the Popover Trigger will always pass true to setOpen

### Context

When using a Popover in conjunction with a form field, using the field as the trigger would previously result in the Popover toggling, even when the input was focused and the user clicked on it again. The user may want to change their cursor position to edit some text, for instance.

It may be desirable to allow the Popover to remain open so long as the input is being interacted with. It is possible to manage the open state and work around this, but I found that it introduces some additional complexity whereas this is a simple boolean prop.
