### PR TITLE
fix: remove dialog description warning when aria-describedby is optional

### DIFF
--- a/.changeset/dialog-description-warning.md
+++ b/.changeset/dialog-description-warning.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-dialog': patch
+---
+
+Remove console warning when dialog has no description; only set aria-describedby when DialogDescription is rendered

--- a/packages/react/dialog/src/dialog.test.tsx
+++ b/packages/react/dialog/src/dialog.test.tsx
@@ -87,8 +87,8 @@ describe('given a default Dialog', () => {
     });
 
     describe('when no description has been provided', () => {
-      it('should warn to the console', () => {
-        expect(consoleWarnMockFunction).toHaveBeenCalledTimes(1);
+      it('should not warn to the console', () => {
+        expect(consoleWarnMockFunction).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -31,6 +31,8 @@ type DialogContextValue = {
   contentId: string;
   titleId: string;
   descriptionId: string;
+  hasDescription: boolean;
+  setHasDescription(value: boolean): void;
   open: boolean;
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
@@ -58,6 +60,7 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
   } = props;
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const contentRef = React.useRef<DialogContentElement>(null);
+  const [hasDescription, setHasDescription] = React.useState(false);
   const [open, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen ?? false,
@@ -73,6 +76,8 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
       contentId={useId()}
       titleId={useId()}
       descriptionId={useId()}
+      hasDescription={hasDescription}
+      setHasDescription={setHasDescription}
       open={open}
       onOpenChange={setOpen}
       onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
@@ -404,7 +409,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
           <DismissableLayer
             role="dialog"
             id={context.contentId}
-            aria-describedby={context.descriptionId}
+            aria-describedby={context.hasDescription ? context.descriptionId : undefined}
             aria-labelledby={context.titleId}
             data-state={getState(context.open)}
             {...contentProps}
@@ -415,7 +420,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
         {process.env.NODE_ENV !== 'production' && (
           <>
             <TitleWarning titleId={context.titleId} />
-            <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />
+
           </>
         )}
       </>
@@ -457,6 +462,11 @@ const DialogDescription = React.forwardRef<DialogDescriptionElement, DialogDescr
   (props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
     const { __scopeDialog, ...descriptionProps } = props;
     const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog);
+    React.useEffect(() => {
+      context.setHasDescription(true);
+      return () => context.setHasDescription(false);
+    }, [context]);
+
     return <Primitive.p id={context.descriptionId} {...descriptionProps} ref={forwardedRef} />;
   },
 );


### PR DESCRIPTION
Fixes #3855

## Problem

When a Dialog is created without a `DialogDescription` component, a console warning fires:
```
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
```

However, per the [APG dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), `aria-describedby` is optional. There are legitimate reasons to omit it, especially when dialog content includes semantic structures (lists, tables, multiple paragraphs) that would be difficult to understand as a single unbroken string by screen readers.

## Fix

- `aria-describedby` is now only set on `DialogContent` when a `DialogDescription` component is actually rendered
- `DialogDescription` registers itself with the Dialog context via `useEffect` on mount
- The console warning for missing description is removed entirely
- The `aria-labelledby` attribute (for `DialogTitle`) is unchanged — title remains required

## Changes

- `DialogContextValue` — added `hasDescription: boolean` and `setHasDescription`
- `Dialog` root — creates `hasDescription` state, passes through context
- `DialogContentImpl` — conditionally sets `aria-describedby`
- `DialogDescription` — registers itself via useEffect
- `dialog.test.tsx` — updated test expectation (no warning when no description)
- All 8 existing tests pass