### PR TITLE
fix(Select): prevent scroll from hidden bubble input in constrained layouts

### DIFF
--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1808,7 +1808,7 @@ const SelectBubbleInput = React.forwardRef<SelectBubbleInputElement, SelectBubbl
         form={form}
         onChange={(event) => onValueChange(event.target.value)}
         {...props}
-        style={{ ...VISUALLY_HIDDEN_STYLES, ...props.style }}
+        style={{ ...VISUALLY_HIDDEN_STYLES, top: 0, left: 0, ...props.style }}
         ref={composedRefs}
         defaultValue={selectValue}
       >


### PR DESCRIPTION
## Description

The hidden native select element (SelectBubbleInput) uses position: absolute (from VISUALLY_HIDDEN_STYLES) but does not pin its location to the top-left of its containing block. In constrained flex layouts (e.g. nested flex containers with height: 100dvh inside a form), the element is positioned low on the page, causing it to extend the scrollable area.

## Fix

Add top: 0 and left: 0 to the SelectBubbleInput style to pin it to the top of its containing block, preventing the layout extension.

Fixes #3875