### PR TITLE
fix(select): guard against null ref in typeahead focus

### DIFF
--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -669,7 +669,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
          * Imperative focus during keydown is risky so we prevent React's batching updates
          * to avoid potential bugs. See: https://github.com/facebook/react/issues/20332
          */
-        setTimeout(() => (nextItem.ref.current as HTMLElement).focus());
+        setTimeout(() => (nextItem.ref.current as HTMLElement)?.focus());
       }
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
	
Fixes #3597

Adds a null check on nextItem.ref.current before calling .focus() in the typeahead search handler within SelectContentImpl.

When using the Select component on mobile browsers (observed on Android Chrome), the DOM element referenced by nextItem.ref.current can be null if the element hasn't mounted yet or has been unmounted due to timing issues.

This causes an unhandled TypeError: Cannot read properties of null (reading 'focus').