### PR TITLE
fix (#3826): In DropdownMenu,  allow Tab navigation to interactive elements w…

### DIFF
--- a/.changeset/public-beans-trade.md
+++ b/.changeset/public-beans-trade.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-menu': major
+---
+
+Allow Tab key navigation to interactive elements within menu content instead of always closing

--- a/.changeset/public-beans-trade.md
+++ b/.changeset/public-beans-trade.md
@@ -1,5 +1,0 @@
----
-'@radix-ui/react-menu': major
----
-
-Allow Tab key navigation to interactive elements within menu content instead of always closing

--- a/.changeset/tired-sides-dance.md
+++ b/.changeset/tired-sides-dance.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-dropdown-menu': patch
+'@radix-ui/react-menu': patch
+---
+
+Allow Tab key navigation to interactive elements within menu content instead of always closing

--- a/apps/storybook/stories/dropdown-menu.stories.module.css
+++ b/apps/storybook/stories/dropdown-menu.stories.module.css
@@ -149,6 +149,34 @@
   border: 1px solid rgb(0 0 0 / 0.3);
 }
 
+.footer {
+  display: flex;
+  gap: 5px;
+  padding: 5px 10px;
+  border-top: 1px solid var(--color-gray100);
+  margin-top: 5px;
+}
+
+.footerButton {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--color-gray100);
+  border-radius: 4px;
+  background-color: var(--color-white);
+  cursor: pointer;
+  font-size: 12px;
+  font-family: apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif;
+
+  &:hover {
+    background-color: var(--color-gray100);
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgb(0 0 0 / 0.5);
+  }
+}
+
 .chromaticArrow {
   fill: var(--color-black);
 }

--- a/apps/storybook/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/stories/dropdown-menu.stories.tsx
@@ -1637,3 +1637,40 @@ const TickIcon = () => (
     <path d="M2 20 L12 28 30 4" />
   </svg>
 );
+
+export const WithFooterActions = () => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className={styles.trigger}>Open</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={styles.content} sideOffset={5}>
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('cut')}>
+            Cut
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('copy')}>
+            Copy
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('paste')}>
+            Paste
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className={styles.separator} />
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('delete')}>
+            Delete
+          </DropdownMenu.Item>
+
+          <div className={styles.footer}>
+            <button className={styles.footerButton} onClick={() => console.log('apply')}>
+              Apply
+            </button>
+            <button className={styles.footerButton} onClick={() => console.log('create new')}>
+              Create New
+            </button>
+          </div>
+
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  </div>
+);
+

--- a/packages/react/dropdown-menu/src/dropdown-menu.test.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import * as DropdownMenu from './dropdown-menu';
+import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
+
+const TRIGGER_TEXT = 'Open';
+const APPLY_TEXT = 'Apply';
+const CREATE_TEXT = 'Create New';
+
+const DropdownMenuWithFooterTest = (props: React.ComponentProps<typeof DropdownMenu.Root>) => (
+  <DropdownMenu.Root {...props}>
+    <DropdownMenu.Trigger>{TRIGGER_TEXT}</DropdownMenu.Trigger>
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Cut</DropdownMenu.Item>
+        <DropdownMenu.Item>Copy</DropdownMenu.Item>
+        <DropdownMenu.Item>Paste</DropdownMenu.Item>
+        <div>
+          <button>{APPLY_TEXT}</button>
+          <button>{CREATE_TEXT}</button>
+        </div>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
+  </DropdownMenu.Root>
+);
+
+describe('given an open DropdownMenu with footer actions', () => {
+  let rendered: RenderResult;
+  const onOpenChange = vi.fn();
+
+  afterEach(() => {
+    cleanup();
+    onOpenChange.mockClear();
+  });
+
+  beforeEach(async () => {
+    rendered = render(
+      <DropdownMenuWithFooterTest defaultOpen modal={false} onOpenChange={onOpenChange} />,
+    );
+    await waitFor(() => expect(rendered.getByText('Cut')).toBeVisible());
+  });
+
+  describe('when pressing Tab at the last tabbable element', () => {
+    beforeEach(() => {
+      const createButton = rendered.getByText(CREATE_TEXT);
+      createButton.focus();
+      fireEvent.keyDown(createButton, { key: 'Tab' });
+    });
+
+    it('should close the menu', async () => {
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe('when pressing Shift+Tab at the first tabbable element', () => {
+    beforeEach(() => {
+      const firstItem = rendered.getByText('Cut');
+      firstItem.focus();
+      fireEvent.keyDown(firstItem, { key: 'Tab', shiftKey: true });
+    });
+
+    it('should close the menu', async () => {
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  describe('when pressing Tab on a middle tabbable element', () => {
+    beforeEach(() => {
+      const applyButton = rendered.getByText(APPLY_TEXT);
+      applyButton.focus();
+      fireEvent.keyDown(applyButton, { key: 'Tab' });
+    });
+
+    it('should not close the menu', () => {
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it('should keep the content visible', () => {
+      expect(rendered.getByText('Cut')).toBeVisible();
+    });
+  });
+});

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -514,8 +514,34 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
                     const isModifierKey = event.ctrlKey || event.altKey || event.metaKey;
                     const isCharacterKey = event.key.length === 1;
                     if (isKeyDownInside) {
-                      // menus should not be navigated using tab key so we prevent it
-                      if (event.key === 'Tab') event.preventDefault();
+                      if (event.key === 'Tab') {
+                        // Allow Tab to navigate to other interactive elements within the menu
+                        // content (e.g. footer buttons). Close the menu when focus would leave.
+                        const content = contentRef.current;
+                        if (content) {
+                          const tabbables = getTabbableCandidates(content);
+                          const focusedElement = document.activeElement as HTMLElement;
+                          const currentIndex = tabbables.indexOf(focusedElement);
+                    
+                          if (!event.shiftKey) {
+                            // Forward Tab: close menu if at the last tabbable element or no tabbables
+                            const isAtEnd =
+                              tabbables.length === 0 ||
+                              (currentIndex !== -1 && currentIndex >= tabbables.length - 1);
+                            if (isAtEnd) {
+                              event.preventDefault();
+                              rootContext.onClose();
+                            }
+                          } else {
+                            // Shift+Tab: close menu if at the first tabbable element
+                            const isAtStart = currentIndex <= 0;
+                            if (isAtStart) {
+                              event.preventDefault();
+                              rootContext.onClose();
+                            }
+                          }
+                        }
+                      }      
                       if (!isModifierKey && isCharacterKey) handleTypeaheadSearch(event.key);
                     }
                     // focus first/last item based on key pressed
@@ -1246,6 +1272,24 @@ function focusFirst(candidates: HTMLElement[]) {
     if (document.activeElement !== PREVIOUSLY_FOCUSED_ELEMENT) return;
   }
 }
+
+/**
+ * Returns a list of tabbable candidates within a container.
+ * Tabbable elements are those with tabIndex >= 0 that are not disabled or hidden.
+ */
+function getTabbableCandidates(container: HTMLElement) {
+  const nodes: HTMLElement[] = [];
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
+    acceptNode: (node: any) => {
+      const isHiddenInput = node.tagName === 'INPUT' && node.type === 'hidden';
+      if (node.disabled || node.hidden || isHiddenInput) return NodeFilter.FILTER_SKIP;
+      return node.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    },
+  });
+  while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement);
+  return nodes;
+}
+
 
 /**
  * Wraps an array around itself at a given start index


### PR DESCRIPTION
Fixes #3826 - Dropdown Footer Accessibility Concern

### Description

Currently, pressing Tab anywhere inside a DropdownMenu immediately closes it via `event.preventDefault()`. This means keyboard users cannot reach interactive elements placed inside the menu content that are outside of `DropdownMenu.Item` - such as footer buttons ("Apply", "Create New", "Save", etc.).

This is a real accessibility gap: it is a common pattern to put action buttons at the bottom of a dropdown panel, and those buttons are completely unreachable by keyboard.

**Changes:**

- Replaced the blanket `event.preventDefault()` on Tab in `MenuContentImpl`'s `onKeyDown` handler with smart Tab navigation logic.
- Tab now cycles freely between tabbable elements within the menu content.
- The menu closes (and focus returns to the trigger) only when Tab would move focus outside the content boundary:
  - **Tab** on the **last** tabbable element → menu closes
  - **Shift+Tab** on the **first** tabbable element → menu closes
- Added a `getTabbableCandidates()` utility using `TreeWalker` to enumerate focusable elements within the content container.
- Added a `WithFooterActions` Storybook story to demonstrate the fix.
- Added unit tests covering boundary and mid-content Tab behaviour.

**How to test manually:**

1. Run `pnpm --filter storybook dev`
2. Open **DropdownMenu → With Footer Actions**
3. Click "Open", then press Tab — focus should move through Cut → Copy → Paste → Delete → Apply → Create New
4. Pressing Tab on "Create New" closes the menu
5. Open again, Shift+Tab on the first item closes the menu
