### PR TITLE
fix(hover-card): avoid preventDefault in passive event listener

### DIFF
--- a/packages/react/hover-card/src/hover-card.tsx
+++ b/packages/react/hover-card/src/hover-card.tsx
@@ -119,7 +119,7 @@ const TRIGGER_NAME = 'HoverCardTrigger';
 
 type HoverCardTriggerElement = React.ComponentRef<typeof Primitive.a>;
 type PrimitiveLinkProps = React.ComponentPropsWithoutRef<typeof Primitive.a>;
-interface HoverCardTriggerProps extends PrimitiveLinkProps { }
+interface HoverCardTriggerProps extends PrimitiveLinkProps {}
 
 const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTriggerProps>(
   (props: ScopedProps<HoverCardTriggerProps>, forwardedRef) => {
@@ -376,7 +376,7 @@ const ARROW_NAME = 'HoverCardArrow';
 
 type HoverCardArrowElement = React.ComponentRef<typeof PopperPrimitive.Arrow>;
 type PopperArrowProps = React.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
-interface HoverCardArrowProps extends PopperArrowProps { }
+interface HoverCardArrowProps extends PopperArrowProps {}
 
 const HoverCardArrow = React.forwardRef<HoverCardArrowElement, HoverCardArrowProps>(
   (props: ScopedProps<HoverCardArrowProps>, forwardedRef) => {

--- a/packages/react/hover-card/src/hover-card.tsx
+++ b/packages/react/hover-card/src/hover-card.tsx
@@ -119,7 +119,7 @@ const TRIGGER_NAME = 'HoverCardTrigger';
 
 type HoverCardTriggerElement = React.ComponentRef<typeof Primitive.a>;
 type PrimitiveLinkProps = React.ComponentPropsWithoutRef<typeof Primitive.a>;
-interface HoverCardTriggerProps extends PrimitiveLinkProps {}
+interface HoverCardTriggerProps extends PrimitiveLinkProps { }
 
 const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTriggerProps>(
   (props: ScopedProps<HoverCardTriggerProps>, forwardedRef) => {
@@ -137,7 +137,15 @@ const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTrig
           onFocus={composeEventHandlers(props.onFocus, context.onOpen)}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
           // prevent focus event on touch devices
-          onTouchStart={composeEventHandlers(props.onTouchStart, (event) => event.preventDefault())}
+          onTouchStart={composeEventHandlers(
+            props.onTouchStart,
+            (event) => {
+              if (event.cancelable) {
+                event.preventDefault();
+              }
+            }
+          )}
+
         />
       </PopperPrimitive.Anchor>
     );
@@ -368,7 +376,7 @@ const ARROW_NAME = 'HoverCardArrow';
 
 type HoverCardArrowElement = React.ComponentRef<typeof PopperPrimitive.Arrow>;
 type PopperArrowProps = React.ComponentPropsWithoutRef<typeof PopperPrimitive.Arrow>;
-interface HoverCardArrowProps extends PopperArrowProps {}
+interface HoverCardArrowProps extends PopperArrowProps { }
 
 const HoverCardArrow = React.forwardRef<HoverCardArrowElement, HoverCardArrowProps>(
   (props: ScopedProps<HoverCardArrowProps>, forwardedRef) => {


### PR DESCRIPTION
🐛 Bug Description

While investigating [shadcn-ui/ui#8777](https://github.com/shadcn-ui/ui/issues/8777)
 (Hover Card Touch Error), I found that the root cause originates from @radix-ui/react-hover-card rather than shadcn/ui.

The issue occurs when touching a HoverCardTrigger on mobile or in Chrome’s mobile emulator.
Console shows:

Unable to preventDefault inside passive event listener

🔍 Root Cause

@radix-ui/react-hover-card currently calls event.preventDefault() unconditionally inside the trigger’s onTouchStart handler.

In React 19, touch event listeners are now passive by default, so calling preventDefault() throws this warning.

File: packages/react/hover-card/src/HoverCard.tsx
Lines: ~93–95

```
onTouchStart={composeEventHandlers(
  props.onTouchStart,
  (event) => event.preventDefault()
)}
```

💡 Fix

Guard the call to only execute when the event is cancelable:

```
- onTouchStart={composeEventHandlers(props.onTouchStart, (event) => event.preventDefault())}
+ onTouchStart={composeEventHandlers(props.onTouchStart, (event) => {
+   if (event.cancelable) {
+     event.preventDefault();
+   }
+ })}
```

✅ Impact

Removes noisy console warnings in React 19 + Chrome mobile emulation

Maintains existing behavior for React 18 and older

No behavior change for desktop or mouse interactions

🧪 Verification

Tested locally in:

React: 19.2.0

Next.js: 16.0.1

Chrome: 142.0.7444.60 (mobile emulation)

System: macOS (Apple M4)

Result:
✅ No warning message
✅ HoverCard still opens correctly on touch interaction

🔗 Related Issue

Upstream Report: [shadcn-ui/ui#8777](https://github.com/shadcn-ui/ui/issues/8777)

Root cause: Radix UI HoverCard

🧱 Summary

Fixes Unable to preventDefault inside passive event listener by checking event.cancelable before calling preventDefault() in HoverCardTrigger