### PR TITLE
(fix issue #3778): track collapsible animating state to avoid rerunning animations on effects rerun 

### DIFF
--- a/apps/storybook/stories/collapsible.stories.module.css
+++ b/apps/storybook/stories/collapsible.stories.module.css
@@ -82,20 +82,20 @@
 
 .animatedContent {
   overflow: hidden;
-  &[data-state='open'] {
+  &[data-state='open'][data-animating='true'] {
     animation: collapsible-slideDown 300ms ease-out;
   }
-  &[data-state='closed'] {
+  &[data-state='closed'][data-animating='true'] {
     animation: collapsible-slideUp 300ms ease-in;
   }
 }
 
 .animatedWidthContent {
   overflow: hidden;
-  &[data-state='open'] {
+  &[data-state='open'][data-animating='true'] {
     animation: collapsible-openRight 300ms ease-out;
   }
-  &[data-state='closed'] {
+  &[data-state='closed'][data-animating='true'] {
     animation: collapsible-closeRight 300ms ease-in;
   }
 }

--- a/packages/react/collapsible/src/collapsible.tsx
+++ b/packages/react/collapsible/src/collapsible.tsx
@@ -151,6 +151,7 @@ const CollapsibleContentImpl = React.forwardRef<
   CollapsibleContentImplElement,
   CollapsibleContentImplProps
 >((props: ScopedProps<CollapsibleContentImplProps>, forwardedRef) => {
+  const [isAnimating, setIsAnimating] = React.useState(false);
   const { __scopeCollapsible, present, children, ...contentProps } = props;
   const context = useCollapsibleContext(CONTENT_NAME, __scopeCollapsible);
   const [isPresent, setIsPresent] = React.useState(present);
@@ -167,6 +168,7 @@ const CollapsibleContentImpl = React.forwardRef<
   const originalStylesRef = React.useRef<Record<string, string>>(undefined);
 
   React.useEffect(() => {
+    setIsAnimating(false);
     const rAF = requestAnimationFrame(() => (isMountAnimationPreventedRef.current = false));
     return () => cancelAnimationFrame(rAF);
   }, []);
@@ -193,6 +195,7 @@ const CollapsibleContentImpl = React.forwardRef<
         node.style.animationName = originalStylesRef.current.animationName!;
       }
 
+      setIsAnimating(true);
       setIsPresent(present);
     }
     /**
@@ -207,6 +210,7 @@ const CollapsibleContentImpl = React.forwardRef<
     <Primitive.div
       data-state={getState(context.open)}
       data-disabled={context.disabled ? '' : undefined}
+      data-animating={isAnimating ? 'true' : 'false'}
       id={context.contentId}
       hidden={!isOpen}
       {...contentProps}


### PR DESCRIPTION
React sets the display to none when the activity is hidden, which resets all animations. Additionally, React re-runs the component effects, which causes some issues.

we can simply avoid this by checking if the empty dependency effect runs as it should only run once but inside an activity it will always run on mode change.
Fixes: #3778 
Closed: better solution was found