### PR TITLE
[Presence] Export usePresence hook

### DIFF
--- a/.changeset/small-wings-punch.md
+++ b/.changeset/small-wings-punch.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-presence': patch
+---
+
+Add export for the usePresence hook in presence.tsx

--- a/packages/react/presence/src/index.ts
+++ b/packages/react/presence/src/index.ts
@@ -1,3 +1,10 @@
 'use client';
-export { Presence, Root } from './presence';
+export {
+  //
+  usePresence,
+  //
+  Presence,
+  //
+  Root,
+} from './presence';
 export type { PresenceProps } from './presence';

--- a/packages/react/presence/src/presence.tsx
+++ b/packages/react/presence/src/presence.tsx
@@ -192,6 +192,8 @@ function getElementRef(element: React.ReactElement<{ ref?: React.Ref<unknown> }>
 const Root = Presence;
 
 export {
+  usePresence,
+  //
   Presence,
   //
   Root,


### PR DESCRIPTION
### Description

Hello,
First of all, thank you for your amazing work on this project. I frequently use the utilities provided by radix-ui/primitives in my projects, and I truly appreciate the quality and flexibility of your components.

This pull request adds an export for the usePresence hook in `presence.tsx`.

### Motivation

The reason for this change is that I wanted to create new, more flexible components by utilizing the internal isPresent state directly. Exporting the usePresence hook allows for greater control and composability when building custom components that need to respond to presence logic.

### Summary of changes

Exported the `usePresence` hook from `presence.tsx.`

Thank you for considering this contribution! Please let me know if there are any changes or additional steps required.