### PR TITLE
fix(direction): respect document-level dir attribute in useDirection when no DirectionProvider is present

### DIFF
--- a/.changeset/free-crabs-watch.md
+++ b/.changeset/free-crabs-watch.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-direction': patch
+---
+
+Respect document-level dir attribute in useDirection when no DirectionProvider is present

--- a/packages/react/direction/src/direction.test.tsx
+++ b/packages/react/direction/src/direction.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
+import { DirectionProvider, useDirection } from './direction';
+import { afterEach, describe, it, beforeEach, expect } from 'vitest';
+
+// Helper component that renders the resolved direction as text
+function DirectionDisplay({ localDir }: { localDir?: 'ltr' | 'rtl' }) {
+  const direction = useDirection(localDir);
+  return <span data-testid="direction">{direction}</span>;
+}
+
+describe('useDirection', () => {
+  let rendered: RenderResult;
+
+  afterEach(() => {
+    cleanup();
+    // Reset document dir after each test
+    document.documentElement.dir = '';
+  });
+
+  describe('given no DirectionProvider and no local dir', () => {
+    describe('when document dir is not set', () => {
+      beforeEach(() => {
+        document.documentElement.dir = '';
+        rendered = render(<DirectionDisplay />);
+      });
+
+      it('should default to ltr', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('ltr');
+      });
+    });
+
+    describe('when document dir is rtl', () => {
+      beforeEach(() => {
+        document.documentElement.dir = 'rtl';
+        rendered = render(<DirectionDisplay />);
+      });
+
+      it('should return rtl from document', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('rtl');
+      });
+    });
+
+    describe('when document dir is ltr', () => {
+      beforeEach(() => {
+        document.documentElement.dir = 'ltr';
+        rendered = render(<DirectionDisplay />);
+      });
+
+      it('should return ltr from document', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('ltr');
+      });
+    });
+  });
+
+  describe('given a DirectionProvider with dir="rtl"', () => {
+    describe('when document dir is ltr', () => {
+      beforeEach(() => {
+        document.documentElement.dir = 'ltr';
+        rendered = render(
+          <DirectionProvider dir="rtl">
+            <DirectionDisplay />
+          </DirectionProvider>,
+        );
+      });
+
+      it('should return rtl from provider (overrides document)', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('rtl');
+      });
+    });
+  });
+
+  describe('given a DirectionProvider with dir="ltr"', () => {
+    describe('when document dir is rtl', () => {
+      beforeEach(() => {
+        document.documentElement.dir = 'rtl';
+        rendered = render(
+          <DirectionProvider dir="ltr">
+            <DirectionDisplay />
+          </DirectionProvider>,
+        );
+      });
+
+      it('should return ltr from provider (overrides document)', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('ltr');
+      });
+    });
+  });
+
+  describe('given a local dir prop', () => {
+    describe('when DirectionProvider is rtl and document is rtl', () => {
+      beforeEach(() => {
+        document.documentElement.dir = 'rtl';
+        rendered = render(
+          <DirectionProvider dir="rtl">
+            <DirectionDisplay localDir="ltr" />
+          </DirectionProvider>,
+        );
+      });
+
+      it('should return ltr from local dir (highest priority)', () => {
+        expect(rendered.getByTestId('direction').textContent).toBe('ltr');
+      });
+    });
+  });
+});

--- a/packages/react/direction/src/direction.tsx
+++ b/packages/react/direction/src/direction.tsx
@@ -20,8 +20,15 @@ const DirectionProvider: React.FC<DirectionProviderProps> = (props) => {
 
 function useDirection(localDir?: Direction) {
   const globalDir = React.useContext(DirectionContext);
-  return localDir || globalDir || 'ltr';
+  const documentDir = getDocumentDirection();
+  return localDir || globalDir || documentDir;
 }
+
+function getDocumentDirection(): Direction {
+  if (typeof document === 'undefined') return 'ltr';
+  return document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr';
+}
+
 
 const Provider = DirectionProvider;
 


### PR DESCRIPTION
Fixes #3830

### Description

`useDirection()` currently falls back to `'ltr'` when no `DirectionProvider` exists in the React tree - completely ignoring `<html dir="rtl">` set at the document level. This causes every Radix component (DropdownMenu, Dialog, Popover, ScrollArea, etc.) to render `dir="ltr"` on its DOM elements, overriding the document's RTL setting.

Teams building Arabic, Hebrew, Persian, or Urdu apps must manually wrap their entire application in `<DirectionProvider dir="rtl">` just to get correct layout - boilerplate that should not be required.

**Fix:** Read `document.documentElement.dir` as a fallback before defaulting to `'ltr'`. Added a `getDocumentDirection()` helper with an SSR guard.

Priority order (unchanged, additive only): `localDir` > `DirectionProvider` context > `<html dir>` > `'ltr'`

**Why this is safe:**
- No breaking changes - `DirectionProvider` and `localDir` still take full precedence. Existing apps are unaffected.
- LTR apps unchanged - if `<html dir>` is not `"rtl"`, result is `'ltr'` as before.
- SSR safe - `typeof document === 'undefined'` guard falls back to `'ltr'` on the server.

**Tests:** Added the first unit tests for the `direction` package (6 tests) covering all priority levels - no provider + document rtl, provider overrides document, local dir overrides provider.

**Storybook not required:** This change is to an internal hook (`useDirection`) with no visual component of its own. There is no UI to demonstrate - the fix is a logic change in a single fallback value.