### PR TITLE
Fix/toast timeout cleanup

### DIFF
--- a/.changeset/fruity-oranges-beg.md
+++ b/.changeset/fruity-oranges-beg.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-toast': patch
+---
+
+Clear close timer on unmount to prevent memory leaks and errors in test environments

--- a/packages/react/toast/src/toast.test.tsx
+++ b/packages/react/toast/src/toast.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import * as Toast from './toast';
+import { describe, it, afterEach, beforeEach, vi, expect } from 'vitest';
+
+const TOAST_TITLE = 'Toast Title';
+
+const ToastTest = ({ duration = 5000 }: { duration?: number }) => {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <Toast.Provider duration={duration}>
+      <Toast.Root open={open} onOpenChange={setOpen}>
+        <Toast.Title>{TOAST_TITLE}</Toast.Title>
+      </Toast.Root>
+      <Toast.Viewport />
+    </Toast.Provider>
+  );
+};
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  describe('timer cleanup on unmount', () => {
+    it('should clear the close timer when the component unmounts before duration expires', () => {
+      const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+
+      const { unmount } = render(<ToastTest duration={5000} />);
+
+      // Advance time partially (not enough to trigger auto-close)
+      vi.advanceTimersByTime(2000);
+
+      // Unmount the component before the timer expires
+      unmount();
+
+      // Verify clearTimeout was called during cleanup
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+
+      // Advance time past the original duration to ensure no errors occur
+      // This would previously cause "ReferenceError: document is not defined" in test environments
+      vi.advanceTimersByTime(5000);
+
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('should not cause errors when unmounting with an active timer', () => {
+      const { unmount } = render(<ToastTest duration={3000} />);
+
+      // Advance time partially
+      vi.advanceTimersByTime(1000);
+
+      // This should not throw any errors
+      expect(() => {
+        unmount();
+        // Advance past the timer duration
+        vi.advanceTimersByTime(5000);
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -535,6 +535,13 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       if (open && !context.isClosePausedRef.current) startTimer(duration);
     }, [open, duration, context.isClosePausedRef, startTimer]);
 
+    // Clear close timer on unmount to prevent memory leaks and errors in test environments
+    React.useEffect(() => {
+      return () => {
+        window.clearTimeout(closeTimerRef.current);
+      };
+    }, []);
+
     React.useEffect(() => {
       onToastAdd();
       return () => onToastRemove();


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description


Fixes #3703

#### Issue Summary

The Toast component's internal close timer (`closeTimerRef`) is not cleared when the component unmounts. This causes `ReferenceError: document is not defined` errors in test environments.

**Reproduction scenario:**
1. Toast opens → Timer starts (e.g., auto-close after 5 seconds)
2. Test ends / Component unmounts after 3 seconds
3. Timer callback executes after remaining 2 seconds
4. `handleClose` tries to access `document.activeElement`
5. Error occurs because `document` doesn't exist in test environment

#### Solution

Added a cleanup effect in `ToastImpl` to clear `closeTimerRef` on unmount:

```tsx
React.useEffect(() => {
  return () => {
    window.clearTimeout(closeTimerRef.current);
  };
}, []);
```

This follows the same pattern used in other Radix components:
- `HoverCard` ([hover-card.tsx:89-94](packages/react/hover-card/src/hover-card.tsx))
- `NavigationMenu` ([navigation-menu.tsx:171-177](packages/react/navigation-menu/src/navigation-menu.tsx))

#### Changes

| File | Change |
|------|--------|
| `packages/react/toast/src/toast.tsx` | Added cleanup effect to clear timer on unmount (+7 lines) |
| `packages/react/toast/src/toast.test.tsx` | Added tests for timer cleanup behavior (new file) |
