### PR TITLE
fix(navigation-menu): set data-state attribute to `NavigationMenuContent` when using `NavigationMenuViewport`

### DIFF
--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -754,6 +754,7 @@ const NavigationMenuContent = React.forwardRef<
   const itemContext = useNavigationMenuItemContext(CONTENT_NAME, props.__scopeNavigationMenu);
   const composedRefs = useComposedRefs(itemContext.contentRef, forwardedRef);
   const open = itemContext.value === context.value;
+  const openState = getOpenState(open);
 
   const commonProps = {
     value: itemContext.value,
@@ -768,7 +769,7 @@ const NavigationMenuContent = React.forwardRef<
   return !context.viewport ? (
     <Presence present={forceMount || open}>
       <NavigationMenuContentImpl
-        data-state={getOpenState(open)}
+        data-state={openState}
         {...commonProps}
         ref={composedRefs}
         onPointerEnter={composeEventHandlers(props.onPointerEnter, context.onContentEnter)}
@@ -784,7 +785,7 @@ const NavigationMenuContent = React.forwardRef<
       />
     </Presence>
   ) : (
-    <ViewportContentMounter forceMount={forceMount} {...commonProps} ref={composedRefs} />
+    <ViewportContentMounter data-state={openState} forceMount={forceMount} {...commonProps} ref={composedRefs} />
   );
 });
 


### PR DESCRIPTION
Issue : https://github.com/radix-ui/primitives/issues/3786

### Description

Passing `data-state` to `ViewportContentMounter` to enable style/animation control when used with `forceMount` and `NavigationMenuViewport`
