### PR TITLE
fix(select): prevent defaulting to first option when no value selected

### DIFF
--- a/.changeset/eager-cycles-slide.md
+++ b/.changeset/eager-cycles-slide.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': major
+---
+
+Fix Select hidden input so it submits empty string when no value is selected

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -223,8 +223,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             tabIndex={-1}
             name={name}
             autoComplete={autoComplete}
-            value={value}
-            // enable form autofill
+            value={value ?? ""}
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
             form={form}


### PR DESCRIPTION
### Description

Fixes #3198

This PR updates the hidden input inside the `Select` component to handle cases 
where no option is selected.

### Changes
- Changed `value={value}` to `value={value ?? ""}` in the hidden input
- Ensures that when no value is selected, the form submits an empty string (`""`) 
  instead of `undefined` or defaulting to the first option

### Before
When a `<Select>` was rendered with no value selected, the hidden input could 
default to the first option’s value, causing forms to submit an unintended result.

### After
If no value is selected, the hidden input now submits an empty string (`""`), 
allowing form submissions to correctly reflect that no selection was made.
