### PR TITLE
refactor: move focus to the last item when opening with ArrowUp

### DIFF
--- a/.changeset/gold-otters-judge.md
+++ b/.changeset/gold-otters-judge.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-dropdown-menu': minor
+---
+
+move focus to the last item when opening with ArrowUp


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

closed #3640

### Description

<!-- Describe the change you are introducing -->

When the ArrowUp key is pressed on the DropdownMenu.Trigger component, the Content should open, and focus must move to the last item.

To implement this, I first created a state, wasOpenedWithArrowUp, to track when the menu is opened with the ArrowUp key.
Next, if wasOpenedWithArrowUp is true, the logic finds all enabled elements with role="menuitem" under the Content.
Finally, the focus() method is called on the last element in that list.