### PR TITLE
[Popper] Add option to disable update position on layout shift

### DIFF
--- a/.yarn/versions/1acbd181.yml
+++ b/.yarn/versions/1acbd181.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-context-menu": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/.yarn/versions/1acbd181.yml
+++ b/.yarn/versions/1acbd181.yml
@@ -8,6 +8,7 @@ releases:
   "@radix-ui/react-popper": patch
   "@radix-ui/react-select": patch
   "@radix-ui/react-tooltip": patch
+  radix-ui: patch
 
 declined:
   - primitives

--- a/packages/react/popper/src/Popper.stories.tsx
+++ b/packages/react/popper/src/Popper.stories.tsx
@@ -132,6 +132,37 @@ export const WithUpdatePositionStrategyAlways = () => {
   );
 };
 
+export const WithoutLayoutShift = () => {
+  const [open, setOpen] = React.useState(false);
+  const [showElement, setShowElement] = React.useState(false);
+
+  return (
+    <Scrollable>
+      <Popper.Root>
+        {showElement && <div>element</div>}
+        &nbsp;
+        <Popper.Anchor className={styles.anchor} onClick={() => setOpen(true)}>
+          open
+        </Popper.Anchor>
+        {open && (
+          <Portal asChild>
+            <Popper.Content
+              className={styles.content}
+              sideOffset={5}
+              updatePositionOnLayoutShift={false}
+            >
+              <button onClick={() => setShowElement(!showElement)}>Toggle element</button>
+              &nbsp;
+              <button onClick={() => setOpen(false)}>close</button>
+              <Popper.Arrow className={styles.arrow} width={20} height={10} />
+            </Popper.Content>
+          </Portal>
+        )}
+      </Popper.Root>
+    </Scrollable>
+  );
+};
+
 export const Chromatic = () => {
   const [scrollContainer1, setScrollContainer1] = React.useState<HTMLDivElement | null>(null);
   const [scrollContainer2, setScrollContainer2] = React.useState<HTMLDivElement | null>(null);

--- a/packages/react/popper/src/Popper.tsx
+++ b/packages/react/popper/src/Popper.tsx
@@ -122,6 +122,7 @@ interface PopperContentProps extends PrimitiveDivProps {
   sticky?: 'partial' | 'always';
   hideWhenDetached?: boolean;
   updatePositionStrategy?: 'optimized' | 'always';
+  updatePositionOnLayoutShift?: boolean;
   onPlaced?: () => void;
 }
 
@@ -140,6 +141,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       sticky = 'partial',
       hideWhenDetached = false,
       updatePositionStrategy = 'optimized',
+      updatePositionOnLayoutShift = true,
       onPlaced,
       ...contentProps
     } = props;
@@ -178,6 +180,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       whileElementsMounted: (...args) => {
         const cleanup = autoUpdate(...args, {
           animationFrame: updatePositionStrategy === 'always',
+          layoutShift: updatePositionOnLayoutShift,
         });
         return cleanup;
       },


### PR DESCRIPTION
### Description

This PR aims to allow setting `layoutShift` in floating-ui `onUpdate` params through `PopperContentProps` by adding an additional prop called `updatePositionOnLayoutShift`.

I also added a new storybook story to demonstrate its usage.

Closes https://github.com/radix-ui/primitives/issues/2555
