### PR TITLE
fix: when specifying the type of One-Time Password Field, the input is displayed as pw.

### DIFF
--- a/.changeset/fluffy-days-kneel.md
+++ b/.changeset/fluffy-days-kneel.md
@@ -1,0 +1,10 @@
+---
+'@radix-ui/react-one-time-password-field': patch
+---
+
+
+
+- As stated in the [documentation](https://www.radix-ui.com/primitives/docs/components/one-time-password-field#root), change default to text.
+- Connect a type to input to display the input value in a different way when the type changes.
+- Add test for this feature
+

--- a/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
@@ -32,6 +32,27 @@ describe('given a default OneTimePasswordField', () => {
     expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
+  it('should mask input value when type is password', async () => {
+    rendered.rerender(
+      <OneTimePasswordField.Root type="password">
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.HiddenInput name="code" />
+      </OneTimePasswordField.Root>
+    );
+
+    const input = rendered.container.querySelector(
+      'input:not([type="hidden"])'
+    ) as HTMLInputElement;
+
+    await userEvent.type(input, '1');
+    expect(input.type).toBe('password');
+
+    const hiddenInput = rendered.container.querySelector(
+      'input[type="hidden"]'
+    ) as HTMLInputElement;
+    expect(hiddenInput.value).toBe('1');
+  });
+
   // TODO: userEvent paste not behaving as expected. Debug and unskip.
   // Replicated in storybook for now.
   it.todo('pastes the code into the input', async () => {

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -211,7 +211,7 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
       form,
       name,
       placeholder,
-      type = 'password',
+      type = 'text',
       // TODO: Change default to vertical when inputs use vertical writing mode
       orientation = 'horizontal',
       dir,
@@ -638,7 +638,7 @@ const OneTimePasswordFieldInput = React.forwardRef<
           return (
             <Primitive.Root.input
               ref={composedInputRef}
-              type="text"
+              type={context.type}
               aria-label={`Character ${index + 1} of ${collection.size}`}
               autoComplete={supportsAutoComplete ? context.autoComplete : 'off'}
               data-1p-ignore={supportsAutoComplete ? undefined : 'true'}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

close #3493 

<!-- Describe the change you are introducing -->
- As stated in the [documentation](https://www.radix-ui.com/primitives/docs/components/one-time-password-field#root), change default `type` to text.
- Connect a type to input to display the input value in a different way when the type changes.
- Add test for this feature

<img width="796" alt="스크린샷 2025-04-28 오후 9 20 30" src="https://github.com/user-attachments/assets/ec35e71f-5a89-4e3c-a68f-102fa117968d" />

<img width="790" alt="스크린샷 2025-04-28 오후 9 20 39" src="https://github.com/user-attachments/assets/2e6deb09-5417-4b72-bfbc-eb3bf3304c0f" />

