### PR TITLE
fix(slot): Handle RSC lazy references with non-PromiseLike payloads

### DIFF
--- a/.changeset/upset-candies-sell.md
+++ b/.changeset/upset-candies-sell.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-slot': patch
+---
+
+fix: Handle RSC lazy references with non-PromiseLike payloads

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -99,22 +99,28 @@ interface SlotCloneProps {
 
 /* @__NO_SIDE_EFFECTS__ */ function createSlotClone(ownerName: string) {
   const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
-    let { children, ...slotProps } = props;
-    if (isLazyComponent(children) && typeof use === 'function') {
-      children = use(children._payload);
+    const { children, ...slotProps } = props;
+
+    // Multiple children is an error
+    if (React.Children.count(children) > 1) {
+      return React.Children.only(null);
     }
 
-    if (React.isValidElement(children)) {
-      const childrenRef = getElementRef(children);
-      const props = mergeProps(slotProps, children.props as AnyProps);
+    // Use Children.toArray to properly unwrap RSC lazy references
+    // (which may have non-PromiseLike payloads that bypass isLazyComponent)
+    const childrenArray = React.Children.toArray(children);
+    if (childrenArray.length === 1 && React.isValidElement(childrenArray[0])) {
+      const child = childrenArray[0];
+      const childRef = getElementRef(child);
+      const mergedProps = mergeProps(slotProps, child.props as AnyProps);
       // do not pass ref to React.Fragment for React 19 compatibility
-      if (children.type !== React.Fragment) {
-        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
+      if (child.type !== React.Fragment) {
+        mergedProps.ref = forwardedRef ? composeRefs(forwardedRef, childRef) : childRef;
       }
-      return React.cloneElement(children, props);
+      return React.cloneElement(child, mergedProps);
     }
 
-    return React.Children.count(children) > 1 ? React.Children.only(null) : null;
+    return null;
   });
 
   SlotClone.displayName = `${ownerName}.SlotClone`;


### PR DESCRIPTION
## Summary

Use `Children.toArray` in `SlotClone` to properly unwrap React lazy components that have non-PromiseLike payloads (common in RSC context).

**Problem:** The existing `isLazyComponent` check requires `isPromiseLike(element._payload)`, but in RSC context the `_payload` may have a different structure, causing lazy references to slip through and break `cloneElement`. This results in components not rendering in production builds.

**Solution:** Use `Children.toArray` which internally resolves lazy children regardless of payload structure, making it a robust solution for RSC compatibility.

Fixes #3776

## Changes

- Replace `isLazyComponent` + `isValidElement(children)` approach with `Children.toArray` in `createSlotClone`
- Early return for multiple children error (maintains original behavior)
- Clean separation of concerns with clear comments

## Test plan

- [x] Existing unit tests pass (10 passed, 2 skipped)
- [x] Tested in real Next.js 16 application with Turbopack production build
- [x] Verified nested Dialog trigger renders correctly in production

## Related issues

- https://github.com/facebook/react/issues/32392
- https://github.com/vercel/next.js/issues/82527