### PR TITLE
[Select] feature: make autoScroll interval configurable

### DIFF
--- a/.yarn/versions/b4415633.yml
+++ b/.yarn/versions/b4415633.yml
@@ -1,3 +1,5 @@
 releases:
   "@radix-ui/react-select": patch
-  primitives: major
+
+declined:
+  - primitives

--- a/.yarn/versions/b4415633.yml
+++ b/.yarn/versions/b4415633.yml
@@ -1,0 +1,3 @@
+releases:
+  "@radix-ui/react-select": patch
+  primitives: major

--- a/packages/react/select/src/Select.stories.tsx
+++ b/packages/react/select/src/Select.stories.tsx
@@ -717,6 +717,71 @@ export const WithVeryLongSelectItems = () => (
   </div>
 );
 
+export const WithCustomAutoScrollInterval = () => (
+  <div
+    style={{
+      padding: 20,
+      display: 'flex',
+      gap: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+    }}
+  >
+    {[
+      { speed: 'slower', interval: 80 },
+      { speed: 'default', interval: undefined },
+      { speed: 'faster', interval: 25 },
+    ].map(({ speed, interval }) => (
+      <Label>
+        {`(${speed} auto-scroll speed)`}
+        <br />
+        Choose an item:
+        <Select.Root defaultValue="item-25">
+          <Select.Trigger className={triggerClass()}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={contentClass()} sideOffset={5}>
+              <Select.ScrollUpButton
+                autoScrollInterval={interval}
+                className={scrollUpButtonClass()}
+              >
+                ▲
+              </Select.ScrollUpButton>
+              <Select.Viewport className={viewportClass()}>
+                {Array.from({ length: 50 }, (_, i) => {
+                  const value = `item-${i + 1}`;
+                  return (
+                    <Select.Item
+                      key={value}
+                      className={itemClass()}
+                      value={value}
+                      disabled={i > 5 && i < 9}
+                    >
+                      <Select.ItemText>item {i + 1}</Select.ItemText>
+                      <Select.ItemIndicator className={indicatorClass()}>
+                        <TickIcon />
+                      </Select.ItemIndicator>
+                    </Select.Item>
+                  );
+                })}
+              </Select.Viewport>
+              <Select.ScrollDownButton
+                autoScrollInterval={interval}
+                className={scrollDownButtonClass()}
+              >
+                ▼
+              </Select.ScrollDownButton>
+              <Select.Arrow />
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+    ))}
+  </div>
+);
+
 export const ChromaticShortOptionsPaddedContent = () => (
   <ChromaticStoryShortOptions paddedElement="content" />
 );


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description


#### Problem
Currently, the autoScroll interval in the scroll buttons is hardcoded to 50ms, which makes it difficult to adjust the scrolling speed for specific use cases.

#### Solution
This change makes the autoScroll interval configurable by allowing a new optional prop, `autoScrollInterval`, to be passed. The interval defaults to 50ms to maintain backward compatibility.

#### Tests
- did not add test

#### Storybook
- Added a new Storybook example to demonstrate the use of `WithCustomAutoScrollInterval` with different values.

#### Backward Compatibility
This change is fully backward-compatible as the `autoScrollInterval` defaults to 50ms, matching the previous implementation.


#### Related Issues
Closes #2829 