### PR TITLE
Rearrange style prop to override unused CSS Variable

### DIFF
--- a/.yarn/versions/780ba100.yml
+++ b/.yarn/versions/780ba100.yml
@@ -1,2 +1,3 @@
 releases:
   "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch

--- a/.yarn/versions/780ba100.yml
+++ b/.yarn/versions/780ba100.yml
@@ -1,0 +1,2 @@
+releases:
+  "@radix-ui/react-context-menu": patch

--- a/.yarn/versions/780ba100.yml
+++ b/.yarn/versions/780ba100.yml
@@ -1,3 +1,4 @@
 releases:
   "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-menubar": patch

--- a/packages/react/context-menu/src/ContextMenu.tsx
+++ b/packages/react/context-menu/src/ContextMenu.tsx
@@ -504,7 +504,6 @@ const ContextMenuSubContent = React.forwardRef<
       {...subContentProps}
       ref={forwardedRef}
       style={{
-        ...props.style,
         // re-namespace exposed content custom properties
         ...{
           '--radix-context-menu-content-transform-origin': 'var(--radix-popper-transform-origin)',
@@ -513,6 +512,7 @@ const ContextMenuSubContent = React.forwardRef<
           '--radix-context-menu-trigger-width': 'var(--radix-popper-anchor-width)',
           '--radix-context-menu-trigger-height': 'var(--radix-popper-anchor-height)',
         },
+        ...props.style,
       }}
     />
   );

--- a/packages/react/dropdown-menu/src/DropdownMenu.tsx
+++ b/packages/react/dropdown-menu/src/DropdownMenu.tsx
@@ -195,7 +195,6 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
           if (!context.modal || isRightClick) hasInteractedOutsideRef.current = true;
         })}
         style={{
-          ...props.style,
           // re-namespace exposed content custom properties
           ...{
             '--radix-dropdown-menu-content-transform-origin':
@@ -206,6 +205,7 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
             '--radix-dropdown-menu-trigger-width': 'var(--radix-popper-anchor-width)',
             '--radix-dropdown-menu-trigger-height': 'var(--radix-popper-anchor-height)',
           },
+          ...props.style,
         }}
       />
     );
@@ -472,7 +472,6 @@ const DropdownMenuSubContent = React.forwardRef<
       {...subContentProps}
       ref={forwardedRef}
       style={{
-        ...props.style,
         // re-namespace exposed content custom properties
         ...{
           '--radix-dropdown-menu-content-transform-origin': 'var(--radix-popper-transform-origin)',
@@ -481,6 +480,7 @@ const DropdownMenuSubContent = React.forwardRef<
           '--radix-dropdown-menu-trigger-width': 'var(--radix-popper-anchor-width)',
           '--radix-dropdown-menu-trigger-height': 'var(--radix-popper-anchor-height)',
         },
+        ...props.style,
       }}
     />
   );

--- a/packages/react/menubar/src/Menubar.tsx
+++ b/packages/react/menubar/src/Menubar.tsx
@@ -380,7 +380,6 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
           { checkForDefaultPrevented: false }
         )}
         style={{
-          ...props.style,
           // re-namespace exposed content custom properties
           ...{
             '--radix-menubar-content-transform-origin': 'var(--radix-popper-transform-origin)',
@@ -389,6 +388,7 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
             '--radix-menubar-trigger-width': 'var(--radix-popper-anchor-width)',
             '--radix-menubar-trigger-height': 'var(--radix-popper-anchor-height)',
           },
+          ...props.style,
         }}
       />
     );
@@ -658,7 +658,6 @@ const MenubarSubContent = React.forwardRef<MenubarSubContentElement, MenubarSubC
         {...subContentProps}
         ref={forwardedRef}
         style={{
-          ...props.style,
           // re-namespace exposed content custom properties
           ...{
             '--radix-menubar-content-transform-origin': 'var(--radix-popper-transform-origin)',
@@ -667,6 +666,7 @@ const MenubarSubContent = React.forwardRef<MenubarSubContentElement, MenubarSubC
             '--radix-menubar-trigger-width': 'var(--radix-popper-anchor-width)',
             '--radix-menubar-trigger-height': 'var(--radix-popper-anchor-height)',
           },
+          ...props.style,
         }}
       />
     );


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

packages: `DropdownMenu`, `ContextMenu`, `Menubar`

Radix-ui allows us to easily add styles by passing a special CSS Variable. This is one of the most useful parts during development, but it can be a disadvantage in terms of debugging and readability because it is expressed as a style prop on the DOM. So we rearranged the order so that `...props.style` covers existing unused CSS Variables.
