### PR TITLE
fix(PopperAnchor): use callback ref instead of dependency-less useEffect

### DIFF
--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -75,19 +75,22 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
     const { __scopePopper, virtualRef, ...anchorProps } = props;
     const context = usePopperContext(ANCHOR_NAME, __scopePopper);
     const ref = React.useRef<PopperAnchorElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
 
-    const anchorRef = React.useRef<Measurable | null>(null);
+    const onAnchorChange = context.onAnchorChange;
+    const callbackRef = React.useCallback(
+      (node: PopperAnchorElement | null) => {
+        ref.current = node;
+        if (node) onAnchorChange(node);
+      },
+      [onAnchorChange]
+    );
+    const composedRefs = useComposedRefs(forwardedRef, virtualRef ? ref : callbackRef);
+
     React.useEffect(() => {
-      const previousAnchor = anchorRef.current;
-      anchorRef.current = virtualRef?.current || ref.current;
-      if (previousAnchor !== anchorRef.current) {
-        // Consumer can anchor the popper to something that isn't
-        // a DOM node e.g. pointer position, so we override the
-        // `anchorRef` with their virtual ref in this case.
-        context.onAnchorChange(anchorRef.current);
+      if (virtualRef?.current) {
+        onAnchorChange(virtualRef.current);
       }
-    });
+    }, [virtualRef, onAnchorChange]);
 
     return virtualRef ? null : <Primitive.div {...anchorProps} ref={composedRefs} />;
   },


### PR DESCRIPTION
Fixes #3858

## Problem

`PopperAnchor` has a `useEffect` with no dependency array that calls `context.onAnchorChange()` (a `setState`) on every render. When many Popper-based components (Tooltip, Popover, DropdownMenu, HoverCard) mount in a single render pass, React counts all these `setState` calls against a single 50-update nested depth limit, causing `Maximum update depth exceeded` errors.

This is not an infinite loop — it is a cumulative depth issue from many independent Popper instances mounting simultaneously. React Strict Mode (which double-invokes effects) makes this worse in development.

## Fix

Replace the dependency-less `useEffect` + `setState` with a callback ref for the DOM anchor case. React calls callback refs during the commit phase, which does not count toward the nested update limit.

The `useEffect` is kept only for the `virtualRef` case (virtual anchors like pointer position), where a DOM node isn't directly available. This effect now has proper dependencies `[virtualRef, onAnchorChange]` so it only re-runs when actually needed.

- Typecheck passes (`tsc --noEmit`)
