### PR TITLE
checkbox: Add unstable `Provider`, `Trigger` and `BubbleInput`

### DIFF
--- a/.changeset/heavy-rockets-allow.md
+++ b/.changeset/heavy-rockets-allow.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-checkbox': minor
+---
+
+Add unstable `Provider`, `Trigger` and `BubbleInput` parts to Checkbox (#3459)

--- a/.changeset/heavy-rockets-allow.md
+++ b/.changeset/heavy-rockets-allow.md
@@ -1,5 +1,6 @@
 ---
 '@radix-ui/react-checkbox': minor
+'radix-ui': minor
 ---
 
 Add unstable `Provider`, `Trigger` and `BubbleInput` parts to Checkbox (#3459)

--- a/apps/storybook/stories/checkbox.stories.tsx
+++ b/apps/storybook/stories/checkbox.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
 import { Checkbox, Label as LabelPrimitive } from 'radix-ui';
 import styles from './checkbox.stories.module.css';
@@ -5,6 +6,194 @@ import styles from './checkbox.stories.module.css';
 export default { title: 'Components/Checkbox' };
 
 export const Styled = () => (
+  <>
+    <p>This checkbox is nested inside a label. The state is uncontrolled.</p>
+
+    <h1>Custom label</h1>
+    <Label>
+      Label{' '}
+      <Checkbox.unstable_Provider>
+        <Checkbox.unstable_Trigger className={styles.root}>
+          <Checkbox.Indicator className={styles.indicator} />
+        </Checkbox.unstable_Trigger>
+      </Checkbox.unstable_Provider>
+    </Label>
+
+    <br />
+    <br />
+
+    <h1>Native label</h1>
+    <label>
+      Label{' '}
+      <Checkbox.unstable_Provider>
+        <Checkbox.unstable_Trigger className={styles.root}>
+          <Checkbox.Indicator className={styles.indicator} />
+        </Checkbox.unstable_Trigger>
+      </Checkbox.unstable_Provider>
+    </label>
+
+    <h1>Native label + native checkbox</h1>
+    <label>
+      Label <input type="checkbox" />
+    </label>
+
+    <h1>Custom label + htmlFor</h1>
+    <Label htmlFor="one">Label</Label>
+    <Checkbox.unstable_Provider>
+      <Checkbox.unstable_Trigger className={styles.root} id="one">
+        <Checkbox.Indicator className={styles.indicator} />
+      </Checkbox.unstable_Trigger>
+    </Checkbox.unstable_Provider>
+
+    <br />
+    <br />
+
+    <h1>Native label + htmlFor</h1>
+    <label htmlFor="two">Label</label>
+    <Checkbox.unstable_Provider>
+      <Checkbox.unstable_Trigger className={styles.root} id="two">
+        <Checkbox.Indicator className={styles.indicator} />
+      </Checkbox.unstable_Trigger>
+    </Checkbox.unstable_Provider>
+
+    <h1>Native label + native checkbox</h1>
+    <label htmlFor="three">Label</label>
+    <input type="checkbox" id="three" />
+  </>
+);
+
+export const Controlled = () => {
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>(true);
+
+  return (
+    <>
+      <p>This checkbox is placed adjacent to its label. The state is controlled.</p>
+      <Label htmlFor="randBox">Label</Label>{' '}
+      <Checkbox.unstable_Provider checked={checked} onCheckedChange={setChecked}>
+        <Checkbox.unstable_Trigger className={styles.root} id="randBox">
+          <Checkbox.Indicator className={styles.indicator} />
+        </Checkbox.unstable_Trigger>
+      </Checkbox.unstable_Provider>
+    </>
+  );
+};
+
+export const Indeterminate = () => {
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
+
+  return (
+    <>
+      <p>
+        <Checkbox.unstable_Provider checked={checked} onCheckedChange={setChecked}>
+          <Checkbox.unstable_Trigger className={styles.root}>
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.unstable_Trigger>
+        </Checkbox.unstable_Provider>
+      </p>
+
+      <button
+        type="button"
+        onClick={() =>
+          setChecked((prevIsChecked) =>
+            prevIsChecked === 'indeterminate' ? false : 'indeterminate'
+          )
+        }
+      >
+        Toggle indeterminate
+      </button>
+    </>
+  );
+};
+
+export const WithinForm = () => {
+  const [data, setData] = React.useState({ optional: false, required: false, stopprop: false });
+  const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
+
+  return (
+    <form
+      onSubmit={(event) => event.preventDefault()}
+      onChange={(event) => {
+        const input = event.target as HTMLInputElement;
+        setData((prevData) => ({ ...prevData, [input.name]: input.checked }));
+      }}
+    >
+      <fieldset>
+        <legend>optional checked: {String(data.optional)}</legend>
+        <label>
+          <Checkbox.Root
+            className={styles.root}
+            name="optional"
+            checked={checked}
+            onCheckedChange={setChecked}
+          >
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.Root>{' '}
+          with label
+        </label>
+        <br />
+        <br />
+
+        <button
+          type="button"
+          onClick={() => {
+            setChecked((v) => (v === 'indeterminate' ? false : 'indeterminate'));
+          }}
+        >
+          Toggle indeterminate
+        </button>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>required checked: {String(data.required)}</legend>
+        <Checkbox.unstable_Provider name="required" required>
+          <Checkbox.unstable_Trigger className={styles.root}>
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.unstable_Trigger>
+          <Checkbox.unstable_BubbleInput />
+        </Checkbox.unstable_Provider>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>stop propagation checked: {String(data.stopprop)}</legend>
+        <Checkbox.unstable_Provider name="stopprop">
+          <Checkbox.unstable_Trigger
+            className={styles.root}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.unstable_Trigger>
+          <Checkbox.unstable_BubbleInput />
+        </Checkbox.unstable_Provider>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>no bubble input checked: {String(data.stopprop)}</legend>
+        <Checkbox.unstable_Provider name="stopprop">
+          <Checkbox.unstable_Trigger className={styles.root}>
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.unstable_Trigger>
+        </Checkbox.unstable_Provider>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <button type="reset">Reset</button>
+      <button>Submit</button>
+    </form>
+  );
+};
+
+export const LegacyStyled = () => (
   <>
     <p>This checkbox is nested inside a label. The state is uncontrolled.</p>
 
@@ -53,7 +242,7 @@ export const Styled = () => (
   </>
 );
 
-export const Controlled = () => {
+export const LegacyControlled = () => {
   const [checked, setChecked] = React.useState<boolean | 'indeterminate'>(true);
 
   return (
@@ -72,7 +261,7 @@ export const Controlled = () => {
   );
 };
 
-export const Indeterminate = () => {
+export const LegacyIndeterminate = () => {
   const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
 
   return (
@@ -97,7 +286,7 @@ export const Indeterminate = () => {
   );
 };
 
-export const WithinForm = () => {
+export const LegacyWithinForm = () => {
   const [data, setData] = React.useState({ optional: false, required: false, stopprop: false });
   const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
 
@@ -170,7 +359,7 @@ export const WithinForm = () => {
   );
 };
 
-export const Animated = () => {
+export const LegacyAnimated = () => {
   const [checked, setChecked] = React.useState<boolean | 'indeterminate'>('indeterminate');
 
   return (
@@ -195,7 +384,7 @@ export const Animated = () => {
   );
 };
 
-export const Chromatic = () => (
+export const LegacyChromatic = () => (
   <>
     <h1>Uncontrolled</h1>
     <h2>Unchecked</h2>
@@ -261,6 +450,6 @@ export const Chromatic = () => (
     </Checkbox.Root>
   </>
 );
-Chromatic.parameters = { chromatic: { disable: false } };
+LegacyChromatic.parameters = { chromatic: { disable: false } };
 
 const Label = (props: any) => <LabelPrimitive.Root {...props} className={styles.label} />;

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { axe } from 'vitest-axe';
 import type { RenderResult } from '@testing-library/react';
-import { cleanup, render, fireEvent } from '@testing-library/react';
-import * as Checkbox from './checkbox';
+import { cleanup, render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import * as Checkbox from '.';
 import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
 
 const CHECKBOX_ROLE = 'checkbox';
@@ -20,34 +20,357 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
-describe('given a default Checkbox', () => {
-  let rendered: RenderResult;
-  let checkbox: HTMLElement;
-  let indicator: HTMLElement | null;
-
-  beforeEach(() => {
-    rendered = render(<LegacyCheckbox />);
-    checkbox = rendered.getByRole(CHECKBOX_ROLE);
-    indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
-  });
-
+describe('Checkbox', () => {
   afterEach(cleanup);
 
-  it('should have no accessibility violations', async () => {
-    expect(await axe(rendered.container)).toHaveNoViolations();
+  describe('given a default Checkbox', () => {
+    let rendered: RenderResult;
+    beforeEach(() => {
+      rendered = render(
+        <Checkbox.unstable_Provider>
+          <Checkbox.unstable_Trigger aria-label="basic checkbox">
+            <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+          </Checkbox.unstable_Trigger>
+        </Checkbox.unstable_Provider>
+      );
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should toggle the indicator when clicked', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      await act(async () => fireEvent.click(checkbox));
+
+      let indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).toBeVisible();
+
+      await act(async () => fireEvent.click(checkbox));
+      indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).not.toBeInTheDocument();
+    });
   });
 
-  describe('when clicking the checkbox', () => {
-    beforeEach(async () => {
-      fireEvent.click(checkbox);
-      indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
+  describe('given a disabled Checkbox', () => {
+    let rendered: RenderResult;
+    beforeEach(() => {
+      rendered = render(
+        <Checkbox.unstable_Provider disabled>
+          <Checkbox.unstable_Trigger aria-label="basic checkbox">
+            <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+          </Checkbox.unstable_Trigger>
+        </Checkbox.unstable_Provider>
+      );
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should not toggle the indicator when clicked', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+
+      await act(async () => fireEvent.click(checkbox));
+      const indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).not.toBeInTheDocument();
+
+      await act(async () => fireEvent.click(checkbox));
+      expect(indicator).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given an uncontrolled `checked` Checkbox', () => {
+    const onCheckedChange = vi.fn();
+    let rendered: RenderResult;
+
+    beforeEach(() => {
+      rendered = render(
+        <Checkbox.unstable_Provider defaultChecked onCheckedChange={onCheckedChange}>
+          <Checkbox.unstable_Trigger aria-label="basic checkbox">
+            <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+          </Checkbox.unstable_Trigger>
+        </Checkbox.unstable_Provider>
+      );
+    });
+
+    afterEach(cleanup);
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
     });
 
     it('should render a visible indicator', () => {
+      const indicator = screen.queryByTestId(INDICATOR_TEST_ID);
       expect(indicator).toBeVisible();
     });
 
-    describe('and clicking the checkbox again', () => {
+    it('should toggle the indicator when clicked', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      await act(async () => fireEvent.click(checkbox));
+      let indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).not.toBeInTheDocument();
+
+      await act(async () => fireEvent.click(checkbox));
+      indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).toBeVisible();
+    });
+
+    it('should call `onCheckedChange` prop', () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      fireEvent.click(checkbox);
+      waitFor(() => {
+        expect(onCheckedChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe('given a controlled Checkbox', () => {
+    const onCheckedChange = vi.fn();
+    let rendered: RenderResult;
+
+    function ControlledCheckbox() {
+      const [checked, setChecked] = React.useState(false);
+      const [blockToggle, setBlockToggle] = React.useState(false);
+      return (
+        <div>
+          <Checkbox.unstable_Provider
+            checked={checked}
+            onCheckedChange={(checked) => {
+              onCheckedChange(checked);
+              if (!blockToggle) {
+                setChecked(checked);
+              }
+            }}
+          >
+            <Checkbox.unstable_Trigger aria-label="basic checkbox">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.unstable_Trigger>
+          </Checkbox.unstable_Provider>
+          <button type="button" onClick={() => setChecked((prev) => !prev)}>
+            Toggle checkbox
+          </button>
+          <button type="button" onClick={() => setBlockToggle((prev) => !prev)}>
+            {blockToggle ? 'Unblock' : 'Block'} checkbox
+          </button>
+        </div>
+      );
+    }
+
+    beforeEach(() => {
+      rendered = render(<ControlledCheckbox />);
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should toggle the indicator', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      await act(async () => fireEvent.click(checkbox));
+      const indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).toBeVisible();
+    });
+
+    it('should call `onCheckedChange` prop', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      await act(async () => fireEvent.click(checkbox));
+      expect(onCheckedChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should not toggle unless state is updated', async () => {
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      const blocker = screen.getByText('Block checkbox');
+      await act(async () => fireEvent.click(blocker));
+      await act(async () => fireEvent.click(checkbox));
+      const indicator = screen.queryByTestId(INDICATOR_TEST_ID);
+      expect(indicator).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given an uncontrolled Checkbox in form with bubble input', () => {
+    const onChange = vi.fn();
+
+    it('should receive change event with next state', async () => {
+      render(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            onChange(target.checked);
+          }}
+        >
+          <Checkbox.unstable_Provider>
+            <Checkbox.unstable_Trigger aria-label="basic checkbox">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.unstable_Trigger>
+            <Checkbox.unstable_BubbleInput />
+          </Checkbox.unstable_Provider>
+        </form>
+      );
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      act(() => fireEvent.click(checkbox));
+      expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    describe('when `defaultChecked` is true', () => {
+      it('should receive change event with next state', async () => {
+        console.log(parseInt(React.version));
+        render(
+          <form
+            onChange={(event) => {
+              const target = event.target as HTMLInputElement;
+              onChange(target.checked);
+            }}
+          >
+            <Checkbox.unstable_Provider defaultChecked>
+              <Checkbox.unstable_Trigger aria-label="basic checkbox">
+                <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+              </Checkbox.unstable_Trigger>
+              <Checkbox.unstable_BubbleInput />
+            </Checkbox.unstable_Provider>
+          </form>
+        );
+
+        const checkbox = screen.getByRole(CHECKBOX_ROLE);
+        act(() => fireEvent.click(checkbox));
+        expect(onChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe('given a controlled Checkbox in form with bubble input', () => {
+    const onChange = vi.fn();
+
+    function ControlledCheckbox() {
+      const [checked, setChecked] = React.useState(false);
+      return (
+        <>
+          <Checkbox.unstable_Provider checked={checked} onCheckedChange={setChecked as any}>
+            <Checkbox.unstable_Trigger aria-label="basic checkbox">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.unstable_Trigger>
+            <Checkbox.unstable_BubbleInput />
+          </Checkbox.unstable_Provider>
+          <button type="button" onClick={() => setChecked((prev) => !prev)}>
+            Toggle checkbox
+          </button>
+        </>
+      );
+    }
+
+    it('should receive change event with controlled state when clicked', async () => {
+      render(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            onChange(target.checked);
+          }}
+        >
+          <ControlledCheckbox />
+        </form>
+      );
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      act(() => fireEvent.click(checkbox));
+      expect(onChange).toHaveBeenCalledWith(true);
+
+      act(() => fireEvent.click(checkbox));
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should receive change event with controlled state when set externally', async () => {
+      render(
+        <form
+          onChange={(event) => {
+            const target = event.target as HTMLInputElement;
+            onChange(target.checked);
+          }}
+        >
+          <ControlledCheckbox />
+        </form>
+      );
+
+      const toggleButton = screen.getByText('Toggle checkbox');
+      act(() => fireEvent.click(toggleButton));
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+  });
+});
+
+describe('Legacy Checkbox', () => {
+  describe('given a default Checkbox', () => {
+    let rendered: RenderResult;
+    let checkbox: HTMLElement;
+    let indicator: HTMLElement | null;
+
+    beforeEach(() => {
+      rendered = render(<LegacyCheckbox />);
+      checkbox = rendered.getByRole(CHECKBOX_ROLE);
+      indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
+    });
+
+    afterEach(cleanup);
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    describe('when clicking the checkbox', () => {
+      beforeEach(async () => {
+        fireEvent.click(checkbox);
+        indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
+      });
+
+      it('should render a visible indicator', () => {
+        expect(indicator).toBeVisible();
+      });
+
+      describe('and clicking the checkbox again', () => {
+        beforeEach(async () => {
+          fireEvent.click(checkbox);
+        });
+
+        it('should remove the indicator', () => {
+          expect(indicator).not.toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  describe('given a disabled Checkbox', () => {
+    let rendered: RenderResult;
+
+    beforeEach(() => {
+      rendered = render(<LegacyCheckbox disabled />);
+    });
+
+    afterEach(cleanup);
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+  });
+
+  describe('given an uncontrolled `checked` Checkbox', () => {
+    let rendered: RenderResult;
+    let checkbox: HTMLElement;
+    let indicator: HTMLElement | null;
+    const onCheckedChange = vi.fn();
+
+    beforeEach(() => {
+      rendered = render(<LegacyCheckbox defaultChecked onCheckedChange={onCheckedChange} />);
+      checkbox = rendered.getByRole(CHECKBOX_ROLE);
+      indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
+    });
+
+    afterEach(cleanup);
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    describe('when clicking the checkbox', () => {
       beforeEach(async () => {
         fireEvent.click(checkbox);
       });
@@ -55,145 +378,102 @@ describe('given a default Checkbox', () => {
       it('should remove the indicator', () => {
         expect(indicator).not.toBeInTheDocument();
       });
+
+      it('should call `onCheckedChange` prop', () => {
+        expect(onCheckedChange).toHaveBeenCalled();
+      });
     });
   });
-});
 
-describe('given a disabled Checkbox', () => {
-  let rendered: RenderResult;
+  describe('given a controlled `checked` Checkbox', () => {
+    let rendered: RenderResult;
+    let checkbox: HTMLElement;
+    const onCheckedChange = vi.fn();
 
-  beforeEach(() => {
-    rendered = render(<LegacyCheckbox disabled />);
-  });
-
-  afterEach(cleanup);
-
-  it('should have no accessibility violations', async () => {
-    expect(await axe(rendered.container)).toHaveNoViolations();
-  });
-});
-
-describe('given an uncontrolled `checked` Checkbox', () => {
-  let rendered: RenderResult;
-  let checkbox: HTMLElement;
-  let indicator: HTMLElement | null;
-  const onCheckedChange = vi.fn();
-
-  beforeEach(() => {
-    rendered = render(<LegacyCheckbox defaultChecked onCheckedChange={onCheckedChange} />);
-    checkbox = rendered.getByRole(CHECKBOX_ROLE);
-    indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
-  });
-
-  afterEach(cleanup);
-
-  it('should have no accessibility violations', async () => {
-    expect(await axe(rendered.container)).toHaveNoViolations();
-  });
-
-  describe('when clicking the checkbox', () => {
-    beforeEach(async () => {
-      fireEvent.click(checkbox);
-    });
-
-    it('should remove the indicator', () => {
-      expect(indicator).not.toBeInTheDocument();
-    });
-
-    it('should call `onCheckedChange` prop', () => {
-      expect(onCheckedChange).toHaveBeenCalled();
-    });
-  });
-});
-
-describe('given a controlled `checked` Checkbox', () => {
-  let rendered: RenderResult;
-  let checkbox: HTMLElement;
-  const onCheckedChange = vi.fn();
-
-  beforeEach(() => {
-    rendered = render(<LegacyCheckbox checked onCheckedChange={onCheckedChange} />);
-    checkbox = rendered.getByRole(CHECKBOX_ROLE);
-  });
-
-  afterEach(cleanup);
-
-  describe('when clicking the checkbox', () => {
     beforeEach(() => {
-      fireEvent.click(checkbox);
+      rendered = render(<LegacyCheckbox checked onCheckedChange={onCheckedChange} />);
+      checkbox = rendered.getByRole(CHECKBOX_ROLE);
     });
 
-    it('should call `onCheckedChange` prop', () => {
-      expect(onCheckedChange).toHaveBeenCalled();
+    afterEach(cleanup);
+
+    describe('when clicking the checkbox', () => {
+      beforeEach(() => {
+        fireEvent.click(checkbox);
+      });
+
+      it('should call `onCheckedChange` prop', () => {
+        expect(onCheckedChange).toHaveBeenCalled();
+      });
     });
   });
-});
 
-describe('given an uncontrolled Checkbox in form', () => {
-  afterEach(cleanup);
+  describe('given an uncontrolled Checkbox in form', () => {
+    afterEach(cleanup);
 
-  describe('when clicking the checkbox', () => {
-    it('should receive change event with target `defaultChecked` same as the `defaultChecked` prop of Checkbox', () =>
-      new Promise((done) => {
-        const rendered = render(
-          <form
-            onChange={(event) => {
-              const target = event.target as HTMLInputElement;
-              expect(target.defaultChecked).toBe(true);
-            }}
-          >
-            <LegacyCheckbox defaultChecked />
-          </form>
-        );
-        const checkbox = rendered.getByRole(CHECKBOX_ROLE);
-        fireEvent.click(checkbox);
-        rendered.rerender(
-          <form
-            onChange={(event) => {
-              const target = event.target as HTMLInputElement;
-              expect(target.defaultChecked).toBe(false);
-              done(null);
-            }}
-          >
-            <LegacyCheckbox defaultChecked={false} />
-          </form>
-        );
-        fireEvent.click(checkbox);
-      }));
+    describe('when clicking the checkbox', () => {
+      it('should receive change event with target `defaultChecked` same as the `defaultChecked` prop of Checkbox', () =>
+        new Promise((done) => {
+          const rendered = render(
+            <form
+              onChange={(event) => {
+                const target = event.target as HTMLInputElement;
+                expect(target.defaultChecked).toBe(true);
+              }}
+            >
+              <LegacyCheckbox defaultChecked />
+            </form>
+          );
+          const checkbox = rendered.getByRole(CHECKBOX_ROLE);
+          fireEvent.click(checkbox);
+          rendered.rerender(
+            <form
+              onChange={(event) => {
+                const target = event.target as HTMLInputElement;
+                expect(target.defaultChecked).toBe(false);
+                done(null);
+              }}
+            >
+              <LegacyCheckbox defaultChecked={false} />
+            </form>
+          );
+          fireEvent.click(checkbox);
+        }));
+    });
   });
-});
 
-describe('given a controlled Checkbox in a form', () => {
-  afterEach(cleanup);
+  describe('given a controlled Checkbox in a form', () => {
+    afterEach(cleanup);
 
-  describe('when clicking the checkbox', () => {
-    it('should receive change event with target `defaultChecked` same as initial value of `checked` of Checkbox', () =>
-      new Promise((done) => {
-        const rendered = render(
-          <form
-            onChange={(event) => {
-              const target = event.target as HTMLInputElement;
-              expect(target.defaultChecked).toBe(true);
-            }}
-          >
-            <LegacyCheckbox checked />
-          </form>
-        );
-        const checkbox = rendered.getByRole(CHECKBOX_ROLE);
-        fireEvent.click(checkbox);
-        rendered.rerender(
-          <form
-            onChange={(event) => {
-              const target = event.target as HTMLInputElement;
-              expect(target.defaultChecked).toBe(true);
-              done(null);
-            }}
-          >
-            <LegacyCheckbox checked={false} />
-          </form>
-        );
-        fireEvent.click(checkbox);
-      }));
+    describe('when clicking the checkbox', () => {
+      it('should receive change event with target `defaultChecked` same as initial value of `checked` of Checkbox', () =>
+        new Promise((done) => {
+          const rendered = render(
+            <form
+              onChange={(event) => {
+                const target = event.target as HTMLInputElement;
+                expect(target.defaultChecked).toBe(true);
+              }}
+            >
+              <LegacyCheckbox checked />
+            </form>
+          );
+          const checkbox = rendered.getByRole(CHECKBOX_ROLE);
+          fireEvent.click(checkbox);
+          rendered.rerender(
+            <form
+              onChange={(event) => {
+                const target = event.target as HTMLInputElement;
+                expect(target.defaultChecked).toBe(true);
+                done(null);
+              }}
+            >
+              <LegacyCheckbox checked={false} />
+            </form>
+          );
+          fireEvent.click(checkbox);
+        }));
+    });
   });
 });
 

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { axe } from 'vitest-axe';
 import type { RenderResult } from '@testing-library/react';
 import { cleanup, render, fireEvent } from '@testing-library/react';
-import { Checkbox, CheckboxIndicator } from './checkbox';
+import * as Checkbox from './checkbox';
 import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
 
 const CHECKBOX_ROLE = 'checkbox';
@@ -26,7 +26,7 @@ describe('given a default Checkbox', () => {
   let indicator: HTMLElement | null;
 
   beforeEach(() => {
-    rendered = render(<CheckboxTest />);
+    rendered = render(<LegacyCheckbox />);
     checkbox = rendered.getByRole(CHECKBOX_ROLE);
     indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
   });
@@ -63,7 +63,7 @@ describe('given a disabled Checkbox', () => {
   let rendered: RenderResult;
 
   beforeEach(() => {
-    rendered = render(<CheckboxTest disabled />);
+    rendered = render(<LegacyCheckbox disabled />);
   });
 
   afterEach(cleanup);
@@ -80,7 +80,7 @@ describe('given an uncontrolled `checked` Checkbox', () => {
   const onCheckedChange = vi.fn();
 
   beforeEach(() => {
-    rendered = render(<CheckboxTest defaultChecked onCheckedChange={onCheckedChange} />);
+    rendered = render(<LegacyCheckbox defaultChecked onCheckedChange={onCheckedChange} />);
     checkbox = rendered.getByRole(CHECKBOX_ROLE);
     indicator = rendered.queryByTestId(INDICATOR_TEST_ID);
   });
@@ -112,7 +112,7 @@ describe('given a controlled `checked` Checkbox', () => {
   const onCheckedChange = vi.fn();
 
   beforeEach(() => {
-    rendered = render(<CheckboxTest checked onCheckedChange={onCheckedChange} />);
+    rendered = render(<LegacyCheckbox checked onCheckedChange={onCheckedChange} />);
     checkbox = rendered.getByRole(CHECKBOX_ROLE);
   });
 
@@ -142,7 +142,7 @@ describe('given an uncontrolled Checkbox in form', () => {
               expect(target.defaultChecked).toBe(true);
             }}
           >
-            <CheckboxTest defaultChecked />
+            <LegacyCheckbox defaultChecked />
           </form>
         );
         const checkbox = rendered.getByRole(CHECKBOX_ROLE);
@@ -155,7 +155,7 @@ describe('given an uncontrolled Checkbox in form', () => {
               done(null);
             }}
           >
-            <CheckboxTest defaultChecked={false} />
+            <LegacyCheckbox defaultChecked={false} />
           </form>
         );
         fireEvent.click(checkbox);
@@ -176,7 +176,7 @@ describe('given a controlled Checkbox in a form', () => {
               expect(target.defaultChecked).toBe(true);
             }}
           >
-            <CheckboxTest checked />
+            <LegacyCheckbox checked />
           </form>
         );
         const checkbox = rendered.getByRole(CHECKBOX_ROLE);
@@ -189,7 +189,7 @@ describe('given a controlled Checkbox in a form', () => {
               done(null);
             }}
           >
-            <CheckboxTest checked={false} />
+            <LegacyCheckbox checked={false} />
           </form>
         );
         fireEvent.click(checkbox);
@@ -197,7 +197,7 @@ describe('given a controlled Checkbox in a form', () => {
   });
 });
 
-function CheckboxTest(props: React.ComponentProps<typeof Checkbox>) {
+function LegacyCheckbox(props: React.ComponentProps<typeof Checkbox.Root>) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     // We use the `hidden` attribute to hide the nested input from both sighted users and the
@@ -210,9 +210,9 @@ function CheckboxTest(props: React.ComponentProps<typeof Checkbox>) {
   }, []);
   return (
     <div ref={containerRef}>
-      <Checkbox aria-label="basic checkbox" {...props}>
-        <CheckboxIndicator data-testid={INDICATOR_TEST_ID} />
-      </Checkbox>
+      <Checkbox.Root aria-label="basic checkbox" {...props}>
+        <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+      </Checkbox.Root>
     </div>
   );
 }

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -10,10 +10,6 @@ import { Primitive } from '@radix-ui/react-primitive';
 
 import type { Scope } from '@radix-ui/react-context';
 
-/* -------------------------------------------------------------------------------------------------
- * Checkbox
- * -----------------------------------------------------------------------------------------------*/
-
 const CHECKBOX_NAME = 'Checkbox';
 
 type ScopedProps<P> = P & { __scopeCheckbox?: Scope };
@@ -22,12 +18,171 @@ const [createCheckboxContext, createCheckboxScope] = createContextScope(CHECKBOX
 type CheckedState = boolean | 'indeterminate';
 
 type CheckboxContextValue = {
-  state: CheckedState;
-  disabled?: boolean;
+  checked: CheckedState;
+  setChecked: React.Dispatch<React.SetStateAction<CheckedState>>;
+  disabled: boolean | undefined;
+  control: HTMLButtonElement | null;
+  setControl: React.Dispatch<React.SetStateAction<HTMLButtonElement | null>>;
+  name: string | undefined;
+  form: string | undefined;
+  value: string | number | readonly string[];
+  hasConsumerStoppedPropagationRef: React.RefObject<boolean>;
+  required: boolean | undefined;
+  defaultChecked: boolean | undefined;
+  isFormControl: boolean;
 };
 
-const [CheckboxProvider, useCheckboxContext] =
+const [CheckboxProviderImpl, useCheckboxContext] =
   createCheckboxContext<CheckboxContextValue>(CHECKBOX_NAME);
+
+/* -------------------------------------------------------------------------------------------------
+ * CheckboxProvider
+ * -----------------------------------------------------------------------------------------------*/
+
+interface CheckboxProviderProps {
+  checked?: CheckedState;
+  defaultChecked?: CheckedState;
+  required?: boolean;
+  onCheckedChange?(checked: CheckedState): void;
+  name?: string;
+  form?: string;
+  disabled?: boolean;
+  value?: string | number | readonly string[];
+  children:
+    | React.ReactNode
+    /**
+     * Note that this API is only used internally to maintain backwards
+     * compatibility. Users should not need to read the context, and this will
+     * be removed in the next major version when the core API changes.
+     * @internal
+     * @deprecated
+     */
+    | ((context: CheckboxContextValue) => React.ReactNode);
+}
+
+const CheckboxProvider: React.FC<ScopedProps<CheckboxProviderProps>> = ({
+  __scopeCheckbox,
+  checked: checkedProp,
+  children,
+  defaultChecked,
+  disabled,
+  form,
+  name,
+  onCheckedChange,
+  required,
+  value = 'on',
+}) => {
+  const [checked, setChecked] = useControllableState({
+    prop: checkedProp,
+    defaultProp: defaultChecked ?? false,
+    onChange: onCheckedChange,
+    caller: CHECKBOX_NAME,
+  });
+  const [control, setControl] = React.useState<HTMLButtonElement | null>(null);
+  const hasConsumerStoppedPropagationRef = React.useRef(false);
+  const isFormControl = control
+    ? !!form || !!control.closest('form')
+    : // We set this to true by default so that events bubble to forms without JS (SSR)
+      true;
+
+  const context: CheckboxContextValue = {
+    checked: checked,
+    disabled: disabled,
+    setChecked: setChecked,
+    control: control,
+    setControl: setControl,
+    name: name,
+    form: form,
+    value: value,
+    hasConsumerStoppedPropagationRef: hasConsumerStoppedPropagationRef,
+    required: required,
+    defaultChecked: isIndeterminate(defaultChecked) ? false : defaultChecked,
+    isFormControl: isFormControl,
+  };
+
+  return (
+    <CheckboxProviderImpl scope={__scopeCheckbox} {...context}>
+      {isFunction(children) ? children(context) : children}
+    </CheckboxProviderImpl>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * CheckboxTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_NAME = 'CheckboxTrigger';
+
+interface CheckboxTriggerProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof Primitive.button>,
+    keyof CheckboxProviderProps
+  > {}
+
+const CheckboxTrigger = React.forwardRef<HTMLButtonElement, CheckboxTriggerProps>(
+  (
+    { __scopeCheckbox, onKeyDown, onClick, ...checkboxProps }: ScopedProps<CheckboxTriggerProps>,
+    forwardedRef
+  ) => {
+    const {
+      control,
+      value,
+      disabled,
+      checked,
+      required,
+      setControl,
+      setChecked,
+      hasConsumerStoppedPropagationRef,
+      isFormControl,
+    } = useCheckboxContext(TRIGGER_NAME, __scopeCheckbox);
+    const composedRefs = useComposedRefs(forwardedRef, setControl);
+
+    const initialCheckedStateRef = React.useRef(checked);
+    React.useEffect(() => {
+      const form = control?.form;
+      if (form) {
+        const reset = () => setChecked(initialCheckedStateRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [control, setChecked]);
+
+    return (
+      <Primitive.button
+        type="button"
+        role="checkbox"
+        aria-checked={isIndeterminate(checked) ? 'mixed' : checked}
+        aria-required={required}
+        data-state={getState(checked)}
+        data-disabled={disabled ? '' : undefined}
+        disabled={disabled}
+        value={value}
+        {...checkboxProps}
+        ref={composedRefs}
+        onKeyDown={composeEventHandlers(onKeyDown, (event) => {
+          // According to WAI ARIA, Checkboxes don't activate on enter keypress
+          if (event.key === 'Enter') event.preventDefault();
+        })}
+        onClick={composeEventHandlers(onClick, (event) => {
+          setChecked((prevChecked) => (isIndeterminate(prevChecked) ? true : !prevChecked));
+          if (isFormControl) {
+            hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+            // if checkbox is in a form, stop propagation from the button so that we only propagate
+            // one click event (from the input). We propagate changes from an input so that native
+            // form validation works and form events reflect checkbox updates.
+            if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+          }
+        })}
+      />
+    );
+  }
+);
+
+CheckboxTrigger.displayName = TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * Checkbox
+ * -----------------------------------------------------------------------------------------------*/
 
 type CheckboxElement = React.ElementRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
@@ -43,80 +198,33 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
     const {
       __scopeCheckbox,
       name,
-      checked: checkedProp,
+      checked,
       defaultChecked,
       required,
       disabled,
-      value = 'on',
+      value,
       onCheckedChange,
       form,
       ...checkboxProps
     } = props;
-    const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
-    const hasConsumerStoppedPropagationRef = React.useRef(false);
-    // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? form || !!button.closest('form') : true;
-    const [checked, setChecked] = useControllableState({
-      prop: checkedProp,
-      defaultProp: defaultChecked ?? false,
-      onChange: onCheckedChange,
-      caller: CHECKBOX_NAME,
-    });
-    const initialCheckedStateRef = React.useRef(checked);
-    React.useEffect(() => {
-      const form = button?.form;
-      if (form) {
-        const reset = () => setChecked(initialCheckedStateRef.current);
-        form.addEventListener('reset', reset);
-        return () => form.removeEventListener('reset', reset);
-      }
-    }, [button, setChecked]);
 
     return (
-      <CheckboxProvider scope={__scopeCheckbox} state={checked} disabled={disabled}>
-        <Primitive.button
-          type="button"
-          role="checkbox"
-          aria-checked={isIndeterminate(checked) ? 'mixed' : checked}
-          aria-required={required}
-          data-state={getState(checked)}
-          data-disabled={disabled ? '' : undefined}
-          disabled={disabled}
-          value={value}
-          {...checkboxProps}
-          ref={composedRefs}
-          onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-            // According to WAI ARIA, Checkboxes don't activate on enter keypress
-            if (event.key === 'Enter') event.preventDefault();
-          })}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            setChecked((prevChecked) => (isIndeterminate(prevChecked) ? true : !prevChecked));
-            if (isFormControl) {
-              hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
-              // if checkbox is in a form, stop propagation from the button so that we only propagate
-              // one click event (from the input). We propagate changes from an input so that native
-              // form validation works and form events reflect checkbox updates.
-              if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
-            }
-          })}
-        />
-        {isFormControl && (
-          <CheckboxBubbleInput
-            control={button}
-            bubbles={!hasConsumerStoppedPropagationRef.current}
-            name={name}
-            value={value}
-            checked={checked}
-            required={required}
-            disabled={disabled}
-            form={form}
-            // We transform because the input is absolutely positioned but we have
-            // rendered it **after** the button. This pulls it back to sit on top
-            // of the button.
-            style={{ transform: 'translateX(-100%)' }}
-            defaultChecked={isIndeterminate(defaultChecked) ? false : defaultChecked}
-          />
+      <CheckboxProvider
+        __scopeCheckbox={__scopeCheckbox}
+        checked={checked}
+        defaultChecked={defaultChecked}
+        disabled={disabled}
+        required={required}
+        onCheckedChange={onCheckedChange}
+        name={name}
+        form={form}
+        value={value}
+      >
+        {({ isFormControl }) => (
+          <>
+            <CheckboxTrigger {...checkboxProps} ref={forwardedRef} />
+            {isFormControl && <CheckboxBubbleInput />}
+          </>
         )}
       </CheckboxProvider>
     );
@@ -146,9 +254,11 @@ const CheckboxIndicator = React.forwardRef<CheckboxIndicatorElement, CheckboxInd
     const { __scopeCheckbox, forceMount, ...indicatorProps } = props;
     const context = useCheckboxContext(INDICATOR_NAME, __scopeCheckbox);
     return (
-      <Presence present={forceMount || isIndeterminate(context.state) || context.state === true}>
+      <Presence
+        present={forceMount || isIndeterminate(context.checked) || context.checked === true}
+      >
         <Primitive.span
-          data-state={getState(context.state)}
+          data-state={getState(context.checked)}
           data-disabled={context.disabled ? '' : undefined}
           {...indicatorProps}
           ref={forwardedRef}
@@ -168,24 +278,28 @@ CheckboxIndicator.displayName = INDICATOR_NAME;
 const BUBBLE_INPUT_NAME = 'CheckboxBubbleInput';
 
 type InputProps = React.ComponentPropsWithoutRef<typeof Primitive.input>;
-interface CheckboxBubbleInputProps extends Omit<InputProps, 'checked'> {
-  checked: CheckedState;
-  control: HTMLElement | null;
-  bubbles: boolean;
-}
+interface CheckboxBubbleInputProps extends Omit<InputProps, 'checked'> {}
 
 const CheckboxBubbleInput = React.forwardRef<HTMLInputElement, CheckboxBubbleInputProps>(
   (
     {
       __scopeCheckbox,
-      control,
-      checked,
-      bubbles = true,
-      defaultChecked,
+
       ...props
     }: ScopedProps<CheckboxBubbleInputProps>,
     forwardedRef
   ) => {
+    const {
+      control,
+      hasConsumerStoppedPropagationRef,
+      checked,
+      defaultChecked,
+      required,
+      disabled,
+      name,
+      value,
+      form,
+    } = useCheckboxContext(BUBBLE_INPUT_NAME, __scopeCheckbox);
     const ref = React.useRef<HTMLInputElement>(null);
     const composedRefs = useComposedRefs(ref, forwardedRef);
     const prevChecked = usePrevious(checked);
@@ -203,13 +317,14 @@ const CheckboxBubbleInput = React.forwardRef<HTMLInputElement, CheckboxBubbleInp
       ) as PropertyDescriptor;
       const setChecked = descriptor.set;
 
+      const bubbles = !hasConsumerStoppedPropagationRef.current;
       if (prevChecked !== checked && setChecked) {
         const event = new Event('click', { bubbles });
         input.indeterminate = isIndeterminate(checked);
         setChecked.call(input, isIndeterminate(checked) ? false : checked);
         input.dispatchEvent(event);
       }
-    }, [prevChecked, checked, bubbles]);
+    }, [prevChecked, checked, hasConsumerStoppedPropagationRef]);
 
     const defaultCheckedRef = React.useRef(isIndeterminate(checked) ? false : checked);
     return (
@@ -217,6 +332,11 @@ const CheckboxBubbleInput = React.forwardRef<HTMLInputElement, CheckboxBubbleInp
         type="checkbox"
         aria-hidden
         defaultChecked={defaultChecked ?? defaultCheckedRef.current}
+        required={required}
+        disabled={disabled}
+        name={name}
+        value={value}
+        form={form}
         {...props}
         tabIndex={-1}
         ref={composedRefs}
@@ -227,6 +347,10 @@ const CheckboxBubbleInput = React.forwardRef<HTMLInputElement, CheckboxBubbleInp
           pointerEvents: 'none',
           opacity: 0,
           margin: 0,
+          // We transform because the input is absolutely positioned but we have
+          // rendered it **after** the button. This pulls it back to sit on top
+          // of the button.
+          transform: 'translateX(-100%)',
         }}
       />
     );
@@ -237,6 +361,10 @@ CheckboxBubbleInput.displayName = BUBBLE_INPUT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
+function isFunction(value: unknown): value is (...args: any[]) => any {
+  return typeof value === 'function';
+}
+
 function isIndeterminate(checked?: CheckedState): checked is 'indeterminate' {
   return checked === 'indeterminate';
 }
@@ -245,6 +373,8 @@ function getState(checked: CheckedState) {
   return isIndeterminate(checked) ? 'indeterminate' : checked ? 'checked' : 'unchecked';
 }
 
+const Provider = CheckboxProvider;
+const Trigger = CheckboxTrigger;
 const Root = Checkbox;
 const Indicator = CheckboxIndicator;
 
@@ -252,9 +382,19 @@ export {
   createCheckboxScope,
   //
   Checkbox,
+  CheckboxProvider,
+  CheckboxTrigger,
   CheckboxIndicator,
   //
   Root,
+  Trigger,
+  Provider,
   Indicator,
 };
-export type { CheckboxProps, CheckboxIndicatorProps, CheckedState };
+export type {
+  CheckboxProps,
+  CheckboxProviderProps,
+  CheckboxTriggerProps,
+  CheckboxIndicatorProps,
+  CheckedState,
+};

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -117,7 +117,9 @@ interface CheckboxTriggerProps
   extends Omit<
     React.ComponentPropsWithoutRef<typeof Primitive.button>,
     keyof CheckboxProviderProps
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 const CheckboxTrigger = React.forwardRef<HTMLButtonElement, CheckboxTriggerProps>(
   (

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -50,16 +50,7 @@ interface CheckboxProviderProps<State extends CheckedState = CheckedState> {
   form?: string;
   disabled?: boolean;
   value?: string | number | readonly string[];
-  children:
-    | React.ReactNode
-    /**
-     * Note that this API is only used internally to maintain backwards
-     * compatibility. Users should not need to read the context, and this will
-     * be removed in the next major version when the core API changes.
-     * @internal
-     * @deprecated
-     */
-    | ((context: CheckboxContextValue<State>) => React.ReactNode);
+  children?: React.ReactNode;
 }
 
 function CheckboxProvider<State extends CheckedState = CheckedState>({
@@ -73,6 +64,8 @@ function CheckboxProvider<State extends CheckedState = CheckedState>({
   onCheckedChange,
   required,
   value = 'on',
+  // @ts-expect-error
+  internal_do_not_use_render,
 }: ScopedProps<CheckboxProviderProps<State>>) {
   const [checked, setChecked] = useControllableState({
     prop: checkedProp,
@@ -110,7 +103,7 @@ function CheckboxProvider<State extends CheckedState = CheckedState>({
       scope={__scopeCheckbox}
       {...(context as unknown as CheckboxContextValue<CheckedState>)}
     >
-      {isFunction(children) ? children(context) : children}
+      {isFunction(internal_do_not_use_render) ? internal_do_not_use_render(context) : children}
     </CheckboxProviderImpl>
   );
 }
@@ -232,14 +225,14 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>(
         name={name}
         form={form}
         value={value}
-      >
-        {({ isFormControl }) => (
+        // @ts-expect-error
+        internal_do_not_use_render={({ isFormControl }: CheckboxContextValue) => (
           <>
             <CheckboxTrigger {...checkboxProps} ref={forwardedRef} />
             {isFormControl && <CheckboxBubbleInput />}
           </>
         )}
-      </CheckboxProvider>
+      />
     );
   }
 );

--- a/packages/react/checkbox/src/index.ts
+++ b/packages/react/checkbox/src/index.ts
@@ -3,19 +3,22 @@ export {
   createCheckboxScope,
   //
   Checkbox,
-  CheckboxProvider,
-  CheckboxTrigger,
+  CheckboxProvider as unstable_CheckboxProvider,
+  CheckboxTrigger as unstable_CheckboxTrigger,
   CheckboxIndicator,
+  CheckboxBubbleInput as unstable_CheckboxBubbleInput,
   //
   Root,
-  Provider,
-  Trigger,
+  Provider as unstable_Provider,
+  Trigger as unstable_Trigger,
   Indicator,
+  BubbleInput as unstable_BubbleInput,
 } from './checkbox';
 export type {
   CheckboxProps,
-  CheckboxProviderProps,
-  CheckboxTriggerProps,
+  CheckboxProviderProps as unstable_CheckboxProviderProps,
+  CheckboxTriggerProps as unstable_CheckboxTriggerProps,
   CheckboxIndicatorProps,
+  CheckboxBubbleInputProps as unstable_CheckboxBubbleInputProps,
   CheckedState,
 } from './checkbox';

--- a/packages/react/checkbox/src/index.ts
+++ b/packages/react/checkbox/src/index.ts
@@ -3,9 +3,19 @@ export {
   createCheckboxScope,
   //
   Checkbox,
+  CheckboxProvider,
+  CheckboxTrigger,
   CheckboxIndicator,
   //
   Root,
+  Provider,
+  Trigger,
   Indicator,
 } from './checkbox';
-export type { CheckboxProps, CheckboxIndicatorProps, CheckedState } from './checkbox';
+export type {
+  CheckboxProps,
+  CheckboxProviderProps,
+  CheckboxTriggerProps,
+  CheckboxIndicatorProps,
+  CheckedState,
+} from './checkbox';


### PR DESCRIPTION
This PR introduces new parts for the Checkbox component. This change is intended to test out a new pattern that we can replicate for other form controls.

Currently our form control components will try to detect whether or not they are associated with a form, and if so, render a hidden input so that native events bubble to the form itself. While this can make behavior feel more like native form elements, the downside is that it adds an additional element that is hard to control and not always what users expect.

The goal is the hand control back to the user. So instead of `Checkbox.Root` rendering both a provider and an input, users can opt in and render the parts that they want.

```tsx
// before
<Checkbox.Root>
  <Checkbox.Indicator />
</Checkbox.Root>

// after
<Checkbox.Provider>
  <Checkbox.Trigger>
    <Checkbox.Indicator />
  </Checkbox.Trigger>
</Checkbox.Provider>
```

Currently these parts are prefixed with `unstable_` since we may want to consider the API more deeply before committing to these patterns. Should we decide to move forward, in a future version we'd probably rename `Checkbox.Provider` to `Checkbox.Root` and get rid of the pre-composed version entirely.

Related:

- #3365
- #874
- #3356
- #1333
- #2987