### PR TITLE
fix: [One-Time Password Field] truncate values ​​that exceed the length when pasting

### DIFF
--- a/.changeset/famous-icons-arrive.md
+++ b/.changeset/famous-icons-arrive.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-one-time-password-field': patch
+---
+
+truncate values ​​that exceed the length when pasting

--- a/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.test.tsx
@@ -64,6 +64,17 @@ describe('given a default OneTimePasswordField', () => {
     await act(async () => await user.paste('1,2,3,4,5,6'));
     expect(getInputValues(inputs)).toBe('1,2,3,4,5,6');
   });
+
+  // TODO: userEvent paste not behaving as expected. Debug and unskip.
+  it.todo('should truncate pasted characters to the number of inputs', async () => {
+    const inputs = screen.getAllByRole<HTMLInputElement>('textbox', {
+      hidden: false,
+    });
+    const firstInput = inputs[0]!;
+    fireEvent.click(firstInput);
+    await act(async () => await user.paste('123456789'));
+    expect(getInputValues(inputs)).toBe('1,2,3,4,5,6');
+  });
 });
 
 function getInputValues(inputs: HTMLInputElement[]) {

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -351,10 +351,12 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
 
         case 'PASTE': {
           const { value: pastedValue } = action;
-          const value = sanitizeValue(pastedValue);
-          if (!value) {
+          const sanitizedValue = sanitizeValue(pastedValue);
+          if (!sanitizedValue) {
             return;
           }
+
+          const value = sanitizedValue.slice(0, collection.size);
 
           flushSync(() => setValue(value));
           focusInput(collection.at(value.length - 1)?.element);


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
close #3550
- truncate values exceed the length of collections when pasting
- There is a concern that SRP may be violated when inserting the corresponding logic into `sanitizeValue`, and therefore, side effects are a concern, so verification is performed in the paste logic.
- Test code is skipped because the pasted values ​​of `@testing-library/user-event` are not assigned to input.

**Test with Storybook**
Case: paste `124868392`
```html
<input autocomplete="off" autocapitalize="off" autocorrect="off" autosave="off" spellcheck="false" readonly="" type="hidden" 
value="124868" 
name="code">
```
![image](https://github.com/user-attachments/assets/77e31a3f-9c31-47d3-847b-7255db0bed3b)

<!-- Describe the change you are introducing -->
