### PR TITLE
feat: add repository.directory to all package.json files

### DIFF
--- a/packages/core/number/package.json
+++ b/packages/core/number/package.json
@@ -44,7 +44,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/core/number"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -44,7 +44,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/core/primitive"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/core/rect/package.json
+++ b/packages/core/rect/package.json
@@ -44,7 +44,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/core/rect"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/accessible-icon/package.json
+++ b/packages/react/accessible-icon/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/accessible-icon"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/accordion/package.json
+++ b/packages/react/accordion/package.json
@@ -73,7 +73,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/accordion"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -70,7 +70,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/alert-dialog"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/announce/package.json
+++ b/packages/react/announce/package.json
@@ -67,7 +67,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/announce"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/arrow/package.json
+++ b/packages/react/arrow/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/arrow"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/aspect-ratio/package.json
+++ b/packages/react/aspect-ratio/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/aspect-ratio"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -69,7 +69,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/avatar"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/checkbox/package.json
+++ b/packages/react/checkbox/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/checkbox"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/collapsible/package.json
+++ b/packages/react/collapsible/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/collapsible"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/collection/package.json
+++ b/packages/react/collection/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/collection"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/compose-refs/package.json
+++ b/packages/react/compose-refs/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/compose-refs"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -71,7 +71,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/context-menu"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/context/package.json
+++ b/packages/react/context/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/context"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/dialog/package.json
+++ b/packages/react/dialog/package.json
@@ -78,7 +78,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/dialog"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/direction/package.json
+++ b/packages/react/direction/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/direction"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/dismissable-layer/package.json
+++ b/packages/react/dismissable-layer/package.json
@@ -70,7 +70,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/dismissable-layer"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/dropdown-menu/package.json
+++ b/packages/react/dropdown-menu/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/dropdown-menu"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/focus-guards/package.json
+++ b/packages/react/focus-guards/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/focus-guards"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/focus-scope/package.json
+++ b/packages/react/focus-scope/package.json
@@ -67,7 +67,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/focus-scope"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/form/package.json
+++ b/packages/react/form/package.json
@@ -70,7 +70,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/form"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/hover-card/package.json
+++ b/packages/react/hover-card/package.json
@@ -73,7 +73,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/hover-card"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/id/package.json
+++ b/packages/react/id/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/id"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/label/package.json
+++ b/packages/react/label/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/label"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/menu/package.json
+++ b/packages/react/menu/package.json
@@ -83,7 +83,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/menu"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/menubar/package.json
+++ b/packages/react/menubar/package.json
@@ -75,7 +75,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/menubar"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/navigation-menu/package.json
+++ b/packages/react/navigation-menu/package.json
@@ -78,7 +78,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/navigation-menu"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/one-time-password-field/package.json
+++ b/packages/react/one-time-password-field/package.json
@@ -77,7 +77,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/one-time-password-field"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/password-toggle-field/package.json
+++ b/packages/react/password-toggle-field/package.json
@@ -73,7 +73,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/password-toggle-field"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/popover/package.json
+++ b/packages/react/popover/package.json
@@ -79,7 +79,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/popover"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/popper/package.json
+++ b/packages/react/popper/package.json
@@ -74,7 +74,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/popper"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/portal/package.json
+++ b/packages/react/portal/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/portal"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/presence/package.json
+++ b/packages/react/presence/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/presence"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/primitive/package.json
+++ b/packages/react/primitive/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/primitive"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/progress/package.json
+++ b/packages/react/progress/package.json
@@ -66,7 +66,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/progress"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/radio-group/package.json
+++ b/packages/react/radio-group/package.json
@@ -74,7 +74,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/radio-group"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/radix-ui/package.json
+++ b/packages/react/radix-ui/package.json
@@ -137,7 +137,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/radix-ui"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/roving-focus/package.json
+++ b/packages/react/roving-focus/package.json
@@ -73,7 +73,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/roving-focus"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -73,7 +73,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/scroll-area"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/select/package.json
+++ b/packages/react/select/package.json
@@ -86,7 +86,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/select"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/separator/package.json
+++ b/packages/react/separator/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/separator"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/slider/package.json
+++ b/packages/react/slider/package.json
@@ -75,7 +75,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/slider"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/slot/package.json
+++ b/packages/react/slot/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/slot"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/switch/package.json
+++ b/packages/react/switch/package.json
@@ -71,7 +71,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/switch"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/tabs/package.json
+++ b/packages/react/tabs/package.json
@@ -72,7 +72,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/tabs"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/toast/package.json
+++ b/packages/react/toast/package.json
@@ -76,7 +76,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/toast"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/toggle-group/package.json
+++ b/packages/react/toggle-group/package.json
@@ -71,7 +71,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/toggle-group"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/toggle/package.json
+++ b/packages/react/toggle/package.json
@@ -67,7 +67,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/toggle"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/toolbar/package.json
+++ b/packages/react/toolbar/package.json
@@ -71,7 +71,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/toolbar"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/tooltip/package.json
+++ b/packages/react/tooltip/package.json
@@ -76,7 +76,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/tooltip"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-callback-ref/package.json
+++ b/packages/react/use-callback-ref/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-callback-ref"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-controllable-state/package.json
+++ b/packages/react/use-controllable-state/package.json
@@ -61,7 +61,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-controllable-state"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-effect-event/package.json
+++ b/packages/react/use-effect-event/package.json
@@ -62,7 +62,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-effect-event"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-escape-keydown/package.json
+++ b/packages/react/use-escape-keydown/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-escape-keydown"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-is-hydrated/package.json
+++ b/packages/react/use-is-hydrated/package.json
@@ -62,7 +62,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-is-hydrated"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-layout-effect/package.json
+++ b/packages/react/use-layout-effect/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-layout-effect"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-previous/package.json
+++ b/packages/react/use-previous/package.json
@@ -57,7 +57,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-previous"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-rect/package.json
+++ b/packages/react/use-rect/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-rect"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/use-size/package.json
+++ b/packages/react/use-size/package.json
@@ -60,7 +60,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/use-size"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"

--- a/packages/react/visually-hidden/package.json
+++ b/packages/react/visually-hidden/package.json
@@ -65,7 +65,8 @@
   "homepage": "https://radix-ui.com/primitives",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/radix-ui/primitives.git"
+    "url": "git+https://github.com/radix-ui/primitives.git",
+    "directory": "packages/react/visually-hidden"
   },
   "bugs": {
     "url": "https://github.com/radix-ui/primitives/issues"


### PR DESCRIPTION
## Problem

Currently, the `package.json` files only point to the repository. However, the directory of the package in this huge monorepo is missing. This makes it unnecessarily hard to locate the root of a package, for example, coming from npmjs.com, or the changelog of a package.

## Solution

Added `directory` field to the `repository` object in all 62 `package.json` files across the monorepo.

Example for `@radix-ui/react-arrow`:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/radix-ui/primitives.git",
  "directory": "packages/react/arrow"
}
```

## Changes

- Updated all 62 `package.json` files under `packages/` to include the correct `repository.directory` field
- Each directory path is relative to the repository root

Fixes #3857