### PR TITLE
Popper: Fix infinite re-renders

### DIFF
--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -82,7 +82,7 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
       // a DOM node e.g. pointer position, so we override the
       // `anchorRef` with their virtual ref in this case.
       context.onAnchorChange(virtualRef?.current || ref.current);
-    });
+    }, [context.onAnchorChange]);
 
     return virtualRef ? null : <Primitive.div {...anchorProps} ref={composedRefs} />;
   }


### PR DESCRIPTION
Fixes the following error:

Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render. Stack: React 4 PopperAnchor popper.tsx:84

### Description

Add context.onAnchorChange to useEffect deps array to prevent infinite re-renders