### PR TITLE
fix(tooltip): handle Window as scroll event target

### DIFF
--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -528,8 +528,9 @@ const TooltipContentImpl = React.forwardRef<TooltipContentImplElement, TooltipCo
     React.useEffect(() => {
       if (context.trigger) {
         const handleScroll = (event: Event) => {
-          const target = event.target as HTMLElement;
-          if (target?.contains(context.trigger)) onClose();
+          const target = event.target;
+          // event.target can be Window when scrolling, which doesn't have .contains()
+          if (target instanceof Node && target.contains(context.trigger)) onClose();
         };
         window.addEventListener('scroll', handleScroll, { capture: true });
         return () => window.removeEventListener('scroll', handleScroll, { capture: true });


### PR DESCRIPTION
## Summary

Fixes #3805

When a scroll event is captured with `{ capture: true }`, the `event.target` can be `Window` instead of an `HTMLElement`. The `Window` object doesn't have a `.contains()` method, which causes a `TypeError: target?.contains() is not a function` error.

## Changes

Added an `instanceof Node` check before calling `.contains()` to ensure the target is a valid DOM node that supports the method.

### Before
```ts
const target = event.target as HTMLElement;
if (target?.contains(context.trigger)) onClose();
```

### After
```ts
const target = event.target;
// event.target can be Window when scrolling, which doesn't have .contains()
if (target instanceof Node && target.contains(context.trigger)) onClose();
```

## Testing

- All existing tooltip tests pass
- The fix handles the edge case where `event.target` is `Window` or `Document` (neither implements `Node`)