### PR TITLE
fix for [OneTimePasswordField] autoComplete not working in Chrome on iOS

### DIFF
--- a/.changeset/kind-icons-tan.md
+++ b/.changeset/kind-icons-tan.md
@@ -3,3 +3,4 @@
 ---
 
 Fix: disable otp input
+Fix: one-time-password-field autoComplete not working in Chrome on iOS

--- a/.changeset/kind-icons-tan.md
+++ b/.changeset/kind-icons-tan.md
@@ -3,4 +3,3 @@
 ---
 
 Fix: disable otp input
-Fix: one-time-password-field autoComplete not working in Chrome on iOS

--- a/.changeset/ready-rules-doubt.md
+++ b/.changeset/ready-rules-doubt.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-one-time-password-field': patch
+---
+
+fix for [OneTimePasswordField] autoComplete not working in Chrome on iOS

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -647,7 +647,6 @@ const OneTimePasswordFieldInput = React.forwardRef<
               data-protonpass-ignore={supportsAutoComplete ? undefined : 'true'}
               data-bwignore={supportsAutoComplete ? undefined : 'true'}
               inputMode={validation?.inputMode}
-              maxLength={1}
               pattern={validation?.pattern}
               readOnly={context.readOnly}
               value={char}

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -567,6 +567,7 @@ const OneTimePasswordFieldInput = React.forwardRef<
     __scopeOneTimePasswordField,
     onInvalidChange,
     index: indexProp,
+    maxLength = 1,
     ...props
   }: ScopedProps<OneTimePasswordFieldInputProps>,
   forwardedRef
@@ -647,6 +648,7 @@ const OneTimePasswordFieldInput = React.forwardRef<
               data-protonpass-ignore={supportsAutoComplete ? undefined : 'true'}
               data-bwignore={supportsAutoComplete ? undefined : 'true'}
               inputMode={validation?.inputMode}
+              maxLength={maxLength}
               pattern={validation?.pattern}
               readOnly={context.readOnly}
               value={char}


### PR DESCRIPTION
- Context: https://github.com/radix-ui/primitives/issues/3641

