### PR TITLE
fix(slot): memoize composed ref in SlotClone to prevent infinite loop…

### DIFF
--- a/.changeset/fix-slot-memoize-ref.md
+++ b/.changeset/fix-slot-memoize-ref.md
@@ -1,0 +1,1 @@
+'@radix-ui/react-slot': patch

--- a/packages/react/slot/src/.changeset/fix-slot-memoize-ref.md
+++ b/packages/react/slot/src/.changeset/fix-slot-memoize-ref.md
@@ -1,1 +1,0 @@
-'@radix-ui/react-slot': patch

--- a/packages/react/slot/src/.changeset/fix-slot-memoize-ref.md
+++ b/packages/react/slot/src/.changeset/fix-slot-memoize-ref.md
@@ -1,0 +1,1 @@
+'@radix-ui/react-slot': patch

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -98,24 +98,37 @@ interface SlotCloneProps {
 }
 
 /* @__NO_SIDE_EFFECTS__ */ function createSlotClone(ownerName: string) {
-  const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
-    let { children, ...slotProps } = props;
-    if (isLazyComponent(children) && typeof use === 'function') {
-      children = use(children._payload);
-    }
+    const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {                                                                                           
+      let { children, ...slotProps } = props;
+      if (isLazyComponent(children) && typeof use === 'function') {                                                                                                              
+        children = use(children._payload);                  
+      }                                                                                                                                                                          
+                                                            
+      // Memoize the composed ref to maintain stable identity across renders.                                                                                                    
+      // In React 19, ref identity changes trigger cleanup + re-attach cycles.
+      // Without memoization, composeRefs creates a new function every render,                                                                                                   
+      // which causes infinite loops when a state setter is used as a ref                                                                                                        
+      // (e.g. Tooltip's setTrigger). See: https://github.com/radix-ui/primitives/issues/3799                                                                                    
+      const childrenRef = React.isValidElement(children) ? getElementRef(children) : null;                                                                                       
+      const composedRef = React.useMemo(                                                                                                                                         
+        () =>                                                                                                                                                                    
+          forwardedRef && childrenRef                       
+            ? composeRefs(forwardedRef, childrenRef)                                                                                                                             
+            : forwardedRef || childrenRef || null,
+        [forwardedRef, childrenRef]                                                                                                                                              
+      );                                                    
 
-    if (React.isValidElement(children)) {
-      const childrenRef = getElementRef(children);
-      const props = mergeProps(slotProps, children.props as AnyProps);
-      // do not pass ref to React.Fragment for React 19 compatibility
-      if (children.type !== React.Fragment) {
-        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef;
-      }
-      return React.cloneElement(children, props);
-    }
-
-    return React.Children.count(children) > 1 ? React.Children.only(null) : null;
-  });
+      if (React.isValidElement(children)) {
+        const props = mergeProps(slotProps, children.props as AnyProps);
+        // do not pass ref to React.Fragment for React 19 compatibility                                                                                                          
+        if (children.type !== React.Fragment) {
+          props.ref = composedRef;                                                                                                                                               
+        }                                                   
+        return React.cloneElement(children, props);
+      }                                                                                                                                                                          
+   
+      return React.Children.count(children) > 1 ? React.Children.only(null) : null;                                                                                              
+    });
 
   SlotClone.displayName = `${ownerName}.SlotClone`;
   return SlotClone;


### PR DESCRIPTION
… in React 19

Fixes #3799

  ## Problem

  In `SlotClone`, `composeRefs(forwardedRef, childrenRef)` is called inline during render, creating a new function identity on every render. In React 19, ref identity changes
  trigger ref cleanup + re-attach. When a state setter is used as a ref (e.g., Tooltip's `setTrigger`), this causes an infinite loop:

  1. New `composeRefs` → React detects ref identity change
  2. React calls cleanup (`setTrigger(null)`) → state update → re-render
  3. Re-render creates another new `composeRefs` → goto 1
  4. "Maximum update depth exceeded"

  ## Solution

  Memoize the composed ref via `React.useMemo` so the ref identity stays stable across renders. The memoization depends on `forwardedRef` and `childrenRef` — it only recomputes
  when the actual refs change, not on every render.

  ## How this differs from #3804

  PR #3804 switches to `useComposedRefs`, but comments there note that `useComposedRefs` itself is unstable when callers pass inline arrow functions. This approach memoizes
  directly at the call site in `SlotClone`, which is the minimal change needed — it keeps `composeRefs` untouched and just stabilizes the ref identity where it matters.

  ## Validation

  Running in production on a large enterprise React 19 app since Feb 2026. Zero recurrence of the infinite loop across Tooltip, Select, Popover, and Dialog components.

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
