### PR TITLE
Implement multi select

### DIFF
--- a/.changeset/quiet-schools-leave.md
+++ b/.changeset/quiet-schools-leave.md
@@ -1,0 +1,6 @@
+---
+"@repo/storybook": patch
+"@radix-ui/react-select": minor
+---
+
+Support `multiple` prop and array `value` and `defaultValue` on Select (#3522)

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -59,6 +59,53 @@ export const Styled = () => (
   </div>
 );
 
+export const MultiSelectStyled = () => (
+  <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+    {POSITIONS.map((position) => (
+      <Label key={position}>
+        Choose some numbers:
+        <Select.Root defaultValue={['two']} multiple>
+          <Select.Trigger className={styles.trigger}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={styles.content} position={position} sideOffset={5}>
+              <Select.Viewport className={styles.viewport}>
+                <Select.Item className={styles.item} value="one">
+                  <Select.ItemText>
+                    One<span aria-hidden> 👍</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="two">
+                  <Select.ItemText>
+                    Two<span aria-hidden> 👌</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="three">
+                  <Select.ItemText>
+                    Three<span aria-hidden> 🤘</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+              <Select.Arrow />
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+    ))}
+  </div>
+);
+
 export const Controlled = () => {
   const [value, setValue] = React.useState('uk');
   return (
@@ -81,6 +128,72 @@ export const Controlled = () => {
               >
                 {value === 'fr' ? '🇫🇷' : value === 'uk' ? '🇬🇧' : value === 'es' ? '🇪🇸' : null}
               </Select.Value>
+              <Select.Icon />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content className={styles.content} position={position} sideOffset={5}>
+                <Select.Viewport className={styles.viewport}>
+                  <Select.Item className={styles.item} value="fr">
+                    <Select.ItemText>
+                      France<span aria-hidden> 🇫🇷</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={styles.item} value="uk">
+                    <Select.ItemText>
+                      United Kingdom<span aria-hidden> 🇬🇧</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={styles.item} value="es">
+                    <Select.ItemText>
+                      Spain<span aria-hidden> 🇪🇸</span>
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                </Select.Viewport>
+                <Select.Arrow />
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
+        </Label>
+      ))}
+    </div>
+  );
+};
+
+export const MultiSelectControlled = () => {
+  const labelMap = {
+    fr: ['🇫🇷', 'France'],
+    uk: ['🇬🇧', 'United Kingdom'],
+    es: ['🇪🇸', 'Spain'],
+  } as const;
+  const [value, setValue] = React.useState(['uk']);
+
+  const [flags, countries] = Object.entries(labelMap).reduce(
+    (mem, [key, [flag, country]]) => {
+      if (value.includes(key)) {
+        mem[0] += ' ' + flag;
+        mem[1] += ' ' + country;
+      }
+      return mem;
+    },
+    ['', '']
+  );
+  return (
+    <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+      {POSITIONS.map((position) => (
+        <Label key={position}>
+          Choose a country:
+          <Select.Root value={value} onValueChange={setValue} multiple>
+            <Select.Trigger className={styles.trigger}>
+              <Select.Value aria-label={countries}>{flags}</Select.Value>
               <Select.Icon />
             </Select.Trigger>
             <Select.Portal>
@@ -452,7 +565,16 @@ export const WithinForm = () => {
 
   function handleChange(event: React.FormEvent<HTMLFormElement>) {
     const formData = new FormData(event.currentTarget);
-    setData(Object.fromEntries((formData as any).entries()));
+    const formDataEntries = Array.from(formData.entries()).reduce(
+      (acc, [key, value]) => {
+        const existing = Array.isArray(acc[key]) ? acc[key] : acc[key] ? [acc[key]] : [];
+        acc[key] = [value, ...existing];
+        return acc;
+      },
+      {} as Record<string, string | File | (string | File)[]>
+    );
+
+    setData(formDataEntries);
   }
 
   return (
@@ -472,6 +594,78 @@ export const WithinForm = () => {
       <Label style={{ display: 'block' }}>
         Country
         <Select.Root name="country" autoComplete="country" defaultValue="fr">
+          <Select.Trigger className={styles.trigger}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={styles.content}>
+              <Select.Viewport className={styles.viewport}>
+                <Select.Item className={styles.item} value="fr">
+                  <Select.ItemText>France</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="uk">
+                  <Select.ItemText>United Kingdom</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="es">
+                  <Select.ItemText>Spain</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+      <br />
+      <button type="submit">Submit</button>
+      <br />
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </form>
+  );
+};
+
+export const MultiSelectWithinForm = () => {
+  const [data, setData] = React.useState({});
+
+  function handleChange(event: React.FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    const formDataEntries = Array.from(formData.entries()).reduce(
+      (acc, [key, value]) => {
+        const existing = Array.isArray(acc[key]) ? acc[key] : acc[key] ? [acc[key]] : [];
+        acc[key] = [value, ...existing];
+        return acc;
+      },
+      {} as Record<string, string | File | (string | File)[]>
+    );
+
+    setData(formDataEntries);
+  }
+
+  return (
+    <form
+      style={{ padding: 50 }}
+      onSubmit={(event) => {
+        handleChange(event);
+        event.preventDefault();
+      }}
+      onChange={handleChange}
+    >
+      <Label style={{ display: 'block' }}>
+        Name
+        <input name="name" autoComplete="name" style={{ display: 'block' }} />
+      </Label>
+      <br />
+      <Label style={{ display: 'block' }}>
+        Country
+        <Select.Root name="country" autoComplete="country" defaultValue={['fr', 'uk']} multiple>
           <Select.Trigger className={styles.trigger}>
             <Select.Value />
             <Select.Icon />

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -63,6 +63,7 @@
     "@repo/typescript-config": "workspace:*",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
+    "@radix-ui/react-label": "workspace:*",
     "eslint": "^9.18.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/react/select/src/select.test.tsx
+++ b/packages/react/select/src/select.test.tsx
@@ -81,20 +81,11 @@ describe('given a single isolated Select', () => {
   beforeEach(() => {
     handleValueChange = vi.fn();
     rendered = render(<SelectTest onValueChange={handleValueChange} />);
-    trigger = rendered.getByRole('listbox', { name: LABEL_TEXT });
+    trigger = rendered.getByRole('combobox', { name: LABEL_TEXT });
   });
 
   it('should have no accessibility violations', async () => {
-    expect(
-      await axe(rendered.container, {
-        rules: {
-          // Listbox role is not an allowed role for button, but is the role for single select
-          // https://www.w3.org/TR/html-aria/#el-button
-          'aria-allowed-attr': { enabled: false },
-          'aria-allowed-role': { enabled: false },
-        },
-      })
-    ).toHaveNoViolations();
+    expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
   describe('after clicking the trigger', () => {
@@ -133,20 +124,11 @@ describe('given a single Select in a form', () => {
         <SelectTest name={SELECT_NAME} />
       </form>
     );
-    trigger = rendered.getByRole('listbox', { name: LABEL_TEXT });
+    trigger = rendered.getByRole('combobox', { name: LABEL_TEXT });
   });
 
   it('should have no accessibility violations', async () => {
-    expect(
-      await axe(rendered.container, {
-        rules: {
-          // Listbox role is not an allowed role for button, but is the role for single select
-          // https://www.w3.org/TR/html-aria/#el-button
-          'aria-allowed-attr': { enabled: false },
-          'aria-allowed-role': { enabled: false },
-        },
-      })
-    ).toHaveNoViolations();
+    expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
   describe('after clicking the trigger', () => {
@@ -174,16 +156,7 @@ describe('given a multiple isolated Select', () => {
   });
 
   it('should have no accessibility violations', async () => {
-    expect(
-      await axe(rendered.container, {
-        rules: {
-          // Listbox role is not an allowed role for button, but is the role for single select
-          // https://www.w3.org/TR/html-aria/#el-button
-          'aria-allowed-attr': { enabled: false },
-          'aria-allowed-role': { enabled: false },
-        },
-      })
-    ).toHaveNoViolations();
+    expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
   describe('after clicking the trigger', () => {
@@ -230,16 +203,7 @@ describe('given a multi Select in a form', () => {
   });
 
   it('should have no accessibility violations', async () => {
-    expect(
-      await axe(rendered.container, {
-        rules: {
-          // Listbox role is not an allowed role for button, but is the role for single select
-          // https://www.w3.org/TR/html-aria/#el-button
-          'aria-allowed-attr': { enabled: false },
-          'aria-allowed-role': { enabled: false },
-        },
-      })
-    ).toHaveNoViolations();
+    expect(await axe(rendered.container)).toHaveNoViolations();
   });
 
   describe('after clicking the trigger', () => {

--- a/packages/react/select/src/select.test.tsx
+++ b/packages/react/select/src/select.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { axe } from 'vitest-axe';
+import type { RenderResult } from '@testing-library/react';
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import * as Select from './select';
+import type { Mock } from 'vitest';
+import { afterEach, describe, it, beforeEach, expect, vi } from 'vitest';
+import { Label } from '@radix-ui/react-label';
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const TickIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 32 32"
+    width="12"
+    height="12"
+    fill="none"
+    stroke="currentcolor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="3"
+  >
+    <path d="M2 20 L12 28 30 4" />
+  </svg>
+);
+
+const LABEL_TEXT = 'Choose';
+const SELECT_NAME = 'select_input';
+const OPTION_ONE_TEXT = 'One';
+const OPTION_ONE_VALUE = 'one';
+const OPTION_TWO_TEXT = 'Two';
+const OPTION_TWO_VALUE = 'two';
+const OPTION_THREE_TEXT = 'Three';
+const OPTION_THREE_VALUE = 'three';
+
+const SelectTest = (props: React.ComponentProps<typeof Select.Root>) => (
+  <Label>
+    {LABEL_TEXT}
+    <Select.Root {...props}>
+      <Select.Trigger>
+        <Select.Value />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content>
+          <Select.Viewport>
+            <Select.Item value={OPTION_ONE_VALUE}>
+              <Select.ItemText>{OPTION_ONE_TEXT}</Select.ItemText>
+              <Select.ItemIndicator>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+            <Select.Item value={OPTION_TWO_VALUE}>
+              <Select.ItemText>{OPTION_TWO_TEXT}</Select.ItemText>
+              <Select.ItemIndicator>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+            <Select.Item value={OPTION_THREE_VALUE}>
+              <Select.ItemText>{OPTION_THREE_TEXT}</Select.ItemText>
+              <Select.ItemIndicator>
+                <TickIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+          </Select.Viewport>
+          <Select.Arrow />
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  </Label>
+);
+
+describe('given a single isolated Select', () => {
+  let handleValueChange: Mock;
+  let rendered: RenderResult;
+  let trigger: HTMLElement;
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    handleValueChange = vi.fn();
+    rendered = render(<SelectTest onValueChange={handleValueChange} />);
+    trigger = rendered.getByRole('listbox', { name: LABEL_TEXT });
+  });
+
+  it('should have no accessibility violations', async () => {
+    expect(
+      await axe(rendered.container, {
+        rules: {
+          // Listbox role is not an allowed role for button, but is the role for single select
+          // https://www.w3.org/TR/html-aria/#el-button
+          'aria-allowed-attr': { enabled: false },
+          'aria-allowed-role': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations();
+  });
+
+  describe('after clicking the trigger', () => {
+    it('should propagate the selected value', async () => {
+      fireEvent.click(trigger);
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_ONE_TEXT }));
+      expect(handleValueChange).toHaveBeenCalledWith(OPTION_ONE_VALUE);
+    });
+  });
+});
+
+describe('given a single Select in a form', () => {
+  let handleFormChange: Mock;
+  let rendered: RenderResult;
+  let trigger: HTMLElement;
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    handleFormChange = vi.fn();
+    rendered = render(
+      <form
+        onChange={(event) => {
+          const formData = new FormData(event.currentTarget);
+          const formDataEntries = Array.from(formData.entries()).reduce(
+            (acc, [key, value]) => {
+              const existing = Array.isArray(acc[key]) ? acc[key] : acc[key] ? [acc[key]] : [];
+              acc[key] = [value, ...existing];
+              return acc;
+            },
+            {} as Record<string, string | File | (string | File)[]>
+          );
+          handleFormChange(formDataEntries);
+        }}
+      >
+        <SelectTest name={SELECT_NAME} />
+      </form>
+    );
+    trigger = rendered.getByRole('listbox', { name: LABEL_TEXT });
+  });
+
+  it('should have no accessibility violations', async () => {
+    expect(
+      await axe(rendered.container, {
+        rules: {
+          // Listbox role is not an allowed role for button, but is the role for single select
+          // https://www.w3.org/TR/html-aria/#el-button
+          'aria-allowed-attr': { enabled: false },
+          'aria-allowed-role': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations();
+  });
+
+  describe('after clicking the trigger', () => {
+    it('should propagate the selected value', () => {
+      fireEvent.click(trigger);
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_ONE_TEXT }));
+      expect(handleFormChange).toHaveBeenCalledWith({
+        [SELECT_NAME]: [OPTION_ONE_VALUE],
+      });
+    });
+  });
+});
+
+describe('given a multiple isolated Select', () => {
+  let handleValueChange: Mock;
+  let rendered: RenderResult;
+  let trigger: HTMLElement;
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    handleValueChange = vi.fn();
+    rendered = render(<SelectTest multiple onValueChange={handleValueChange} />);
+    trigger = rendered.getByRole('combobox', { name: LABEL_TEXT });
+  });
+
+  it('should have no accessibility violations', async () => {
+    expect(
+      await axe(rendered.container, {
+        rules: {
+          // Listbox role is not an allowed role for button, but is the role for single select
+          // https://www.w3.org/TR/html-aria/#el-button
+          'aria-allowed-attr': { enabled: false },
+          'aria-allowed-role': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations();
+  });
+
+  describe('after clicking the trigger', () => {
+    it('should propagate the selected value', () => {
+      fireEvent.click(trigger);
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_ONE_TEXT }));
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_TWO_TEXT }));
+
+      expect(handleValueChange).toHaveBeenCalledWith(
+        expect.arrayContaining([OPTION_ONE_VALUE, OPTION_TWO_VALUE])
+      );
+    });
+  });
+});
+
+describe('given a multi Select in a form', () => {
+  let handleFormChange: Mock;
+  let rendered: RenderResult;
+  let trigger: HTMLElement;
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    handleFormChange = vi.fn();
+    rendered = render(
+      <form
+        onChange={(event) => {
+          const formData = new FormData(event.currentTarget);
+          const formDataEntries = Array.from(formData.entries()).reduce(
+            (acc, [key, value]) => {
+              const existing = Array.isArray(acc[key]) ? acc[key] : acc[key] ? [acc[key]] : [];
+              acc[key] = [value, ...existing];
+              return acc;
+            },
+            {} as Record<string, string | File | (string | File)[]>
+          );
+          handleFormChange(formDataEntries);
+        }}
+      >
+        <SelectTest multiple name={SELECT_NAME} />
+      </form>
+    );
+    trigger = rendered.getByRole('combobox', { name: LABEL_TEXT });
+  });
+
+  it('should have no accessibility violations', async () => {
+    expect(
+      await axe(rendered.container, {
+        rules: {
+          // Listbox role is not an allowed role for button, but is the role for single select
+          // https://www.w3.org/TR/html-aria/#el-button
+          'aria-allowed-attr': { enabled: false },
+          'aria-allowed-role': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations();
+  });
+
+  describe('after clicking the trigger', () => {
+    it('should propagate the selected value', () => {
+      fireEvent.click(trigger);
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_ONE_TEXT }));
+      fireEvent.click(rendered.getByRole('option', { name: OPTION_TWO_TEXT }));
+      expect(handleFormChange).toHaveBeenCalledWith({
+        [SELECT_NAME]: expect.arrayContaining([OPTION_ONE_VALUE, OPTION_TWO_VALUE]),
+      });
+    });
+  });
+});

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -57,10 +57,11 @@ type SelectContextValue = {
   valueNodeHasChildren: boolean;
   onValueNodeHasChildrenChange(hasChildren: boolean): void;
   contentId: string;
-  value: string | undefined;
-  onValueChange(value: string): void;
+  value: string[] | string | undefined;
+  onValueChange(value: string[] | string): void;
   open: boolean;
   required?: boolean;
+  multiple?: boolean;
   onOpenChange(open: boolean): void;
   dir: SelectProps['dir'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
@@ -79,23 +80,23 @@ const [SelectNativeOptionsProvider, useSelectNativeOptionsContext] =
   createSelectContext<SelectNativeOptionsContextValue>(SELECT_NAME);
 
 interface ControlledClearableSelectProps {
-  value: string | undefined;
+  value: string[] | string | undefined;
   defaultValue?: never;
-  onValueChange: (value: string | undefined) => void;
+  onValueChange: (value: string[] | string | undefined) => void;
 }
 
 interface ControlledUnclearableSelectProps {
-  value: string;
+  value: string[] | string;
   defaultValue?: never;
-  onValueChange: (value: string) => void;
+  onValueChange: (value: string[] | string) => void;
 }
 
 interface UncontrolledSelectProps {
   value?: never;
-  defaultValue?: string;
+  defaultValue?: string[] | string;
   onValueChange?: {
-    (value: string): void;
-    (value: string | undefined): void;
+    (value: string[] | string): void;
+    (value: string[] | string | undefined): void;
   };
 }
 
@@ -122,11 +123,21 @@ interface SelectSharedProps {
 // it works as expected and doesn't cause problems)
 type _FutureSelectProps = SelectSharedProps & SelectControlProps;
 
-type SelectProps = SelectSharedProps & {
-  value?: string;
-  defaultValue?: string;
-  onValueChange?(value: string): void;
-};
+type SelectProps = SelectSharedProps &
+  (
+    | {
+        value?: string;
+        defaultValue?: string;
+        onValueChange?(value: string): void;
+        multiple?: never | false;
+      }
+    | {
+        value?: string[];
+        defaultValue?: string[];
+        onValueChange?(value: string[]): void;
+        multiple: true;
+      }
+  );
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const {
@@ -144,6 +155,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     disabled,
     required,
     form,
+    multiple,
   } = props;
   const popperScope = usePopperScope(__scopeSelect);
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
@@ -196,6 +208,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
         dir={direction}
         triggerPointerDownPosRef={triggerPointerDownPosRef}
         disabled={disabled}
+        multiple={multiple}
       >
         <Collection.Provider scope={__scopeSelect}>
           <SelectNativeOptionsProvider
@@ -225,9 +238,18 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             autoComplete={autoComplete}
             value={value}
             // enable form autofill
-            onChange={(event) => setValue(event.target.value)}
+            onChange={(event) => {
+              if (multiple) {
+                setValue(
+                  Array.from(event.currentTarget.selectedOptions).map((option) => option.value)
+                );
+              } else {
+                setValue(event.target.value);
+              }
+            }}
             disabled={disabled}
             form={form}
+            multiple={multiple}
           >
             {value === undefined ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}
@@ -288,7 +310,8 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
           type="button"
-          role="combobox"
+          // https://w3c.github.io/html-aam/#el-select-listbox
+          role={context.multiple ? 'combobox' : 'listbox'}
           aria-controls={context.contentId}
           aria-expanded={context.open}
           aria-required={context.required}
@@ -1258,7 +1281,9 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     } = props;
     const context = useSelectContext(ITEM_NAME, __scopeSelect);
     const contentContext = useSelectContentContext(ITEM_NAME, __scopeSelect);
-    const isSelected = context.value === value;
+    const isSelected = context.multiple
+      ? context.value?.includes(value) || false
+      : context.value === value;
     const [textValue, setTextValue] = React.useState(textValueProp ?? '');
     const [isFocused, setIsFocused] = React.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, (node) =>
@@ -1268,7 +1293,17 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const handleSelect = () => {
-      if (!disabled) {
+      if (disabled) {
+        return;
+      }
+
+      if (context.multiple) {
+        const initValue = (context.value as string[]) ?? [];
+        const newValue = isSelected
+          ? initValue.filter((item) => item !== value)
+          : [...(initValue as string[]), value];
+        context.onValueChange(newValue);
+      } else {
         context.onValueChange(value);
         context.onOpenChange(false);
       }
@@ -1638,6 +1673,15 @@ const BUBBLE_INPUT_NAME = 'SelectBubbleInput';
 type InputProps = React.ComponentPropsWithoutRef<typeof Primitive.select>;
 interface SwitchBubbleInputProps extends InputProps {}
 
+function doValuesMatch(a: SwitchBubbleInputProps['value'], b: SwitchBubbleInputProps['value']) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) => item === b[index]);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+  return a === b;
+}
+
 const SelectBubbleInput = React.forwardRef<HTMLSelectElement, SwitchBubbleInputProps>(
   ({ __scopeSelect, value, ...props }: ScopedProps<SwitchBubbleInputProps>, forwardedRef) => {
     const ref = React.useRef<HTMLSelectElement>(null);
@@ -1648,18 +1692,21 @@ const SelectBubbleInput = React.forwardRef<HTMLSelectElement, SwitchBubbleInputP
     React.useEffect(() => {
       const select = ref.current;
       if (!select) return;
+      if (doValuesMatch(prevValue, value)) return;
 
-      const selectProto = window.HTMLSelectElement.prototype;
-      const descriptor = Object.getOwnPropertyDescriptor(
-        selectProto,
-        'value'
-      ) as PropertyDescriptor;
-      const setValue = descriptor.set;
-      if (prevValue !== value && setValue) {
-        const event = new Event('change', { bubbles: true });
-        setValue.call(select, value);
-        select.dispatchEvent(event);
+      const setOptionSelected = Object.getOwnPropertyDescriptor(
+        window.HTMLOptionElement.prototype,
+        'selected'
+      )?.set;
+
+      if (setOptionSelected) {
+        const selectedValues = Array.isArray(value) ? value : [value];
+        for (const option of select.options) {
+          setOptionSelected.call(option, selectedValues.includes(option.value));
+        }
       }
+
+      select.dispatchEvent(new Event('change', { bubbles: true }));
     }, [prevValue, value]);
 
     /**
@@ -1689,7 +1736,10 @@ SelectBubbleInput.displayName = BUBBLE_INPUT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function shouldShowPlaceholder(value?: string) {
+function shouldShowPlaceholder(value?: string[] | string) {
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.every((v) => v === '');
+  }
   return value === '' || value === undefined;
 }
 

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -310,8 +310,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
       <PopperPrimitive.Anchor asChild {...popperScope}>
         <Primitive.button
           type="button"
-          // https://w3c.github.io/html-aam/#el-select-listbox
-          role={context.multiple ? 'combobox' : 'listbox'}
+          role="combobox"
           aria-controls={context.contentId}
           aria-expanded={context.open}
           aria-required={context.required}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2431,6 +2431,9 @@ importers:
         specifier: ^2.6.3
         version: 2.6.3(@types/react@19.1.0)(react@19.1.0)
     devDependencies:
+      '@radix-ui/react-label':
+        specifier: workspace:*
+        version: link:../label
       '@repo/builder':
         specifier: workspace:*
         version: link:../../../internal/builder


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
closes: #1270 

Implements the `multiple` option for Select.
![image](https://github.com/user-attachments/assets/251cc88b-6ffd-4d1f-a452-6b232d13c626)

Changes the form implementation (SelectBubbleInput) to update the option selected prop, instead of the select value prop. this is how the multiple select maintains the value, instead of having an array implementation in the select value. The single select also supports this, and as shown in the added tests, will still update the form as needed.

Externally, the prop type are more limiting then the HTMLSelectElement as it allows value to be an array on single, and string on multiple, however, react generates an error for these cases. 

Internally, not have complex typing and type checks throughout the component, I've elected instead to do some basic checks and assumptions.

I added some basic tests to the Select component. Ideally I would use `userEvent` instead of `fireEvent`, however, due to the many event handlers and functions missing from jsdom, I've left the tests as very basic tests. Perhaps using vitest browser mode could help with testing the complex components like Select?

Thank you for taking a look at this PR. Any and all feedback is welcome!

