### PR TITLE
fix: click callback inside `SelectItem` shouldn't be omitted

### DIFF
--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -678,6 +678,47 @@ export const WithinDialog = () => (
   </div>
 );
 
+export const WithLink = () => (
+  <div style={{ padding: 50 }}>
+    <Label>
+      Choose a number:
+      <Select.Root defaultValue="two">
+        <Select.Trigger className={styles.trigger}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content className={styles.content}>
+            <Select.Viewport className={styles.viewport}>
+              <Select.Item className={styles.item} value="one">
+                <Select.ItemText>One</Select.ItemText>
+                <a href="/#" target="_blank" rel="noopener noreferrer">
+                  (link)
+                </a>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={styles.item} value="two">
+                <Select.ItemText>Two</Select.ItemText>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={styles.item} value="three">
+                <Select.ItemText>Three</Select.ItemText>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+    </Label>
+  </div>
+);
+
 export const WithVeryLongSelectItems = () => (
   <div style={{ paddingLeft: 300 }}>
     <Label>

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1269,8 +1269,13 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
 
     const handleSelect = () => {
       if (!disabled) {
-        context.onValueChange(value);
-        context.onOpenChange(false);
+        const startTransition = React.startTransition
+          ? React.startTransition
+          : window.requestAnimationFrame;
+        startTransition(() => {
+          context.onValueChange(value);
+          context.onOpenChange(false);
+        });
       }
     };
 


### PR DESCRIPTION
Fixes: https://github.com/radix-ui/primitives/issues/3460

Wrap with `startTransition` will allow consecutive logic can be handled correctly 