### PR TITLE
fix data-state not set for Scrollbar type "always"

### DIFF
--- a/.changeset/itchy-beans-doubt.md
+++ b/.changeset/itchy-beans-doubt.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-scroll-area': patch
+---
+
+Fix Scrollbar with type "always" not setting the data-state attribute

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -223,7 +223,7 @@ const ScrollAreaScrollbar = React.forwardRef<ScrollAreaScrollbarElement, ScrollA
     ) : context.type === 'auto' ? (
       <ScrollAreaScrollbarAuto {...scrollbarProps} ref={forwardedRef} forceMount={forceMount} />
     ) : context.type === 'always' ? (
-      <ScrollAreaScrollbarVisible {...scrollbarProps} ref={forwardedRef} />
+      <ScrollAreaScrollbarVisible {...scrollbarProps} ref={forwardedRef} data-state="visible" />
     ) : null;
   }
 );


### PR DESCRIPTION
closes #3637 

### Description

Add the `data-state="visible"` attribute to Scrollbars that are always visible

### Note
The attribute is set here as `ScrollAreaScrollbarVisible` is an abstraction for the other Scrollbars