### PR TITLE
[OneTimePasswordField] sync focus with controlled value updates when autoFocus is enabled

### DIFF
--- a/apps/storybook/stories/one-time-password-field.stories.tsx
+++ b/apps/storybook/stories/one-time-password-field.stories.tsx
@@ -192,6 +192,62 @@ function ControlledImpl(props: OneTimePasswordField.OneTimePasswordFieldProps) {
   );
 }
 
+export const ControlledWithVirtualKeyboard: Story = {
+  render: (args) => <ControlledWithPresetAndVirtualKeyboard {...args} />,
+  name: 'Controlled with preset and virtual keyboard',
+};
+
+function ControlledWithPresetAndVirtualKeyboard(
+  props: OneTimePasswordField.OneTimePasswordFieldProps
+) {
+  const [code, setCode] = React.useState('1');
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+
+  const appendRandomDigit = React.useCallback(() => {
+    if (code.length >= 6) {
+      return;
+    }
+
+    const randomDigit = String(Math.floor(Math.random() * 10));
+    setCode((previous) => previous + randomDigit);
+  }, [code.length]);
+
+  return (
+    <div className={styles.viewport}>
+      <div className={styles.field}>
+        <OneTimePasswordField.Root
+          className={styles.otpRoot}
+          autoFocus
+          ref={rootRef}
+          onValueChange={(value) => setCode(value)}
+          value={code}
+          {...props}
+        >
+          <OneTimePasswordField.Input />
+          <Separator.Root orientation="vertical" className={styles.separator} />
+          <OneTimePasswordField.Input />
+          <Separator.Root orientation="vertical" className={styles.separator} />
+          <OneTimePasswordField.Input />
+          <Separator.Root orientation="vertical" className={styles.separator} />
+          <OneTimePasswordField.Input />
+          <Separator.Root orientation="vertical" className={styles.separator} />
+          <OneTimePasswordField.Input />
+          <Separator.Root orientation="vertical" className={styles.separator} />
+          <OneTimePasswordField.Input />
+
+          <OneTimePasswordField.HiddenInput name="code" />
+        </OneTimePasswordField.Root>
+      </div>
+
+      <button type="button" onClick={appendRandomDigit} disabled={code.length >= 6}>
+        Add random digit
+      </button>
+
+      <output className={styles.output}>{code || 'code'}</output>
+    </div>
+  );
+}
+
 export const PastedAndDeletedControlled: Story = {
   render: (args) => <ControlledImpl {...args} />,
   name: 'Pasted and deleted (controlled test)',

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -430,6 +430,29 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
     }, [attemptSubmit, autoSubmit, currentValue, length, onAutoSubmit, value]);
     const isHydrated = useIsHydrated();
 
+    // Sync focus to controlled value changes when controlled or autoFocus is true
+    React.useEffect(() => {
+      // Run when:
+      // - autoFocus is true (explicit opt-in for uncontrolled), OR
+      // - component is controlled (valueProp provided) so external updates keep focus in sync
+      const isControlled = valueProp != null;
+      if (!autoFocus && !isControlled) {
+        return;
+      }
+      const totalValue = value.join('');
+      const nextIndex = clamp(totalValue.length, [0, collection.size - 1]);
+      const active = (rootRef.current?.ownerDocument ?? document).activeElement as Element | null;
+      const activeIndex = collection.indexOf(active as HTMLInputElement);
+      if (activeIndex === nextIndex) {
+        return;
+      }
+      const target = collection.at(nextIndex)?.element ?? null;
+      // Defer to the next frame to avoid click-to-blur conflicts (e.g. with virtual keyboards)
+      requestAnimationFrame(() => {
+        focusInput(target ?? undefined);
+      });
+    }, [autoFocus, collection, value, valueProp]);
+
     return (
       <OneTimePasswordFieldContext
         scope={__scopeOneTimePasswordField}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

When the OTP field is controlled and autoFocus is enabled, the component now aligns focus with the current value. This supports flows where an external input (e.g., a virtual keyboard) updates the value directly. For example, if value becomes "1", the second input is focused and ready for the next digit.

#### What changed

Added an effect that, on value change, focuses the input corresponding to the current value length.
This runs only when:

- The component is controlled (value prop provided), and
- autoFocus is true.

#### Why

In setups using virtual keyboards, the OTP field receives programmatic value updates and must keep the UI focus in sync so the next cell is immediately ready for entry.

#### Impact

No changes for uncontrolled usage or when autoFocus is false.
Backward compatible.

#### Tests
Updated tests to cover focus syncing on controlled value changes. Added story with "virtual keyboard-button"
