### PR TITLE
[Context Menu] fix: stop infinite re-renders when the menu is closed

### DIFF
--- a/packages/react/context-menu/src/context-menu.tsx
+++ b/packages/react/context-menu/src/context-menu.tsx
@@ -112,8 +112,10 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
 
     return (
       <>
-        <MenuPrimitive.Anchor {...menuScope} virtualRef={virtualRef} />
-        <Primitive.span
+			{context.open && (
+				<MenuPrimitive.Anchor {...menuScope} virtualRef={virtualRef} />
+			)}
+      <Primitive.span
           data-state={context.open ? 'open' : 'closed'}
           data-disabled={disabled ? '' : undefined}
           {...triggerProps}


### PR DESCRIPTION
### Description

When the context menu is closed the anchor component bringing the menu is still open so if a component using the context menu trigger re-renders quite frequently it will cause an infinite re-render loop with the menu as it's still rendered even when the context menu is supposed to be closed. 

The problem seem to come from `<MenuPrimitive.Anchor>` which uses a virtual ref to measure its bounding client rect. If the trigger is frequently re-rendered it triggers constant state updates in the positioning logic (even the the context menu is closed) and ultimately causes an infinite update loop that has probably to do with radix's menu (not so familiar with it but it must be reacting with this in an inifinite rendering way). 

### Warning

This fixed the issue on my end that has also been reported here https://github.com/radix-ui/primitives/issues/2717#issuecomment-2649190273 and in my issue https://github.com/radix-ui/primitives/issues/3385 but due to my unfamiliarity with this project please make sure this does not have any unintentional side effects. 
