### PR TITLE
[DropdownMenu] Fix touch devices trigger bug

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ There are many ways to contribute to the project. Code is just one possible mean
 
 ## Working on your first Pull Request?
 
-There are a lot of great resources on creating a good pull request. We've included a few below, but don't be shy—we appreciate all contriibutions and are happy to help those who are willing to help us!
+There are a lot of great resources on creating a good pull request. We've included a few below, but don't be shy—we appreciate all contributions and are happy to help those who are willing to help us!
 
 - [How to Contribute to a Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Fixes an issue where `DropdownMenuTrigger` would open inadvertently on touch-based scroll (#1912).

The previous PR for this fix (#2616) was rejected as it broke a feature where the user can select an item in one click (pointer down on trigger, move, pointer up on item). This PR retains that behaviour.

See the related PR (#2939) for the Select component. 

Touch before:

https://github.com/user-attachments/assets/3aab7419-c7be-4283-ba99-b849a89e1e61

Touch after:

https://github.com/user-attachments/assets/22590f10-e888-432e-aa2a-3d5eac08f02e

Pointer down behaviour for mouse devices has been preserved:

https://github.com/user-attachments/assets/506efe81-2d03-4676-90c1-350e707ac461

**Note:** I was unable to replicate #1658 (also addressed in #2939) with the Dropdown Menu component, so I haven't copied the changes that were made to `SelectItem` over to `DropdownMenuItem`. Happy to do so if you'd like me to.