### PR TITLE
Add Menu.SubContent align='end'

### DIFF
--- a/.changeset/witty-parts-take.md
+++ b/.changeset/witty-parts-take.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-menu': patch
+---
+
+Adds the align property to Menu.SubContent

--- a/apps/storybook/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/stories/dropdown-menu.stories.tsx
@@ -366,6 +366,85 @@ export const Submenus = () => {
   );
 };
 
+export const InvertedWithSubmenus = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className={styles.trigger}>Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={styles.content} sideOffset={5} side="top">
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('new-tab')}>
+            New Tab
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('new-window')}>
+            New Window
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className={styles.separator} />
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger className={subTriggerClass}>
+              Bookmarks →
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                className={styles.content}
+                sideOffset={12}
+                alignOffset={-6}
+                align="end"
+              >
+                <DropdownMenu.Item className={styles.item} onSelect={() => console.log('index')}>
+                  Inbox
+                </DropdownMenu.Item>
+                <DropdownMenu.Item className={styles.item} onSelect={() => console.log('calendar')}>
+                  Calendar
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator className={styles.separator} />
+                <DropdownMenu.Sub>
+                  <DropdownMenu.SubTrigger className={subTriggerClass}>
+                    WorkOS →
+                  </DropdownMenu.SubTrigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.SubContent
+                      className={styles.content}
+                      sideOffset={12}
+                      alignOffset={-6}
+                      align="end"
+                    >
+                      <DropdownMenu.Item
+                        className={styles.item}
+                        onSelect={() => console.log('stitches')}
+                      >
+                        Stitches
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={styles.item}
+                        onSelect={() => console.log('composer')}
+                      >
+                        Composer
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={styles.item}
+                        onSelect={() => console.log('radix')}
+                      >
+                        Radix
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Arrow />
+                    </DropdownMenu.SubContent>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Sub>
+                <DropdownMenu.Separator className={styles.separator} />
+                <DropdownMenu.Item className={styles.item} onSelect={() => console.log('notion')}>
+                  Notion
+                </DropdownMenu.Item>
+                <DropdownMenu.Arrow />
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  </div>
+);
+
 export const WithLabels = () => (
   <div style={{ textAlign: 'center', padding: 50 }}>
     <DropdownMenu.Root>

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -1147,6 +1147,8 @@ MenuSubTrigger.displayName = SUB_TRIGGER_NAME;
 
 const SUB_CONTENT_NAME = 'MenuSubContent';
 
+type AlignSubContent = Exclude<(typeof PopperPrimitive.ALIGN_OPTIONS)[number], 'center'>;
+
 type MenuSubContentElement = MenuContentImplElement;
 interface MenuSubContentProps
   extends Omit<
@@ -1158,12 +1160,18 @@ interface MenuSubContentProps
    * controlling animation with React animation libraries.
    */
   forceMount?: true;
+
+  /**
+   * Controls the direction the subcontent appears from its anchor menu item
+   * Default: start
+   */
+  align?: AlignSubContent;
 }
 
 const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentProps>(
   (props: ScopedProps<MenuSubContentProps>, forwardedRef) => {
     const portalContext = usePortalContext(CONTENT_NAME, props.__scopeMenu);
-    const { forceMount = portalContext.forceMount, ...subContentProps } = props;
+    const { forceMount = portalContext.forceMount, align = 'start', ...subContentProps } = props;
     const context = useMenuContext(CONTENT_NAME, props.__scopeMenu);
     const rootContext = useMenuRootContext(CONTENT_NAME, props.__scopeMenu);
     const subContext = useMenuSubContext(SUB_CONTENT_NAME, props.__scopeMenu);
@@ -1178,7 +1186,7 @@ const MenuSubContent = React.forwardRef<MenuSubContentElement, MenuSubContentPro
               aria-labelledby={subContext.triggerId}
               {...subContentProps}
               ref={composedRefs}
-              align="start"
+              align={align}
               side={rootContext.dir === 'rtl' ? 'left' : 'right'}
               disableOutsidePointerEvents={false}
               disableOutsideScroll={false}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

This adds a subset (start | end) of Menu align prop to support submenus that flow directionally up from their anchor instead of down. This was super handy for building a dropdown set in my app which started bottom aligned and flowed upwards

**Added storybook**

<img width="964" height="450" alt="Screenshot 2025-07-22 at 7 59 26 PM" src="https://github.com/user-attachments/assets/baf6dcc3-0f64-4f3c-a24b-5555a3406a63" />

**Used nominal type for reasonable LSP**

<img width="1422" height="316" alt="Screenshot 2025-07-22 at 8 01 29 PM" src="https://github.com/user-attachments/assets/21f0107a-de81-4b10-a3d6-fc7bd3f516fc" />
