### PR TITLE
fix: [One-Time Password Field] focus otp's first input when autoFocus props is true.

### DIFF
--- a/.changeset/forty-taxis-train.md
+++ b/.changeset/forty-taxis-train.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-one-time-password-field': patch
+---
+
+fix: focus 1st input when autoFocus is true

--- a/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
@@ -53,6 +53,25 @@ describe('given a default OneTimePasswordField', () => {
     expect(hiddenInput.value).toBe('1');
   });
 
+  it('should focus on first input when autoFocus is true', () => {
+    rendered.rerender(
+      <OneTimePasswordField.Root autoFocus>
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.HiddenInput name="code" />
+      </OneTimePasswordField.Root>
+    );
+
+    const firstInput = rendered.container.querySelector(
+      'input:not([type="hidden"])'
+    ) as HTMLInputElement;
+    expect(document.activeElement).toBe(firstInput);
+  });
+
   // TODO: userEvent paste not behaving as expected. Debug and unskip.
   // Replicated in storybook for now.
   it.todo('pastes the code into the input', async () => {

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -405,6 +405,12 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
     }, [locateForm]);
 
     React.useEffect(() => {
+      if (autoFocus && firstInput) {
+        firstInput.focus();
+      }
+    }, [autoFocus, firstInput]);
+
+    React.useEffect(() => {
       const form = locateForm();
       if (form) {
         const reset = () => dispatch({ type: 'CLEAR', reason: 'Reset' });


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

close #3538 
- Add test for `autoFocus` props
- focus first input when `autoFocus` is true

<img width="783" alt="스크린샷 2025-05-17 오후 5 07 38" src="https://github.com/user-attachments/assets/76e05d57-8683-4c0d-b309-07121b86fc9d" />

`autoFocus: false`

<img width="763" alt="스크린샷 2025-05-17 오후 5 07 44" src="https://github.com/user-attachments/assets/6e7f1c5b-642d-415d-b256-b4cabc69d8d4" />

`autoFocus: true`

<!-- Describe the change you are introducing -->
