### PR TITLE
docs: fix duplicated words in comments

### DIFF
--- a/packages/react/one-time-password-field/src/one-time-password-field.tsx
+++ b/packages/react/one-time-password-field/src/one-time-password-field.tsx
@@ -117,7 +117,7 @@ interface OneTimePasswordFieldOwnProps {
    */
   dir?: RovingFocusGroupProps['dir'];
   /**
-   * Whether or not the the field's input elements are disabled.
+   * Whether or not the field's input elements are disabled.
    */
   disabled?: boolean;
   /**

--- a/packages/react/separator/src/separator.tsx
+++ b/packages/react/separator/src/separator.tsx
@@ -19,7 +19,7 @@ interface SeparatorProps extends PrimitiveDivProps {
   orientation?: Orientation;
   /**
    * Whether or not the component is purely decorative. When true, accessibility-related attributes
-   * are updated so that that the rendered element is removed from the accessibility tree.
+   * are updated so that the rendered element is removed from the accessibility tree.
    */
   decorative?: boolean;
 }

--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -299,7 +299,7 @@ const ToastViewport = React.forwardRef<ToastViewportElement, ToastViewportProps>
           />
         )}
         {/**
-         * tabindex on the the list so that it can be focused when items are removed. we focus
+         * tabindex on the list so that it can be focused when items are removed. we focus
          * the list instead of the viewport so it announces number of items remaining.
          */}
         <Collection.Slot scope={__scopeToast}>


### PR DESCRIPTION
Fixes a few duplicated-word typos in comments/JSDoc across React primitive packages.

This is a text-only cleanup and does not affect runtime behavior.