### PR TITLE
Portal: Add PortalProvider for default container context

### DIFF
--- a/.changeset/add-portal-provider.md
+++ b/.changeset/add-portal-provider.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-portal': minor
+---
+
+Added `PortalProvider` to set a default portal container via context, useful for Shadow DOM scenarios

--- a/packages/react/portal/src/index.ts
+++ b/packages/react/portal/src/index.ts
@@ -1,7 +1,8 @@
 'use client';
 export {
   Portal,
+  PortalProvider,
   //
   Root,
 } from './portal';
-export type { PortalProps } from './portal';
+export type { PortalProps, PortalProviderProps } from './portal';

--- a/packages/react/portal/src/portal.tsx
+++ b/packages/react/portal/src/portal.tsx
@@ -4,6 +4,28 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
 /* -------------------------------------------------------------------------------------------------
+ * PortalProvider
+ * -----------------------------------------------------------------------------------------------*/
+
+const PortalContext = React.createContext<Element | DocumentFragment | null>(null);
+PortalContext.displayName = 'PortalContext';
+
+interface PortalProviderProps {
+  children: React.ReactNode;
+  /**
+   * The default container element for portaled content.
+   * @defaultValue document.body
+   */
+  container: Element | DocumentFragment;
+}
+
+const PortalProvider: React.FC<PortalProviderProps> = ({ container, children }) => {
+  return <PortalContext.Provider value={container}>{children}</PortalContext.Provider>;
+};
+
+PortalProvider.displayName = 'PortalProvider';
+
+/* -------------------------------------------------------------------------------------------------
  * Portal
  * -----------------------------------------------------------------------------------------------*/
 
@@ -20,9 +42,10 @@ interface PortalProps extends PrimitiveDivProps {
 
 const Portal = React.forwardRef<PortalElement, PortalProps>((props, forwardedRef) => {
   const { container: containerProp, ...portalProps } = props;
+  const contextContainer = React.useContext(PortalContext);
   const [mounted, setMounted] = React.useState(false);
   useLayoutEffect(() => setMounted(true), []);
-  const container = containerProp || (mounted && globalThis?.document?.body);
+  const container = containerProp || contextContainer || (mounted && globalThis?.document?.body);
   return container
     ? ReactDOM.createPortal(<Primitive.div {...portalProps} ref={forwardedRef} />, container)
     : null;
@@ -36,7 +59,8 @@ const Root = Portal;
 
 export {
   Portal,
+  PortalProvider,
   //
   Root,
 };
-export type { PortalProps };
+export type { PortalProps, PortalProviderProps };


### PR DESCRIPTION
## Summary

Add `PortalProvider` component to `@radix-ui/react-portal`, allowing users to set a default portal container via React context. This is particularly useful for **browser extensions** and **Shadow DOM** scenarios, where portaling to `document.body` breaks style isolation.

Without `PortalProvider`, every portal-based component (Dialog, Popover, Tooltip, Select, Menu, etc.) needs an explicit `container` prop — tedious and error-prone. Now users can set it once at the top level:

```tsx
function App() {
  const [container, setContainer] = React.useState<HTMLElement | null>(null);
  return (
    <Portal.PortalProvider container={container!}>
      <div ref={setContainer} />
      <Dialog.Root>
        <Dialog.Trigger>Open</Dialog.Trigger>
        <Dialog.Portal>  {/* no container prop needed */}
          <Dialog.Content>...</Dialog.Content>
        </Dialog.Portal>
      </Dialog.Root>
    </Portal.PortalProvider>
  );
}
```

Container priority: explicit `container` prop > `PortalProvider` context > `document.body`

No changes needed to downstream components — they all pass `container` through to `Portal`, so `undefined` now falls back to context automatically.

## Related issues

- Closes https://github.com/radix-ui/primitives/issues/2845 — [Feat:Portal] Override default portal'd location
- Related https://github.com/shadcn-ui/ui/issues/7936 — [feat]: Add Shadow DOM Support to React Components

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [ ] Verify Portal still renders to `document.body` by default (no PortalProvider)
- [ ] Verify PortalProvider sets the default container for nested Portals
- [ ] Verify explicit `container` prop on Portal overrides PortalProvider

🤖 Generated with [Claude Code](https://claude.com/claude-code)