### PR TITLE
deps: Bump dependency on use-sync-external-store

### DIFF
--- a/.changeset/ripe-rockets-hide.md
+++ b/.changeset/ripe-rockets-hide.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-use-is-hydrated': minor
+---
+
+Update the dependency specification for use-sync-external-store

--- a/packages/react/use-is-hydrated/package.json
+++ b/packages/react/use-is-hydrated/package.json
@@ -35,7 +35,7 @@
     "build": "radix-build"
   },
   "dependencies": {
-    "use-sync-external-store": "^1.4.0"
+    "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3059,7 +3059,7 @@ importers:
   packages/react/use-is-hydrated:
     dependencies:
       use-sync-external-store:
-        specifier: ^1.4.0
+        specifier: ^1.5.0
         version: 1.5.0(react@19.1.0)
     devDependencies:
       '@repo/builder':


### PR DESCRIPTION
This PR bumps the semver range for use-sync-external-store to ensure that the installed version has an `exports` field in package.json so that it can be successfully imported

### Description

Details from the related issue #3489:

```
 Error: Directory import '/home/runner/work/val.town/val.town/node_modules/use-sync-external-store/shim' is not supported resolving ES modules imported from /home/runner/work/val.town/val.town/node_modules/@radix-ui/react-use-is-hydrated/dist/index.mjs
Did you mean to import "use-sync-external-store/shim/index.js"?
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { code: 'ERR_UNSUPPORTED_DIR_IMPORT', url: 'file:///home/runner/work/val.town/val.town/node_modules/use-sync-external-store/shim' }
```

Getting the same issue trying to run tests with vitest. The line, afaict:

https://github.com/radix-ui/primitives/blob/f2e6c688035d880a832d44755d31d39ba87c1d35/packages/react/use-is-hydrated/src/use-is-hydrated.tsx#L1

It looks like use-sync-external-store _does_ have an exports field in package.json:

https://github.com/facebook/react/blob/bc6184dd993e6ea0efdee7553293676db774c3ca/packages/use-sync-external-store/package.json#L5-L20

But that was added in 1.5.0, and use-sync-external-store has a semver spec of 1.4.0 and up:

https://github.com/radix-ui/primitives/blob/f2e6c688035d880a832d44755d31d39ba87c1d35/packages/react/use-is-hydrated/package.json#L38

So this probably needs to be bumped to 1.5.0.