### PR TITLE
fix(Tooltip): lift __scopeTooltip declaration to fix ESLint no-use-before-define

### DIFF
--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -15,11 +15,12 @@ import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
 import type { Scope } from '@radix-ui/react-context';
 
-type ScopedProps<P = {}> = P & { __scopeTooltip?: Scope };
 const [createTooltipContext, createTooltipScope] = createContextScope('Tooltip', [
   createPopperScope,
 ]);
 const usePopperScope = createPopperScope();
+
+type ScopedProps<P = {}> = P & { __scopeTooltip?: Scope };
 
 /* -------------------------------------------------------------------------------------------------
  * TooltipProvider


### PR DESCRIPTION
This PR lifts the `__scopeTooltip` declaration to the top of Tooltip.tsx to comply with the ESLint `no-use-before-define` rule.  

This fixes errors when using `createTooltipContext` and does not affect existing Tooltip functionality.

Standardizing this pattern across all components is recommended but out of scope for this PR.
