### PR TITLE
[ScrollArea] Support customize ScrollAreaViewport content style

### DIFF
--- a/packages/react/scroll-area/src/ScrollArea.tsx
+++ b/packages/react/scroll-area/src/ScrollArea.tsx
@@ -137,11 +137,12 @@ const VIEWPORT_NAME = 'ScrollAreaViewport';
 type ScrollAreaViewportElement = React.ElementRef<typeof Primitive.div>;
 interface ScrollAreaViewportProps extends PrimitiveDivProps {
   nonce?: string;
+  contentStyle?: React.CSSProperties;
 }
 
 const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAreaViewportProps>(
   (props: ScopedProps<ScrollAreaViewportProps>, forwardedRef) => {
-    const { __scopeScrollArea, children, nonce, ...viewportProps } = props;
+    const { __scopeScrollArea, children, nonce, contentStyle, ...viewportProps } = props;
     const context = useScrollAreaContext(VIEWPORT_NAME, __scopeScrollArea);
     const ref = React.useRef<ScrollAreaViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
@@ -182,7 +183,10 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
            * widths that change. We'll wait to see what use-cases consumers come up with there
            * before trying to resolve it.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div
+            ref={context.onContentChange}
+            style={{ ...contentStyle, minWidth: '100%', display: 'table' }}
+          >
             {children}
           </div>
         </Primitive.div>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

I hope to add `min-height: 100%` style to the wrapper element of the content, but I can't achieve it now.

I used ScrollArea to encapsulate a Drawer that supports scrolling by default, but in some scenarios, users want the content to have a fixed 100% height, and this should be defined through CSS rather than additional component properties. Currently, it is not possible to perform any operations on the content element under ScrollAreaViewport from the outside.
