### PR TITLE
Fix a bug where the pointer type was incorrectly initialized, and int…

### DIFF
--- a/.changeset/curly-goats-laugh.md
+++ b/.changeset/curly-goats-laugh.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': minor
+---
+
+Fix a bug where the pointer type was incorrectly initialized, and introduce an option for opening the select when clicking the trigger’s label.

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -59,6 +59,53 @@ export const Styled = () => (
   </div>
 );
 
+export const SyntheticClick = () => (
+  <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+    {POSITIONS.map((position) => (
+      <Label key={position}>
+        Choose a number:
+        <Select.Root defaultValue="two">
+          <Select.Trigger className={styles.trigger} syntheticClick={true}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={styles.content} position={position} sideOffset={5}>
+              <Select.Viewport className={styles.viewport}>
+                <Select.Item className={styles.item} value="one">
+                  <Select.ItemText>
+                    One<span aria-hidden> 👍</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="two">
+                  <Select.ItemText>
+                    Two<span aria-hidden> 👌</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="three">
+                  <Select.ItemText>
+                    Three<span aria-hidden> 🤘</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+              <Select.Arrow />
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+    ))}
+  </div>
+);
+
 export const Controlled = () => {
   const [value, setValue] = React.useState('uk');
   return (

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -19,6 +19,7 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { usePrevious } from '@radix-ui/react-use-previous';
+
 import { VISUALLY_HIDDEN_STYLES } from '@radix-ui/react-visually-hidden';
 import { hideOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
@@ -248,17 +249,50 @@ const TRIGGER_NAME = 'SelectTrigger';
 
 type SelectTriggerElement = React.ComponentRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
-interface SelectTriggerProps extends PrimitiveButtonProps {}
+interface SelectTriggerProps extends PrimitiveButtonProps {
+  /**
+   * When `true`, the Select will open when a label for the trigger is clicked
+   * even if the pointer type is `mouse`.
+   */
+  syntheticClick?: boolean;
+}
+
+import { useEffect, useRef } from 'react';
+
+const usePointerType = () => {
+  const pointerTypeRef = useRef<PointerEvent['pointerType']>('touch');
+  const updatePointerType = React.useEffectEvent((event: PointerEvent) => {
+    pointerTypeRef.current = event.pointerType;
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    document.addEventListener('pointermove', updatePointerType, {
+      once: true,
+      signal: abortController.signal,
+    });
+    // this is just incase the mouse is already on the user's target
+    document.addEventListener('pointerdown', updatePointerType, {
+      once: true,
+      signal: abortController.signal,
+    });
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+
+  return pointerTypeRef;
+};
 
 const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>(
   (props: ScopedProps<SelectTriggerProps>, forwardedRef) => {
+    const pointerTypeRef = usePointerType();
     const { __scopeSelect, disabled = false, ...triggerProps } = props;
     const popperScope = usePopperScope(__scopeSelect);
     const context = useSelectContext(TRIGGER_NAME, __scopeSelect);
     const isDisabled = context.disabled || disabled;
     const composedRefs = useComposedRefs(forwardedRef, context.onTriggerChange);
     const getItems = useCollection(__scopeSelect);
-    const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const [searchRef, handleTypeaheadSearch, resetTypeahead] = useTypeaheadSearch((search) => {
       const enabledItems = getItems().filter((item) => !item.disabled);
@@ -310,13 +344,11 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
             event.currentTarget.focus();
 
             // Open on click when using a touch or pen device
-            if (pointerTypeRef.current !== 'mouse') {
+            if (props.syntheticClick || pointerTypeRef.current !== 'mouse') {
               handleOpen(event);
             }
           })}
           onPointerDown={composeEventHandlers(triggerProps.onPointerDown, (event) => {
-            pointerTypeRef.current = event.pointerType;
-
             // prevent implicit pointer capture
             // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
             const target = event.target as HTMLElement;


### PR DESCRIPTION
## Fix pointerType state tracking and introduce an option for opening the select when clicking the trigger\'s label.
### Description
there was an issue reported on [chadcn](https://github.com/shadcn-ui/ui/issues/9171) where the label opens the select but after the select is clicked the label no longer opens it just focuses the trigger.

this change will resolve the issue by getting the pointer type on the very first pointer move in the document, I also added an option for the user to get the label to always open the drop down if that is what they desier 


