### PR TITLE
feat(Slot): mergeProps handlers should return the value of the child handler

### DIFF
--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -106,8 +106,9 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
       // if the handler exists on both, we compose them
       if (slotPropValue && childPropValue) {
         overrideProps[propName] = (...args: unknown[]) => {
-          childPropValue(...args);
+          const result = childPropValue(...args);
           slotPropValue(...args);
+          return result;
         };
       }
       // but if it exists only on the slot, we use only this one


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

In some cases, we can return values from the event handlers. The best use-case I have for this is the following:

```tsx
<Button
  onClick={() => mutateAsync({...})}
>
```

In a case like this, we can use the fact that `mutateAsync` returns a `Promise` to automatically turn on a "loading" state on our button, and turn it off when the promise resolves/rejects.

But if `Slot` doesn't "forward" the return value of the event child handler, this use-case becomes impossible if Button is in a Slot (that also applies an onClick handler)

```tsx
<Tooltip>
  <Button onClick={() => mutateAsync({...})} />
</Tooltip>
```

This PR proposes that `Slot` should return the return value of the child handler. This makes `Slot` even more "transparent" to developers using it.


---

- [x] 📝 Use a meaningful title for the pull request and include the name of the package modified.
- [ ] ✅ Add or edit tests to reflect the change (run `yarn test`).
- [ ] 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- [x] 🙏 Please review your own PR to check for anything you may have missed.

If you like the idea of this PR, I can try and think of tests / storybook examples