### PR TITLE
fix: tooltip KeepOpenOnActivation missing onPointerDown

### DIFF
--- a/apps/storybook/stories/tooltip.stories.tsx
+++ b/apps/storybook/stories/tooltip.stories.tsx
@@ -668,6 +668,7 @@ export const KeepOpenOnActivation = () => {
           ref={triggerRef}
           className={styles.trigger}
           onClick={(event) => event.preventDefault()}
+          onPointerDown={(event) => event.preventDefault()}
         >
           Hover or Focus me
         </Tooltip.Trigger>


### PR DESCRIPTION
### Description
The provided example `KeepOpenOnActivation` is not ignoring the pointer events, it is lacking `onPointerDown`.
