### PR TITLE
Fix Dialog's RemoveScroll and disableOutsidePointerEvents work with forceMount

### DIFF
--- a/.changeset/green-needles-jump.md
+++ b/.changeset/green-needles-jump.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-dialog": patch
+---
+
+Fix Dialog's RemoveScroll and disableOutsidePointerEvents work with forceMount

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -203,7 +203,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
     return (
       // Make sure `Content` is scrollable even when it doesn't live inside `RemoveScroll`
       // ie. when `Overlay` and `Content` are siblings
-      <RemoveScroll as={Slot} allowPinchZoom shards={[context.contentRef]}>
+      <RemoveScroll enable={context.isOpen} as={Slot} allowPinchZoom shards={[context.contentRef]}>
         <Primitive.div
           data-state={getState(context.open)}
           {...overlayProps}
@@ -275,7 +275,7 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
         // we make sure focus isn't trapped once `DialogContent` has been closed
         // (closed !== unmounted when animating out)
         trapFocus={context.open}
-        disableOutsidePointerEvents
+        disableOutsidePointerEvents={context.open}
         onCloseAutoFocus={composeEventHandlers(props.onCloseAutoFocus, (event) => {
           event.preventDefault();
           context.triggerRef.current?.focus();


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Some screnario requires forceMount to be used.

But `pointer-events: none` is added to `<body>` even when the force mounted dialog is closed

This PR conditionally enables related side effects only when open:
- RemoveScroll
- disableOutsidePointerEvents

### Fixes

- https://github.com/radix-ui/primitives/issues/2023
- https://github.com/radix-ui/primitives/issues/3100