### PR TITLE
Popover: only set aria-controls if open

### DIFF
--- a/.changeset/stale-clubs-teach.md
+++ b/.changeset/stale-clubs-teach.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-popover': patch
+---
+
+Popover: only set aria-controls if open

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -144,7 +144,7 @@ const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerPro
         type="button"
         aria-haspopup="dialog"
         aria-expanded={context.open}
-        aria-controls={context.contentId}
+        aria-controls={context.open ? context.contentId : undefined}
         data-state={getState(context.open)}
         {...triggerProps}
         ref={composedTriggerRef}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

At the moment, we always set `aria-controls` in the `Popover.Trigger`, even if `context.open` is false, i.e. when there should be no element with the given id. This is illegal: We must only provide this id if the element exists. 

Fix: Only render `aria-controls` if `context.open`.

Similar logic already exists e.g. in [`TooltipTrigger aria-describedby`](https://github.com/radix-ui/primitives/blob/2bab24a811e45c7a83198659272097f6cfa5a165/packages/react/tooltip/src/tooltip.tsx#L288)

I could not find tests for this component (I can create a new test file if you want).

The functionality is already covered in the existing Storybook.