### PR TITLE
Dropdown menu native form submit

### DIFF
--- a/.changeset/true-taxes-cross.md
+++ b/.changeset/true-taxes-cross.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-menu': patch
+---
+
+defer onClose to allow native behavior to complete

--- a/apps/storybook/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/stories/dropdown-menu.stories.tsx
@@ -1637,3 +1637,23 @@ const TickIcon = () => (
     <path d="M2 20 L12 28 30 4" />
   </svg>
 );
+
+export const WithNativeFormSubmit = () => {
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '200vh' }}
+    >
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item asChild>
+            <button type="submit" form="my-form">Submit</button> 
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+       <form id="my-form" action="/submit" method="post" />
+    </div>
+  );
+};

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -629,7 +629,8 @@ const MenuItem = React.forwardRef<MenuItemElement, MenuItemProps>(
         if (itemSelectEvent.defaultPrevented) {
           isPointerDownRef.current = false;
         } else {
-          rootContext.onClose();
+          // Defer `onClose` to allow native element behavior to complete
+          setTimeout(() => rootContext.onClose(), 0);
         }
       }
     };


### PR DESCRIPTION
Closes https://github.com/radix-ui/primitives/issues/3789

### Description

Previously, this could be submitted with keyboard navigation:
```tsx
import { DropdownMenu } from '@radix-ui/react-dropdown-menu';
 function Example() {
  return (
    <>
      <DropdownMenu.Root>
        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
        <DropdownMenu.Content>
          <DropdownMenu.Item asChild>
            {/* Does NOT submit the form */}
            <button type="submit" form="my-form">Submit</button>
             {/* Adding onClick={() => {}} DOES submit the form */}
            {/* <button type="submit" form="my-form" onClick={() => {}}>Submit</button> */}
          </DropdownMenu.Item>
        </DropdownMenu.Content>
      </DropdownMenu.Root>
       <form id="my-form" action="/submit" method="post" />
    </>
  );
}
```
But using mouse to click did not work. 