### PR TITLE
Fix `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` when starting Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "types:check": "pnpm -r --parallel run typecheck",
     "test": "vitest",
     "test:ci": "vitest run && pnpm cypress:ci",
-    "storybook": "BROWSER=none pnpm --filter=@repo/storybook run dev -p 9009",
+    "storybook": "pnpm --filter=@repo/storybook run dev -p 9009 --no-open",
     "storybook:build": "BROWSER=none pnpm --filter=@repo/storybook run build",
     "storybook:serve": "pnpm --filter=@repo/storybook run serve",
     "cypress:ci": "start-server-and-test 'pnpm dev' http://localhost:9009 'pnpm cypress:install && pnpm cypress:run'",


### PR DESCRIPTION
Fixes #3808.

### Description

Replace `BROWSER=none` with `--no-open` in storybook script.
