### PR TITLE
feat: Add fallback z-index when contentZIndex is undefined - in React / Popper

### DIFF
--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -242,7 +242,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
           ...floatingStyles,
           transform: isPositioned ? floatingStyles.transform : 'translate(0, -200%)', // keep off the page when measuring
           minWidth: 'max-content',
-          zIndex: contentZIndex,
+          zIndex: contentZIndex, ?? 1000,
           ['--radix-popper-transform-origin' as any]: [
             middlewareData.transformOrigin?.x,
             middlewareData.transformOrigin?.y,


### PR DESCRIPTION
This PR fixes an issue where <PopperContent> receives contentZIndex={undefined}, causing the floating element to render with an incorrect or default stacking order(auto).
The fix ensures that the z-index is only applied when a valid value is passed, preventing unwanted stacking behaviour.