### PR TITLE
Make useEscapeKeydown's event capture optional

### DIFF
--- a/packages/react/dismissable-layer/src/dismissable-layer.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.tsx
@@ -37,6 +37,15 @@ interface DismissableLayerProps extends PrimitiveDivProps {
    */
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   /**
+   * If escape key event handler should avoid capturing the event before it is dispatched
+   * to the EventTarget.
+   *
+   * See: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#capture
+   *
+   * @default false (i.e., capture the event).
+   */
+  ignoreEscapeKeyCapture?: boolean;
+  /**
    * Event handler called when the a `pointerdown` event happens outside of the `DismissableLayer`.
    * Can be prevented.
    */
@@ -62,6 +71,7 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
   (props, forwardedRef) => {
     const {
       disableOutsidePointerEvents = false,
+      ignoreEscapeKeyCapture,
       onEscapeKeyDown,
       onPointerDownOutside,
       onFocusOutside,
@@ -99,15 +109,19 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
       if (!event.defaultPrevented) onDismiss?.();
     }, ownerDocument);
 
-    useEscapeKeydown((event) => {
-      const isHighestLayer = index === context.layers.size - 1;
-      if (!isHighestLayer) return;
-      onEscapeKeyDown?.(event);
-      if (!event.defaultPrevented && onDismiss) {
-        event.preventDefault();
-        onDismiss();
-      }
-    }, ownerDocument);
+    useEscapeKeydown(
+      (event) => {
+        const isHighestLayer = index === context.layers.size - 1;
+        if (!isHighestLayer) return;
+        onEscapeKeyDown?.(event);
+        if (!event.defaultPrevented && onDismiss) {
+          event.preventDefault();
+          onDismiss();
+        }
+      },
+      ownerDocument,
+      ignoreEscapeKeyCapture
+    );
 
     React.useEffect(() => {
       if (!node) return;

--- a/packages/react/use-escape-keydown/src/use-escape-keydown.tsx
+++ b/packages/react/use-escape-keydown/src/use-escape-keydown.tsx
@@ -6,7 +6,8 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
  */
 function useEscapeKeydown(
   onEscapeKeyDownProp?: (event: KeyboardEvent) => void,
-  ownerDocument: Document = globalThis?.document
+  ownerDocument: Document = globalThis?.document,
+  capture = true
 ) {
   const onEscapeKeyDown = useCallbackRef(onEscapeKeyDownProp);
 
@@ -16,9 +17,9 @@ function useEscapeKeydown(
         onEscapeKeyDown(event);
       }
     };
-    ownerDocument.addEventListener('keydown', handleKeyDown, { capture: true });
-    return () => ownerDocument.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }, [onEscapeKeyDown, ownerDocument]);
+    ownerDocument.addEventListener('keydown', handleKeyDown, { capture });
+    return () => ownerDocument.removeEventListener('keydown', handleKeyDown, { capture });
+  }, [onEscapeKeyDown, ownerDocument, capture]);
 }
 
 export { useEscapeKeydown };


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `yarn test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
This was originally implemented to address #2653. 
This was introduced here: https://github.com/radix-ui/primitives/pull/2761
There are other's impacted based on this issue: https://github.com/radix-ui/primitives/issues/3422

This was quite the sweeping change and makes it quite difficult for anyone to intercept this. Many libraries/components rely on checking various states of the event to determine if they will perform some function and now internal components cannot handle this event first and Radix sets the defaultPrevented state of this. From a sanity POV, does it really make sense to have some higher level component handle this before the component has a chance? 

I'm more of the opinion that this behavior should be rolled back completely - or even keep this PR, but flip the defaults (i.e., capture is disabled by default rather than enabled - which I only did to keep this inline with current functionality).

In this PR we can expose this behavior at least. Without the "ignore/disabling" of the capture in this PR, as far as I can tell, it would necessitate creating a Dialog/Dismissable Context so lower level components can hook into this behavior - and even still it's not going to be great b/c useEscapeKeydown calls `preventDefault` which other components are going to check.

E.g., react-select's menu cannot be closed with the escape key, becasue the Dialog/DismissableLayer eats the event and prevents default on it and closes the dialog. Alternatively, it leaves the dialog open and the menu open as the Dialog/DismissableLayer still prevents default, preventing react-select from closing.


<!-- Describe the change you are introducing -->
Change: allow control of escape keydown capture.