### PR TITLE
Rerender of Item List length change

### DIFF
--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -540,7 +540,7 @@ const SliderThumb = React.forwardRef<SliderThumbElement, SliderThumbProps>(
     const composedRefs = useComposedRefs(forwardedRef, (node) => setThumb(node));
     const index = React.useMemo(
       () => (thumb ? getItems().findIndex((item) => item.ref.current === thumb) : -1),
-      [getItems, thumb]
+      [getItems().length, thumb]
     );
     return <SliderThumbImpl {...props} ref={composedRefs} index={index} />;
   }


### PR DESCRIPTION
### Description

Currently we only rerender when the thumb changes but the list of thumbs my not be ready. This allows us to also rerender when the list changes length.

I have tested the rerenders in my local environment in React 19 it was 4 before the change and is 4 after the change, in Preact it is now 3 rerenders with the last rerender being the only time the items array contains anything.

related: #3610 