### PR TITLE
Prevent render loop in `Popper`

### DIFF
--- a/.changeset/rude-toys-think.md
+++ b/.changeset/rude-toys-think.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-popper': patch
+---
+
+Prevent render loop in Popper

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -77,11 +77,16 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
     const ref = React.useRef<PopperAnchorElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref);
 
+    const anchorRef = React.useRef<Measurable | null>(null);
     React.useEffect(() => {
-      // Consumer can anchor the popper to something that isn't
-      // a DOM node e.g. pointer position, so we override the
-      // `anchorRef` with their virtual ref in this case.
-      context.onAnchorChange(virtualRef?.current || ref.current);
+      const previousAnchor = anchorRef.current;
+      anchorRef.current = virtualRef?.current || ref.current;
+      if (previousAnchor !== anchorRef.current) {
+        // Consumer can anchor the popper to something that isn't
+        // a DOM node e.g. pointer position, so we override the
+        // `anchorRef` with their virtual ref in this case.
+        context.onAnchorChange(anchorRef.current);
+      }
     });
 
     return virtualRef ? null : <Primitive.div {...anchorProps} ref={composedRefs} />;


### PR DESCRIPTION
There have been a few other PRs (#3500, #3386) meant to address this issue, but I think this is the approach we ultimately want. We _do_ want to check if the ref has changed on every render (as refs aren't reactive) but we need to do a defensive check that the ref values have actually changed.

Fixes #2717 and #3385.