### PR TITLE
Close tooltip on pointer down

### DIFF
--- a/.yarn/versions/6b740aa8.yml
+++ b/.yarn/versions/6b740aa8.yml
@@ -1,0 +1,4 @@
+releases:
+  "@radix-ui/react-tooltip": minor
+  primitives: minor
+  radix-ui: minor

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -303,6 +303,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             hasPointerMoveOpenedRef.current = false;
           })}
           onPointerDown={composeEventHandlers(props.onPointerDown, () => {
+            context.onClose();
             isPointerDownRef.current = true;
             document.addEventListener('pointerup', handlePointerUp, { once: true });
           })}

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -303,7 +303,9 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             hasPointerMoveOpenedRef.current = false;
           })}
           onPointerDown={composeEventHandlers(props.onPointerDown, () => {
-            context.onClose();
+            if (context.open) {
+              context.onClose();
+            }
             isPointerDownRef.current = true;
             document.addEventListener('pointerup', handlePointerUp, { once: true });
           })}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR closes the tooltip automatically `onPointerDown`.

Attached are the before and after behaviours:

## Before

https://github.com/user-attachments/assets/5752322f-4afe-41c3-9d50-91d72d50b909

## After

https://github.com/user-attachments/assets/16326be9-4a4b-4abb-b2b9-ad2dc470d6fb









