### PR TITLE
Slottable: Improve displayName for easier debugging

### DIFF
--- a/.yarn/versions/057c467a.yml
+++ b/.yarn/versions/057c467a.yml
@@ -1,13 +1,46 @@
 releases:
+  "@radix-ui/react-accessible-icon": patch
+  "@radix-ui/react-accordion": patch
   "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-announce": patch
+  "@radix-ui/react-arrow": patch
+  "@radix-ui/react-aspect-ratio": patch
+  "@radix-ui/react-avatar": patch
+  "@radix-ui/react-checkbox": patch
+  "@radix-ui/react-collapsible": patch
   "@radix-ui/react-collection": patch
+  "@radix-ui/react-context-menu": patch
   "@radix-ui/react-dialog": patch
+  "@radix-ui/react-dismissable-layer": patch
+  "@radix-ui/react-dropdown-menu": patch
+  "@radix-ui/react-focus-scope": patch
+  "@radix-ui/react-form": patch
+  "@radix-ui/react-hover-card": patch
+  "@radix-ui/react-label": patch
   "@radix-ui/react-menu": patch
+  "@radix-ui/react-menubar": patch
+  "@radix-ui/react-navigation-menu": patch
   "@radix-ui/react-popover": patch
+  "@radix-ui/react-popper": patch
+  "@radix-ui/react-portal": patch
   "@radix-ui/react-primitive": patch
+  "@radix-ui/react-progress": patch
+  "@radix-ui/react-radio-group": patch
+  "@radix-ui/react-roving-focus": patch
+  "@radix-ui/react-scroll-area": patch
   "@radix-ui/react-select": patch
+  "@radix-ui/react-separator": patch
+  "@radix-ui/react-slider": patch
   "@radix-ui/react-slot": minor
+  "@radix-ui/react-switch": patch
+  "@radix-ui/react-tabs": patch
+  "@radix-ui/react-toast": patch
+  "@radix-ui/react-toggle": patch
+  "@radix-ui/react-toggle-group": patch
+  "@radix-ui/react-toolbar": patch
   "@radix-ui/react-tooltip": patch
+  "@radix-ui/react-visually-hidden": patch
+  radix-ui: minor
 
 declined:
   - primitives

--- a/.yarn/versions/057c467a.yml
+++ b/.yarn/versions/057c467a.yml
@@ -1,0 +1,13 @@
+releases:
+  "@radix-ui/react-alert-dialog": patch
+  "@radix-ui/react-collection": patch
+  "@radix-ui/react-dialog": patch
+  "@radix-ui/react-menu": patch
+  "@radix-ui/react-popover": patch
+  "@radix-ui/react-primitive": patch
+  "@radix-ui/react-select": patch
+  "@radix-ui/react-slot": minor
+  "@radix-ui/react-tooltip": patch
+
+declined:
+  - primitives

--- a/packages/react/alert-dialog/src/alert-dialog.tsx
+++ b/packages/react/alert-dialog/src/alert-dialog.tsx
@@ -4,7 +4,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { createDialogScope } from '@radix-ui/react-dialog';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { Slottable } from '@radix-ui/react-slot';
+import { createSlottable } from '@radix-ui/react-slot';
 
 import type { Scope } from '@radix-ui/react-context';
 
@@ -106,6 +106,8 @@ type AlertDialogContentElement = React.ElementRef<typeof DialogPrimitive.Content
 type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
 interface AlertDialogContentProps
   extends Omit<DialogContentProps, 'onPointerDownOutside' | 'onInteractOutside'> {}
+
+const Slottable = createSlottable('AlertDialogContent');
 
 const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
   (props: ScopedProps<AlertDialogContentProps>, forwardedRef) => {

--- a/packages/react/collection/src/collection.tsx
+++ b/packages/react/collection/src/collection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot, type Slot } from '@radix-ui/react-slot';
 
 type SlotProps = React.ComponentPropsWithoutRef<typeof Slot>;
 type CollectionElement = HTMLElement;
@@ -54,12 +54,13 @@ function createCollection<ItemElement extends HTMLElement, ItemData = {}>(name: 
 
   const COLLECTION_SLOT_NAME = name + 'CollectionSlot';
 
+  const CollectionSlotImpl = createSlot(COLLECTION_SLOT_NAME);
   const CollectionSlot = React.forwardRef<CollectionElement, CollectionProps>(
     (props, forwardedRef) => {
       const { scope, children } = props;
       const context = useCollectionContext(COLLECTION_SLOT_NAME, scope);
       const composedRefs = useComposedRefs(forwardedRef, context.collectionRef);
-      return <Slot ref={composedRefs}>{children}</Slot>;
+      return <CollectionSlotImpl ref={composedRefs}>{children}</CollectionSlotImpl>;
     }
   );
 
@@ -77,6 +78,7 @@ function createCollection<ItemElement extends HTMLElement, ItemData = {}>(name: 
     scope: any;
   };
 
+  const CollectionItemSlotImpl = createSlot(ITEM_SLOT_NAME);
   const CollectionItemSlot = React.forwardRef<ItemElement, CollectionItemSlotProps>(
     (props, forwardedRef) => {
       const { scope, children, ...itemData } = props;
@@ -90,9 +92,9 @@ function createCollection<ItemElement extends HTMLElement, ItemData = {}>(name: 
       });
 
       return (
-        <Slot {...{ [ITEM_DATA_ATTR]: '' }} ref={composedRefs}>
+        <CollectionItemSlotImpl {...{ [ITEM_DATA_ATTR]: '' }} ref={composedRefs}>
           {children}
-        </Slot>
+        </CollectionItemSlotImpl>
       );
     }
   );

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -12,7 +12,7 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
 import { RemoveScroll } from 'react-remove-scroll';
 import { hideOthers } from 'aria-hidden';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot } from '@radix-ui/react-slot';
 
 import type { Scope } from '@radix-ui/react-context';
 
@@ -192,6 +192,8 @@ DialogOverlay.displayName = OVERLAY_NAME;
 type DialogOverlayImplElement = React.ElementRef<typeof Primitive.div>;
 type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface DialogOverlayImplProps extends PrimitiveDivProps {}
+
+const Slot = createSlot('DialogOverlay.RemoveScroll');
 
 const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverlayImplProps>(
   (props: ScopedProps<DialogOverlayImplProps>, forwardedRef) => {

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -15,7 +15,7 @@ import { Presence } from '@radix-ui/react-presence';
 import { Primitive, dispatchDiscreteCustomEvent } from '@radix-ui/react-primitive';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { hideOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
@@ -353,6 +353,8 @@ interface MenuContentImplProps
   onFocusOutside?: DismissableLayerProps['onFocusOutside'];
   onInteractOutside?: DismissableLayerProps['onInteractOutside'];
 }
+
+const Slot = createSlot('MenuContent.ScrollLock');
 
 const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImplProps>(
   (props: ScopedProps<MenuContentImplProps>, forwardedRef) => {

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -11,7 +11,7 @@ import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { hideOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
@@ -238,6 +238,8 @@ const PopoverContent = React.forwardRef<PopoverContentTypeElement, PopoverConten
 PopoverContent.displayName = CONTENT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
+
+const Slot = createSlot('PopoverContent.RemoveScroll');
 
 type PopoverContentTypeElement = PopoverContentImplElement;
 interface PopoverContentTypeProps

--- a/packages/react/primitive/src/primitive.tsx
+++ b/packages/react/primitive/src/primitive.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot } from '@radix-ui/react-slot';
 
 const NODES = [
   'a',
@@ -34,6 +34,7 @@ interface PrimitiveForwardRefComponent<E extends React.ElementType>
  * -----------------------------------------------------------------------------------------------*/
 
 const Primitive = NODES.reduce((primitive, node) => {
+  const Slot = createSlot(`Primitive.${node}`);
   const Node = React.forwardRef((props: PrimitivePropsWithRef<typeof node>, forwardedRef: any) => {
     const { asChild, ...primitiveProps } = props;
     const Comp: any = asChild ? Slot : node;

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -14,7 +14,7 @@ import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Primitive } from '@radix-ui/react-primitive';
-import { Slot } from '@radix-ui/react-slot';
+import { createSlot } from '@radix-ui/react-slot';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
@@ -495,6 +495,8 @@ interface SelectContentImplProps
 
   position?: 'item-aligned' | 'popper';
 }
+
+const Slot = createSlot('SelectContent.RemoveScroll');
 
 const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectContentImplProps>(
   (props: ScopedProps<SelectContentImplProps>, forwardedRef) => {

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -3,5 +3,7 @@ export {
   Slottable,
   //
   Root,
+  createSlot,
+  createSlottable,
 } from './slot';
 export type { SlotProps } from './slot';

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -117,7 +117,10 @@ function isSlottable(
   child: React.ReactNode
 ): child is React.ReactElement<SlottableProps, typeof Slottable> {
   return (
-    React.isValidElement(child) && '__radixId' in child && child.__radixId === SLOTTABLE_IDENTIFIER
+    React.isValidElement(child) &&
+    typeof child.type === 'function' &&
+    '__radixId' in child.type &&
+    child.type.__radixId === SLOTTABLE_IDENTIFIER
   );
 }
 

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -9,45 +9,51 @@ interface SlotProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
 }
 
-const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
-  const { children, ...slotProps } = props;
-  const childrenArray = React.Children.toArray(children);
-  const slottable = childrenArray.find(isSlottable);
+function createSlot(ownerName: string) {
+  const SlotClone = createSlotClone(ownerName);
+  const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
+    const { children, ...slotProps } = props;
+    const childrenArray = React.Children.toArray(children);
+    const slottable = childrenArray.find(isSlottable);
 
-  if (slottable) {
-    // the new element to render is the one passed as a child of `Slottable`
-    const newElement = slottable.props.children;
+    if (slottable) {
+      // the new element to render is the one passed as a child of `Slottable`
+      const newElement = slottable.props.children;
 
-    const newChildren = childrenArray.map((child) => {
-      if (child === slottable) {
-        // because the new element will be the one rendered, we are only interested
-        // in grabbing its children (`newElement.props.children`)
-        if (React.Children.count(newElement) > 1) return React.Children.only(null);
-        return React.isValidElement(newElement)
-          ? (newElement.props as { children: React.ReactNode }).children
-          : null;
-      } else {
-        return child;
-      }
-    });
+      const newChildren = childrenArray.map((child) => {
+        if (child === slottable) {
+          // because the new element will be the one rendered, we are only interested
+          // in grabbing its children (`newElement.props.children`)
+          if (React.Children.count(newElement) > 1) return React.Children.only(null);
+          return React.isValidElement(newElement)
+            ? (newElement.props as { children: React.ReactNode }).children
+            : null;
+        } else {
+          return child;
+        }
+      });
+
+      return (
+        <SlotClone {...slotProps} ref={forwardedRef}>
+          {React.isValidElement(newElement)
+            ? React.cloneElement(newElement, undefined, newChildren)
+            : null}
+        </SlotClone>
+      );
+    }
 
     return (
       <SlotClone {...slotProps} ref={forwardedRef}>
-        {React.isValidElement(newElement)
-          ? React.cloneElement(newElement, undefined, newChildren)
-          : null}
+        {children}
       </SlotClone>
     );
-  }
+  });
 
-  return (
-    <SlotClone {...slotProps} ref={forwardedRef}>
-      {children}
-    </SlotClone>
-  );
-});
+  Slot.displayName = `${ownerName}.Slot`;
+  return Slot;
+}
 
-Slot.displayName = 'Slot';
+const Slot = createSlot('Slot');
 
 /* -------------------------------------------------------------------------------------------------
  * SlotClone
@@ -57,31 +63,51 @@ interface SlotCloneProps {
   children: React.ReactNode;
 }
 
-const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
-  const { children, ...slotProps } = props;
+function createSlotClone(ownerName: string) {
+  const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
+    const { children, ...slotProps } = props;
 
-  if (React.isValidElement(children)) {
-    const childrenRef = getElementRef(children);
-    const props = mergeProps(slotProps, children.props as AnyProps);
-    // do not pass ref to React.Fragment for React 19 compatibility
-    if (children.type !== React.Fragment) {
-      props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
+    if (React.isValidElement(children)) {
+      const childrenRef = getElementRef(children);
+      const props = mergeProps(slotProps, children.props as AnyProps);
+      // do not pass ref to React.Fragment for React 19 compatibility
+      if (children.type !== React.Fragment) {
+        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
+      }
+      return React.cloneElement(children, props);
     }
-    return React.cloneElement(children, props);
-  }
 
-  return React.Children.count(children) > 1 ? React.Children.only(null) : null;
-});
+    return React.Children.count(children) > 1 ? React.Children.only(null) : null;
+  });
 
-SlotClone.displayName = 'SlotClone';
+  SlotClone.displayName = `${ownerName}.SlotClone`;
+  return SlotClone;
+}
 
 /* -------------------------------------------------------------------------------------------------
  * Slottable
  * -----------------------------------------------------------------------------------------------*/
 
-const Slottable = ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
-};
+const SLOTTABLE_IDENTIFIER = Symbol('radix.slottable');
+
+interface SlottableProps {
+  children: React.ReactNode;
+}
+
+interface SlottableComponent extends React.FC<SlottableProps> {
+  __radixId: symbol;
+}
+
+function createSlottable(ownerName: string) {
+  const Slottable: SlottableComponent = ({ children }) => {
+    return <>{children}</>;
+  };
+  Slottable.displayName = `${ownerName}.Slottable`;
+  Slottable.__radixId = SLOTTABLE_IDENTIFIER;
+  return Slottable;
+}
+
+const Slottable = createSlottable('Slottable');
 
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -89,8 +115,10 @@ type AnyProps = Record<string, any>;
 
 function isSlottable(
   child: React.ReactNode
-): child is React.ReactElement<React.ComponentProps<typeof Slottable>, typeof Slottable> {
-  return React.isValidElement(child) && child.type === Slottable;
+): child is React.ReactElement<SlottableProps, typeof Slottable> {
+  return (
+    React.isValidElement(child) && '__radixId' in child && child.__radixId === SLOTTABLE_IDENTIFIER
+  );
 }
 
 function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
@@ -150,12 +178,12 @@ function getElementRef(element: React.ReactElement) {
   return (element.props as { ref?: React.Ref<unknown> }).ref || (element as any).ref;
 }
 
-const Root = Slot;
-
 export {
+  createSlot,
+  createSlottable,
   Slot,
   Slottable,
   //
-  Root,
+  Slot as Root,
 };
 export type { SlotProps };

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -9,7 +9,7 @@ import { createPopperScope } from '@radix-ui/react-popper';
 import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
 import { Primitive } from '@radix-ui/react-primitive';
-import { Slottable } from '@radix-ui/react-slot';
+import { createSlottable } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
@@ -500,6 +500,8 @@ interface TooltipContentImplProps extends Omit<PopperContentProps, 'onPlaced'> {
    */
   onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
 }
+
+const Slottable = createSlottable('TooltipContent');
 
 const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipContentImplProps>(
   (props: ScopedProps<TooltipContentImplProps>, forwardedRef) => {


### PR DESCRIPTION
Something that has bugged me for a while is how Radix components add a lot of noise to the component tree view in React dev tools. This largely has to do with our use of the `Slot` component, which results in a view that is hard to grok and makes it more annoying to debug with so many components just named `Slot`.

![CleanShot 2025-04-02 at 14 32 42](https://github.com/user-attachments/assets/2df90002-dd28-46d3-90f1-6c49cf687b55)

This PR introduces functions to create `Slot` and `Slottable` components with unique display names to make things a little less chaotic.

![CleanShot 2025-04-02 at 14 32 25](https://github.com/user-attachments/assets/31b191ff-f59c-4980-87bd-1fd5533601b5)

In the future I'd like to propose eliminating internal usage of `Slot` for a functional approach to actually clean up the component tree as much as possible. This is an interim solution that avoids major refactoring.