### PR TITLE
docs: complete documentation section in philosophy.md

### DIFF
--- a/philosophy.md
+++ b/philosophy.md
@@ -82,7 +82,15 @@ Our goal is to create a well-funded open-source component library that the commu
 
 ### Documentation
 
-TODO
+- Documentation should be comprehensive yet concise, explaining the "why" behind design decisions
+- Every component should have clear examples demonstrating common use cases
+- API references should include type information, default values, and accessibility notes
+- Include migration guides when introducing breaking changes
+- Provide copy-pasteable code snippets that work out of the box
+- Document known limitations and edge cases transparently
+- Keep examples focused on one concept at a time to reduce cognitive load
+- Include interactive playgrounds where possible for hands-on exploration
+- Accessibility documentation should explain both what the component does automatically and what the developer is responsible for
 
 ### Misc
 


### PR DESCRIPTION
## Summary

Completed the `TODO` placeholder in the Documentation section of `philosophy.md`.

## Changes

Added documentation principles that align with the existing philosophy:

- **Comprehensive yet concise**: Explain the "why" behind design decisions
- **Clear examples**: Demonstrate common use cases for every component
- **API references**: Include type information, default values, and accessibility notes
- **Migration guides**: Provide guidance when introducing breaking changes
- **Copy-pasteable snippets**: Ensure examples work out of the box
- **Transparency**: Document known limitations and edge cases
- **Focused examples**: One concept at a time to reduce cognitive load
- **Interactive playgrounds**: Enable hands-on exploration where possible
- **Accessibility documentation**: Clarify what the component does automatically vs. developer responsibility

## Motivation

The philosophy document establishes important guiding principles for Radix Primitives. Having the Documentation section filled in helps contributors and maintainers understand the expected standards for component documentation.

These guidelines are especially relevant given the accessibility-first approach of Radix, where clear documentation of accessibility features is crucial.