### PR TITLE
feat(scroll-area): add `contentProps` to `ScrollArea.Viewport`Feat/scroll area content props

### DIFF
--- a/.changeset/scroll-area-content-props.md
+++ b/.changeset/scroll-area-content-props.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-scroll-area': minor
+---
+
+Added `contentProps` to `ScrollArea.Viewport` for forwarding props to the internal content wrapper div, enabling layout customization (e.g. overriding the default `display: table`) without `!important`.

--- a/apps/storybook/stories/scroll-area.stories.tsx
+++ b/apps/storybook/stories/scroll-area.stories.tsx
@@ -113,7 +113,7 @@ export const ContentProps = () => {
         {Array.from({ length: 20 }).map((_, index) => (
           <div
             key={index}
-            style={{ padding: '8px 12px', borderBottom: '1px solid #eee' }}
+            style={{ padding: '8px 12px', borderBottom: '1px solid #eee', whiteSpace: 'nowrap' }}
           >
             Item {index + 1} - This is a long text that should be constrained by the container width
           </div>

--- a/apps/storybook/stories/scroll-area.stories.tsx
+++ b/apps/storybook/stories/scroll-area.stories.tsx
@@ -105,6 +105,51 @@ export const Animated = () => {
   );
 };
 
+export const ContentProps = () => {
+  return (
+    <div className={styles.root}>
+      <h2>Default (display: table)</h2>
+      <ScrollAreaStory type="always" style={{ width: 400, height: 300 }}>
+        {Array.from({ length: 20 }).map((_, index) => (
+          <div
+            key={index}
+            style={{ padding: '8px 12px', borderBottom: '1px solid #eee' }}
+          >
+            Item {index + 1} - This is a long text that should be constrained by the container width
+          </div>
+        ))}
+      </ScrollAreaStory>
+
+      <h2>With contentProps (display: flex)</h2>
+      <ScrollArea.Root
+        type="always"
+        className={styles.scrollArea}
+        style={{ width: 400, height: 300 }}
+      >
+        <ScrollArea.Viewport
+          className={styles.scrollAreaViewport}
+          contentProps={{
+            style: { display: 'flex', flexDirection: 'column' },
+          }}
+        >
+          {Array.from({ length: 20 }).map((_, index) => (
+            <div
+              key={index}
+              style={{ padding: '8px 12px', borderBottom: '1px solid #eee' }}
+            >
+              Item {index + 1} - This is a long text that should be constrained by the container
+              width
+            </div>
+          ))}
+        </ScrollArea.Viewport>
+        <ScrollArea.Scrollbar className={styles.scrollbar} orientation="vertical">
+          <ScrollArea.Thumb className={styles.thumb} />
+        </ScrollArea.Scrollbar>
+      </ScrollArea.Root>
+    </div>
+  );
+};
+
 export const Chromatic = () => (
   <div className={styles.root}>
     <h1>Vertical</h1>

--- a/packages/react/scroll-area/src/scroll-area.test.tsx
+++ b/packages/react/scroll-area/src/scroll-area.test.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import * as ScrollArea from './scroll-area';
+
+const VIEWPORT_TEST_ID = 'scroll-area-viewport';
+const CONTENT_TEXT = 'Scroll content';
+
+const ScrollAreaTest = (props: {
+  contentProps?: React.HTMLAttributes<HTMLDivElement>;
+}) => (
+  <ScrollArea.Root type="always" style={{ width: 200, height: 200 }}>
+    <ScrollArea.Viewport data-testid={VIEWPORT_TEST_ID} contentProps={props.contentProps}>
+      <div>{CONTENT_TEXT}</div>
+    </ScrollArea.Viewport>
+    <ScrollArea.Scrollbar orientation="vertical">
+      <ScrollArea.Thumb />
+    </ScrollArea.Scrollbar>
+  </ScrollArea.Root>
+);
+
+describe('ScrollArea', () => {
+  afterEach(cleanup);
+
+  describe('given a default ScrollArea', () => {
+    it('should render content inside the viewport', () => {
+      const rendered = render(<ScrollAreaTest />);
+      expect(rendered.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    });
+
+    it('should render the internal content wrapper with default display: table', () => {
+      const rendered = render(<ScrollAreaTest />);
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper).toBeTruthy();
+      expect(contentWrapper.style.display).toBe('table');
+      expect(contentWrapper.style.minWidth).toBe('100%');
+    });
+  });
+
+  describe('given contentProps', () => {
+    it('should forward style overrides to the content wrapper', () => {
+      const rendered = render(
+        <ScrollAreaTest
+          contentProps={{ style: { display: 'flex', flexDirection: 'column' } }}
+        />
+      );
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper.style.display).toBe('flex');
+      expect(contentWrapper.style.flexDirection).toBe('column');
+      // minWidth should still be present as a base style
+      expect(contentWrapper.style.minWidth).toBe('100%');
+    });
+
+    it('should forward className to the content wrapper', () => {
+      const rendered = render(
+        <ScrollAreaTest contentProps={{ className: 'custom-content' }} />
+      );
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper.classList.contains('custom-content')).toBe(true);
+    });
+
+    it('should forward data attributes to the content wrapper', () => {
+      const rendered = render(
+        <ScrollAreaTest contentProps={{ 'data-slot': 'content' } as any} />
+      );
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper.getAttribute('data-slot')).toBe('content');
+    });
+
+    it('should allow overriding only display while preserving minWidth', () => {
+      const rendered = render(
+        <ScrollAreaTest contentProps={{ style: { display: 'block' } }} />
+      );
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper.style.display).toBe('block');
+      expect(contentWrapper.style.minWidth).toBe('100%');
+    });
+
+    it('should allow overriding minWidth', () => {
+      const rendered = render(
+        <ScrollAreaTest contentProps={{ style: { minWidth: '0' } }} />
+      );
+      const viewport = rendered.getByTestId(VIEWPORT_TEST_ID);
+      const contentWrapper = viewport.firstElementChild as HTMLElement;
+      expect(contentWrapper.style.minWidth).toBe('0');
+      expect(contentWrapper.style.display).toBe('table');
+    });
+
+    it('should still render children correctly when contentProps is provided', () => {
+      const rendered = render(
+        <ScrollAreaTest
+          contentProps={{ style: { display: 'flex', flexDirection: 'column' } }}
+        />
+      );
+      expect(rendered.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -135,11 +135,21 @@ const VIEWPORT_NAME = 'ScrollAreaViewport';
 type ScrollAreaViewportElement = React.ComponentRef<typeof Primitive.div>;
 interface ScrollAreaViewportProps extends PrimitiveDivProps {
   nonce?: string;
+  /**
+   * Optional props to pass to the inner content wrapper `div`.
+   * Useful for overriding the default `display: table` layout when it conflicts
+   * with your content's sizing needs (e.g. flex or grid layouts).
+   *
+   * Note: The content wrapper uses `display: table` by default to ensure accurate
+   * scroll width/height measurement for thumb sizing. Overriding `display` may
+   * affect thumb size accuracy for horizontally-scrolling content.
+   */
+  contentProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAreaViewportProps>(
   (props: ScopedProps<ScrollAreaViewportProps>, forwardedRef) => {
-    const { __scopeScrollArea, children, nonce, ...viewportProps } = props;
+    const { __scopeScrollArea, children, nonce, contentProps, ...viewportProps } = props;
     const context = useScrollAreaContext(VIEWPORT_NAME, __scopeScrollArea);
     const ref = React.useRef<ScrollAreaViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
@@ -180,7 +190,11 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
            * widths that change. We'll wait to see what use-cases consumers come up with there
            * before trying to resolve it.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div
+            {...contentProps}
+            ref={context.onContentChange}
+            style={{ minWidth: '100%', display: 'table', ...contentProps?.style }}
+          >
             {children}
           </div>
         </Primitive.div>


### PR DESCRIPTION
### Description

`ScrollArea.Viewport` renders an internal `<div>` wrapper around its children with an inline style of `display: table; min-width: 100%`. This is intentional — the table layout ensures accurate content size measurement for scrollbar thumb sizing.

However, this forces a table layout on all consumers, which conflicts with common patterns like flex or grid layouts. Today the only workaround is `!important` in CSS, which is fragile and goes against styling best practices.

This PR adds a `contentProps` prop to `ScrollArea.Viewport` that forwards attributes to the internal content wrapper `<div>`, allowing consumers to override `display` (and other props) cleanly:

<ScrollArea.Viewport
  contentProps={{
    style: { display: 'flex', flexDirection: 'column' },
    className: 'my-content',
  }}
>
  {children}
</ScrollArea.Viewport>

**Style merging strategy:** base styles (minWidth: 100%, display: table) are applied first, then contentProps.style spreads on top — so consumers can selectively override only what they need while the rest is preserved.

### Checklist
[x] Code change in packages/react/scroll-area/src/scroll-area.tsx
[x] Tests added in packages/react/scroll-area/src/scroll-area.test.tsx (8 tests, all passing)
[x] Storybook example added (ContentProps story) comparing default vs overridden layout
[x] JSDoc with usage notes and caveats on the new prop
[x] No breaking changes — contentProps is optional, defaults to undefined

### Test plan
`pnpm test` — 8 new tests covering:
 - Default behavior: content wrapper has display: table and minWidth: 100%
 - contentProps.style overrides display while preserving minWidth
 - contentProps.style overrides minWidth while preserving display
 - contentProps.className forwarded to content wrapper
 - contentProps data attributes forwarded
 - Children render correctly with contentProps
`pnpm dev` — Storybook `ContentProps` story shows side-by-side comparison