### PR TITLE
dispatch slideEnd when pointerCapture is lost

### DIFF
--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -407,6 +407,7 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
       ...sliderProps
     } = props;
     const context = useSliderContext(SLIDER_NAME, __scopeSlider);
+    const isDragging = React.useRef(false);
 
     return (
       <Primitive.span
@@ -430,6 +431,7 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
         onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
           const target = event.target as HTMLElement;
           target.setPointerCapture(event.pointerId);
+          isDragging.current = true;
           // Prevent browser focus behaviour because we focus a thumb manually when values change.
           event.preventDefault();
           // Touch devices have a delay before focusing so won't focus if touch immediately moves
@@ -449,7 +451,14 @@ const SliderImpl = React.forwardRef<SliderImplElement, SliderImplProps>(
           if (target.hasPointerCapture(event.pointerId)) {
             target.releasePointerCapture(event.pointerId);
             onSlideEnd(event);
+            isDragging.current = false;
           }
+        })}
+        onLostPointerCapture={composeEventHandlers(props.onLostPointerCapture, (event) => {
+          if (isDragging.current) {
+            onSlideEnd(event);
+          }
+          isDragging.current = false;
         })}
       />
     );


### PR DESCRIPTION
This is meant to address https://github.com/radix-ui/primitives/issues/1760.

When testing I noticed that `pointerUp` fires unreliably. In order to reliably commit updates when a slide ends I also need to monitor `lostPointerCapture`. I don't know how to consistently force this event to emit but it seems more likely when I drag outside of the browser window.

This demo is shot from this branch on the storybook view. The log is associated with the event listener that is calling `onSlideEnd`.


https://github.com/user-attachments/assets/08004e45-5f59-4249-b28f-5728d98fabce

