### PR TITLE
fix: edit dialog accessiblity validation logic available in shadow dom

### DIFF
--- a/.changeset/cool-moles-invite.md
+++ b/.changeset/cool-moles-invite.md
@@ -1,0 +1,7 @@
+---
+'@radix-ui/react-dialog': patch
+---
+
+- Improved accessibility check logic in Dialog component
+  - Restricted title and description element checks to be scoped within Dialog Content for more accurate validation
+  - Enhanced compatibility with Shadow DOM environments

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -414,7 +414,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
         </FocusScope>
         {process.env.NODE_ENV !== 'production' && (
           <>
-            <TitleWarning titleId={context.titleId} />
+            <TitleWarning titleId={context.titleId} contentRef={contentRef} />
             <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />
           </>
         )}
@@ -503,9 +503,12 @@ const [WarningProvider, useWarningContext] = createContext(TITLE_WARNING_NAME, {
   docsSlug: 'dialog',
 });
 
-type TitleWarningProps = { titleId?: string };
+type TitleWarningProps = {
+  titleId?: string;
+  contentRef: React.RefObject<DialogContentElement | null>;
+};
 
-const TitleWarning: React.FC<TitleWarningProps> = ({ titleId }) => {
+const TitleWarning: React.FC<TitleWarningProps> = ({ titleId, contentRef }) => {
   const titleWarningContext = useWarningContext(TITLE_WARNING_NAME);
 
   const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
@@ -516,10 +519,10 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 
   React.useEffect(() => {
     if (titleId) {
-      const hasTitle = document.getElementById(titleId);
+      const hasTitle = contentRef.current?.querySelector(`#${titleId}`);
       if (!hasTitle) console.error(MESSAGE);
     }
-  }, [MESSAGE, titleId]);
+  }, [MESSAGE, contentRef, titleId]);
 
   return null;
 };
@@ -539,7 +542,7 @@ const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef, des
     const describedById = contentRef.current?.getAttribute('aria-describedby');
     // if we have an id and the user hasn't set aria-describedby={undefined}
     if (descriptionId && describedById) {
-      const hasDescription = document.getElementById(descriptionId);
+      const hasDescription = contentRef.current?.querySelector(`#${descriptionId}`);
       if (!hasDescription) console.warn(MESSAGE);
     }
   }, [MESSAGE, contentRef, descriptionId]);


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

close #3484 

<!-- Describe the change you are introducing -->
- Fixed accessibility validation logic for Dialog Title and Description.
  - Passing `ContentRef` props `<TitleWarning titleId={context.titleId} contentRef={contentRef} />`
  - Validate in the Content `contentRef.current?.querySelector(`#${titleId}`);`
- Strictly check if it is inside Content as the error message says
- **Compatible with Shadow DOM** (The document-based logic of the existing logic does not work when used in shadow DOM)
- (Performance improvement is also expected as it checks a narrow range inside the content. But I didn't think it was important so I didn't bother measuring it haha)

This is test code. All passed. But I will include it if you give me feedback that it needs to be committed.
```tsx
    describe('when in Shadow DOM', () => {
      let shadowRoot: ShadowRoot;
      let shadowContainer: HTMLElement;

      beforeEach(() => {
        // make shadow root
        const host = document.createElement('div');
        document.body.appendChild(host);
        shadowRoot = host.attachShadow({ mode: 'open' });

        // render dialog in the shadow root
        shadowContainer = document.createElement('div');
        shadowRoot.appendChild(shadowContainer);

        cleanup();
        rendered = render(
          <Dialog.Root defaultOpen>
            <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
            <Dialog.Overlay />
            <Dialog.Content>
              <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
              <Dialog.Description>Description</Dialog.Description>
              <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
            </Dialog.Content>
          </Dialog.Root>,
          { container: shadowContainer }
        );
      });

      afterEach(() => {
        document.body.innerHTML = '';
      });

      it('should not show any errors when title is present in Shadow DOM', () => {
        expect(consoleErrorMockFunction).not.toHaveBeenCalled();
      });

      it('should not show any warnings when description is present in Shadow DOM', () => {
        consoleWarnMockFunction.mockClear();
        expect(consoleWarnMockFunction).not.toHaveBeenCalled();
      });
    });
```

```bash
 ✓ packages/react/dialog/src/dialog.test.tsx (10 tests) 272ms
   ✓ given a default Dialog > should have no accessibility violations in default state 76ms
   ✓ given a default Dialog > after clicking the trigger > when no description has been provided > should warn to the console 22ms
   ✓ given a default Dialog > after clicking the trigger > when no title has been provided > should display an error in the console 60ms
   ✓ given a default Dialog > after clicking the trigger > when aria-describedby is set to undefined > should not warn to the console 32ms
   ✓ given a default Dialog > after clicking the trigger > should open the content 9ms
   ✓ given a default Dialog > after clicking the trigger > should have no accessibility violations 26ms
   ✓ given a default Dialog > after clicking the trigger > should focus the close button 8ms
   ✓ given a default Dialog > after clicking the trigger > when pressing escape > should close the content 11ms
   ✓ given a default Dialog > after clicking the trigger > when in Shadow DOM > should not show any errors when title is present in Shadow DOM 15ms
   ✓ given a default Dialog > after clicking the trigger > when in Shadow DOM > should not show any warnings when description is present in Shadow DOM 13ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  17:19:52
   Duration  984ms
```
