### PR TITLE
[Slider] onValueCommit not called when start/end are equal

### DIFF
--- a/.yarn/versions/a5937b9e.yml
+++ b/.yarn/versions/a5937b9e.yml
@@ -1,0 +1,5 @@
+releases:
+  primitives: decline
+
+declined:
+  - "@radix-ui/react-slider"

--- a/packages/react/slider/src/Slider.tsx
+++ b/packages/react/slider/src/Slider.tsx
@@ -133,7 +133,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
       setValues((prevValues = []) => {
         const nextValues = getNextSortedValues(prevValues, nextValue, atIndex);
         if (hasMinStepsBetweenValues(nextValues, minStepsBetweenThumbs * step)) {
-          valueIndexToChangeRef.current = nextValues.indexOf(nextValue);
+          valueIndexToChangeRef.current = atIndex;
           const hasChanged = String(nextValues) !== String(prevValues);
           if (hasChanged && commit) onValueCommit(nextValues);
           return hasChanged ? nextValues : prevValues;


### PR DESCRIPTION
### onValueCommit not called when start/end are equal

### Description

For multi-value sliders where two values are allowed to overlap, `onValueCommit` will not be called for overlapping values.

#1760

### Steps to reproduce

```
<Slider.Root
	defaultValue={[10, 30]}
	minStepsBetweenThumbs={0}
>
	<Slider.Track>
		<Slider.Range />
	</Slider.Track>
	<Slider.Thumb />
	<Slider.Thumb />
</Slider.Root>
```

Dragging the END value equal to the START value will trigger `onValueChange` but will not trigger `onValueCommit`, despite the end value having changed.

https://github.com/user-attachments/assets/106c1611-d459-48fa-93a1-0ba5394dc292


### Cause

`updateValues()` is responsible for setting `valueIndexToChangeRef`, which is used later by `handleSlideEnd()` to determine if changes have been made. The problem is that `updateValues()` will attempt to find the relevant index by searching for the current value -- using **the first index found**. If the array contains multiple identical values, this strategy will fail.

Effectively when multiple Thumbs have identical values, the first index is always used. This means that `handleSlideEnd()` will only check for changes in the first Thumb's value.

Changing values using the keyboard works as expected, this bug only affects dragging behavior. Changing the first value always works as expected.

### Fix

`updateValues()` already receives an index parameter; it's used to validate that the minSteps has been satisfied, and in some cases used for change detection. Using this index instead of trying to infer it by searching the first occurrence of the value solves the issue.




