### PR TITLE
fix(slot): use memoized useComposedRefs in SlotClone to prevent React 19 infinite loops

### DIFF
--- a/.changeset/fix-slot-clone-composed-refs.md
+++ b/.changeset/fix-slot-clone-composed-refs.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-slot': patch
+---
+
+Fixed infinite re-render loop in React 19 caused by `SlotClone` creating a new `composeRefs` callback on every render. Now uses memoized `useComposedRefs` to keep ref identity stable.

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { composeRefs } from '@radix-ui/react-compose-refs';
+import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
 
 declare module 'react' {
   interface ReactElement {
@@ -104,12 +104,23 @@ interface SlotCloneProps {
       children = use(children._payload);
     }
 
+    const childrenRef = React.isValidElement(children)
+      ? getElementRef(children)
+      : undefined;
+
+    // useComposedRefs memoizes the composed callback so that ref identity is
+    // stable across renders.  The previous raw `composeRefs()` call created a
+    // new function every render, which in React 19 causes an unmount/remount
+    // cycle (because React treats a new callback-ref-with-cleanup as a
+    // different ref), leading to infinite re-render loops when a state setter
+    // is passed as one of the refs (e.g. SelectTrigger's onTriggerChange).
+    const composedRef = useComposedRefs(forwardedRef, childrenRef);
+
     if (React.isValidElement(children)) {
-      const childrenRef = getElementRef(children);
       const props = mergeProps(slotProps, children.props as AnyProps);
       // do not pass ref to React.Fragment for React 19 compatibility
       if (children.type !== React.Fragment) {
-        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
+        props.ref = composedRef;
       }
       return React.cloneElement(children, props);
     }


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by an AI agent (Claude Code). Human verification of the fix and its implications is still outstanding.

## Summary

- `SlotClone` now uses `useComposedRefs()` (memoized via `React.useCallback`) instead of raw `composeRefs()` to compose forwarded and children refs
- This keeps the composed ref callback identity stable across renders, preventing React 19's ref unmount/remount cycle from triggering infinite loops

## Reproduction

**Minimal repro repo**: https://github.com/yannisgu/radix-tanstack-form-react19-repro

```bash
git clone https://github.com/yannisgu/radix-tanstack-form-react19-repro
cd radix-tanstack-form-react19-repro/radix-select-tanstack-form
pnpm install && pnpm dev
# Open http://localhost:5173 — tab freezes
```

## Problem

`SlotClone` calls `composeRefs(forwardedRef, childrenRef)` directly on every render, creating a **new function** each time. In React 19, `setRef()` returns `ref(value)`, which React treats as a cleanup function. When React sees a new callback ref with cleanup on each render, it unmounts the old ref (calling cleanup) and mounts the new one — triggering any state setters passed as refs (e.g. `SelectTrigger`'s `onTriggerChange`, or `Checkbox`'s `useSize`).

This state update during commit causes a re-render, which creates another new `composeRefs` function, which triggers another unmount/remount — an infinite synchronous loop that **freezes the browser tab**.

The bug is particularly severe when combined with libraries that trigger re-renders during the commit phase (e.g. `@tanstack/react-form`'s `useField` layout effect with no dependency array), but can occur with any component that has effects or state updates during commit.

## Root cause chain

1. `SlotClone` calls `composeRefs()` → new function identity every render
2. `setRef(ref, value)` returns `ref(value)` → React 19 treats it as cleanup ref
3. New ref identity + cleanup → React unmounts old ref, mounts new ref
4. Ref mount triggers state setter (e.g. `onTriggerChange`) → re-render
5. Re-render → step 1 → infinite loop

## Fix

Replace raw `composeRefs()` with `useComposedRefs()`, which wraps the call in `React.useCallback`. This was already the intended pattern — `useComposedRefs` exists for exactly this purpose but wasn't used in `SlotClone`.

## Affected components

Any Radix component using `Slot`/`asChild` that passes a state setter as a ref:
- `@radix-ui/react-select` (SelectTrigger + onTriggerChange)
- `@radix-ui/react-checkbox` (useSize state setter)
- `@radix-ui/react-popover`, `@radix-ui/react-tooltip`, `@radix-ui/react-dialog`, etc.

Fixes #3799