### PR TITLE
[Switch] fix : Hidden input for Switch does not render "over the button"

### DIFF
--- a/.yarn/versions/9b826bac.yml
+++ b/.yarn/versions/9b826bac.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-switch": patch

--- a/.yarn/versions/9b826bac.yml
+++ b/.yarn/versions/9b826bac.yml
@@ -1,2 +1,5 @@
 releases:
   "@radix-ui/react-switch": patch
+
+declined:
+  - primitives

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -57,6 +57,10 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
 
     return (
       <SwitchProvider scope={__scopeSwitch} checked={checked} disabled={disabled}>
+        {/*
+        Wrap with div to prevent input from escaping component bounds
+        link : https://github.com/radix-ui/primitives/issues/3235
+        */}
         <div style={{ position: 'relative', display: 'inline-flex' }}>
           <Primitive.button
             type="button"

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -59,7 +59,6 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
       <SwitchProvider scope={__scopeSwitch} checked={checked} disabled={disabled}>
         {/*
         Wrap with div to prevent input from escaping component bounds
-        link : https://github.com/radix-ui/primitives/issues/3235
         */}
         <div style={{ position: 'relative', display: 'inline-flex' }}>
           <Primitive.button

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -73,6 +73,9 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
               setChecked((prevChecked) => !prevChecked);
               if (isFormControl) {
                 hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+                // if switch is in a form, stop propagation from the button so that we only propagate
+                // one click event (from the input). We propagate changes from an input so that native
+                // form validation works and form events reflect switch updates.
                 if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
               }
             })}

--- a/packages/react/switch/src/Switch.tsx
+++ b/packages/react/switch/src/Switch.tsx
@@ -57,44 +57,39 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
 
     return (
       <SwitchProvider scope={__scopeSwitch} checked={checked} disabled={disabled}>
-        <Primitive.button
-          type="button"
-          role="switch"
-          aria-checked={checked}
-          aria-required={required}
-          data-state={getState(checked)}
-          data-disabled={disabled ? '' : undefined}
-          disabled={disabled}
-          value={value}
-          {...switchProps}
-          ref={composedRefs}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            setChecked((prevChecked) => !prevChecked);
-            if (isFormControl) {
-              hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
-              // if switch is in a form, stop propagation from the button so that we only propagate
-              // one click event (from the input). We propagate changes from an input so that native
-              // form validation works and form events reflect switch updates.
-              if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
-            }
-          })}
-        />
-        {isFormControl && (
-          <BubbleInput
-            control={button}
-            bubbles={!hasConsumerStoppedPropagationRef.current}
-            name={name}
-            value={value}
-            checked={checked}
-            required={required}
+        <div style={{ position: 'relative', display: 'inline-flex' }}>
+          <Primitive.button
+            type="button"
+            role="switch"
+            aria-checked={checked}
+            aria-required={required}
+            data-state={getState(checked)}
+            data-disabled={disabled ? '' : undefined}
             disabled={disabled}
-            form={form}
-            // We transform because the input is absolutely positioned but we have
-            // rendered it **after** the button. This pulls it back to sit on top
-            // of the button.
-            style={{ transform: 'translateX(-100%)' }}
+            value={value}
+            {...switchProps}
+            ref={composedRefs}
+            onClick={composeEventHandlers(props.onClick, (event) => {
+              setChecked((prevChecked) => !prevChecked);
+              if (isFormControl) {
+                hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+                if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+              }
+            })}
           />
-        )}
+          {isFormControl && (
+            <BubbleInput
+              control={button}
+              bubbles={!hasConsumerStoppedPropagationRef.current}
+              name={name}
+              value={value}
+              checked={checked}
+              required={required}
+              disabled={disabled}
+              form={form}
+            />
+          )}
+        </div>
       </SwitchProvider>
     );
   }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

Closes #3235 

### Description

<!-- Describe the change you are introducing -->

The BubbleInput within the Switch component had an absolute positioning applied, but there was no parent node with relative positioning, causing the component to overflow its intended area.

- Added a div wrapper around `<Primitive.button />` and `<BubbleInput />` and applied the necessary styles.
- Removed the `transform: translate(-100%)` property previously applied as an inline style on BubbleInput.

#### AS-IS

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a7512242-4bc7-42b5-9e08-0f5d6c67db77">


#### TO-BE

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a292c018-57a1-41c4-bbb8-45ee61bb21b7">

#### Test Result
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2740eb02-fd10-461a-98c7-3b1150230514">

#### Storybook 
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/df994de4-11ef-410d-8850-f8f03f535e75">
