### PR TITLE
[Slot] use stable composed refs in SlotClone

### DIFF
--- a/.changeset/famous-socks-deny.md
+++ b/.changeset/famous-socks-deny.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-slot': patch
+---
+
+use stable composed refs in SlotClone

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Slot, Slottable } from './slot';
 import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
 
@@ -139,6 +140,36 @@ describe('given a Button with Slottable', () => {
   });
 });
 
+describe('given an Input', () => {
+  const handleRef = vi.fn();
+
+  beforeEach(() => {
+    handleRef.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  describe('without asChild', () => {
+    it('should only call function refs once', async () => {
+      render(<Input ref={handleRef} />);
+      await userEvent.type(screen.getByRole('textbox'), 'foo');
+      expect(handleRef).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with asChild', () => {
+    it('should only call function refs once', async () => {
+      render(
+        <Input asChild ref={handleRef}>
+          <input />
+        </Input>
+      );
+      await userEvent.type(screen.getByRole('textbox'), 'foo');
+      expect(handleRef).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
 type TriggerProps = React.ComponentProps<'button'> & { as: React.ElementType };
 
 const Trigger = ({ as: Comp = 'button', ...props }: TriggerProps) => <Comp {...props} />;
@@ -157,6 +188,27 @@ const Button = React.forwardRef<
       {iconLeft}
       <Slottable>{children}</Slottable>
       {iconRight}
+    </Comp>
+  );
+});
+
+const Input = React.forwardRef<
+  React.ElementRef<'input'>,
+  React.ComponentProps<'input'> & {
+    asChild?: boolean;
+  }
+>(({ asChild, children, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot : 'input';
+  const [value, setValue] = useState('');
+
+  return (
+    <Comp
+      {...props}
+      onChange={(event) => setValue(event.target.value)}
+      ref={forwardedRef}
+      value={value}
+    >
+      {children}
     </Comp>
   );
 });

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeRefs } from '@radix-ui/react-compose-refs';
+import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
 
 /* -------------------------------------------------------------------------------------------------
  * Slot
@@ -66,13 +66,14 @@ interface SlotCloneProps {
 /* @__NO_SIDE_EFFECTS__ */ function createSlotClone(ownerName: string) {
   const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
     const { children, ...slotProps } = props;
+    const childrenRef = React.isValidElement(children) ? getElementRef(children) : undefined;
+    const ref = useComposedRefs(childrenRef, forwardedRef);
 
     if (React.isValidElement(children)) {
-      const childrenRef = getElementRef(children);
       const props = mergeProps(slotProps, children.props as AnyProps);
       // do not pass ref to React.Fragment for React 19 compatibility
       if (children.type !== React.Fragment) {
-        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
+        props.ref = ref;
       }
       return React.cloneElement(children, props);
     }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

right now we are passing an anonymous function (returned from `composeRefs()` as `ref` to cloned slot. but this causes the ref callback to re-trigger on every render since react is seeing a new function being passed on every new render. so we replace the anonymous function with the stable `useComposedRefs` hook instead which uses `useCallback` under the hood and only re-creates the callback when the arguments change.

added two tests - one using native `<input />` and another using `Slot` to showcase how both should behave the same.