### PR TITLE
Use primitives for bubble input components

### DIFF
--- a/.changeset/hungry-baboons-greet.md
+++ b/.changeset/hungry-baboons-greet.md
@@ -1,0 +1,11 @@
+---
+'@radix-ui/react-visually-hidden': minor
+'@radix-ui/react-radio-group': minor
+'@radix-ui/react-primitive': minor
+'@radix-ui/react-checkbox': minor
+'@radix-ui/react-select': minor
+'@radix-ui/react-slider': minor
+'@radix-ui/react-switch': minor
+---
+
+All form controls with internal bubble inputs now use the Radix `Primitive` component by default. This will allow us to expose these components directly so users can better control this behavior in the future.

--- a/packages/react/primitive/src/primitive.tsx
+++ b/packages/react/primitive/src/primitive.tsx
@@ -16,6 +16,7 @@ const NODES = [
   'nav',
   'ol',
   'p',
+  'select',
   'span',
   'svg',
   'ul',

--- a/packages/react/switch/src/switch.tsx
+++ b/packages/react/switch/src/switch.tsx
@@ -81,7 +81,7 @@ const Switch = React.forwardRef<SwitchElement, SwitchProps>(
           })}
         />
         {isFormControl && (
-          <BubbleInput
+          <SwitchBubbleInput
             control={button}
             bubbles={!hasConsumerStoppedPropagationRef.current}
             name={name}
@@ -130,53 +130,77 @@ const SwitchThumb = React.forwardRef<SwitchThumbElement, SwitchThumbProps>(
 
 SwitchThumb.displayName = THUMB_NAME;
 
-/* ---------------------------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------------------------------
+ * SwitchBubbleInput
+ * -----------------------------------------------------------------------------------------------*/
 
-type InputProps = React.ComponentPropsWithoutRef<'input'>;
-interface BubbleInputProps extends Omit<InputProps, 'checked'> {
+const BUBBLE_INPUT_NAME = 'SwitchBubbleInput';
+
+type InputProps = React.ComponentPropsWithoutRef<typeof Primitive.input>;
+interface SwitchBubbleInputProps extends Omit<InputProps, 'checked'> {
   checked: boolean;
   control: HTMLElement | null;
   bubbles: boolean;
 }
 
-const BubbleInput = (props: BubbleInputProps) => {
-  const { control, checked, bubbles = true, ...inputProps } = props;
-  const ref = React.useRef<HTMLInputElement>(null);
-  const prevChecked = usePrevious(checked);
-  const controlSize = useSize(control);
+const SwitchBubbleInput = React.forwardRef<HTMLInputElement, SwitchBubbleInputProps>(
+  (
+    {
+      __scopeSwitch,
+      control,
+      checked,
+      bubbles = true,
+      ...props
+    }: ScopedProps<SwitchBubbleInputProps>,
+    forwardedRef
+  ) => {
+    const ref = React.useRef<HTMLInputElement>(null);
+    const composedRefs = useComposedRefs(ref, forwardedRef);
+    const prevChecked = usePrevious(checked);
+    const controlSize = useSize(control);
 
-  // Bubble checked change to parents (e.g form change event)
-  React.useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(inputProto, 'checked') as PropertyDescriptor;
-    const setChecked = descriptor.set;
-    if (prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles });
-      setChecked.call(input, checked);
-      input.dispatchEvent(event);
-    }
-  }, [prevChecked, checked, bubbles]);
+    // Bubble checked change to parents (e.g form change event)
+    React.useEffect(() => {
+      const input = ref.current;
+      if (!input) return;
 
-  return (
-    <input
-      type="checkbox"
-      aria-hidden
-      defaultChecked={checked}
-      {...inputProps}
-      tabIndex={-1}
-      ref={ref}
-      style={{
-        ...props.style,
-        ...controlSize,
-        position: 'absolute',
-        pointerEvents: 'none',
-        opacity: 0,
-        margin: 0,
-      }}
-    />
-  );
-};
+      const inputProto = window.HTMLInputElement.prototype;
+      const descriptor = Object.getOwnPropertyDescriptor(
+        inputProto,
+        'checked'
+      ) as PropertyDescriptor;
+      const setChecked = descriptor.set;
+      if (prevChecked !== checked && setChecked) {
+        const event = new Event('click', { bubbles });
+        setChecked.call(input, checked);
+        input.dispatchEvent(event);
+      }
+    }, [prevChecked, checked, bubbles]);
+
+    return (
+      <input
+        type="checkbox"
+        aria-hidden
+        defaultChecked={checked}
+        {...props}
+        tabIndex={-1}
+        ref={composedRefs}
+        style={{
+          ...props.style,
+          ...controlSize,
+          position: 'absolute',
+          pointerEvents: 'none',
+          opacity: 0,
+          margin: 0,
+        }}
+      />
+    );
+  }
+);
+
+SwitchBubbleInput.displayName = BUBBLE_INPUT_NAME;
+
+/* -----------------------------------------------------------------------------------------------*/
 
 function getState(checked: boolean) {
   return checked ? 'checked' : 'unchecked';

--- a/packages/react/visually-hidden/src/index.ts
+++ b/packages/react/visually-hidden/src/index.ts
@@ -2,5 +2,7 @@ export {
   VisuallyHidden,
   //
   Root,
+  //
+  VISUALLY_HIDDEN_STYLES,
 } from './visually-hidden';
 export type { VisuallyHiddenProps } from './visually-hidden';

--- a/packages/react/visually-hidden/src/visually-hidden.tsx
+++ b/packages/react/visually-hidden/src/visually-hidden.tsx
@@ -5,6 +5,20 @@ import { Primitive } from '@radix-ui/react-primitive';
  * VisuallyHidden
  * -----------------------------------------------------------------------------------------------*/
 
+const VISUALLY_HIDDEN_STYLES = Object.freeze({
+  // See: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden.scss
+  position: 'absolute',
+  border: 0,
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  wordWrap: 'normal',
+}) satisfies React.CSSProperties;
+
 const NAME = 'VisuallyHidden';
 
 type VisuallyHiddenElement = React.ElementRef<typeof Primitive.span>;
@@ -17,20 +31,7 @@ const VisuallyHidden = React.forwardRef<VisuallyHiddenElement, VisuallyHiddenPro
       <Primitive.span
         {...props}
         ref={forwardedRef}
-        style={{
-          // See: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden.scss
-          position: 'absolute',
-          border: 0,
-          width: 1,
-          height: 1,
-          padding: 0,
-          margin: -1,
-          overflow: 'hidden',
-          clip: 'rect(0, 0, 0, 0)',
-          whiteSpace: 'nowrap',
-          wordWrap: 'normal',
-          ...props.style,
-        }}
+        style={{ ...VISUALLY_HIDDEN_STYLES, ...props.style }}
       />
     );
   }
@@ -46,5 +47,7 @@ export {
   VisuallyHidden,
   //
   Root,
+  //
+  VISUALLY_HIDDEN_STYLES,
 };
 export type { VisuallyHiddenProps };


### PR DESCRIPTION
A long-standing issue is the lack of control users have over the internal "bubble input" components we render in our form controls. Because these components are rendered as implementation details rather than exposed directly, users struggle to access or control them when they cause unexpected behaviors.

Ultimately we want users to take control of these components, and even opt-out these implementations altogether when conflicts arise. Related: https://github.com/radix-ui/primitives/issues/3365.

This PR in a small first step in that direction. Each primitive's `BubbleInput` will now use a `Primitive` node rather than the built-in JSX DOM component, and accepts forwarded refs to match the behavior of other component parts.