### PR TITLE
chore(.github/workflows): update github actions 'uses' to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Read Node version
         id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - name: Set Node version
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Read Node version
         id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - name: Set Node version
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'
       - name: Install dependencies

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Read Node version
         id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - name: Set Node version
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'
           registry-url: 'https://registry.npmjs.org'
@@ -37,7 +37,7 @@ jobs:
           --data '{"required_status_checks":null,"enforce_admins":false,"required_pull_request_reviews":null,"restrictions":null}'
 
       - name: Commit release candidate
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'Publish release candidate'
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Read Node version
         id: node_version
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       - name: Set Node version
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '${{ steps.node_version.outputs.NVMRC }}'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.yarn/versions/a8175507.yml
+++ b/.yarn/versions/a8175507.yml
@@ -1,0 +1,2 @@
+declined:
+  - primitives


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

![image](https://github.com/user-attachments/assets/428c35ec-699d-4e11-a923-9aa423ba27f3)

* github actions is now using node version 20 but `actions/checkout@v2`, `actions/setup-nodes@v2` are using node verion 16 which is deprecated in github actions, so i update it all v4, you can see [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
* also update `actions/cache@v1` to latest version v4


<!-- Describe the change you are introducing -->
