### PR TITLE
fix(focus-scope): defer MutationObserver focus recovery to prevent hijacking during Tab transitions

### DIFF
--- a/packages/react/focus-scope/src/focus-scope.tsx
+++ b/packages/react/focus-scope/src/focus-scope.tsx
@@ -108,12 +108,25 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
       // When the focused element gets removed from the DOM, browsers move focus
       // back to the document.body. In this case, we move focus to the container
       // to keep focus trapped correctly.
+      //
+      // We defer the focus check to the next animation frame because DOM mutations
+      // from framework re-renders (e.g. React) can temporarily remove and re-add nodes,
+      // causing activeElement to briefly become document.body during normal focus
+      // transitions (like Tab). Without deferring, the MutationObserver would
+      // incorrectly hijack focus to the container before the browser completes
+      // moving focus to the next tabbable element.
       function handleMutations(mutations: MutationRecord[]) {
         const focusedElement = document.activeElement as HTMLElement | null;
         if (focusedElement !== document.body) return;
-        for (const mutation of mutations) {
-          if (mutation.removedNodes.length > 0) focus(container);
-        }
+        const hasMutationRemovedNodes = mutations.some(
+          (mutation) => mutation.removedNodes.length > 0
+        );
+        if (!hasMutationRemovedNodes) return;
+        requestAnimationFrame(() => {
+          if (document.activeElement === document.body) {
+            focus(container);
+          }
+        });
       }
 
       document.addEventListener('focusin', handleFocusIn);


### PR DESCRIPTION
## Summary

Fixes a bug where focus is incorrectly hijacked to the FocusScope container during normal Tab key navigation when a React re-render coincides with the focus transition.

**Root cause:** When tabbing away from an input that triggers a state update on blur (e.g., `react-hook-form` validation), React's commit phase can remove and re-add DOM nodes via `commitMutationEffects` → `commitDeletions`. This fires the `MutationObserver` callback in `handleMutations` while `document.activeElement` is temporarily `document.body` — the browser is mid-transition between the old focused element and the next tabbable target. The synchronous `focus(container)` call intercepts this transition and moves focus to the FocusScope container (`tabIndex: -1`) instead of letting the browser complete the Tab to the next element.

**Fix:** Defer the `document.activeElement === document.body` check to `requestAnimationFrame`. This allows the browser to complete the focus transition first:
- If `activeElement` has moved to the next tabbable element → no-op (correct behavior)
- If `activeElement` is still `document.body` → the focused element was genuinely removed, so we correctly recover by focusing the container

## Reproduction

1. Open a Radix `Dialog` with `trapped` focus scope
2. Add a form input that triggers a React re-render on blur (e.g., `react-hook-form` with `onBlur` validation or `onChange` in a blur handler)
3. Tab through the form — when leaving the input, focus jumps to the dialog container div instead of the next tabbable element

## Test plan

- [ ] Tab forward through all elements in a trapped FocusScope — focus should move sequentially without jumping to the container
- [ ] Tab forward through elements where an `onBlur` handler triggers a React re-render — focus should still move to the next element
- [ ] Shift+Tab backward through all elements — same behavior
- [ ] When a focused element is genuinely removed from the DOM (not a re-render), focus should still recover to the container
- [ ] Focus trapping still works: clicking outside the scope should pull focus back
- [ ] Loop behavior still works: tabbing past the last element wraps to the first (when `loop={true}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)