### PR TITLE
refactor: adjust aria-controls to triggers according to conditions

### DIFF
--- a/.changeset/brown-falcons-battle.md
+++ b/.changeset/brown-falcons-battle.md
@@ -1,0 +1,9 @@
+---
+'@radix-ui/react-navigation-menu': patch
+'@radix-ui/react-popover': patch
+'@radix-ui/react-dialog': patch
+'@radix-ui/react-select': patch
+'@radix-ui/react-menu': patch
+---
+
+adjust aria-controls to triggers according to conditions.

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -105,7 +105,7 @@ const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>
         type="button"
         aria-haspopup="dialog"
         aria-expanded={context.open}
-        aria-controls={context.contentId}
+        aria-controls={context.open ? context.contentId : undefined}
         data-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -1049,7 +1049,7 @@ const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, MenuSubTriggerPro
           id={subContext.triggerId}
           aria-haspopup="menu"
           aria-expanded={context.open}
-          aria-controls={subContext.contentId}
+          aria-controls={context.open ? subContext.contentId : undefined}
           data-state={getOpenState(context.open)}
           {...props}
           ref={composeRefs(forwardedRef, subContext.onTriggerChange)}

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -498,7 +498,7 @@ const NavigationMenuTrigger = React.forwardRef<
             data-disabled={disabled ? '' : undefined}
             data-state={getOpenState(open)}
             aria-expanded={open}
-            aria-controls={contentId}
+            aria-controls={open ? contentId : undefined}
             {...triggerProps}
             ref={composedRefs}
             onPointerEnter={composeEventHandlers(props.onPointerEnter, () => {

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -144,7 +144,7 @@ const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerPro
         type="button"
         aria-haspopup="dialog"
         aria-expanded={context.open}
-        aria-controls={context.contentId}
+        aria-controls={context.open ? context.contentId : undefined}
         data-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -289,7 +289,7 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
         <Primitive.button
           type="button"
           role="combobox"
-          aria-controls={context.contentId}
+          aria-controls={context.open ? context.contentId : undefined}
           aria-expanded={context.open}
           aria-required={context.required}
           aria-autocomplete="none"


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

related #3560

Applied the aria-controls attribute conditionally to trigger components. 
The aria-controls attribute points to the id of elements whose content or presence is controlled by the trigger. [reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls)

The key consideration is that the referenced id must always exist in the DOM.
The dropdown-menu component already implements this approach, but the other components did not follow this pattern, so I have updated them accordingly.

Modified components:
- dialog
- menu
- navigation-menu
- popover
- select

p.s) The collapsible and tabs components were not modified because the elements referenced by their aria-controls attributes are always present in the DOM.

<!-- Describe the change you are introducing -->
