### PR TITLE
Support orientation property in Menubar

### DIFF
--- a/apps/storybook/stories/menubar.stories.module.css
+++ b/apps/storybook/stories/menubar.stories.module.css
@@ -4,6 +4,11 @@
   padding: 2px;
 }
 
+.rootVertical {
+  display: flex;
+  flex-direction: column;
+}
+
 .trigger {
   padding: 6px 16px;
   border: 0;

--- a/apps/storybook/stories/menubar.stories.tsx
+++ b/apps/storybook/stories/menubar.stories.tsx
@@ -10,7 +10,10 @@ export default { title: 'Components/Menubar' };
 export const Styled = () => {
   const [loop, setLoop] = React.useState(false);
   const [rtl, setRtl] = React.useState(false);
+  const [vertical, setVertical] = React.useState(false);
   const dir = rtl ? 'rtl' : 'ltr';
+  const orientation = vertical ? 'vertical' : 'horizontal';
+  const menubarContentSide = vertical ? 'right' : 'bottom';
   const checkOptions = [
     'Always Show Bookmarks Bar',
     'Always Show Toolbar in Fullscreen',
@@ -49,14 +52,24 @@ export const Styled = () => {
           />
           Loop
         </label>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={vertical}
+            onChange={(event) => setVertical(event.currentTarget.checked)}
+          />
+          Vertical
+        </label>
       </div>
 
       <div dir={dir}>
-        <Menubar.Root className={styles.root} loop={loop} dir={dir}>
+        <Menubar.Root className={`${styles.root} ${orientation === 'vertical' ? styles.rootVertical : ''}`}
+          loop={loop} dir={dir} orientation={orientation}>
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>File</Menubar.Trigger>
             <Menubar.Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Item className={styles.item}>New Tab</Menubar.Item>
                 <Menubar.Item className={styles.item}>New Window</Menubar.Item>
                 <Menubar.Item className={styles.item}>New Incognito Window</Menubar.Item>
@@ -82,7 +95,7 @@ export const Styled = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>Edit</Menubar.Trigger>
             <Menubar.Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Item className={styles.item}>Undo</Menubar.Item>
                 <Menubar.Item className={styles.item}>Redo</Menubar.Item>
                 <Menubar.Separator className={styles.separator} />
@@ -124,7 +137,7 @@ export const Styled = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>View</Menubar.Trigger>
             <Menubar.Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 {checkOptions.map((option) => (
                   <Menubar.CheckboxItem
                     key={option}
@@ -158,7 +171,7 @@ export const Styled = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>Profiles</Menubar.Trigger>
             <Menubar.Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.RadioGroup value={radioSelection} onValueChange={setRadioSelection}>
                   {radioOptions.map((option) => (
                     <Menubar.RadioItem key={option} className={styles.item} value={option}>
@@ -176,7 +189,7 @@ export const Styled = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>History</Menubar.Trigger>
             <Menubar.Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Label className={styles.label}>Work</Menubar.Label>
                 <Menubar.Item className={styles.item}>Radix</Menubar.Item>
                 <Menubar.Item className={styles.item}>Github</Menubar.Item>
@@ -197,7 +210,10 @@ export const Styled = () => {
 export const Cypress = () => {
   const [loop, setLoop] = React.useState(false);
   const [rtl, setRtl] = React.useState(false);
+  const [vertical, setVertical] = React.useState(false);
   const [portalled, setPortalled] = React.useState(false);
+  const orientation = vertical ? 'vertical' : 'horizontal';
+  const menubarContentSide = vertical ? 'right' : 'bottom';
 
   const dir = rtl ? 'rtl' : 'ltr';
   const Portal = portalled ? Menubar.Portal : React.Fragment;
@@ -234,6 +250,15 @@ export const Cypress = () => {
         <label>
           <input
             type="checkbox"
+            checked={vertical}
+            onChange={(event) => setVertical(event.currentTarget.checked)}
+          />
+          Vertical
+        </label>
+
+        <label>
+          <input
+            type="checkbox"
             checked={portalled}
             onChange={(event) => setPortalled(event.currentTarget.checked)}
           />
@@ -241,11 +266,12 @@ export const Cypress = () => {
         </label>
       </div>
       <div dir={dir}>
-        <Menubar.Root className={styles.root} loop={loop} dir={dir}>
+        <Menubar.Root className={`${styles.root} ${orientation === 'vertical' ? styles.rootVertical : ''}`}
+          loop={loop} dir={dir} orientation={orientation}>
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>File</Menubar.Trigger>
             <Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Item className={styles.item}>New Tab</Menubar.Item>
                 <Menubar.Item className={styles.item}>New Window</Menubar.Item>
                 <Menubar.Item className={styles.item}>New Incognito Window</Menubar.Item>
@@ -269,7 +295,7 @@ export const Cypress = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>Edit</Menubar.Trigger>
             <Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Item className={styles.item} disabled>
                   Undo
                 </Menubar.Item>
@@ -336,7 +362,7 @@ export const Cypress = () => {
           <Menubar.Menu>
             <Menubar.Trigger className={styles.trigger}>History</Menubar.Trigger>
             <Portal>
-              <Menubar.Content className={styles.content} sideOffset={2}>
+              <Menubar.Content className={styles.content} sideOffset={2} side={menubarContentSide}>
                 <Menubar.Item className={styles.item}>Radix</Menubar.Item>
                 <Menubar.Item className={styles.item}>Github</Menubar.Item>
                 <Menubar.Item className={styles.item}>WorkOS</Menubar.Item>

--- a/apps/storybook/stories/menubar.stories.tsx
+++ b/apps/storybook/stories/menubar.stories.tsx
@@ -13,7 +13,7 @@ export const Styled = () => {
   const [vertical, setVertical] = React.useState(false);
   const dir = rtl ? 'rtl' : 'ltr';
   const orientation = vertical ? 'vertical' : 'horizontal';
-  const menubarContentSide = vertical ? 'right' : 'bottom';
+  const menubarContentSide = vertical ? (rtl ? 'left' : 'right'): 'bottom';
   const checkOptions = [
     'Always Show Bookmarks Bar',
     'Always Show Toolbar in Fullscreen',
@@ -213,10 +213,10 @@ export const Cypress = () => {
   const [vertical, setVertical] = React.useState(false);
   const [portalled, setPortalled] = React.useState(false);
   const orientation = vertical ? 'vertical' : 'horizontal';
-  const menubarContentSide = vertical ? 'right' : 'bottom';
 
   const dir = rtl ? 'rtl' : 'ltr';
   const Portal = portalled ? Menubar.Portal : React.Fragment;
+  const menubarContentSide = vertical ? (rtl ? 'left' : 'right'): 'bottom';
 
   return (
     <div

--- a/packages/react/menubar/CHANGELOG.md
+++ b/packages/react/menubar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @radix-ui/react-menubar
 
+## 1.1.17
+
+- Support new property `orientation (vertical | horizontal)` in `Menubar.Root`
+
 ## 1.1.16
 
 - Updated dependencies: `@radix-ui/primitive@1.1.3`, `@radix-ui/react-context@1.1.3`, `@radix-ui/react-menu@2.1.16`, `@radix-ui/react-collection@1.1.8`, `@radix-ui/react-primitive@2.1.4`, `@radix-ui/react-roving-focus@1.1.11`

--- a/packages/react/menubar/package.json
+++ b/packages/react/menubar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radix-ui/react-menubar",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "license": "MIT",
   "source": "./src/index.ts",
   "main": "./src/index.ts",

--- a/packages/react/menubar/src/menubar.tsx
+++ b/packages/react/menubar/src/menubar.tsx
@@ -14,6 +14,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state';
 
 import type { Scope } from '@radix-ui/react-context';
 
+type Orientation = 'vertical' | 'horizontal';
 type Direction = 'ltr' | 'rtl';
 
 /* -------------------------------------------------------------------------------------------------
@@ -41,6 +42,7 @@ type MenubarContextValue = {
   value: string;
   dir: Direction;
   loop: boolean;
+  orientation: Orientation;
   onMenuOpen(value: string): void;
   onMenuClose(): void;
   onMenuToggle(value: string): void;
@@ -57,6 +59,7 @@ interface MenubarProps extends PrimitiveDivProps {
   defaultValue?: string;
   onValueChange?: (value: string) => void;
   loop?: RovingFocusGroupProps['loop'];
+  orientation?: Orientation;
   dir?: RovingFocusGroupProps['dir'];
 }
 
@@ -68,6 +71,7 @@ const Menubar = React.forwardRef<MenubarElement, MenubarProps>(
       onValueChange,
       defaultValue,
       loop = true,
+      orientation = 'horizontal',
       dir,
       ...menubarProps
     } = props;
@@ -108,13 +112,14 @@ const Menubar = React.forwardRef<MenubarElement, MenubarProps>(
         )}
         dir={direction}
         loop={loop}
+        orientation={orientation}
       >
         <Collection.Provider scope={__scopeMenubar}>
           <Collection.Slot scope={__scopeMenubar}>
             <RovingFocusGroup.Root
               asChild
               {...rovingFocusGroupScope}
-              orientation="horizontal"
+              orientation={orientation}
               loop={loop}
               dir={direction}
               currentTabStopId={currentTabStopId}
@@ -260,10 +265,10 @@ const MenubarTrigger = React.forwardRef<MenubarTriggerElement, MenubarTriggerPro
               onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
                 if (disabled) return;
                 if (['Enter', ' '].includes(event.key)) context.onMenuToggle(menuContext.value);
-                if (event.key === 'ArrowDown') context.onMenuOpen(menuContext.value);
+                if (event.key === (context.orientation === 'vertical' ? 'ArrowRight' : 'ArrowDown')) context.onMenuOpen(menuContext.value);
                 // prevent keydown from scrolling window / first focused item to execute
                 // that keydown (inadvertently closing the menu)
-                if (['Enter', ' ', 'ArrowDown'].includes(event.key)) {
+                if (['Enter', ' ', context.orientation === 'vertical' ? 'ArrowRight' : 'ArrowDown'].includes(event.key)) {
                   menuContext.wasKeyboardTriggerOpenRef.current = true;
                   event.preventDefault();
                 }
@@ -349,7 +354,7 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
         onKeyDown={composeEventHandlers(
           props.onKeyDown,
           (event) => {
-            if (['ArrowRight', 'ArrowLeft'].includes(event.key)) {
+            if (context.orientation !== 'vertical' && ['ArrowRight', 'ArrowLeft'].includes(event.key)) {
               const target = event.target as HTMLElement;
               const targetIsSubTrigger = target.hasAttribute('data-radix-menubar-subtrigger');
               const isKeyDownInsideSubMenu =

--- a/packages/react/menubar/src/menubar.tsx
+++ b/packages/react/menubar/src/menubar.tsx
@@ -265,10 +265,12 @@ const MenubarTrigger = React.forwardRef<MenubarTriggerElement, MenubarTriggerPro
               onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
                 if (disabled) return;
                 if (['Enter', ' '].includes(event.key)) context.onMenuToggle(menuContext.value);
-                if (event.key === (context.orientation === 'vertical' ? 'ArrowRight' : 'ArrowDown')) context.onMenuOpen(menuContext.value);
+                const verticalOpenMenuKey = context.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+                const openMenuKey = context.orientation === 'vertical' ? verticalOpenMenuKey : 'ArrowDown';
+                if (event.key === openMenuKey) context.onMenuOpen(menuContext.value);
                 // prevent keydown from scrolling window / first focused item to execute
                 // that keydown (inadvertently closing the menu)
-                if (['Enter', ' ', context.orientation === 'vertical' ? 'ArrowRight' : 'ArrowDown'].includes(event.key)) {
+                if (['Enter', ' ', openMenuKey].includes(event.key)) {
                   menuContext.wasKeyboardTriggerOpenRef.current = true;
                   event.preventDefault();
                 }
@@ -354,12 +356,13 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
         onKeyDown={composeEventHandlers(
           props.onKeyDown,
           (event) => {
+            const target = event.target as HTMLElement;
+            const isKeyDownInsideSubMenu =
+              target.closest('[data-radix-menubar-content]') !== event.currentTarget;
+            
             // Prevent navigation when orientation is vertical and menubar content is triggered.
             if (context.orientation !== 'vertical' && ['ArrowRight', 'ArrowLeft'].includes(event.key)) {
-              const target = event.target as HTMLElement;
               const targetIsSubTrigger = target.hasAttribute('data-radix-menubar-subtrigger');
-              const isKeyDownInsideSubMenu =
-                target.closest('[data-radix-menubar-content]') !== event.currentTarget;
 
               const prevMenuKey = context.dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft';
               const isPrevKey = prevMenuKey === event.key;
@@ -382,6 +385,11 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
 
               const [nextValue] = candidateValues;
               if (nextValue) context.onMenuOpen(nextValue);
+            } else if (context.orientation === 'vertical' && !isKeyDownInsideSubMenu) {
+              if (event.key === (context.dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft')) {
+                context.onMenuClose();
+                event.preventDefault();
+              }
             }
           },
           { checkForDefaultPrevented: false },

--- a/packages/react/menubar/src/menubar.tsx
+++ b/packages/react/menubar/src/menubar.tsx
@@ -354,6 +354,7 @@ const MenubarContent = React.forwardRef<MenubarContentElement, MenubarContentPro
         onKeyDown={composeEventHandlers(
           props.onKeyDown,
           (event) => {
+            // Prevent navigation when orientation is vertical and menubar content is triggered.
             if (context.orientation !== 'vertical' && ['ArrowRight', 'ArrowLeft'].includes(event.key)) {
               const target = event.target as HTMLElement;
               const targetIsSubTrigger = target.hasAttribute('data-radix-menubar-subtrigger');


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
Support `orientation` property in Menubar to support vertical display. Its default value is `horizontal`, and also supports `vertical`.
Below is the behavior comparison:

| Behavior | horizontal | vertical|
| --- | --- | --- |
| Navigation | `ArrowLeft` and `ArrowRight` | `ArrowUp` and `ArrowDown` |
| Open Menubar Content | `ArrowDown` | `LeftToRight` ? `ArrowRight` : `ArrowLeft` |
| Close Menubar Content | `Esc` to close all | `Esc` to close all, and `LeftToRight` ? `ArrowLeft` : `ArrowRight` |
| Navigation when Menubar Content is open | The new navigated menu's content is auto open | Cannot navigate when Menubar Content is open|

I am a newer to `Radix Primitives`, and not sure whether there are anything I missed to change. For example, How do we update the documentation in the official website https://www.radix-ui.com/primitives/docs/components/menubar ?

