### PR TITLE
feat(select): support multiple selection via `multiple` prop

### DIFF
--- a/.changeset/multi-select-clouds-sing.md
+++ b/.changeset/multi-select-clouds-sing.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-select': minor
+'@repo/storybook': patch
+---
+
+Add multi-select support via a new `multiple` prop on `Select.Root`. When `multiple` is `true`, `value` / `defaultValue` accept `string[]`, `onValueChange` receives the new array, and selecting an item toggles it without closing the popover. The hidden native `<select>` is rendered with the `multiple` attribute so `FormData` carries every selected option. The listbox advertises `aria-multiselectable="true"`, `aria-selected` reflects the real selection regardless of focus, and `Select.Content` defaults to `position="popper"` because the item-aligned positioner has no single anchor in multi-select.

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -59,6 +59,119 @@ export const Styled = () => (
   </div>
 );
 
+export const MultiSelectStyled = () => {
+  const [value, setValue] = React.useState<string[]>(['two']);
+  const labels = { one: 'One 👍', two: 'Two 👌', three: 'Three 🤘' };
+  const triggerLabel =
+    value.length === 0
+      ? null
+      : value.map((v) => labels[v as keyof typeof labels]).join(', ');
+  return (
+  <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+    <Label>
+      Choose some numbers:
+      <Select.Root value={value} onValueChange={setValue} multiple>
+        <Select.Trigger className={styles.trigger}>
+          <Select.Value placeholder="Pick one or more">{triggerLabel}</Select.Value>
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content className={styles.content} sideOffset={5}>
+            <Select.Viewport className={styles.viewport}>
+              <Select.Item className={styles.item} value="one">
+                <Select.ItemText>
+                  One<span aria-hidden> 👍</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={styles.item} value="two">
+                <Select.ItemText>
+                  Two<span aria-hidden> 👌</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+              <Select.Item className={styles.item} value="three">
+                <Select.ItemText>
+                  Three<span aria-hidden> 🤘</span>
+                </Select.ItemText>
+                <Select.ItemIndicator className={styles.indicator}>
+                  <TickIcon />
+                </Select.ItemIndicator>
+              </Select.Item>
+            </Select.Viewport>
+            <Select.Arrow />
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+    </Label>
+  </div>
+  );
+};
+
+export const MultiSelectControlled = () => {
+  const LABELS: Record<string, [string, string]> = {
+    fr: ['🇫🇷', 'France'],
+    uk: ['🇬🇧', 'United Kingdom'],
+    es: ['🇪🇸', 'Spain'],
+  };
+  const [value, setValue] = React.useState<string[]>(['uk']);
+
+  const flags = value.map((v) => LABELS[v]?.[0] ?? '').join(' ');
+  const countries = value.map((v) => LABELS[v]?.[1] ?? '').join(', ');
+
+  return (
+    <div style={{ display: 'flex', gap: 20, padding: 50 }}>
+      <Label>
+        Choose countries:
+        <Select.Root value={value} onValueChange={setValue} multiple>
+          <Select.Trigger className={styles.trigger}>
+            <Select.Value aria-label={countries} placeholder="Pick countries">
+              {flags || null}
+            </Select.Value>
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={styles.content} sideOffset={5}>
+              <Select.Viewport className={styles.viewport}>
+                <Select.Item className={styles.item} value="fr">
+                  <Select.ItemText>
+                    France<span aria-hidden> 🇫🇷</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="uk">
+                  <Select.ItemText>
+                    United Kingdom<span aria-hidden> 🇬🇧</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="es">
+                  <Select.ItemText>
+                    Spain<span aria-hidden> 🇪🇸</span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+              <Select.Arrow />
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+      <pre style={{ alignSelf: 'center' }}>{JSON.stringify(value)}</pre>
+    </div>
+  );
+};
+
 export const Controlled = () => {
   const [value, setValue] = React.useState('uk');
   return (
@@ -474,6 +587,96 @@ export const WithinForm = () => {
         <Select.Root name="country" autoComplete="country" defaultValue="fr">
           <Select.Trigger className={styles.trigger}>
             <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={styles.content}>
+              <Select.Viewport className={styles.viewport}>
+                <Select.Item className={styles.item} value="fr">
+                  <Select.ItemText>France</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="uk">
+                  <Select.ItemText>United Kingdom</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+                <Select.Item className={styles.item} value="es">
+                  <Select.ItemText>Spain</Select.ItemText>
+                  <Select.ItemIndicator className={styles.indicator}>
+                    <TickIcon />
+                  </Select.ItemIndicator>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </Label>
+      <br />
+      <button type="submit">Submit</button>
+      <br />
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </form>
+  );
+};
+
+export const MultiSelectWithinForm = () => {
+  const [data, setData] = React.useState<Record<string, FormDataEntryValue | FormDataEntryValue[]>>(
+    {},
+  );
+  const [countries, setCountries] = React.useState<string[]>(['fr', 'uk']);
+  const COUNTRY_LABELS: Record<string, string> = {
+    fr: 'France',
+    uk: 'United Kingdom',
+    es: 'Spain',
+  };
+  const triggerLabel =
+    countries.length === 0
+      ? null
+      : countries.map((c) => COUNTRY_LABELS[c] ?? c).join(', ');
+
+  function handleChange(event: React.FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    const next: Record<string, FormDataEntryValue | FormDataEntryValue[]> = {};
+    for (const [key, value] of formData.entries()) {
+      if (key in next) {
+        const existing = next[key];
+        next[key] = Array.isArray(existing) ? [...existing, value] : [existing!, value];
+      } else {
+        next[key] = value;
+      }
+    }
+    setData(next);
+  }
+
+  return (
+    <form
+      style={{ padding: 50 }}
+      onSubmit={(event) => {
+        handleChange(event);
+        event.preventDefault();
+      }}
+      onChange={handleChange}
+    >
+      <Label style={{ display: 'block' }}>
+        Name
+        <input name="name" autoComplete="name" style={{ display: 'block' }} />
+      </Label>
+      <br />
+      <Label style={{ display: 'block' }}>
+        Countries
+        <Select.Root
+          name="countries"
+          autoComplete="country"
+          value={countries}
+          onValueChange={setCountries}
+          multiple
+        >
+          <Select.Trigger className={styles.trigger}>
+            <Select.Value placeholder="Pick countries">{triggerLabel}</Select.Value>
             <Select.Icon />
           </Select.Trigger>
           <Select.Portal>

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -57,10 +57,11 @@ type SelectContextValue = {
   valueNodeHasChildren: boolean;
   onValueNodeHasChildrenChange(hasChildren: boolean): void;
   contentId: string;
-  value: string | undefined;
-  onValueChange(value: string): void;
+  value: string[] | string | undefined;
+  onValueChange(value: string[] | string): void;
   open: boolean;
   required?: boolean;
+  multiple?: boolean;
   onOpenChange(open: boolean): void;
   dir: SelectProps['dir'];
   triggerPointerDownPosRef: React.MutableRefObject<{ x: number; y: number } | null>;
@@ -122,11 +123,21 @@ interface SelectSharedProps {
 // it works as expected and doesn't cause problems)
 type _FutureSelectProps = SelectSharedProps & SelectControlProps;
 
-type SelectProps = SelectSharedProps & {
-  value?: string;
-  defaultValue?: string;
-  onValueChange?(value: string): void;
-};
+type SelectProps = SelectSharedProps &
+  (
+    | {
+        value?: string;
+        defaultValue?: string;
+        onValueChange?(value: string): void;
+        multiple?: false;
+      }
+    | {
+        value?: string[];
+        defaultValue?: string[];
+        onValueChange?(value: string[]): void;
+        multiple: true;
+      }
+  );
 
 const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
   const {
@@ -144,6 +155,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
     disabled,
     required,
     form,
+    multiple,
   } = props;
   const popperScope = usePopperScope(__scopeSelect);
   const [trigger, setTrigger] = React.useState<SelectTriggerElement | null>(null);
@@ -196,6 +208,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
         dir={direction}
         triggerPointerDownPosRef={triggerPointerDownPosRef}
         disabled={disabled}
+        multiple={multiple}
       >
         <Collection.Provider scope={__scopeSelect}>
           <SelectNativeOptionsProvider
@@ -225,9 +238,18 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             autoComplete={autoComplete}
             value={value}
             // enable form autofill
-            onChange={(event) => setValue(event.target.value)}
+            onChange={(event) => {
+              if (multiple) {
+                setValue(
+                  Array.from(event.currentTarget.selectedOptions).map((option) => option.value)
+                );
+              } else {
+                setValue(event.target.value);
+              }
+            }}
             disabled={disabled}
             form={form}
+            multiple={multiple}
           >
             {value === undefined ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}
@@ -261,6 +283,8 @@ const SelectTrigger = React.forwardRef<SelectTriggerElement, SelectTriggerProps>
     const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const [searchRef, handleTypeaheadSearch, resetTypeahead] = useTypeaheadSearch((search) => {
+      // Closed-state typeahead cycles `context.value` through matches — no analog in multi-select.
+      if (context.multiple) return;
       const enabledItems = getItems().filter((item) => !item.disabled);
       const currentItem = enabledItems.find((item) => item.value === context.value);
       const nextItem = findNextItem(enabledItems, search, currentItem);
@@ -536,9 +560,11 @@ const Slot = createSlot('SelectContent.RemoveScroll');
 
 const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectContentImplProps>(
   (props: ScopedProps<SelectContentImplProps>, forwardedRef) => {
+    const context = useSelectContext(CONTENT_NAME, props.__scopeSelect);
     const {
       __scopeSelect,
-      position = 'item-aligned',
+      // Item-aligned positioning has no single anchor in multi-select.
+      position = context.multiple ? 'popper' : 'item-aligned',
       onCloseAutoFocus,
       onEscapeKeyDown,
       onPointerDownOutside,
@@ -557,7 +583,6 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
       //
       ...contentProps
     } = props;
-    const context = useSelectContext(CONTENT_NAME, __scopeSelect);
     const [content, setContent] = React.useState<SelectContentImplElement | null>(null);
     const [viewport, setViewport] = React.useState<SelectViewportElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
@@ -758,6 +783,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
             >
               <SelectPosition
                 role="listbox"
+                aria-multiselectable={context.multiple || undefined}
                 id={context.contentId}
                 data-state={context.open ? 'open' : 'closed'}
                 dir={context.dir}
@@ -1258,7 +1284,9 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     } = props;
     const context = useSelectContext(ITEM_NAME, __scopeSelect);
     const contentContext = useSelectContentContext(ITEM_NAME, __scopeSelect);
-    const isSelected = context.value === value;
+    const isSelected = context.multiple
+      ? Array.isArray(context.value) && context.value.includes(value)
+      : context.value === value;
     const [textValue, setTextValue] = React.useState(textValueProp ?? '');
     const [isFocused, setIsFocused] = React.useState(false);
     const composedRefs = useComposedRefs(forwardedRef, (node) =>
@@ -1268,7 +1296,12 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
     const handleSelect = () => {
-      if (!disabled) {
+      if (disabled) return;
+      if (context.multiple) {
+        const prev = Array.isArray(context.value) ? context.value : [];
+        const next = isSelected ? prev.filter((v) => v !== value) : [...prev, value];
+        context.onValueChange(next);
+      } else {
         context.onValueChange(value);
         context.onOpenChange(false);
       }
@@ -1301,8 +1334,9 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             role="option"
             aria-labelledby={textId}
             data-highlighted={isFocused ? '' : undefined}
-            // `isFocused` caveat fixes stuttering in VoiceOver
-            aria-selected={isSelected && isFocused}
+            // single-select gates on `isFocused` to fix stuttering in VoiceOver; multi-select
+            // must reflect the real selection regardless of focus.
+            aria-selected={context.multiple ? isSelected : isSelected && isFocused}
             data-state={isSelected ? 'checked' : 'unchecked'}
             aria-disabled={disabled || undefined}
             data-disabled={disabled ? '' : undefined}
@@ -1400,8 +1434,13 @@ const SelectItemText = React.forwardRef<SelectItemTextElement, SelectItemTextPro
       <>
         <Primitive.span id={itemContext.textId} {...itemTextProps} ref={composedRefs} />
 
-        {/* Portal the select item text into the trigger value node */}
-        {itemContext.isSelected && context.valueNode && !context.valueNodeHasChildren
+        {/* Portal the select item text into the trigger value node.
+            Skipped in multi-select — multiple selected items would collide on the same node;
+            callers should pass `children` to `Select.Value` to render the trigger label. */}
+        {itemContext.isSelected &&
+        context.valueNode &&
+        !context.valueNodeHasChildren &&
+        !context.multiple
           ? ReactDOM.createPortal(itemTextProps.children, context.valueNode)
           : null}
       </>
@@ -1638,28 +1677,41 @@ const BUBBLE_INPUT_NAME = 'SelectBubbleInput';
 type InputProps = React.ComponentPropsWithoutRef<typeof Primitive.select>;
 interface SwitchBubbleInputProps extends InputProps {}
 
+function doValuesMatch(a: SwitchBubbleInputProps['value'], b: SwitchBubbleInputProps['value']) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) => item === b[index]);
+  }
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+  return a === b;
+}
+
 const SelectBubbleInput = React.forwardRef<HTMLSelectElement, SwitchBubbleInputProps>(
   ({ __scopeSelect, value, ...props }: ScopedProps<SwitchBubbleInputProps>, forwardedRef) => {
     const ref = React.useRef<HTMLSelectElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref);
     const prevValue = usePrevious(value);
 
-    // Bubble value change to parents (e.g form change event)
+    // Set `selected` directly on each option (bypassing React's controlled tracking) so the
+    // same path works for both `<select>` and `<select multiple>`, then bubble a change event.
     React.useEffect(() => {
       const select = ref.current;
       if (!select) return;
+      if (doValuesMatch(prevValue, value)) return;
 
-      const selectProto = window.HTMLSelectElement.prototype;
-      const descriptor = Object.getOwnPropertyDescriptor(
-        selectProto,
-        'value',
-      ) as PropertyDescriptor;
-      const setValue = descriptor.set;
-      if (prevValue !== value && setValue) {
-        const event = new Event('change', { bubbles: true });
-        setValue.call(select, value);
-        select.dispatchEvent(event);
+      const setOptionSelected = Object.getOwnPropertyDescriptor(
+        window.HTMLOptionElement.prototype,
+        'selected'
+      )?.set;
+
+      if (setOptionSelected) {
+        const selectedValues = Array.isArray(value) ? value : value != null ? [value] : [];
+        for (const option of select.options) {
+          setOptionSelected.call(option, selectedValues.includes(option.value));
+        }
       }
+
+      select.dispatchEvent(new Event('change', { bubbles: true }));
     }, [prevValue, value]);
 
     /**
@@ -1689,7 +1741,10 @@ SelectBubbleInput.displayName = BUBBLE_INPUT_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
-function shouldShowPlaceholder(value?: string) {
+function shouldShowPlaceholder(value?: string[] | string) {
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.every((v) => v === '');
+  }
   return value === '' || value === undefined;
 }
 


### PR DESCRIPTION
### Description

Implements `multiple` support on `Select.Root`. Closes #1270.

This builds on the design explored in #3522 (thanks @Zach-Jaensch) and addresses gaps in that PR around accessibility, positioning, and trigger behavior so multi-select stays consistent with the rest of Radix.

#### Changes

- **API** — `Select.Root` accepts a `multiple` prop. With `multiple: true`, `value` / `defaultValue` are `string[]` and `onValueChange` receives the new array. The single-select branch is unchanged — no migration required.
- **Selection** — Selecting an item in multi-mode toggles it without closing the popover. Single-select close-on-select behavior is preserved.
- **Native form** — `SelectBubbleInput` renders the hidden `<select>` with the `multiple` attribute and sets `option.selected` imperatively, so the same code path serves single and multi. `FormData` carries one entry per selected option.
- **A11y** — `aria-multiselectable="true"` is set on the listbox, and `aria-selected` on items reflects real selection state in multi (the existing VoiceOver `isFocused` workaround is preserved only for single-select).
- **Positioning** — `Select.Content` defaults to `position="popper"` in multi-select because the item-aligned positioner has no single anchor.
- **Trigger label** — The `Select.ItemText` portal into `Select.Value` is skipped in multi-select to avoid collisions on the same DOM node; multi-select callers pass \`children\` to `Select.Value` (see the new stories for the pattern).
- **Typeahead** — Closed-state typeahead on the trigger is a no-op in multi-select since there is no implicit \"current\" value to cycle.

#### Storybook

Three new stories were added next to the existing ones:

- \`MultiSelectStyled\` — uncontrolled-style demo with default value
- \`MultiSelectControlled\` — controlled, showing the recommended \`Select.Value\` children pattern
- \`MultiSelectWithinForm\` — verifies \`FormData\` produces one entry per selected option

#### Tests

The Select package currently has no unit tests in-repo; verification was done via the new Storybook stories plus \`pnpm typecheck\` and \`pnpm lint\` (both clean across the workspace, including \`@repo/storybook\`). Happy to add tests if you'd like — the test file from #3522 could be a starting point.

#### Compared to #3522

This PR keeps the API shape from #3522 (the \`multiple\` discriminated union and the \`option.selected\` form-integration trick) and adds the changes needed to make multi-select land cleanly: \`aria-multiselectable\`, the \`aria-selected\` fix, the popper fallback, the no-op trigger typeahead, and the \`ItemText\` portal skip. Happy to coordinate with #3522 if you'd prefer to land that one first and layer these fixes on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)