### PR TITLE
fix(VisuallyHidden): Prevent scroll overflow issues by adding explicit positioning

### DIFF
--- a/packages/react/visually-hidden/src/VisuallyHidden.tsx
+++ b/packages/react/visually-hidden/src/VisuallyHidden.tsx
@@ -29,6 +29,8 @@ const VisuallyHidden = React.forwardRef<VisuallyHiddenElement, VisuallyHiddenPro
           clip: 'rect(0, 0, 0, 0)',
           whiteSpace: 'nowrap',
           wordWrap: 'normal',
+          top: 0,
+          left:0,
           ...props.style,
         }}
       />


### PR DESCRIPTION
### Description

This PR addresses an issue where the VisuallyHidden component could trigger unwanted scrollbars when used within containers that have `overflow-y-scroll` applied. By adding explicit `top: 0` and `left: 0` positioning to the component, it properly constrains the element within its parent container boundaries.

Changes made:
- Added `top: 0` and `left: 0` to the inline style properties of the VisuallyHidden component