### PR TITLE
[DismissableLayer] Fix race condition between layers closing at the same time

### DIFF
--- a/packages/react/dismissable-layer/src/dismissable-layer.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.tsx
@@ -127,6 +127,7 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
         ) {
           ownerDocument.body.style.pointerEvents = originalBodyPointerEvents;
         }
+        context.layersWithOutsidePointerEventsDisabled.delete(node);
       };
     }, [node, ownerDocument, disableOutsidePointerEvents, context]);
 
@@ -140,7 +141,6 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
       return () => {
         if (!node) return;
         context.layers.delete(node);
-        context.layersWithOutsidePointerEventsDisabled.delete(node);
         dispatchUpdate();
       };
     }, [node, context]);


### PR DESCRIPTION
### Description

I encountered a bug where multiple layers closing at the same time would both determine that `context.layersWithOutsidePointerEventsDisabled.size > 1` which prevented the pointer events from being reset back to it's original value.  By moving the `context.layersWithOutsidePointerEventsDisabled.delete(node)` to inside of the clean up method for the outer events hook, the race condition is resolved.

I see the comment about "We purposefully prevent combining this effect with the `disableOutsidePointerEvents` effect" which this PR might not be aligned with.  My thought is that the context.layers could represent the "creation order" while context.layersWithOutsidePointerEventsDisabled would not need to adhere to that.

