### PR TITLE
[Toast] Add `onOpenChange` to Toast.Provider

### DIFF
--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -66,6 +66,10 @@ interface ToastProviderProps {
    * @defaultValue 50
    */
   swipeThreshold?: number;
+  /**
+   * Callback for when a toast opens or closes
+   */
+  onOpenChange?(toastCount: number): void
 }
 
 const ToastProvider: React.FC<ToastProviderProps> = (props: ScopedProps<ToastProviderProps>) => {
@@ -76,11 +80,16 @@ const ToastProvider: React.FC<ToastProviderProps> = (props: ScopedProps<ToastPro
     swipeDirection = 'right',
     swipeThreshold = 50,
     children,
+    onOpenChange,
   } = props;
   const [viewport, setViewport] = React.useState<ToastViewportElement | null>(null);
   const [toastCount, setToastCount] = React.useState(0);
   const isFocusedToastEscapeKeyDownRef = React.useRef(false);
   const isClosePausedRef = React.useRef(false);
+
+  useEffect(() => {
+    onOpenChange.?(toastCount)
+  }, [toastCount])
 
   if (!label.trim()) {
     console.error(


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR introduces a `onOpenChange` prop to the Toast.Provider. It's useful if you want to implement some side effect whenever a certain number of toasts is presended. 

In my case I need to hide a certain element when one or more toasts are present.
