### PR TITLE
fix(PopperAnchor): use callback ref to prevent "Maximum update depth exceeded"

### DIFF
--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -74,20 +74,29 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
   (props: ScopedProps<PopperAnchorProps>, forwardedRef) => {
     const { __scopePopper, virtualRef, ...anchorProps } = props;
     const context = usePopperContext(ANCHOR_NAME, __scopePopper);
-    const ref = React.useRef<PopperAnchorElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
 
-    const anchorRef = React.useRef<Measurable | null>(null);
+    // Use a callback ref to avoid useEffect's dependency-less update loop
+    // that causes "Maximum update depth exceeded" with many Popper instances.
+    const anchorRef = React.useCallback(
+      (node: PopperAnchorElement | null) => {
+        if (node) {
+          context.onAnchorChange(node);
+        }
+      },
+      [context.onAnchorChange],
+    );
+
+    const ref = React.useRef<PopperAnchorElement>(null);
+    const composedRefs = useComposedRefs(
+      forwardedRef,
+      virtualRef ? ref : anchorRef,
+    );
+
     React.useEffect(() => {
-      const previousAnchor = anchorRef.current;
-      anchorRef.current = virtualRef?.current || ref.current;
-      if (previousAnchor !== anchorRef.current) {
-        // Consumer can anchor the popper to something that isn't
-        // a DOM node e.g. pointer position, so we override the
-        // `anchorRef` with their virtual ref in this case.
-        context.onAnchorChange(anchorRef.current);
+      if (virtualRef?.current) {
+        context.onAnchorChange(virtualRef.current);
       }
-    });
+    }, [virtualRef, context.onAnchorChange]);
 
     return virtualRef ? null : <Primitive.div {...anchorProps} ref={composedRefs} />;
   },


### PR DESCRIPTION
### Description

**Fixes [#3858](https://github.com/radix-ui/primitives/issues/3858)**

`PopperAnchor` has a `useEffect` with **no dependency array** that calls `context.onAnchorChange()` (which is `setState`) on every render. When a page has 50+ Radix components that use Popper internally (Tooltip, Popover, DropdownMenu, HoverCard), each `PopperAnchor` calls `setState` during the passive effects phase on mount, causing:

```
Error: Maximum update depth exceeded.
```

This is not an infinite loop — it is a cumulative depth issue from too many independent Popper instances mounting simultaneously, each contributing to React's nested update counter.

### Fix

Replace the dependency-less `useEffect` + `setState` with a **callback ref**. React calls callback refs during DOM attachment in the commit phase, which does not count toward the nested update limit. The `useEffect` is kept only for the `virtualRef` case (non-DOM anchors like pointer positions).

### Verified

The fix was verified via `pnpm patch` on `@radix-ui/react-popper@1.2.7` by the original reporter. A page with 60+ Radix Tooltip components no longer throws "Maximum update depth exceeded" on initial render.
