### PR TITLE
Popper: Add positioning props

### DIFF
--- a/.yarn/versions/4d3ad0f6.yml
+++ b/.yarn/versions/4d3ad0f6.yml
@@ -1,0 +1,11 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+  primitives: patch

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -445,6 +445,33 @@ export const Chromatic = () => {
 };
 Chromatic.parameters = { chromatic: { disable: false } };
 
+export const WithAbsolutePositionStrategy = () => {
+  return (
+    <div
+      style={{
+        padding: '300px',
+        height: '200vh',
+        width: '200vw',
+      }}
+    >
+      <Popper.Root>
+        <Popper.Anchor className={anchorClass({ size: 'small' })}>#1</Popper.Anchor>
+        <Portal asChild>
+          <Popper.Content
+            positionStrategy="absolute"
+            disablePositionUpdate
+            className={contentClass({ size: 'small' })}
+            sideOffset={5}
+          >
+            <Popper.Arrow className={arrowClass()} width={10} height={5} />
+            Some content
+          </Popper.Content>
+        </Portal>
+      </Popper.Root>
+    </div>
+  );
+};
+
 const Scrollable = (props: any) => (
   <div
     style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -121,7 +121,9 @@ interface PopperContentProps extends PrimitiveDivProps {
   collisionPadding?: number | Partial<Record<Side, number>>;
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
+  disablePositionUpdate?: boolean;
   updatePositionStrategy?: 'optimized' | 'always';
+  positionStrategy?: 'fixed' | 'absolute';
   onPlaced?: () => void;
 }
 
@@ -139,6 +141,9 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       collisionPadding: collisionPaddingProp = 0,
       sticky = 'partial',
       hideWhenDetached = false,
+      // default to `fixed` strategy to avoid focus scroll issues
+      positionStrategy = 'fixed',
+      disablePositionUpdate = false,
       updatePositionStrategy = 'optimized',
       onPlaced,
       ...contentProps
@@ -172,15 +177,16 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
     };
 
     const { refs, floatingStyles, placement, isPositioned, middlewareData } = useFloating({
-      // default to `fixed` strategy so users don't have to pick and we also avoid focus scroll issues
-      strategy: 'fixed',
+      strategy: positionStrategy,
       placement: desiredPlacement,
-      whileElementsMounted: (...args) => {
-        const cleanup = autoUpdate(...args, {
-          animationFrame: updatePositionStrategy === 'always',
-        });
-        return cleanup;
-      },
+      whileElementsMounted: disablePositionUpdate
+        ? undefined
+        : (...args) => {
+            const cleanup = autoUpdate(...args, {
+              animationFrame: updatePositionStrategy === 'always',
+            });
+            return cleanup;
+          },
       elements: {
         reference: context.anchor,
       },


### PR DESCRIPTION
### Description

PR adds props `positionStrategy` and `disablePositionUpdate` to be able to specify `floating-ui`'s `absolute` strategy and avoid unnecessary `autoUpdate` calls.

### Context

This changes would be helpful when you try to avoid popper's content glitches when scrolling page

**Before**

![before](https://github.com/user-attachments/assets/c6611a53-abd5-4fd8-b292-32ced1c99d43)

**After**

![after](https://github.com/user-attachments/assets/b3c593ba-3134-4567-99e5-296ca2bdcfbd)
