### PR TITLE
feat(tooltip): add overflow-only trigger support

### DIFF
--- a/.changeset/smart-laws-drum.md
+++ b/.changeset/smart-laws-drum.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-tooltip': minor
+---
+
+Add `onlyShowOnOverflow` and `overflowTolerance` to `Tooltip.Trigger` to enhance UX for overflow-only tooltip use cases. `onlyShowOnOverflow` defaults to `false`, preserving existing behavior and accessibility unless explicitly enabled. Even when explicitly enabled it preserves accessibility - only gates hover.

--- a/apps/storybook/stories/tooltip.stories.module.css
+++ b/apps/storybook/stories/tooltip.stories.module.css
@@ -7,6 +7,28 @@
 .trigger {
 }
 
+.overflowStoryGrid {
+  display: grid;
+  gap: 24px;
+  max-width: 720px;
+}
+
+.overflowStoryRow {
+  display: grid;
+  gap: 8px;
+}
+
+.overflowStoryLabel {
+  font-size: 13px;
+}
+
+.overflowTrigger {
+  width: 180px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .content {
   transform-origin: var(--radix-tooltip-content-transform-origin);
   /* ensures content isn't selectable */

--- a/apps/storybook/stories/tooltip.stories.tsx
+++ b/apps/storybook/stories/tooltip.stories.tsx
@@ -21,6 +21,67 @@ export const Styled = () => (
   </Tooltip.Provider>
 );
 
+export const OverflowOnly = () => (
+  <Tooltip.Provider delayDuration={0}>
+    <div className={styles.overflowStoryGrid}>
+      <div className={styles.overflowStoryRow}>
+        <span className={styles.overflowStoryLabel}>
+          Opens: overflowing trigger with `onlyShowOnOverflow`
+        </span>
+        <Tooltip.Root>
+          <Tooltip.Trigger className={styles.overflowTrigger} onlyShowOnOverflow>
+            A very long label that overflows the trigger and reveals the full value in a tooltip
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content className={styles.content} sideOffset={5}>
+              A very long label that overflows the trigger and reveals the full value in a tooltip
+              <Tooltip.Arrow className={styles.arrow} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </div>
+
+      <div className={styles.overflowStoryRow}>
+        <span className={styles.overflowStoryLabel}>
+          Stays closed: text fits, so `onlyShowOnOverflow` blocks hover open
+        </span>
+        <Tooltip.Root>
+          <Tooltip.Trigger className={styles.overflowTrigger} onlyShowOnOverflow>
+            Short label
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content className={styles.content} sideOffset={5}>
+              This should stay closed on hover because the trigger does not overflow
+              <Tooltip.Arrow className={styles.arrow} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </div>
+
+      <div className={styles.overflowStoryRow}>
+        <span className={styles.overflowStoryLabel}>
+          Custom tolerance: small overflow is ignored with `overflowTolerance=20`
+        </span>
+        <Tooltip.Root>
+          <Tooltip.Trigger
+            className={styles.overflowTrigger}
+            onlyShowOnOverflow
+            overflowTolerance={20}
+          >
+            A label that clips a little
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content className={styles.content} sideOffset={5}>
+              This should stay closed unless the overflow exceeds the custom tolerance
+              <Tooltip.Arrow className={styles.arrow} offset={10} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </div>
+    </div>
+  </Tooltip.Provider>
+);
+
 export const Controlled = () => {
   const [open, setOpen] = React.useState(true);
   return (

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -129,6 +129,31 @@ describe('Tooltip', () => {
     });
   });
 
+  it('opens on focus even when onlyShowOnOverflow is true and not overflowing', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger onlyShowOnOverflow>Tooltip Trigger</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content>
+              Tooltip Content
+              <Tooltip.Arrow />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    mockElementOverflowSize(trigger, { clientWidth: 100, scrollWidth: 102 });
+
+    await trigger.focus();
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Tooltip Content')[0]).toBeVisible();
+    });
+  });
+
   it('opens when onlyShowOnOverflow is true and the trigger is overflowing', async () => {
     render(
       <Tooltip.Provider>

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -3,6 +3,28 @@ import * as Tooltip from './tooltip';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect } from 'vitest';
 
+function mockElementOverflowSize(
+  element: HTMLElement,
+  {
+    clientWidth,
+    scrollWidth,
+    clientHeight = 20,
+    scrollHeight = clientHeight,
+  }: {
+    clientWidth: number;
+    scrollWidth: number;
+    clientHeight?: number;
+    scrollHeight?: number;
+  },
+) {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+  });
+}
+
 describe('Tooltip', () => {
   afterEach(cleanup);
 
@@ -79,6 +101,56 @@ describe('Tooltip', () => {
     userEvent.click(trigger);
     await waitFor(() => {
       expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not open when onlyShowOnOverflow is true and the trigger is not overflowing', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger onlyShowOnOverflow>Tooltip Trigger</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content>
+              Tooltip Content
+              <Tooltip.Arrow />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    mockElementOverflowSize(trigger, { clientWidth: 100, scrollWidth: 102 });
+
+    await userEvent.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens when onlyShowOnOverflow is true and the trigger is overflowing', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger onlyShowOnOverflow>Tooltip Trigger</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content>
+              Tooltip Content
+              <Tooltip.Arrow />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    mockElementOverflowSize(trigger, { clientWidth: 100, scrollWidth: 103 });
+
+    await userEvent.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Tooltip Content')[0]).toBeVisible();
     });
   });
 });

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -259,14 +259,42 @@ Tooltip.displayName = TOOLTIP_NAME;
  * -----------------------------------------------------------------------------------------------*/
 
 const TRIGGER_NAME = 'TooltipTrigger';
+const DEFAULT_OVERFLOW_TOLERANCE = 2;
 
 type TooltipTriggerElement = React.ComponentRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
-interface TooltipTriggerProps extends PrimitiveButtonProps {}
+interface TooltipTriggerProps extends PrimitiveButtonProps {
+  /**
+   * When `true`, the tooltip will only open on hover if the trigger's content is overflowing.
+   *
+   * ⚠️ Accessibility:
+   * This prop only gates **pointer (hover)** interactions.
+   * Focus-triggered tooltips are always allowed to ensure assistive technologies
+   * (e.g. screen readers, keyboard navigation) can access the tooltip content.
+   *
+   * This prop is intended for truncated/ellipsis content, not for semantic tooltips.
+   *
+   * @defaultValue false
+   */
+  onlyShowOnOverflow?: boolean;
+
+  /**
+   * Tolerance in pixels used when determining overflow.
+   * Helps avoid false positives due to sub-pixel rounding.
+   *
+   * @defaultValue 2
+   */
+  overflowTolerance?: number;
+}
 
 const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerProps>(
   (props: ScopedProps<TooltipTriggerProps>, forwardedRef) => {
-    const { __scopeTooltip, ...triggerProps } = props;
+    const {
+      __scopeTooltip,
+      onlyShowOnOverflow = false,
+      overflowTolerance = DEFAULT_OVERFLOW_TOLERANCE,
+      ...triggerProps
+    } = props;
     const context = useTooltipContext(TRIGGER_NAME, __scopeTooltip);
     const providerContext = useTooltipProviderContext(TRIGGER_NAME, __scopeTooltip);
     const popperScope = usePopperScope(__scopeTooltip);
@@ -275,6 +303,10 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
     const isPointerDownRef = React.useRef(false);
     const hasPointerMoveOpenedRef = React.useRef(false);
     const handlePointerUp = React.useCallback(() => (isPointerDownRef.current = false), []);
+    const handleTriggerEnter = React.useCallback(() => {
+      if (onlyShowOnOverflow && !isElementOverflowing(ref.current, overflowTolerance)) return;
+      context.onTriggerEnter();
+    }, [context, overflowTolerance, onlyShowOnOverflow]);
 
     React.useEffect(() => {
       return () => document.removeEventListener('pointerup', handlePointerUp);
@@ -295,7 +327,7 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
               !hasPointerMoveOpenedRef.current &&
               !providerContext.isPointerInTransitRef.current
             ) {
-              context.onTriggerEnter();
+              handleTriggerEnter();
               hasPointerMoveOpenedRef.current = true;
             }
           })}
@@ -657,6 +689,13 @@ function getPaddedExitPoints(exitPoint: Point, exitSide: Side, padding = 5) {
       break;
   }
   return paddedExitPoints;
+}
+
+function isElementOverflowing(element?: HTMLElement | null, tolerance = 0) {
+  return element
+    ? element.scrollWidth - element.clientWidth > tolerance ||
+        element.scrollHeight - element.clientHeight > tolerance
+    : false;
 }
 
 function getPointsFromRect(rect: DOMRect) {

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -695,7 +695,7 @@ function isElementOverflowing(element?: HTMLElement | null, tolerance = 0) {
   return element
     ? element.scrollWidth - element.clientWidth > tolerance ||
         element.scrollHeight - element.clientHeight > tolerance
-    : false;
+    : true; // preserve default behavior if no element provided
 }
 
 function getPointsFromRect(rect: DOMRect) {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->

Add `onlyShowOnOverflow` and `overflowTolerance` to `Tooltip.Trigger` to enhance UX for overflow-only tooltip use cases. `onlyShowOnOverflow` defaults to `false`, preserving existing behavior and accessibility unless explicitly enabled. Even when explicitly enabled it preserves accessibility - only gates hover.
