### PR TITLE
fix(select): scroll button bumpiness

### DIFF
--- a/.changeset/bumpy-jokes-judge.md
+++ b/.changeset/bumpy-jokes-judge.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+fix: scroll button display bumpiness


### PR DESCRIPTION
### Description

this pr intends to fix bumpiness caused by the scroll button when reaching top/bottom of the content getting hidden. the pr updates the style of the button and display them accordingly to the first/last element height.

| state | preview |
| -------|------|
| before | <video src="https://github.com/user-attachments/assets/13156545-ad90-4d52-911a-50bc18a1042b" /> |
| after | <video src="https://github.com/user-attachments/assets/ecc3e4a9-da33-44d0-b913-307fb93194ce" /> | 

