### PR TITLE
fix: #2375 tooltip rerenders on hover

### DIFF
--- a/.yarn/versions/1d095e39.yml
+++ b/.yarn/versions/1d095e39.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/tooltip/src/Tooltip.tsx
+++ b/packages/react/tooltip/src/Tooltip.tsx
@@ -30,7 +30,7 @@ const DEFAULT_DELAY_DURATION = 700;
 const TOOLTIP_OPEN = 'tooltip.open';
 
 type TooltipProviderContextValue = {
-  isOpenDelayed: boolean;
+  isOpenDelayedRef: React.MutableRefObject<boolean>;
   delayDuration: number;
   onOpen(): void;
   onClose(): void;
@@ -71,7 +71,7 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
     disableHoverableContent = false,
     children,
   } = props;
-  const [isOpenDelayed, setIsOpenDelayed] = React.useState(true);
+  const isOpenDelayedRef = React.useRef(true);
   const isPointerInTransitRef = React.useRef(false);
   const skipDelayTimerRef = React.useRef(0);
 
@@ -83,16 +83,16 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
   return (
     <TooltipProviderContextProvider
       scope={__scopeTooltip}
-      isOpenDelayed={isOpenDelayed}
+      isOpenDelayedRef={isOpenDelayedRef}
       delayDuration={delayDuration}
       onOpen={React.useCallback(() => {
         window.clearTimeout(skipDelayTimerRef.current);
-        setIsOpenDelayed(false);
+        isOpenDelayedRef.current = false;
       }, [])}
       onClose={React.useCallback(() => {
         window.clearTimeout(skipDelayTimerRef.current);
         skipDelayTimerRef.current = window.setTimeout(
-          () => setIsOpenDelayed(true),
+          () => isOpenDelayedRef.current = true,
           skipDelayDuration
         );
       }, [skipDelayDuration])}
@@ -229,9 +229,9 @@ const Tooltip: React.FC<TooltipProps> = (props: ScopedProps<TooltipProps>) => {
         trigger={trigger}
         onTriggerChange={setTrigger}
         onTriggerEnter={React.useCallback(() => {
-          if (providerContext.isOpenDelayed) handleDelayedOpen();
+          if (providerContext.isOpenDelayedRef.current) handleDelayedOpen();
           else handleOpen();
-        }, [providerContext.isOpenDelayed, handleDelayedOpen, handleOpen])}
+        }, [providerContext.isOpenDelayedRef, handleDelayedOpen, handleOpen])}
         onTriggerLeave={React.useCallback(() => {
           if (disableHoverableContent) {
             handleClose();


### PR DESCRIPTION
### Description
closes #2375 

Every mounted tooltip is re-rendered on hover. This resulted in quite noticeable performance problems as our app has a lot of elements with tooltip

Here are some profiles from our app:
before: 
![image](https://github.com/user-attachments/assets/bcf30038-6ad9-432c-a63d-07e44bc583fe)

after:
![image](https://github.com/user-attachments/assets/c275e317-67e5-43f1-9e0b-f63fd36aade6)


Since `isOpenDelayed` is used only in event callbacks replacing it with `ref` seems like a safe and useful change

Please let me know if anything is missing or more tests with proofs are required