### PR TITLE
fix: use internal useSyncExternalStore instead of the React one

### DIFF
--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
+    "@radix-ui/react-use-is-hydrated": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },
   "devDependencies": {

--- a/packages/react/avatar/src/avatar.tsx
+++ b/packages/react/avatar/src/avatar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createContextScope } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
+import { useIsHydrated } from '@radix-ui/react-use-is-hydrated';
 import { Primitive } from '@radix-ui/react-primitive';
 
 import type { Scope } from '@radix-ui/react-context';
@@ -176,18 +177,6 @@ function useImageLoadingStatus(
   }, [image, crossOrigin, referrerPolicy]);
 
   return loadingStatus;
-}
-
-function subscribe() {
-  return () => {};
-}
-
-function useIsHydrated() {
-  return React.useSyncExternalStore(
-    subscribe,
-    () => true,
-    () => false
-  );
 }
 
 const Root = Avatar;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,9 @@ importers:
       '@radix-ui/react-use-callback-ref':
         specifier: workspace:*
         version: link:../use-callback-ref
+      '@radix-ui/react-use-is-hydrated':
+        specifier: workspace:*
+        version: link:../use-is-hydrated
       '@radix-ui/react-use-layout-effect':
         specifier: workspace:*
         version: link:../use-layout-effect


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

Fixes https://github.com/radix-ui/primitives/issues/3479
Use internal hook `packages/react/use-is-hydrated/src/use-is-hydrated.tsx` instead of the `useSyncExternalStore` from React (it breaks on React version < 18)


<!-- Describe the change you are introducing -->
