### PR TITLE
[Avatar] Support cross origin in useImageLoadingStatus

### DIFF
--- a/.yarn/versions/ba4cea70.yml
+++ b/.yarn/versions/ba4cea70.yml
@@ -1,0 +1,5 @@
+releases:
+  "@radix-ui/react-avatar": patch
+
+declined:
+  - primitives

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -62,7 +62,10 @@ const AvatarImage = React.forwardRef<AvatarImageElement, AvatarImageProps>(
   (props: ScopedProps<AvatarImageProps>, forwardedRef) => {
     const { __scopeAvatar, src, onLoadingStatusChange = () => {}, ...imageProps } = props;
     const context = useAvatarContext(IMAGE_NAME, __scopeAvatar);
-    const imageLoadingStatus = useImageLoadingStatus(src, imageProps.referrerPolicy);
+    const imageLoadingStatus = useImageLoadingStatus(src, {
+      referrerPolicy: imageProps.referrerPolicy,
+      crossOrigin: imageProps.crossOrigin,
+    });
     const handleLoadingStatusChange = useCallbackRef((status: ImageLoadingStatus) => {
       onLoadingStatusChange(status);
       context.onImageLoadingStatusChange(status);
@@ -116,7 +119,12 @@ AvatarFallback.displayName = FALLBACK_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function useImageLoadingStatus(src?: string, referrerPolicy?: React.HTMLAttributeReferrerPolicy) {
+interface UseImageLoadingStatusOptions {
+  referrerPolicy?: React.HTMLAttributeReferrerPolicy;
+  crossOrigin?: string | null;
+}
+
+function useImageLoadingStatus(src?: string, options?: UseImageLoadingStatusOptions) {
   const [loadingStatus, setLoadingStatus] = React.useState<ImageLoadingStatus>('idle');
 
   useLayoutEffect(() => {
@@ -137,14 +145,17 @@ function useImageLoadingStatus(src?: string, referrerPolicy?: React.HTMLAttribut
     image.onload = updateStatus('loaded');
     image.onerror = updateStatus('error');
     image.src = src;
-    if (referrerPolicy) {
-      image.referrerPolicy = referrerPolicy;
+    if (options?.referrerPolicy) {
+      image.referrerPolicy = options.referrerPolicy;
+    }
+    if (options?.crossOrigin) {
+      image.crossOrigin = options.crossOrigin;
     }
 
     return () => {
       isMounted = false;
     };
-  }, [src, referrerPolicy]);
+  }, [src, options]);
 
   return loadingStatus;
 }

--- a/packages/react/avatar/src/Avatar.tsx
+++ b/packages/react/avatar/src/Avatar.tsx
@@ -144,13 +144,13 @@ function useImageLoadingStatus(src?: string, options?: UseImageLoadingStatusOpti
     setLoadingStatus('loading');
     image.onload = updateStatus('loaded');
     image.onerror = updateStatus('error');
-    image.src = src;
     if (options?.referrerPolicy) {
       image.referrerPolicy = options.referrerPolicy;
     }
     if (options?.crossOrigin) {
       image.crossOrigin = options.crossOrigin;
     }
+    image.src = src;
 
     return () => {
       isMounted = false;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

### Add `crossOrigin` Support to `useImageLoadingStatus` Hook

This PR adds `crossOrigin` support to the `useImageLoadingStatus` hook to handle images hosted on external domains that require specific `crossOrigin` settings (`anonymous` or `use-credentials`).  

By including this option, we ensure broader compatibility with external image sources and resolve potential loading issues. 

*Note: I haven’t added a test for this as I’m not entirely sure how to approach testing this scenario.*   