### PR TITLE
refactor: replace ElementRef to ComponentRef in dialog

### DIFF
--- a/.changeset/sweet-mice-sleep.md
+++ b/.changeset/sweet-mice-sleep.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-dialog': patch
+---
+
+replace deprecated `ElementRef` to `ComponentRef`

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -91,7 +91,7 @@ Dialog.displayName = DIALOG_NAME;
 
 const TRIGGER_NAME = 'DialogTrigger';
 
-type DialogTriggerElement = React.ElementRef<typeof Primitive.button>;
+type DialogTriggerElement = React.ComponentRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
 interface DialogTriggerProps extends PrimitiveButtonProps {}
 
@@ -190,7 +190,7 @@ const DialogOverlay = React.forwardRef<DialogOverlayElement, DialogOverlayProps>
 
 DialogOverlay.displayName = OVERLAY_NAME;
 
-type DialogOverlayImplElement = React.ElementRef<typeof Primitive.div>;
+type DialogOverlayImplElement = React.ComponentRef<typeof Primitive.div>;
 type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface DialogOverlayImplProps extends PrimitiveDivProps {}
 
@@ -357,7 +357,7 @@ const DialogContentNonModal = React.forwardRef<DialogContentTypeElement, DialogC
 
 /* -----------------------------------------------------------------------------------------------*/
 
-type DialogContentImplElement = React.ElementRef<typeof DismissableLayer>;
+type DialogContentImplElement = React.ComponentRef<typeof DismissableLayer>;
 type DismissableLayerProps = React.ComponentPropsWithoutRef<typeof DismissableLayer>;
 type FocusScopeProps = React.ComponentPropsWithoutRef<typeof FocusScope>;
 interface DialogContentImplProps extends Omit<DismissableLayerProps, 'onDismiss'> {
@@ -429,7 +429,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
 
 const TITLE_NAME = 'DialogTitle';
 
-type DialogTitleElement = React.ElementRef<typeof Primitive.h2>;
+type DialogTitleElement = React.ComponentRef<typeof Primitive.h2>;
 type PrimitiveHeading2Props = React.ComponentPropsWithoutRef<typeof Primitive.h2>;
 interface DialogTitleProps extends PrimitiveHeading2Props {}
 
@@ -449,7 +449,7 @@ DialogTitle.displayName = TITLE_NAME;
 
 const DESCRIPTION_NAME = 'DialogDescription';
 
-type DialogDescriptionElement = React.ElementRef<typeof Primitive.p>;
+type DialogDescriptionElement = React.ComponentRef<typeof Primitive.p>;
 type PrimitiveParagraphProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
 interface DialogDescriptionProps extends PrimitiveParagraphProps {}
 
@@ -469,7 +469,7 @@ DialogDescription.displayName = DESCRIPTION_NAME;
 
 const CLOSE_NAME = 'DialogClose';
 
-type DialogCloseElement = React.ElementRef<typeof Primitive.button>;
+type DialogCloseElement = React.ComponentRef<typeof Primitive.button>;
 interface DialogCloseProps extends PrimitiveButtonProps {}
 
 const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
- `ElementRef` is deprecated but used in `dialog`.
- Replace `ElementRef` to `ComponentRef`.
- To limit to DOM elements, have to use `HTMLxxxElement` directly, but I think that's the most appropriate way for now, logically.
- There is no logical difference, as I simply converted the old type to a modern one.