### PR TITLE
Bump react-remove-scroll to 2.7.2 for iOS text selection fix in Dialog

### DIFF
--- a/.changeset/orange-bobcats-send.md
+++ b/.changeset/orange-bobcats-send.md
@@ -1,0 +1,7 @@
+---
+'@radix-ui/react-dismissable-layer': patch
+'@radix-ui/react-popover': patch
+'@radix-ui/react-dialog': patch
+'@radix-ui/react-select': patch
+'@radix-ui/react-menu': patch
+---

--- a/.changeset/orange-bobcats-send.md
+++ b/.changeset/orange-bobcats-send.md
@@ -5,3 +5,5 @@
 '@radix-ui/react-select': patch
 '@radix-ui/react-menu': patch
 ---
+
+Fixed a bug where iOS text selection and editing on HTML inputs within `react-dialog` were broken.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -17,7 +17,7 @@
     "radix-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-remove-scroll": "^2.6.3"
+    "react-remove-scroll": "^2.7.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^19.2.0",
     "react-test-renderer": "^19.2.0",
     "react-is": "^19.2.0",
-    "react-remove-scroll": "^2.6.3",
+    "react-remove-scroll": "^2.7.2",
     "replace-in-files": "^3.0.0",
     "start-server-and-test": "^2.1.2",
     "typescript": "^5.9.3",

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -48,7 +48,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.2.4",
-    "react-remove-scroll": "^2.6.3"
+    "react-remove-scroll": "^2.7.2"
   },
   "devDependencies": {
     "@repo/builder": "workspace:*",

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -50,7 +50,7 @@
     "eslint": "^9.38.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-remove-scroll": "^2.6.3",
+    "react-remove-scroll": "^2.7.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -52,7 +52,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "aria-hidden": "^1.2.4",
-    "react-remove-scroll": "^2.6.3"
+    "react-remove-scroll": "^2.7.2"
   },
   "devDependencies": {
     "@repo/builder": "workspace:*",

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -49,7 +49,7 @@
     "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "aria-hidden": "^1.2.4",
-    "react-remove-scroll": "^2.6.3"
+    "react-remove-scroll": "^2.7.2"
   },
   "devDependencies": {
     "@repo/builder": "workspace:*",

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -55,7 +55,7 @@
     "@radix-ui/react-use-previous": "workspace:*",
     "@radix-ui/react-visually-hidden": "workspace:*",
     "aria-hidden": "^1.2.4",
-    "react-remove-scroll": "^2.6.3"
+    "react-remove-scroll": "^2.7.2"
   },
   "devDependencies": {
     "@repo/builder": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.0
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
       react-test-renderer:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
@@ -177,8 +177,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.1.1
@@ -931,8 +931,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       '@repo/builder':
         specifier: workspace:*
@@ -1035,8 +1035,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1395,8 +1395,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       '@repo/builder':
         specifier: workspace:*
@@ -1733,8 +1733,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       '@repo/builder':
         specifier: workspace:*
@@ -2406,8 +2406,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       react-remove-scroll:
-        specifier: ^2.6.3
-        version: 2.6.3(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^2.7.2
+        version: 2.7.2(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       '@repo/builder':
         specifier: workspace:*
@@ -6905,8 +6905,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-remove-scroll@2.6.3:
-    resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
@@ -11790,7 +11790,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
-  react-remove-scroll@2.6.3(@types/react@19.2.2)(react@19.2.0):
+  react-remove-scroll@2.7.2(@types/react@19.2.2)(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.2)(react@19.2.0)


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

There has been a subtle long-standing bug expressed in Radix dialogs (and perhaps other primitives) due to the `react-remove-scroll` dependency. iOS users are unable to move the text selection handles within a dialog box. This was reported https://github.com/theKashey/react-remove-scroll/issues/130 and fixed in https://github.com/theKashey/react-remove-scroll/pull/144.

This was also reported to this repo by a few people over the years:

Fixes #2492
Fixes #3331

Bumping the `react-remove-scroll` version to 2.7.2 applies the fix. I confirmed by putting some inputs in the Dialog Storybook, and selecting text with my iOS 26 iPhone:

https://github.com/user-attachments/assets/56f1849a-7cca-4838-bf87-33da32d0ed2c


