### PR TITLE
Add explicit role to child div of ScrollAreaViewport

### DIFF
--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -180,7 +180,7 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
            * widths that change. We'll wait to see what use-cases consumers come up with there
            * before trying to resolve it.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }} role="presentation">
             {children}
           </div>
         </Primitive.div>


### PR DESCRIPTION
### Description

The `ScrollAreaViewport` renders a `div` with a `display: table` style. This can cause issues in browsers (such as Chrome) that implicitly generate an element role based on specific heuristics; in this case, `role: LayoutTable`.

By adding an explicit `role: presentation` to this node, we prevent any guessing by the browser, ensuring that no additional and unexpected semantics are included in the accessibility tree.