### PR TITLE
Add portal container prop to dialog content

### DIFF
--- a/.changeset/witty-ants-notice.md
+++ b/.changeset/witty-ants-notice.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-dialog': minor
+---
+
+Add portal container prop to dialog content props

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -229,6 +229,11 @@ interface DialogContentProps extends DialogContentTypeProps {
    * controlling animation with React animation libraries.
    */
   forceMount?: true;
+
+  /**
+  * Specify a container element to portal the content into.
+  */
+  portalContainer?: Element | DocumentFragment | null;
 }
 
 const DialogContent = React.forwardRef<DialogContentElement, DialogContentProps>(


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Added `portalContainer` prop to `DialogContentProps` in order to pass portal to render the content into in case we don't want to use the default `document.body`
