### PR TITLE
Popper: Fix anchor positioning when using custom anchor

### DIFF
--- a/.changeset/fix-popper-anchor-positioning.md
+++ b/.changeset/fix-popper-anchor-positioning.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-popper': patch
+---
+
+Fixed `Popper.Anchor` positioning when `PopoverAnchor` and `PopoverTrigger` coexist as siblings or with CSS absolute positioning

--- a/apps/storybook/stories/popover.stories.tsx
+++ b/apps/storybook/stories/popover.stories.tsx
@@ -267,6 +267,38 @@ export const CustomAnchor = () => (
   </Popover.Root>
 );
 
+export const CustomAnchorSibling = () => (
+  <Popover.Root>
+    <Popover.Anchor
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: 250,
+        padding: 20,
+        margin: 100,
+        backgroundColor: '#eee',
+      }}
+    >
+      Item
+    </Popover.Anchor>
+    <Popover.Trigger className={styles.trigger} style={{ margin: '0 100px' }}>
+      open
+    </Popover.Trigger>
+    <Popover.Portal>
+      <Popover.Content
+        className={styles.content}
+        side="right"
+        sideOffset={1}
+        align="start"
+        style={{ borderRadius: 0, width: 200, height: 100 }}
+      >
+        <Popover.Close>close</Popover.Close>
+      </Popover.Content>
+    </Popover.Portal>
+  </Popover.Root>
+);
+
 export const WithSlottedTrigger = () => {
   return (
     <Popover.Root>

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -77,15 +77,13 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
     const ref = React.useRef<PopperAnchorElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref);
 
-    const anchorRef = React.useRef<Measurable | null>(null);
     React.useEffect(() => {
-      const previousAnchor = anchorRef.current;
-      anchorRef.current = virtualRef?.current || ref.current;
-      if (previousAnchor !== anchorRef.current) {
-        // Consumer can anchor the popper to something that isn't
-        // a DOM node e.g. pointer position, so we override the
-        // `anchorRef` with their virtual ref in this case.
-        context.onAnchorChange(anchorRef.current);
+      // Consumer can anchor the popper to something that isn't
+      // a DOM node e.g. pointer position, so we override the
+      // `anchorRef` with their virtual ref in this case.
+      const desiredAnchor = virtualRef?.current || ref.current;
+      if (context.anchor !== desiredAnchor) {
+        context.onAnchorChange(desiredAnchor);
       }
     });
 


### PR DESCRIPTION
### Description

When both `PopoverAnchor` and `PopoverTrigger` are present, the trigger briefly registers itself as the anchor. After the custom anchor takes over, its effect compares against its own previous value, sees no change, and skips the update — so the popover stays on the trigger.

This PR compares against the current anchor in context instead of a local previous value. This should still prevent unnecessary updates while correctly picking up the custom anchor.

Closes #3659
Closes #3760
