### PR TITLE
[Dialog]: feature export useDialogContext

### DIFF
--- a/packages/react/dialog/src/Dialog.tsx
+++ b/packages/react/dialog/src/Dialog.tsx
@@ -555,6 +555,7 @@ const Close = DialogClose;
 
 export {
   createDialogScope,
+  useDialogContext,
   //
   Dialog,
   DialogTrigger,


### PR DESCRIPTION
### Description

Exporting useDialogContext for the purpose of having access to triggering open/close dialog in a child component of Dialog without making it controlled by the parent component

Closes: https://github.com/radix-ui/primitives/issues/3274
