### PR TITLE
[Slot] add nested slottable support

### DIFF
--- a/.changeset/sixty-pets-clap.md
+++ b/.changeset/sixty-pets-clap.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-slot': patch
+---
+
+Support slotting onto nested children

--- a/apps/ssr-testing/app/slot/client.tsx
+++ b/apps/ssr-testing/app/slot/client.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import * as React from 'react';
+import { Slot } from 'radix-ui';
+
+export const Link = React.forwardRef<
+  React.ComponentRef<'a'>,
+  React.ComponentProps<'a'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'a';
+  return <Comp {...props} ref={forwardedRef} />;
+});
+
+export const LinkSlottable = React.forwardRef<
+  React.ComponentRef<'a'>,
+  React.ComponentProps<'a'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'a';
+  return (
+    <Comp {...props} ref={forwardedRef}>
+      <span>left</span>
+      <Slot.Slottable>{props.children}</Slot.Slottable>
+      <span>right</span>
+    </Comp>
+  );
+});
+
+export const LinkButton = React.forwardRef<
+  React.ComponentRef<typeof Link>,
+  React.ComponentProps<typeof Link>
+>((props, forwardedRef) => (
+  <Button asChild>
+    <Link {...props} ref={forwardedRef}>
+      {props.children}
+    </Link>
+  </Button>
+));
+
+export const Button = React.forwardRef<
+  React.ComponentRef<'button'>,
+  React.ComponentProps<'button'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }} />;
+});
+
+export const ButtonSlottable = React.forwardRef<
+  React.ComponentRef<'button'>,
+  React.ComponentProps<'button'> & { asChild?: boolean }
+>(({ children, asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return (
+    <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <span>left</span>
+      <Slot.Slottable>{children}</Slot.Slottable>
+      <span>right</span>
+    </Comp>
+  );
+});
+
+export const ButtonNestedSlottable = React.forwardRef<
+  React.ComponentRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ children, asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return (
+    <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <Slot.Slottable child={children}>
+        {(slottable) => (
+          <>
+            <span>left</span>
+            <b>bold {slottable}</b>
+            <span>right</span>
+          </>
+        )}
+      </Slot.Slottable>
+    </Comp>
+  );
+});
+
+export const IconButtonNestedSlottable = React.forwardRef<
+  React.ComponentRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ children, ...props }, forwardedRef) => {
+  return (
+    <Button {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <Slot.Root>
+        <Slot.Slottable child={children}>
+          {(slottable) => (
+            <>
+              <span>ICON</span>
+              <b>bold {slottable}</b>
+            </>
+          )}
+        </Slot.Slottable>
+      </Slot.Root>
+    </Button>
+  );
+});

--- a/apps/ssr-testing/app/slot/page.tsx
+++ b/apps/ssr-testing/app/slot/page.tsx
@@ -1,13 +1,141 @@
 import * as React from 'react';
-import { Slot } from 'radix-ui';
+import * as Client from './client';
+import * as Server from './server';
 
 export default function Page() {
   return (
-    <Slot.Root>
-      <span>I'm in a </span>
-      <Slot.Slottable>
-        <em>Slot!?</em>
-      </Slot.Slottable>
-    </Slot.Root>
+    <>
+      <p>All components should be rendered as links</p>
+
+      <h2>Client.LinkButton</h2>
+
+      <Client.LinkButton href="/">children</Client.LinkButton>
+
+      <h2>Client.Button as Client.Link</h2>
+
+      <Client.Button asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Client.Button>
+
+      <h2>Client.Button as Server.Link</h2>
+
+      <Client.Button asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Client.Button>
+
+      <h2>Client.Button as Client.LinkSlottable</h2>
+
+      <Client.Button asChild>
+        <Client.LinkSlottable href="/">children</Client.LinkSlottable>
+      </Client.Button>
+
+      <h2>Client.Button as Server.LinkSlottable</h2>
+
+      <Client.Button asChild>
+        <Server.LinkSlottable href="/">children</Server.LinkSlottable>
+      </Client.Button>
+
+      <h2>Client.ButtonSlottable as Server.Link</h2>
+
+      <Client.ButtonSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Client.ButtonSlottable>
+
+      <h2>Client.ButtonSlottable as Client.Link</h2>
+
+      <Client.ButtonSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Client.ButtonSlottable>
+
+      <h2>Client.ButtonNestedSlottable as Server.Link</h2>
+
+      <Client.ButtonNestedSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Client.ButtonNestedSlottable>
+
+      <h2>Client.ButtonNestedSlottable as Client.Link</h2>
+
+      <Client.ButtonNestedSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Client.ButtonNestedSlottable>
+
+      <h2>Client.IconButtonNestedSlottable as Server.Link</h2>
+
+      <Client.IconButtonNestedSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Client.IconButtonNestedSlottable>
+
+      <h2>Client.IconButtonNestedSlottable as Client.Link</h2>
+
+      <Client.IconButtonNestedSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Client.IconButtonNestedSlottable>
+
+      <hr />
+
+      <h2>Server.LinkButton</h2>
+
+      <Server.LinkButton href="/">children</Server.LinkButton>
+
+      <h2>Server.Button as Server.Link</h2>
+
+      <Server.Button asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Server.Button>
+
+      <h2>Server.Button as Client.Link</h2>
+
+      <Server.Button asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Server.Button>
+
+      <h2>Server.Button as Server.LinkSlottable</h2>
+
+      <Server.Button asChild>
+        <Server.LinkSlottable href="/">children</Server.LinkSlottable>
+      </Server.Button>
+
+      <h2>Server.Button as Client.LinkSlottable</h2>
+
+      <Server.Button asChild>
+        <Client.LinkSlottable href="/">children</Client.LinkSlottable>
+      </Server.Button>
+
+      <h2>Server.ButtonSlottable as Client.Link</h2>
+
+      <Server.ButtonSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Server.ButtonSlottable>
+
+      <h2>Server.ButtonSlottable as Server.Link</h2>
+
+      <Server.ButtonSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Server.ButtonSlottable>
+
+      <h2>Server.ButtonNestedSlottable as Client.Link</h2>
+
+      <Server.ButtonNestedSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Server.ButtonNestedSlottable>
+
+      <h2>Server.ButtonNestedSlottable as Server.Link</h2>
+
+      <Server.ButtonNestedSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Server.ButtonNestedSlottable>
+
+      <h2>Server.IconButtonNestedSlottable as Server.Link</h2>
+
+      <Server.IconButtonNestedSlottable asChild>
+        <Server.Link href="/">children</Server.Link>
+      </Server.IconButtonNestedSlottable>
+
+      <h2>Server.IconButtonNestedSlottable as Client.Link</h2>
+
+      <Server.IconButtonNestedSlottable asChild>
+        <Client.Link href="/">children</Client.Link>
+      </Server.IconButtonNestedSlottable>
+    </>
   );
 }

--- a/apps/ssr-testing/app/slot/server.tsx
+++ b/apps/ssr-testing/app/slot/server.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Slot } from 'radix-ui';
+import * as Client from './client';
+
+export const Link = React.forwardRef<
+  React.ComponentRef<'a'>,
+  React.ComponentProps<'a'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'a';
+  return <Comp {...props} ref={forwardedRef} />;
+});
+
+export const LinkSlottable = React.forwardRef<
+  React.ComponentRef<'a'>,
+  React.ComponentProps<'a'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'a';
+  return (
+    <Comp {...props} ref={forwardedRef}>
+      <span>left</span>
+      <Slot.Slottable>{props.children}</Slot.Slottable>
+      <span>right</span>
+    </Comp>
+  );
+});
+
+export const LinkButton = React.forwardRef<
+  React.ComponentRef<typeof Link>,
+  React.ComponentProps<typeof Link>
+>((props, forwardedRef) => (
+  <Button asChild>
+    <Link {...props} ref={forwardedRef}>
+      {props.children}
+    </Link>
+  </Button>
+));
+
+export const Button = React.forwardRef<
+  React.ComponentRef<'button'>,
+  React.ComponentProps<'button'> & { asChild?: boolean }
+>(({ asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }} />;
+});
+
+export const ButtonSlottable = React.forwardRef<
+  React.ComponentRef<'button'>,
+  React.ComponentProps<'button'> & { asChild?: boolean }
+>(({ children, asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return (
+    <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <span>left</span>
+      <Slot.Slottable>{children}</Slot.Slottable>
+      <span>right</span>
+    </Comp>
+  );
+});
+
+export const ButtonNestedSlottable = React.forwardRef<
+  React.ComponentRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ children, asChild = false, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot.Root : 'button';
+  return (
+    <Comp {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <Slot.Slottable child={children}>
+        {(slottable) => (
+          <>
+            <span>left</span>
+            <b>bold {slottable}</b>
+            <span>right</span>
+          </>
+        )}
+      </Slot.Slottable>
+    </Comp>
+  );
+});
+
+export const IconButtonNestedSlottable = React.forwardRef<
+  React.ComponentRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ children, ...props }, forwardedRef) => {
+  return (
+    <Client.Button {...props} ref={forwardedRef} style={{ display: 'flex', gap: '3rem' }}>
+      <Slot.Root>
+        <Slot.Slottable child={children}>
+          {(slottable) => (
+            <>
+              <span>ICON</span>
+              <b>bold {slottable}</b>
+            </>
+          )}
+        </Slot.Slottable>
+      </Slot.Root>
+    </Client.Button>
+  );
+});

--- a/packages/react/slot/src/__snapshots__/slot.test.tsx.snap
+++ b/packages/react/slot/src/__snapshots__/slot.test.tsx.snap
@@ -36,6 +36,74 @@ exports[`given a Button with Slottable > without asChild > should render a butto
 </div>
 `;
 
+exports[`given a Button with Slottable nesting > with asChild > should render a link with a span around its children 1`] = `
+<div>
+  <a
+    href="https://radix-ui.com"
+  >
+    <span>
+      Button 
+      <em>
+        text
+      </em>
+    </span>
+  </a>
+</div>
+`;
+
+exports[`given a Button with Slottable nesting > with asChild > should render a link with icon on the left/right and a span around its children 1`] = `
+<div>
+  <a
+    href="https://radix-ui.com"
+  >
+    <span>
+      left
+    </span>
+    <span>
+      Button 
+      <em>
+        text
+      </em>
+    </span>
+    <span>
+      right
+    </span>
+  </a>
+</div>
+`;
+
+exports[`given a Button with Slottable nesting > without asChild > should render a button with a span around its children 1`] = `
+<div>
+  <button>
+    <span>
+      Button 
+      <em>
+        text
+      </em>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`given a Button with Slottable nesting > without asChild > should render a button with icon on the left/right and a span around its children 1`] = `
+<div>
+  <button>
+    <span>
+      left
+    </span>
+    <span>
+      Button 
+      <em>
+        text
+      </em>
+    </span>
+    <span>
+      right
+    </span>
+  </button>
+</div>
+`;
+
 exports[`given a Slot with React lazy components > with a lazy component in Button with Slottable > should render a lazy link with icon on the left/right 1`] = `
 <div>
   <a

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -140,6 +140,57 @@ describe('given a Button with Slottable', () => {
   });
 });
 
+describe('given a Button with Slottable nesting', () => {
+  afterEach(cleanup);
+  describe('without asChild', () => {
+    it('should render a button with a span around its children', async () => {
+      const tree = render(
+        <ButtonNested>
+          Button <em>text</em>
+        </ButtonNested>
+      );
+
+      expect(tree.container).toMatchSnapshot();
+    });
+
+    it('should render a button with icon on the left/right and a span around its children', async () => {
+      const tree = render(
+        <ButtonNested iconLeft={<span>left</span>} iconRight={<span>right</span>}>
+          Button <em>text</em>
+        </ButtonNested>
+      );
+
+      expect(tree.container).toMatchSnapshot();
+    });
+  });
+
+  describe('with asChild', () => {
+    it('should render a link with a span around its children', async () => {
+      const tree = render(
+        <ButtonNested asChild>
+          <a href="https://radix-ui.com">
+            Button <em>text</em>
+          </a>
+        </ButtonNested>
+      );
+
+      expect(tree.container).toMatchSnapshot();
+    });
+
+    it('should render a link with icon on the left/right and a span around its children', async () => {
+      const tree = render(
+        <ButtonNested asChild iconLeft={<span>left</span>} iconRight={<span>right</span>}>
+          <a href="https://radix-ui.com">
+            Button <em>text</em>
+          </a>
+        </ButtonNested>
+      );
+
+      expect(tree.container).toMatchSnapshot();
+    });
+  });
+});
+
 // TODO: Unskip when underlying issue is resolved
 // Reverted in https://github.com/radix-ui/primitives/pull/3554
 describe.skip('given an Input', () => {
@@ -248,6 +299,24 @@ const Button = React.forwardRef<
     <Comp {...props} ref={forwardedRef}>
       {iconLeft}
       <Slottable>{children}</Slottable>
+      {iconRight}
+    </Comp>
+  );
+});
+
+const ButtonNested = React.forwardRef<
+  React.ComponentRef<'button'>,
+  React.ComponentProps<'button'> & {
+    asChild?: boolean;
+    iconLeft?: React.ReactNode;
+    iconRight?: React.ReactNode;
+  }
+>(({ children, asChild = false, iconLeft, iconRight, ...props }, forwardedRef) => {
+  const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp {...props} ref={forwardedRef}>
+      {iconLeft}
+      <Slottable child={children}>{(slottable) => <span>{slottable}</span>}</Slottable>
       {iconRight}
     </Comp>
   );

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -7,80 +7,65 @@ declare module 'react' {
   }
 }
 
-const REACT_LAZY_TYPE = Symbol.for('react.lazy');
-
-interface LazyReactElement extends React.ReactElement {
-  $$typeof: typeof REACT_LAZY_TYPE;
-  _payload: PromiseLike<Exclude<React.ReactNode, PromiseLike<any>>>;
-}
-
 /* -------------------------------------------------------------------------------------------------
  * Slot
  * -----------------------------------------------------------------------------------------------*/
 
 export type Usable<T> = PromiseLike<T> | React.Context<T>;
-const use: typeof React.use | undefined = (React as any)[' use '.trim().toString()];
 
 interface SlotProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
 }
 
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return typeof value === 'object' && value !== null && 'then' in value;
-}
-
-function isLazyComponent(element: React.ReactNode): element is LazyReactElement {
-  return (
-    element != null &&
-    typeof element === 'object' &&
-    '$$typeof' in element &&
-    element.$$typeof === REACT_LAZY_TYPE &&
-    '_payload' in element &&
-    isPromiseLike(element._payload)
-  );
-}
-
 /* @__NO_SIDE_EFFECTS__ */ export function createSlot(ownerName: string) {
-  const SlotClone = createSlotClone(ownerName);
   const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
     let { children, ...slotProps } = props;
+    let slottableElement: React.ReactElement | null = null;
+    const newChildren: React.ReactNode[] = [];
+
     if (isLazyComponent(children) && typeof use === 'function') {
       children = use(children._payload);
     }
-    const childrenArray = React.Children.toArray(children);
-    const slottable = childrenArray.find(isSlottable);
 
-    if (slottable) {
-      // the new element to render is the one passed as a child of `Slottable`
-      const newElement = slottable.props.children;
+    React.Children.forEach(children, (maybeSlottable) => {
+      if (isSlottable(maybeSlottable)) {
+        const slottable = maybeSlottable;
+        let child = 'child' in slottable.props ? slottable.props.child : slottable.props.children;
 
-      const newChildren = childrenArray.map((child) => {
-        if (child === slottable) {
-          // because the new element will be the one rendered, we are only interested
-          // in grabbing its children (`newElement.props.children`)
-          if (React.Children.count(newElement) > 1) return React.Children.only(null);
-          return React.isValidElement(newElement)
-            ? (newElement.props as { children: React.ReactNode }).children
-            : null;
-        } else {
-          return child;
+        if (isLazyComponent(child) && typeof use === 'function') {
+          child = use(child._payload);
         }
-      });
 
-      return (
-        <SlotClone {...slotProps} ref={forwardedRef}>
-          {React.isValidElement(newElement)
-            ? React.cloneElement(newElement, undefined, newChildren)
-            : null}
-        </SlotClone>
-      );
+        slottableElement = getSlottableElementFromSlottable(slottable, child);
+        newChildren.push((slottableElement?.props as any)?.children);
+      } else {
+        newChildren.push(maybeSlottable);
+      }
+    });
+
+    if (slottableElement) {
+      slottableElement = React.cloneElement(slottableElement, undefined, newChildren);
+    } else if (React.Children.count(children) === 1 && React.isValidElement(children)) {
+      slottableElement = children;
     }
 
-    return (
-      <SlotClone {...slotProps} ref={forwardedRef}>
-        {children}
-      </SlotClone>
-    );
+    if (!slottableElement) {
+      if ((children || children === 0) && process.env.NODE_ENV !== 'production') {
+        console.warn(createSlotWarning(ownerName));
+      }
+      return children;
+    }
+
+    const slottableElementRef = getElementRef(slottableElement);
+    const composedRefs = composeRefs(forwardedRef, slottableElementRef);
+    const mergedProps = mergeProps(slotProps, slottableElement.props ?? {});
+
+    // do not pass ref to React.Fragment for React 19 compatibility
+    if (slottableElement.type !== React.Fragment) {
+      mergedProps.ref = forwardedRef ? composedRefs : slottableElementRef;
+    }
+
+    return React.cloneElement(slottableElement, mergedProps);
   });
 
   Slot.displayName = `${ownerName}.Slot`;
@@ -90,55 +75,26 @@ function isLazyComponent(element: React.ReactNode): element is LazyReactElement 
 const Slot = createSlot('Slot');
 
 /* -------------------------------------------------------------------------------------------------
- * SlotClone
- * -----------------------------------------------------------------------------------------------*/
-
-interface SlotCloneProps {
-  children: React.ReactNode;
-}
-
-/* @__NO_SIDE_EFFECTS__ */ function createSlotClone(ownerName: string) {
-  const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
-    let { children, ...slotProps } = props;
-    if (isLazyComponent(children) && typeof use === 'function') {
-      children = use(children._payload);
-    }
-
-    if (React.isValidElement(children)) {
-      const childrenRef = getElementRef(children);
-      const props = mergeProps(slotProps, children.props as AnyProps);
-      // do not pass ref to React.Fragment for React 19 compatibility
-      if (children.type !== React.Fragment) {
-        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
-      }
-      return React.cloneElement(children, props);
-    }
-
-    return React.Children.count(children) > 1 ? React.Children.only(null) : null;
-  });
-
-  SlotClone.displayName = `${ownerName}.SlotClone`;
-  return SlotClone;
-}
-
-/* -------------------------------------------------------------------------------------------------
  * Slottable
  * -----------------------------------------------------------------------------------------------*/
 
-const SLOTTABLE_IDENTIFIER = Symbol('radix.slottable');
+const SLOTTABLE_IDENTIFIER = Symbol.for('radix.slottable');
 
-interface SlottableProps {
-  children: React.ReactNode;
-}
+type SlottableChildrenProps = { children: React.ReactNode };
+type SlottableRenderFnProps = {
+  child: React.ReactNode;
+  children: (slottable: React.ReactNode) => React.ReactNode;
+};
 
+type SlottableProps = SlottableRenderFnProps | SlottableChildrenProps;
 interface SlottableComponent extends React.FC<SlottableProps> {
   __radixId: symbol;
 }
 
 /* @__NO_SIDE_EFFECTS__ */ export function createSlottable(ownerName: string) {
-  const Slottable: SlottableComponent = ({ children }) => {
-    return <>{children}</>;
-  };
+  const Slottable: SlottableComponent = (props) =>
+    'child' in props ? props.children(props.child) : props.children;
+
   Slottable.displayName = `${ownerName}.Slottable`;
   Slottable.__radixId = SLOTTABLE_IDENTIFIER;
   return Slottable;
@@ -146,20 +102,25 @@ interface SlottableComponent extends React.FC<SlottableProps> {
 
 const Slottable = createSlottable('Slottable');
 
-/* ---------------------------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------------------------------
+ * getSlottableElementFromSlottable
+ * -----------------------------------------------------------------------------------------------*/
+
+const getSlottableElementFromSlottable = (slottable: SlottableElement, child: React.ReactNode) => {
+  if ('child' in slottable.props) {
+    const child = slottable.props.child;
+    if (!React.isValidElement<React.PropsWithChildren>(child)) return null;
+    return React.cloneElement(child, undefined, slottable.props.children(child.props.children));
+  }
+
+  return React.isValidElement(child) ? child : null;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * mergeProps
+ * -----------------------------------------------------------------------------------------------*/
 
 type AnyProps = Record<string, any>;
-
-function isSlottable(
-  child: React.ReactNode,
-): child is React.ReactElement<SlottableProps, typeof Slottable> {
-  return (
-    React.isValidElement(child) &&
-    typeof child.type === 'function' &&
-    '__radixId' in child.type &&
-    child.type.__radixId === SLOTTABLE_IDENTIFIER
-  );
-}
 
 function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
   // all child props should override
@@ -195,6 +156,10 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
   return { ...slotProps, ...overrideProps };
 }
 
+/* -------------------------------------------------------------------------------------------------
+ * getElementRef
+ * -----------------------------------------------------------------------------------------------*/
+
 // Before React 19 accessing `element.props.ref` will throw a warning and suggest using `element.ref`
 // After React 19 accessing `element.ref` does the opposite.
 // https://github.com/facebook/react/pull/28348
@@ -218,6 +183,49 @@ function getElementRef(element: React.ReactElement) {
   // Not DEV
   return (element.props as { ref?: React.Ref<unknown> }).ref || (element as any).ref;
 }
+
+/* ---------------------------------------------------------------------------------------------- */
+
+type SlottableElement = React.ReactElement<SlottableProps, SlottableComponent>;
+
+function isSlottable(
+  child: React.ReactNode,
+): child is React.ReactElement<SlottableProps, typeof Slottable> {
+  return (
+    React.isValidElement(child) &&
+    typeof child.type === 'function' &&
+    '__radixId' in child.type &&
+    child.type.__radixId === SLOTTABLE_IDENTIFIER
+  );
+}
+
+const REACT_LAZY_TYPE = Symbol.for('react.lazy');
+
+interface LazyReactElement extends React.ReactElement {
+  $$typeof: typeof REACT_LAZY_TYPE;
+  _payload: PromiseLike<Exclude<React.ReactNode, PromiseLike<any>>>;
+}
+
+function isLazyComponent(element: React.ReactNode): element is LazyReactElement {
+  return (
+    element != null &&
+    typeof element === 'object' &&
+    '$$typeof' in element &&
+    element.$$typeof === REACT_LAZY_TYPE &&
+    '_payload' in element &&
+    isPromiseLike(element._payload)
+  );
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object' && value !== null && 'then' in value;
+}
+
+const createSlotWarning = (ownerName: string) => {
+  return `${ownerName} failed to slot onto its children. Expected a single React element child or \`Slottable\`.`;
+};
+
+const use: typeof React.use | undefined = (React as any)[' use '.trim().toString()];
 
 export {
   Slot,


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This is inspired by #2197 and should resolve #3626, but I've made it backwards compatible and also improved the implementation of `Slot` slightly:

- Avoids rendering redundant extra `Slot.SlotClone` comps
- Replaces `React.Children.only()` error with a more intuitive warning
- Adds tests including thorough use-case examples in `ssr-testing`
