### PR TITLE
slider: ensure onValueCommit is called when range narrows to single value

### DIFF
--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -119,9 +119,7 @@ const Slider = React.forwardRef<SliderElement, SliderProps>(
     }
 
     function handleSlideEnd() {
-      const prevValue = valuesBeforeSlideStartRef.current[valueIndexToChangeRef.current];
-      const nextValue = values[valueIndexToChangeRef.current];
-      const hasChanged = nextValue !== prevValue;
+      const hasChanged = String(values) !== String(valuesBeforeSlideStartRef.current);
       if (hasChanged) onValueCommit(values);
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where onValueCommit was not fired when dragging a range slider thumb to overlap another.

## Problem

When dragging the right thumb of a range slider to overlap the left thumb (e.g. [105, 107] ? [105, 105]), onValueCommit was never fired.

## Root Cause

handleSlideEnd compared individual thumb values using alueIndexToChangeRef.current as the index. However, when two thumbs land on the same value, indexOf returns  for both, causing the comparison to check the left thumb against itself.

## Fix

Changed handleSlideEnd to compare the full value arrays using String(values) !== String(prevValues), matching the approach already used in updateValues.

## Testing

- [x] Manual testing with range slider
- [x] Verified onValueCommit fires when thumbs overlap
- [x] All existing slider tests pass

Fixes radix-ui/primitives#3698
Fixes radix-ui/primitives#3829