### PR TITLE
refactor: omit id prop in dialog description and title

### DIFF
--- a/.changeset/gold-pants-pay.md
+++ b/.changeset/gold-pants-pay.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-dialog': minor
+---
+
+Prevent customizing id directly in Dialog Description and Title

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -431,7 +431,7 @@ const TITLE_NAME = 'DialogTitle';
 
 type DialogTitleElement = React.ComponentRef<typeof Primitive.h2>;
 type PrimitiveHeading2Props = React.ComponentPropsWithoutRef<typeof Primitive.h2>;
-interface DialogTitleProps extends PrimitiveHeading2Props {}
+interface DialogTitleProps extends Omit<PrimitiveHeading2Props,"id"> {}
 
 const DialogTitle = React.forwardRef<DialogTitleElement, DialogTitleProps>(
   (props: ScopedProps<DialogTitleProps>, forwardedRef) => {
@@ -451,7 +451,7 @@ const DESCRIPTION_NAME = 'DialogDescription';
 
 type DialogDescriptionElement = React.ComponentRef<typeof Primitive.p>;
 type PrimitiveParagraphProps = React.ComponentPropsWithoutRef<typeof Primitive.p>;
-interface DialogDescriptionProps extends PrimitiveParagraphProps {}
+interface DialogDescriptionProps extends Omit<PrimitiveParagraphProps,"id"> {}
 
 const DialogDescription = React.forwardRef<DialogDescriptionElement, DialogDescriptionProps>(
   (props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
related to #3579
In the current accessibility verification algorithm, there is no way to verify when a user uses a custom id. Therefore, as a convention, we do not allow IDs to be specified in Title and Description.
If we want to enable custom ids,we should only fetch the id via ref and validate it. So the Provider's code will change somewhat.
The simple way right now is to discourage writing ids via types.