### PR TITLE
ci(gh permissions): restrict gh token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,6 +20,8 @@ env:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   publish-snapshot:
     if: github.repository == 'radix-ui/primitives'

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -11,6 +11,8 @@ env:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   publish-stable:
     if: github.repository == 'radix-ui/primitives'


### PR DESCRIPTION
### Description

* Your ossf scorecard score is a little low
* Try to increase token score by restricting GitHub permissions
* [radix-ui scorecard](https://scorecard.dev/viewer/?uri=github.com/radix-ui/primitives)

I don't think the gh token permissions will affect npmjs registry publishing
