### PR TITLE
[Popper] Fix regression when an occluded submenu stays visible even with enabled `hideWhenDetached` flag

### DIFF
--- a/.yarn/versions/588134e5.yml
+++ b/.yarn/versions/588134e5.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -74,7 +74,7 @@ export const Submenus = () => {
           Scrollable
         </label>
       </div>
-      <MenuWithAnchor style={scrollable ? { overflow: 'scroll', height: 100 } : undefined}>
+      <MenuWithAnchor className={scrollable ? scrollableMenuClass() : undefined}>
         <Menu.Item className={itemClass()} onSelect={() => window.alert('undo')}>
           Undo
         </Menu.Item>
@@ -520,6 +520,11 @@ const animatedItemIndicatorClass = css({
   },
 });
 
+const scrollableMenuClass = css({
+  overflow: 'scroll',
+  height: 100,
+});
+
 export const TickIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -542,4 +547,5 @@ export const classes = {
   itemClass,
   separatorClass,
   subTriggerClass,
+  scrollableMenuClass,
 };

--- a/packages/react/menu/src/Menu.stories.tsx
+++ b/packages/react/menu/src/Menu.stories.tsx
@@ -37,6 +37,7 @@ export const Submenus = () => {
   const [open4, setOpen4] = React.useState(false);
   const [rtl, setRtl] = React.useState(false);
   const [animated, setAnimated] = React.useState(false);
+  const [scrollable, setScrollable] = React.useState(false);
 
   React.useEffect(() => {
     if (rtl) {
@@ -64,12 +65,38 @@ export const Submenus = () => {
           />
           Animated
         </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={scrollable}
+            onChange={(event) => setScrollable(event.currentTarget.checked)}
+          />
+          Scrollable
+        </label>
       </div>
-      <MenuWithAnchor>
+      <MenuWithAnchor style={scrollable ? { overflow: 'scroll', height: 100 } : undefined}>
         <Menu.Item className={itemClass()} onSelect={() => window.alert('undo')}>
           Undo
         </Menu.Item>
-        <Submenu open={open1} onOpenChange={setOpen1} animated={animated}>
+
+        <Menu.Separator className={separatorClass()} />
+        <Menu.Item className={itemClass()} disabled onSelect={() => window.alert('cut')}>
+          Cut
+        </Menu.Item>
+        <Menu.Item className={itemClass()} onSelect={() => window.alert('copy')}>
+          Copy
+        </Menu.Item>
+        <Menu.Item className={itemClass()} onSelect={() => window.alert('paste')}>
+          Paste
+        </Menu.Item>
+
+        <Menu.Separator className={separatorClass()} />
+        <Submenu
+          open={open1}
+          onOpenChange={setOpen1}
+          animated={animated}
+          hideWhenDetached={scrollable}
+        >
           <Menu.Item className={itemClass()} disabled>
             Disabled
           </Menu.Item>
@@ -125,17 +152,6 @@ export const Submenus = () => {
             Three
           </Menu.Item>
         </Submenu>
-
-        <Menu.Separator className={separatorClass()} />
-        <Menu.Item className={itemClass()} disabled onSelect={() => window.alert('cut')}>
-          Cut
-        </Menu.Item>
-        <Menu.Item className={itemClass()} onSelect={() => window.alert('copy')}>
-          Copy
-        </Menu.Item>
-        <Menu.Item className={itemClass()} onSelect={() => window.alert('paste')}>
-          Paste
-        </Menu.Item>
       </MenuWithAnchor>
     </DirectionProvider>
   );

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -135,7 +135,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       alignOffset = 0,
       arrowPadding = 0,
       avoidCollisions = true,
-      collisionBoundary = [],
+      collisionBoundary,
       collisionPadding: collisionPaddingProp = 0,
       sticky = 'partial',
       hideWhenDetached = false,
@@ -161,12 +161,16 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         ? collisionPaddingProp
         : { top: 0, right: 0, bottom: 0, left: 0, ...collisionPaddingProp };
 
-    const boundary = Array.isArray(collisionBoundary) ? collisionBoundary : [collisionBoundary];
-    const hasExplicitBoundaries = boundary.length > 0;
+    const boundary = collisionBoundary
+      ? Array.isArray(collisionBoundary)
+        ? collisionBoundary
+        : [collisionBoundary]
+      : undefined;
+    const hasExplicitBoundaries = boundary !== undefined && boundary.length > 0;
 
     const detectOverflowOptions = {
       padding: collisionPadding,
-      boundary: boundary.filter(isNotNull),
+      boundary: boundary ? boundary.filter(isNotNull) : undefined,
       // with `strategy: 'fixed'`, this is the only way to get it to respect boundaries
       altBoundary: hasExplicitBoundaries,
     };


### PR DESCRIPTION
### Description
There seems to be a regression in [`react-popper`](https://github.com/radix-ui/primitives/tree/main/packages/react/popper) component in versions `1.1.3` and newer, which affected submenus in scrollable menus.

#### Problem
When a menu is rendered, which
* Has `hideWhenDetached` flag enabled.
* Has a submenu.
* Has menu height short enough to require scrolling to see the submenu.

Then in the latest versions of [`react-menu`](https://github.com/radix-ui/primitives/blob/main/packages/react/menu/) component this submenu stays on screen even when its parent item is scrolled out of the visible area.

| Behavior in `react-popper` 1.1.2 and this branch | Behavior in `react-popper` 1.1.3 |
| -------------------- | ----------------|
| <video src="https://github.com/user-attachments/assets/a3321bf4-b637-45ab-a7c8-4decb20f64b0"></video> | <video src="https://github.com/user-attachments/assets/578f4339-04ba-4f86-8c34-bf60ad0fd67f"></video> |

#### Root cause
This regression seems to be caused by changes in this PR: https://github.com/radix-ui/primitives/pull/2185
* These changes blocked the default boundary detection strategy in Floating UI, because [now Radix always sets a non-empty value to the `boundary` option passed to the `hide` middleware](https://github.com/radix-ui/primitives/blob/5d265807126c6122cc842bacc52f4fc4a9ce7a11/packages/react/popper/src/Popper.tsx#L168). Now an empty array is passed as `boundary` option, when no `collisionBoundary` prop is defined, instead of an `undefined` value in version 1.1.2.
* Because prior to version 1.1.3, we didn't pass `boundary` option at all, [this let Floating UI fall back to its default `clippingAncestors` value](https://floating-ui.com/docs/detectOverflow#boundary). But because now we pass an empty array instead, which is a truthy value, the default fallback value is never used.

#### Proposed changes
This PR adds an extra check for undefined `collisionBoundary` prop. When it's not defined, then we don't override the default `boundary` value passed to Floating UI helpers either.

A few tweaks are also made to the `<Menu>` component's storybook to reproduce the issue and test the fix.
