### PR TITLE
Dialog/Select/Popover/Menu: Fix focus guards incorrectly getting aria-hidden

### DIFF
--- a/.changeset/major-crabs-retire.md
+++ b/.changeset/major-crabs-retire.md
@@ -1,0 +1,8 @@
+---
+'@radix-ui/react-popover': patch
+'@radix-ui/react-dialog': patch
+'@radix-ui/react-select': patch
+'@radix-ui/react-menu': patch
+---
+
+Fix focus guards being incorrectly marked as aria-hidden when content opens, resolving a WCAG 2.1.1 Level A violation

--- a/packages/react/dialog/src/dialog.test.tsx
+++ b/packages/react/dialog/src/dialog.test.tsx
@@ -128,6 +128,14 @@ describe('given a default Dialog', () => {
       expect(closeButton).toHaveFocus();
     });
 
+    it('should not set aria-hidden on focus guards', () => {
+      const focusGuards = document.querySelectorAll('[data-radix-focus-guard]');
+      expect(focusGuards.length).toBeGreaterThan(0);
+      focusGuards.forEach((guard) => {
+        expect(guard).not.toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+
     describe('when pressing escape', () => {
       beforeEach(() => {
         fireEvent.keyDown(document.activeElement!, { key: 'Escape' });

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -263,9 +263,14 @@ const DialogContentModal = React.forwardRef<DialogContentTypeElement, DialogCont
     const composedRefs = useComposedRefs(forwardedRef, context.contentRef, contentRef);
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+    // Also exclude focus guards so they remain accessible to screen readers despite being
+    // siblings of the portal — otherwise tabindex="0" + aria-hidden="true" violates WCAG 2.1.1.
     React.useEffect(() => {
       const content = contentRef.current;
-      if (content) return hideOthers(content);
+      if (content) {
+        const focusGuards = Array.from(document.querySelectorAll('[data-radix-focus-guard]'));
+        return hideOthers([content, ...focusGuards]);
+      }
     }, []);
 
     return (

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -262,9 +262,14 @@ const MenuRootContentModal = React.forwardRef<MenuRootContentTypeElement, MenuRo
     const composedRefs = useComposedRefs(forwardedRef, ref);
 
     // Hide everything from ARIA except the `MenuContent`
+    // Also exclude focus guards so they remain accessible to screen readers despite being
+    // siblings of the portal — otherwise tabindex="0" + aria-hidden="true" violates WCAG 2.1.1.
     React.useEffect(() => {
       const content = ref.current;
-      if (content) return hideOthers(content);
+      if (content) {
+        const focusGuards = Array.from(document.querySelectorAll('[data-radix-focus-guard]'));
+        return hideOthers([content, ...focusGuards]);
+      }
     }, []);
 
     return (

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -254,9 +254,14 @@ const PopoverContentModal = React.forwardRef<PopoverContentTypeElement, PopoverC
     const isRightClickOutsideRef = React.useRef(false);
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+    // Also exclude focus guards so they remain accessible to screen readers despite being
+    // siblings of the portal — otherwise tabindex="0" + aria-hidden="true" violates WCAG 2.1.1.
     React.useEffect(() => {
       const content = contentRef.current;
-      if (content) return hideOthers(content);
+      if (content) {
+        const focusGuards = Array.from(document.querySelectorAll('[data-radix-focus-guard]'));
+        return hideOthers([content, ...focusGuards]);
+      }
     }, []);
 
     return (

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -570,8 +570,13 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const firstValidItemFoundRef = React.useRef(false);
 
     // aria-hide everything except the content (better supported equivalent to setting aria-modal)
+    // Also exclude focus guards so they remain accessible to screen readers despite being
+    // siblings of the portal — otherwise tabindex="0" + aria-hidden="true" violates WCAG 2.1.1.
     React.useEffect(() => {
-      if (content) return hideOthers(content);
+      if (content) {
+        const focusGuards = Array.from(document.querySelectorAll('[data-radix-focus-guard]'));
+        return hideOthers([content, ...focusGuards]);
+      }
     }, [content]);
 
     // Make sure the whole tree has focus guards as our `Select` may be


### PR DESCRIPTION
### Description

When a modal component (Dialog, Select, Popover, Menu) opens, `hideOthers(content)` from the `aria-hidden` package marks all siblings of the content in `document.body` as `aria-hidden="true"`. This includes the focus guard `<span>` elements injected by `useFocusGuards` at the edges of `document.body`.

The result: focus guards have both `tabindex="0"` (making them keyboard-focusable) **and** `aria-hidden="true"` (hiding them from the accessibility tree). This is a **WCAG 2.1.1 Level A violation** — keyboard-focusable elements must not be hidden from assistive technology.

Reported by axe and Level Access audit tools:
```html
<span data-radix-focus-guard="" tabindex="0" aria-hidden="true" style="outline: none; opacity: 0; position: fixed; pointer-events: none;"></span>
```

**Fix:** Pass focus guards as additional elements to `hideOthers` so they are excluded from the `aria-hidden` treatment. The `[data-radix-focus-guard]` selector targets exactly the spans created by `createFocusGuard()` in `@radix-ui/react-focus-guards`.

The same pattern existed in all four components that call both `useFocusGuards` and `hideOthers`, so all four are fixed here.

Fixes #3593