### PR TITLE
[ToggleGroup] OnValueChange type handle undefined value

### DIFF
--- a/.changeset/tangy-birds-care.md
+++ b/.changeset/tangy-birds-care.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-toggle-group': patch
+---
+
+updated onValueChange prop type definition

--- a/packages/react/toggle-group/src/toggle-group.tsx
+++ b/packages/react/toggle-group/src/toggle-group.tsx
@@ -76,7 +76,7 @@ interface ToggleGroupImplSingleProps extends ToggleGroupImplProps {
   /**
    * The callback that fires when the value of the toggle group changes.
    */
-  onValueChange?(value: string): void;
+  onValueChange?(value: string | undefined): void;
 }
 
 const ToggleGroupImplSingle = React.forwardRef<


### PR DESCRIPTION
closes https://github.com/radix-ui/primitives/issues/3738

### Description

Changed onValueChange type in toggle-group to `onValueChange?(value: string | undefined): void;`

This makes the type more correct as unselecting a toggle can call the handler with `undefined`. 
If a user defines their state like this: `const [value, setValue] = React.useState<string>(""); `, they can have an unsuspecting undefined set by `onValueChange` call.