### PR TITLE
[DropdownMenu] Replace onPointerDown handler by onClick

### DIFF
--- a/packages/react/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.tsx
@@ -115,6 +115,11 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
           onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
+          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
+            // prevent trigger focusing when opening
+            // this allows the content to be given focus without competition
+            if (!context.open) event.preventDefault();
+          })}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
             if (['Enter', ' '].includes(event.key)) context.onOpenToggle();

--- a/packages/react/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.tsx
@@ -114,16 +114,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
-            // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
-            // but not when the control key is pressed (avoiding MacOS right click)
-            if (!disabled && event.button === 0 && event.ctrlKey === false) {
-              context.onOpenToggle();
-              // prevent trigger focusing when opening
-              // this allows the content to be given focus without competition
-              if (!context.open) event.preventDefault();
-            }
-          })}
+          onClick={composeEventHandlers(props.onClick, context.onOpenToggle)}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) return;
             if (['Enter', ' '].includes(event.key)) context.onOpenToggle();


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->
Fixes https://github.com/radix-ui/primitives/issues/3424

### Description

This pull request will fix the issue https://github.com/radix-ui/primitives/issues/3424
I'm not sure about the usage of the `onPointerDown` on the DropdownMenu since the `onClick` handler is used on all radix-ui components with trigger (Dialog, Popover)

I keep the "prevent trigger focusing when opening" behaviour but removed the "only call handler if it's the left button (mousedown gets triggered by all mouse buttons)" behaviour by using the `onClick` instead of the `onPointerDown` 

<!-- Describe the change you are introducing -->
