### PR TITLE
fix(slider): handle scientific notation in getDecimalCount for steps …

### DIFF
--- a/packages/react/slider/src/slider.tsx
+++ b/packages/react/slider/src/slider.tsx
@@ -780,8 +780,24 @@ function linearScale(input: readonly [number, number], output: readonly [number,
   };
 }
 
+// function getDecimalCount(value: number) {
+//   return (String(value).split('.')[1] || '').length;
+// }
 function getDecimalCount(value: number) {
-  return (String(value).split('.')[1] || '').length;
+  if (!Number.isFinite(value)) return 0;
+
+  const str = value.toString();
+
+  if (str.includes('e')) {
+    const [coefficient, exponent] = str.split('e');
+    const decimalPart = coefficient.split('.')[1] || '';
+    const exponentNum = Number(exponent);
+
+    return Math.max(0, decimalPart.length - exponentNum);
+  }
+
+  const decimalPart = str.split('.')[1];
+  return decimalPart ? decimalPart.length : 0;
 }
 
 function roundValue(value: number, decimalCount: number) {


### PR DESCRIPTION
fix(slider): handle precision for values <= 1e-7

Fixes #3852

### Description

Fixes an issue where Slider precision breaks for values <= 1e-7 due to improper handling of scientific notation in decimal count calculation.

The previous implementation of `getDecimalCount` did not correctly handle scientific notation values, leading to incorrect slider step precision calculation.

This update ensures:
- Proper handling of scientific notation (e.g. 1e-7)
- Correct decimal precision calculation for slider steps
- No change in public API or component behavior

This is a non-breaking internal fix with no changes to public API.

### Testing

- Verified manually in Storybook with step values <= 1e-7
- Ensured no regression in slider dragging behavior
- All existing tests pass (`pnpm test`)

<img width="508" height="222" alt="image" src="https://github.com/user-attachments/assets/21b6194f-2c49-4f9b-b959-b4b704e78deb" />

### Notes

- No additional tests added as existing slider behavior tests already cover precision handling paths.
- No Storybook changes required as UI behavior remains unchanged.