### PR TITLE
fix(tooltip): skipDelayDuration of 0 actually prevents delay skipping

### DIFF
--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -86,10 +86,12 @@ const TooltipProvider: React.FC<TooltipProviderProps> = (
       isOpenDelayedRef={isOpenDelayedRef}
       delayDuration={delayDuration}
       onOpen={React.useCallback(() => {
+        if (skipDelayDuration <= 0) return;
         window.clearTimeout(skipDelayTimerRef.current);
         isOpenDelayedRef.current = false;
-      }, [])}
+      }, [skipDelayDuration])}
       onClose={React.useCallback(() => {
+        if (skipDelayDuration <= 0) return;
         window.clearTimeout(skipDelayTimerRef.current);
         skipDelayTimerRef.current = window.setTimeout(
           () => (isOpenDelayedRef.current = true),


### PR DESCRIPTION
Fixes #3873

## Problem

When `skipDelayDuration` is set to 0, the onOpen and onClose handlers still toggled `isOpenDelayedRef` (via a 0ms setTimeout in onClose). This meant that moving between two tooltip triggers could cause the second tooltip to open instantly, even though the user explicitly set skipDelayDuration=0 to deactivate skip behavior entirely.

## Root cause

The `onOpen` callback always set `isOpenDelayedRef.current = false`, and `onClose` always scheduled a setTimeout(0) to set it back to `true`. With skipDelayDuration=0, the setTimeout fires in the next event-loop tick — so any tooltip opened before that tick sees the skip state and opens without delay.

## Fix

Added an early return in both `onOpen` and `onClose` when `skipDelayDuration <= 0`. When skip is disabled, the ref stays at its default `true` and no timer is scheduled, so every open always goes through the normal delay path.

Added `skipDelayDuration` to the dependency arrays of both callbacks (previously missing from onOpen).