### PR TITLE
feat(dependencies): bump `react-remove-scroll` to v2.6.1

### DIFF
--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -41,7 +41,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.1"
+    "react-remove-scroll": "^2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -41,7 +41,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.0"
+    "react-remove-scroll": "2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-use-escape-keydown": "workspace:*"
   },
   "devDependencies": {
-    "react-remove-scroll": "2.6.1"
+    "react-remove-scroll": "^2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-use-escape-keydown": "workspace:*"
   },
   "devDependencies": {
-    "react-remove-scroll": "2.6.0"
+    "react-remove-scroll": "2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -45,7 +45,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.1"
+    "react-remove-scroll": "^2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -45,7 +45,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.0"
+    "react-remove-scroll": "2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.1"
+    "react-remove-scroll": "^2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.0"
+    "react-remove-scroll": "2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -48,7 +48,7 @@
     "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.1"
+    "react-remove-scroll": "^2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -48,7 +48,7 @@
     "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.6.0"
+    "react-remove-scroll": "2.6.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,7 +2246,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: "npm:^1.1.1"
-    react-remove-scroll: "npm:2.6.0"
+    react-remove-scroll: "npm:2.6.1"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -2281,7 +2281,7 @@ __metadata:
     "@radix-ui/react-primitive": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     "@radix-ui/react-use-escape-keydown": "workspace:*"
-    react-remove-scroll: "npm:2.6.0"
+    react-remove-scroll: "npm:2.6.1"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -2453,7 +2453,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-callback-ref": "workspace:*"
     aria-hidden: "npm:^1.1.1"
-    react-remove-scroll: "npm:2.6.0"
+    react-remove-scroll: "npm:2.6.1"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -2543,7 +2543,7 @@ __metadata:
     "@radix-ui/react-slot": "workspace:*"
     "@radix-ui/react-use-controllable-state": "workspace:*"
     aria-hidden: "npm:^1.1.1"
-    react-remove-scroll: "npm:2.6.0"
+    react-remove-scroll: "npm:2.6.1"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -2764,7 +2764,7 @@ __metadata:
     "@radix-ui/react-use-previous": "workspace:*"
     "@radix-ui/react-visually-hidden": "workspace:*"
     aria-hidden: "npm:^1.1.1"
-    react-remove-scroll: "npm:2.6.0"
+    react-remove-scroll: "npm:2.6.1"
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
@@ -11870,38 +11870,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-remove-scroll-bar@npm:^2.3.6":
-  version: 2.3.6
-  resolution: "react-remove-scroll-bar@npm:2.3.6"
+"react-remove-scroll-bar@npm:^2.3.7":
+  version: 2.3.8
+  resolution: "react-remove-scroll-bar@npm:2.3.8"
   dependencies:
-    react-style-singleton: "npm:^2.2.1"
+    react-style-singleton: "npm:^2.2.2"
     tslib: "npm:^2.0.0"
   peerDependencies:
-    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5ab8eda61d5b10825447d11e9c824486c929351a471457c22452caa19b6898e18c3af6a46c3fa68010c713baed1eb9956106d068b4a1058bdcf97a1a9bbed734
+  checksum: 10/6c0f8cff98b9f49a4ee2263f1eedf12926dced5ce220fbe83bd93544460e2a7ec8ec39b35d1b2a75d2fced0b2d64afeb8e66f830431ca896e05a20585f9fc350
   languageName: node
   linkType: hard
 
-"react-remove-scroll@npm:2.6.0":
-  version: 2.6.0
-  resolution: "react-remove-scroll@npm:2.6.0"
+"react-remove-scroll@npm:2.6.1":
+  version: 2.6.1
+  resolution: "react-remove-scroll@npm:2.6.1"
   dependencies:
-    react-remove-scroll-bar: "npm:^2.3.6"
+    react-remove-scroll-bar: "npm:^2.3.7"
     react-style-singleton: "npm:^2.2.1"
     tslib: "npm:^2.1.0"
     use-callback-ref: "npm:^1.3.0"
     use-sidecar: "npm:^1.1.2"
   peerDependencies:
-    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9fac79e1c2ed2c85729bfe82f61ef4ae5ce51f478736a13892a9a11e05cbd4e9599f9f0e012cb5fc0719e18dc1dd687ab61f516193228615df636db8b851245e
+  checksum: 10/ee7d2ea0b1225d43c1102488f29f855a639e4589a086d5e56d656517495fe3ffbc235e2045893e23c44f60aa93281f882199d01ea2a68139adba9713bf3500a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Updated react-remove-scroll from version 2.6.0 to 2.6.1

This version resolves the peer dependency error encountered during installation when using React 19

https://github.com/theKashey/react-remove-scroll