### PR TITLE
chore(slot): apply strict types to SlotCloneProps

### DIFF
--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -59,7 +59,7 @@ const Slot = createSlot('Slot');
  * SlotClone
  * -----------------------------------------------------------------------------------------------*/
 
-interface SlotCloneProps {
+interface SlotCloneProps extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Applied stricter typing to SlotCloneProps.

#### AS-IS

<img width="274" alt="스크린샷 2025-04-14 오후 9 28 49" src="https://github.com/user-attachments/assets/0e272d0e-3762-4c76-9eac-75633cec8b27" />

#### TO-BE

<img width="659" alt="스크린샷 2025-04-14 오후 9 30 41" src="https://github.com/user-attachments/assets/c05b178c-cac1-4baa-86a4-2f66573f4cb2" />


<!-- Describe the change you are introducing -->
