### PR TITLE
feat: export context hooks for components

### DIFF
--- a/packages/react/accordion/src/accordion.tsx
+++ b/packages/react/accordion/src/accordion.tsx
@@ -526,6 +526,11 @@ export {
   Header,
   Trigger,
   Content,
+  //
+  useAccordionContext,
+  useAccordionItemContext,
+  useAccordionValueContext,
+  useAccordionCollapsibleContext,
 };
 export type {
   AccordionSingleProps,

--- a/packages/react/accordion/src/index.ts
+++ b/packages/react/accordion/src/index.ts
@@ -13,6 +13,11 @@ export {
   Header,
   Trigger,
   Content,
+  //
+  useAccordionContext,
+  useAccordionItemContext,
+  useAccordionValueContext,
+  useAccordionCollapsibleContext,
 } from './accordion';
 export type {
   AccordionSingleProps,

--- a/packages/react/alert-dialog/src/alert-dialog.tsx
+++ b/packages/react/alert-dialog/src/alert-dialog.tsx
@@ -294,6 +294,8 @@ export {
   Cancel,
   Title,
   Description,
+  //
+  useAlertDialogContentContext,
 };
 export type {
   AlertDialogProps,

--- a/packages/react/alert-dialog/src/index.ts
+++ b/packages/react/alert-dialog/src/index.ts
@@ -21,6 +21,8 @@ export {
   Cancel,
   Title,
   Description,
+  //
+  useAlertDialogContentContext,
 } from './alert-dialog';
 export type {
   AlertDialogProps,

--- a/packages/react/avatar/src/avatar.tsx
+++ b/packages/react/avatar/src/avatar.tsx
@@ -193,5 +193,7 @@ export {
   Root,
   Image,
   Fallback,
+  //
+  useAvatarContext,
 };
 export type { AvatarProps, AvatarImageProps, AvatarFallbackProps };

--- a/packages/react/avatar/src/index.ts
+++ b/packages/react/avatar/src/index.ts
@@ -9,5 +9,7 @@ export {
   Root,
   Image,
   Fallback,
+  //
+  useAvatarContext,
 } from './avatar';
 export type { AvatarProps, AvatarImageProps, AvatarFallbackProps } from './avatar';

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -402,6 +402,8 @@ export {
   CheckboxTrigger as Trigger,
   CheckboxIndicator as Indicator,
   CheckboxBubbleInput as BubbleInput,
+  //
+  useCheckboxContext,
 };
 export type {
   CheckboxProps,

--- a/packages/react/checkbox/src/index.ts
+++ b/packages/react/checkbox/src/index.ts
@@ -13,6 +13,8 @@ export {
   Trigger as unstable_Trigger,
   Indicator,
   BubbleInput as unstable_BubbleInput,
+  //
+  useCheckboxContext,
 } from './checkbox';
 export type {
   CheckboxProps,

--- a/packages/react/collapsible/src/collapsible.tsx
+++ b/packages/react/collapsible/src/collapsible.tsx
@@ -242,5 +242,7 @@ export {
   Root,
   Trigger,
   Content,
+  //
+  useCollapsibleContext,
 };
 export type { CollapsibleProps, CollapsibleTriggerProps, CollapsibleContentProps };

--- a/packages/react/collapsible/src/index.ts
+++ b/packages/react/collapsible/src/index.ts
@@ -9,6 +9,8 @@ export {
   Root,
   Trigger,
   Content,
+  //
+  useCollapsibleContext,
 } from './collapsible';
 export type {
   CollapsibleProps,

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -578,6 +578,8 @@ export {
   Close,
   //
   WarningProvider,
+  //
+  useDialogContext,
 };
 export type {
   DialogProps,

--- a/packages/react/dialog/src/index.ts
+++ b/packages/react/dialog/src/index.ts
@@ -21,6 +21,8 @@ export {
   Close,
   //
   WarningProvider,
+  //
+  useDialogContext,
 } from './dialog';
 export type {
   DialogProps,

--- a/packages/react/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.tsx
@@ -545,6 +545,8 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useDropdownMenuContext,
 };
 export type {
   DropdownMenuProps,

--- a/packages/react/dropdown-menu/src/index.ts
+++ b/packages/react/dropdown-menu/src/index.ts
@@ -35,6 +35,8 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useDropdownMenuContext,
 } from './dropdown-menu';
 export type {
   DropdownMenuProps,

--- a/packages/react/form/src/form.tsx
+++ b/packages/react/form/src/form.tsx
@@ -716,6 +716,10 @@ export {
   Message,
   ValidityState,
   Submit,
+  //
+  useFormFieldContext,
+  useValidationContext,
+  useAriaDescriptionContext,
 };
 
 export type {

--- a/packages/react/form/src/index.ts
+++ b/packages/react/form/src/index.ts
@@ -17,6 +17,10 @@ export {
   Message,
   ValidityState,
   Submit,
+  //
+  useFormFieldContext,
+  useValidationContext,
+  useAriaDescriptionContext,
 } from './form';
 
 export type {

--- a/packages/react/hover-card/src/hover-card.tsx
+++ b/packages/react/hover-card/src/hover-card.tsx
@@ -425,6 +425,8 @@ export {
   Portal,
   Content,
   Arrow,
+  //
+  useHoverCardContext,
 };
 export type {
   HoverCardProps,

--- a/packages/react/hover-card/src/index.ts
+++ b/packages/react/hover-card/src/index.ts
@@ -13,6 +13,8 @@ export {
   Portal,
   Content,
   Arrow,
+  //
+  useHoverCardContext,
 } from './hover-card';
 export type {
   HoverCardProps,

--- a/packages/react/menu/src/index.ts
+++ b/packages/react/menu/src/index.ts
@@ -35,6 +35,9 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useMenuContext,
+  useRadioGroupContext,
 } from './menu';
 export type {
   MenuProps,

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -1374,6 +1374,9 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useMenuContext,
+  useRadioGroupContext,
 };
 export type {
   MenuProps,

--- a/packages/react/menubar/src/index.ts
+++ b/packages/react/menubar/src/index.ts
@@ -37,6 +37,8 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useMenubarContext,
 } from './menubar';
 export type {
   MenubarProps,

--- a/packages/react/menubar/src/menubar.tsx
+++ b/packages/react/menubar/src/menubar.tsx
@@ -743,6 +743,8 @@ export {
   Sub,
   SubTrigger,
   SubContent,
+  //
+  useMenubarContext,
 };
 export type {
   MenubarProps,

--- a/packages/react/navigation-menu/src/index.ts
+++ b/packages/react/navigation-menu/src/index.ts
@@ -21,6 +21,8 @@ export {
   Indicator,
   Content,
   Viewport,
+  //
+  useNavigationMenuContext,
 } from './navigation-menu';
 export type {
   NavigationMenuProps,

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -1272,6 +1272,8 @@ export {
   Indicator,
   Content,
   Viewport,
+  //
+  useNavigationMenuContext,
 };
 export type {
   NavigationMenuProps,

--- a/packages/react/popover/src/index.ts
+++ b/packages/react/popover/src/index.ts
@@ -17,6 +17,8 @@ export {
   Content,
   Close,
   Arrow,
+  //
+  usePopoverContext,
 } from './popover';
 export type {
   PopoverProps,

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -519,6 +519,8 @@ export {
   Content,
   Close,
   Arrow,
+  //
+  usePopoverContext,
 };
 export type {
   PopoverProps,

--- a/packages/react/popper/src/index.ts
+++ b/packages/react/popper/src/index.ts
@@ -14,6 +14,8 @@ export {
   //
   SIDE_OPTIONS,
   ALIGN_OPTIONS,
+  //
+  usePopperContext,
 } from './popper';
 export type {
   PopperProps,

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -418,5 +418,7 @@ export {
   //
   SIDE_OPTIONS,
   ALIGN_OPTIONS,
+  //
+  usePopperContext,
 };
 export type { PopperProps, PopperAnchorProps, PopperContentProps, PopperArrowProps };

--- a/packages/react/progress/src/index.ts
+++ b/packages/react/progress/src/index.ts
@@ -7,5 +7,7 @@ export {
   //
   Root,
   Indicator,
+  //
+  useProgressContext,
 } from './progress';
 export type { ProgressProps, ProgressIndicatorProps } from './progress';

--- a/packages/react/progress/src/progress.tsx
+++ b/packages/react/progress/src/progress.tsx
@@ -156,5 +156,7 @@ export {
   //
   Root,
   Indicator,
+  //
+  useProgressContext,
 };
 export type { ProgressProps, ProgressIndicatorProps };

--- a/packages/react/radio-group/src/index.ts
+++ b/packages/react/radio-group/src/index.ts
@@ -9,5 +9,7 @@ export {
   Root,
   Item,
   Indicator,
+  //
+  useRadioGroupContext,
 } from './radio-group';
 export type { RadioGroupProps, RadioGroupItemProps, RadioGroupIndicatorProps } from './radio-group';

--- a/packages/react/radio-group/src/radio-group.tsx
+++ b/packages/react/radio-group/src/radio-group.tsx
@@ -220,5 +220,7 @@ export {
   Root,
   Item,
   Indicator,
+  //
+  useRadioGroupContext,
 };
 export type { RadioGroupProps, RadioGroupItemProps, RadioGroupIndicatorProps };

--- a/packages/react/radio-group/src/radio.tsx
+++ b/packages/react/radio-group/src/radio.tsx
@@ -211,5 +211,7 @@ export {
   //
   Radio,
   RadioIndicator,
+  //
+  useRadioContext,
 };
 export type { RadioProps };

--- a/packages/react/scroll-area/src/index.ts
+++ b/packages/react/scroll-area/src/index.ts
@@ -13,6 +13,9 @@ export {
   Scrollbar,
   Thumb,
   Corner,
+  //
+  useScrollAreaContext,
+  useScrollbarContext,
 } from './scroll-area';
 export type {
   ScrollAreaProps,

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -1029,6 +1029,9 @@ export {
   Scrollbar,
   Thumb,
   Corner,
+  //
+  useScrollAreaContext,
+  useScrollbarContext,
 };
 export type {
   ScrollAreaProps,

--- a/packages/react/select/src/index.ts
+++ b/packages/react/select/src/index.ts
@@ -35,6 +35,8 @@ export {
   ScrollDownButton,
   Separator,
   Arrow,
+  //
+  useSelectContext,
 } from './select';
 export type {
   SelectProps,

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1820,6 +1820,8 @@ export {
   ScrollDownButton,
   Separator,
   Arrow,
+  //
+  useSelectContext,
 };
 export type {
   SelectProps,

--- a/packages/react/slider/src/index.ts
+++ b/packages/react/slider/src/index.ts
@@ -11,5 +11,8 @@ export {
   Track,
   Range,
   Thumb,
+  //
+  useSliderContext,
+  useSliderOrientationContext,
 } from './slider';
 export type { SliderProps, SliderTrackProps, SliderRangeProps, SliderThumbProps } from './slider';

--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -806,5 +806,8 @@ export {
   Track,
   Range,
   Thumb,
+  //
+  useSliderContext,
+  useSliderOrientationContext,
 };
 export type { SliderProps, SliderTrackProps, SliderRangeProps, SliderThumbProps };

--- a/packages/react/switch/src/index.ts
+++ b/packages/react/switch/src/index.ts
@@ -7,5 +7,7 @@ export {
   //
   Root,
   Thumb,
+  //
+  useSwitchContext,
 } from './switch';
 export type { SwitchProps, SwitchThumbProps } from './switch';

--- a/packages/react/switch/src/switch.tsx
+++ b/packages/react/switch/src/switch.tsx
@@ -217,5 +217,7 @@ export {
   //
   Root,
   Thumb,
+  //
+  useSwitchContext,
 };
 export type { SwitchProps, SwitchThumbProps };

--- a/packages/react/tabs/src/index.ts
+++ b/packages/react/tabs/src/index.ts
@@ -11,5 +11,7 @@ export {
   List,
   Trigger,
   Content,
+  //
+  useTabsContext,
 } from './tabs';
 export type { TabsProps, TabsListProps, TabsTriggerProps, TabsContentProps } from './tabs';

--- a/packages/react/tabs/src/tabs.tsx
+++ b/packages/react/tabs/src/tabs.tsx
@@ -294,5 +294,7 @@ export {
   List,
   Trigger,
   Content,
+  //
+  useTabsContext,
 };
 export type { TabsProps, TabsListProps, TabsTriggerProps, TabsContentProps };

--- a/packages/react/toast/src/index.ts
+++ b/packages/react/toast/src/index.ts
@@ -17,6 +17,8 @@ export {
   Description,
   Action,
   Close,
+  //
+  useToastProviderContext,
 } from './toast';
 export type {
   ToastProviderProps,

--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -976,6 +976,8 @@ export {
   Description,
   Action,
   Close,
+  //
+  useToastProviderContext,
 };
 export type {
   ToastProviderProps,

--- a/packages/react/toggle-group/src/index.ts
+++ b/packages/react/toggle-group/src/index.ts
@@ -7,6 +7,9 @@ export {
   //
   Root,
   Item,
+  //
+  useToggleGroupContext,
+  useToggleGroupValueContext,
 } from './toggle-group';
 export type {
   ToggleGroupSingleProps,

--- a/packages/react/toggle-group/src/toggle-group.tsx
+++ b/packages/react/toggle-group/src/toggle-group.tsx
@@ -314,5 +314,8 @@ export {
   //
   Root,
   Item,
+  //
+  useToggleGroupContext,
+  useToggleGroupValueContext,
 };
 export type { ToggleGroupSingleProps, ToggleGroupMultipleProps, ToggleGroupItemProps };

--- a/packages/react/toolbar/src/index.ts
+++ b/packages/react/toolbar/src/index.ts
@@ -15,6 +15,8 @@ export {
   Link,
   ToggleGroup,
   ToggleItem,
+  //
+  useToolbarContext,
 } from './toolbar';
 export type {
   ToolbarProps,

--- a/packages/react/toolbar/src/toolbar.tsx
+++ b/packages/react/toolbar/src/toolbar.tsx
@@ -238,6 +238,8 @@ export {
   Link,
   ToggleGroup,
   ToggleItem,
+  //
+  useToolbarContext,
 };
 export type {
   ToolbarProps,

--- a/packages/react/tooltip/src/index.ts
+++ b/packages/react/tooltip/src/index.ts
@@ -15,6 +15,8 @@ export {
   Portal,
   Content,
   Arrow,
+  //
+  useTooltipContext,
 } from './tooltip';
 export type {
   TooltipProps,

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -769,6 +769,8 @@ export {
   Portal,
   Content,
   Arrow,
+  //
+  useTooltipContext,
 };
 export type {
   TooltipProviderProps,


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
We can’t access the internal state/context of Radix components (like Dialog, Checkbox, Toggle, etc.) from outside their subtree.

Discussion: https://github.com/radix-ui/primitives/discussions/3536
