### PR TITLE
fix(select): select item firing click events when disabled

### DIFF
--- a/.changeset/legal-lights-visit.md
+++ b/.changeset/legal-lights-visit.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+Disable pointer events on select item when disabled. Fixes #3683

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1309,6 +1309,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             tabIndex={disabled ? undefined : -1}
             {...itemProps}
             ref={composedRefs}
+            style={{pointerEvents: disabled ? 'none' : 'auto'}}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}
             onClick={composeEventHandlers(itemProps.onClick, () => {


### PR DESCRIPTION
### Description
Fixes #3683 

- Click events should not be fired when disabled prop is passed on the select item. 
- To achieve this, disabling all pointer events on the select item when it is disabled, if not passed pointer events will be set to 'auto', which is the default.