### PR TITLE
refactor: add aria-disabled on radio-group root

### DIFF
--- a/.changeset/hot-areas-teach.md
+++ b/.changeset/hot-areas-teach.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-radio-group': patch
+---
+
+add aria-disabled on radio-group root

--- a/packages/react/radio-group/src/radio-group.tsx
+++ b/packages/react/radio-group/src/radio-group.tsx
@@ -96,6 +96,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
             role="radiogroup"
             aria-required={required}
             aria-orientation={orientation}
+            aria-disabled={disabled}
             data-disabled={disabled ? '' : undefined}
             dir={direction}
             {...groupProps}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

When the disabled prop is passed to RadioGroup.Root, it currently only adds the data-disabled attribute.

While this disabled state is indeed propagated to all RadioGroup.Item components, screen reader users must individually check each RadioGroup.Item to understand that the entire RadioGroup is disabled.

To enhance accessibility and provide a clearer experience for screen reader users, I have added aria-disabled to RadioGroup.Root. This allows screen reader users to immediately perceive the overall disabled state of the RadioGroup at a glance, without needing to navigate through each individual item.
