### PR TITLE
fix(select): pass __selectScope to PopperContent component

### DIFF
--- a/.changeset/gentle-rivers-worry.md
+++ b/.changeset/gentle-rivers-worry.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+fix(select): pass \_\_selectScope to PopperContent component

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -536,8 +536,8 @@ const Slot = createSlot('SelectContent.RemoveScroll');
 
 const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectContentImplProps>(
   (props: ScopedProps<SelectContentImplProps>, forwardedRef) => {
+    const { __scopeSelect } = props
     const {
-      __scopeSelect,
       position = 'item-aligned',
       onCloseAutoFocus,
       onEscapeKeyDown,


### PR DESCRIPTION
### Problem
The `__selectScope` property was not being passed through to `PopperContent`, causing scope-related errors when using custom scopes with Select components.

### Root Cause
The spread operator `...contentProps` was inadvertently filtering out the `__selectScope` property, which is required for proper component scoping in Radix UI primitives.

### Solution
Updated the component to explicitly pass `__selectScope` to `PopperContent`, ensuring proper scope inheritance.

### Use Case
This fix enables the following pattern to work correctly:

```typescript
import * as SelectPrimitive from "@radix-ui/react-select";

function MySelect(props: any) {
  const scope = useComposedScopes();
  return <SelectPrimitive.Root {...scope} {...props} />
}