### PR TITLE
Fix tooltip skipDelayDuration with disableHoverableContent

### DIFF
--- a/apps/storybook/stories/tooltip.stories.tsx
+++ b/apps/storybook/stories/tooltip.stories.tsx
@@ -174,9 +174,9 @@ export const CustomDurations = () => (
     </div>
 
     <h2>Custom (0ms to move from one to another tooltip = never skip)</h2>
-    <div style={{ display: 'flex', gap: 50 }}>
+    <div style={{ display: 'flex', gap: 0 }}>
       <Tooltip.Provider skipDelayDuration={0}>
-        <Tooltip.Root>
+        <Tooltip.Root disableHoverableContent>
           <Tooltip.Trigger className={styles.trigger}>Hover me</Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content className={styles.content} sideOffset={5}>
@@ -185,7 +185,7 @@ export const CustomDurations = () => (
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
-        <Tooltip.Root>
+        <Tooltip.Root disableHoverableContent>
           <Tooltip.Trigger className={styles.trigger}>Hover me</Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content className={styles.content} sideOffset={5}>
@@ -194,7 +194,7 @@ export const CustomDurations = () => (
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
-        <Tooltip.Root>
+        <Tooltip.Root disableHoverableContent>
           <Tooltip.Trigger className={styles.trigger}>Hover me</Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content className={styles.content} sideOffset={5}>

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -76,8 +76,7 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
   const skipDelayTimerRef = React.useRef(0);
 
   React.useEffect(() => {
-    const skipDelayTimer = skipDelayTimerRef.current;
-    return () => window.clearTimeout(skipDelayTimer);
+    return () => window.clearTimeout(skipDelayTimerRef.current);
   }, []);
 
   return (

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -86,15 +86,19 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
       isOpenDelayedRef={isOpenDelayedRef}
       delayDuration={delayDuration}
       onOpen={React.useCallback(() => {
-        window.clearTimeout(skipDelayTimerRef.current);
-        isOpenDelayedRef.current = false;
-      }, [])}
+        if (skipDelayDuration > 0) {
+          window.clearTimeout(skipDelayTimerRef.current);
+          isOpenDelayedRef.current = false;
+        }
+      }, [skipDelayDuration])}
       onClose={React.useCallback(() => {
-        window.clearTimeout(skipDelayTimerRef.current);
-        skipDelayTimerRef.current = window.setTimeout(
-          () => (isOpenDelayedRef.current = true),
-          skipDelayDuration
-        );
+        if (skipDelayDuration > 0) {
+          window.clearTimeout(skipDelayTimerRef.current);
+          skipDelayTimerRef.current = window.setTimeout(
+            () => (isOpenDelayedRef.current = true),
+            skipDelayDuration
+          );
+        }
       }, [skipDelayDuration])}
       isPointerInTransitRef={isPointerInTransitRef}
       onPointerInTransitChange={React.useCallback((inTransit: boolean) => {

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -98,6 +98,8 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
             () => (isOpenDelayedRef.current = true),
             skipDelayDuration
           );
+        } else {
+          isOpenDelayedRef.current = true;
         }
       }, [skipDelayDuration])}
       isPointerInTransitRef={isPointerInTransitRef}


### PR DESCRIPTION
## Background

Scenario:

- Multiple `<Tooltip.Trigger>`'s are `0px` apart
- `<Tooltip.Provider skipDelayDuration={0}>`
- `<Tooltip.Root disableHoverableContent>` (not sure why this is required to reproduce)

Problem:

- The `delayDuration` will be skipped, even though `skipDelayDuration` is 0

## Solution

Before:

- Even when `skipDelayDuration` was set to `0`:
  - `onOpen` sets `skipDelayTimerRef.current = false`
  - `onClose` waits to set `skipDelayTimerRef.current = true` for `0ms` in `setTimeout()`
- So there's a very brief tick where `skipDelayTimerRef.current` is `false`

```tsx
onOpen={() => {
  clearTimeout(skipDelayTimerRef.current)
  isOpenDelayedRef.current = false
}}
onClose={() => {
  setTimeout(() => {
    isOpenDelayedRef.current = true
  }, skipDelayDuration /* 0ms */)
}}
```

After:

- When `skipDelayDuration` is `<= 0`:
  - `onOpen` never set `skipDelayTimerRef.current = false`
  - `onClose` instantly set `skipDelayTimerRef.current = true`
    - Just in case `skipDelayDuration` changed between `onOpen` and `onClose`

```tsx
onOpen={() => {
  if (skipDelayDuration > 0) {
    isOpenDelayedRef.current = false
  }
}}
onClose={() => {
  if (skipDelayDuration > 0) {
    // ...setTimeout...
  } else {
    isOpenDelayedRef.current = false
  }
}}
```

## Additional Fix

The cleanup code for `skipDelayTimerRef` is always using the initial value even as many different timers may be set/cleared.

```tsx
const skipDelayTimerRef = useRef(0)

useEffect(() => {
  const skipDelayTimer = skipDelayTimerRef.current
  return () => {
    // `skipDelayTimer` will always be `0`
    // unless `onClose` was somehow called before this effect fired
    // but even then, it will be the initial timer forever
    clearTimeout(skipDelayTimer)
  }
}, [])
```

After: Always clear the last value of `skipDelayTimerRef`

```tsx
useEffect(() => {
  return () => clearTimeout(skipDelayTimerRef.current);
}, [])
```