### PR TITLE
Fix Presence component memory leak

### DIFF
--- a/packages/react/presence/src/Presence.tsx
+++ b/packages/react/presence/src/Presence.tsx
@@ -153,7 +153,12 @@ function usePresence(present: boolean) {
   return {
     isPresent: ['mounted', 'unmountSuspended'].includes(state),
     ref: React.useCallback((node: HTMLElement) => {
-      if (node) stylesRef.current = getComputedStyle(node);
+      if (node) {
+        stylesRef.current = getComputedStyle(node);
+      }
+      else {
+        stylesRef.current = {} as any;
+      }
       setNode(node);
     }, []),
   };


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Fixes #3202 

Took a while to track this down, but here goes:
When the child of Presence component gets unmounted, `stylesRef` is not clean up, which in turn prevents the detached nodes from being garbage collected, as it's holding a reference to the node. Affects any radix component that depends on Presence.
* Tooltip, HoverCard, etc. – leaves a new detached node after every hover/unhover
* Dialog, Popover, DropdownMenu, etc.  – leaves detached nodes around after closing

Note when testing: please build React for production first, as the dev-mode itself can have memory leaks.

Alternative could be to use WeakRef, but I wasn't sure how the Radix team feels about its browser support.