### PR TITLE
Fixed OneTimePasswordField's dispatch function.

### DIFF
--- a/.changeset/neat-ends-read.md
+++ b/.changeset/neat-ends-read.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-one-time-password-field': patch
+---
+
+Fixed the dispatch handler's funcionality.

--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -12,7 +12,6 @@ import type { Scope } from '@radix-ui/react-context';
 import { createContextScope } from '@radix-ui/react-context';
 import { useDirection } from '@radix-ui/react-direction';
 import { clamp } from '@radix-ui/number';
-import { useEffectEvent } from '@radix-ui/react-use-effect-event';
 
 type InputValidationType = 'alpha' | 'numeric' | 'alphanumeric' | 'none';
 
@@ -266,7 +265,7 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
     });
 
     // Update function *specifically* for event handlers.
-    const dispatch = useEffectEvent<Dispatcher>((action) => {
+    const dispatch = React.useCallback<Dispatcher>((action) => {
       switch (action.type) {
         case 'SET_CHAR': {
           const { index, char } = action;
@@ -361,7 +360,7 @@ const OneTimePasswordField = React.forwardRef<HTMLDivElement, OneTimePasswordFie
           return;
         }
       }
-    });
+    }, [ collection, sanitizeValue, setValue, validation, value, ]);
 
     // re-validate when the validation type changes
     const validationTypeRef = React.useRef(validation);


### PR DESCRIPTION
As described by issue #3709, starting with React 19.2, the `OneTimePasswordField` component no longer functions properly.

The issue being React's `useEffectEvent` hook being used to define the `dispatch` function instead of using React's `useCallback` hook which allows dependencies to be supplied. Particularly the `collection` state value wouldn't update properly causing the value inside the `dispatch` function to be out of sync with the latest state.

React 19.1:

<img width="1531" height="451" alt="524183999-bfd4b6a3-f23d-4197-a3ca-118cf784d67a" src="https://github.com/user-attachments/assets/2aea5c47-0772-4822-9212-2d65b58ad993" />

React 19.2:

<img width="1525" height="291" alt="524184971-f99da422-f13e-4e5d-980f-60e42750b9f3" src="https://github.com/user-attachments/assets/8e93aee3-2f20-4076-b209-b0da62b8a826" />

Caveats of the `useEffectEvent` hook according the [documentation of React](https://react.dev/reference/react/useEffectEvent#caveats):

<img width="912" height="316" alt="524189928-ca5b67c5-a570-40e5-9aec-2a8fd7fef859" src="https://github.com/user-attachments/assets/c55931a7-1ce6-4517-92e5-5532f343e3bb" />

So I have updated the `dispatch` to make use of React's `useCallback` hook instead restoring the functionality of `OneTimePasswordField`.