### PR TITLE
fix(exports): Add ./package.json to publishConfig exports

### DIFF
--- a/packages/react/radix-ui/package.json
+++ b/packages/react/radix-ui/package.json
@@ -33,7 +33,8 @@
           "types": "./dist/*.d.ts",
           "default": "./dist/*.js"
         }
-      }
+      },
+      "./package.json": "./package.json"
     }
   },
   "files": [


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
 Add `"./package.json": "./package.json"` to the `publishConfig.exports` map in `packages/react/radix-ui/package.json`.

  The existing `"./*"` wildcard pattern intercepts `require.resolve('radix-ui/package.json')`, causing Node.js to look for `./dist/package.json.mjs` instead of the actual file. This breaks tools like Storybook that resolve `package.json` to read package metadata.

The [Node.js docs](https://nodejs.org/api/packages.html) explicitly recommend exporting `./package.json` when using an exports map to avoid breaking changes.

Fixes #3818