### PR TITLE
Allow aria-description to describe Dialog and AlertDialog

### DIFF
--- a/.changeset/new-otters-bet.md
+++ b/.changeset/new-otters-bet.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-alert-dialog': patch
+'@radix-ui/react-dialog': patch
+---
+
+Allow aria-description attribute to describe the dialog>wq

--- a/packages/react/alert-dialog/src/alert-dialog.tsx
+++ b/packages/react/alert-dialog/src/alert-dialog.tsx
@@ -248,11 +248,16 @@ const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef }) =
 
 You can add a description to the \`${CONTENT_NAME}\` by passing a \`${DESCRIPTION_NAME}\` component as a child, which also benefits sighted users by adding visible context to the dialog.
 
-Alternatively, you can use your own component as a description by assigning it an \`id\` and passing the same value to the \`aria-describedby\` prop in \`${CONTENT_NAME}\`. If the description is confusing or duplicative for sighted users, you can use the \`@radix-ui/react-visually-hidden\` primitive as a wrapper around your description component.
+Alternatively, you can either use the \`aria-description\` attribute or your own component as a description by assigning it an \`id\` and passing the same value to the \`aria-describedby\` prop in \`${CONTENT_NAME}\`. If the description is confusing or duplicative for sighted users, you can use the \`@radix-ui/react-visually-hidden\` primitive as a wrapper around your description component.
 
 For more information, see https://radix-ui.com/primitives/docs/components/alert-dialog`;
 
   React.useEffect(() => {
+    if (contentRef.current?.getAttribute('aria-description')) {
+      // the alert dialog is described by the aria-description attribute
+      return;
+    }
+
     const hasDescription = document.getElementById(
       contentRef.current?.getAttribute('aria-describedby')!
     );

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -533,9 +533,14 @@ type DescriptionWarningProps = {
 
 const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef, descriptionId }) => {
   const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
-  const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
+  const MESSAGE = `Warning: Missing \`Description\` or \`aria-description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
 
   React.useEffect(() => {
+    if (contentRef.current?.getAttribute('aria-description')) {
+      // the dialog is described by the aria-description attribute
+      return;
+    }
+
     const describedById = contentRef.current?.getAttribute('aria-describedby');
     // if we have an id and the user hasn't set aria-describedby={undefined}
     if (descriptionId && describedById) {


### PR DESCRIPTION
### Description

Currently, the `Dialog` and `AlertDialog` components log a warning if neither a `DialogDescription` / `AlertDialogDescription` component nor a custom component with `aria-describedby` attribute is used.

It shouldn't be necessary to provide a visible description to a dialog, as some of them can be 
self-explanatory. 

With this PR, the aria-description is also accepted to provide a description to screen readers.
