### PR TITLE
fix(navigation-menu): keep dropdown open on click after hover-open

### DIFF
--- a/.changeset/navigation-menu-stick-on-hover-then-click.md
+++ b/.changeset/navigation-menu-stick-on-hover-then-click.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-navigation-menu': patch
+---
+
+Keep dropdown open on click after hover-open. Previously a hover-opened trigger would close on the first click; now it stays open (matching Base UI's `stickIfOpen` behavior). Subsequent clicks still toggle closed; click-to-open is unchanged.

--- a/.changeset/navigation-menu-stick-on-hover-then-click.md
+++ b/.changeset/navigation-menu-stick-on-hover-then-click.md
@@ -2,4 +2,8 @@
 '@radix-ui/react-navigation-menu': patch
 ---
 
-Keep dropdown open on click after hover-open. Previously a hover-opened trigger would close on the first click; now it stays open (matching Base UI's `stickIfOpen` behavior). Subsequent clicks still toggle closed; click-to-open is unchanged.
+Keep dropdown open on click after hover-open.
+
+Previously, hovering a trigger opened the dropdown but a subsequent click on the same trigger closed it, because `onItemSelect` toggled state based purely on whether the current open value matched the trigger — with no notion of how the menu was opened. The trigger now swallows a click when it was just opened by hover, so the dropdown sticks open. Subsequent clicks still toggle closed; click-to-open on a closed trigger is unchanged.
+
+For folks comparing primitives in the shadcn ecosystem, Base UI's `NavigationMenuTrigger` gets the same behavior via Floating UI's `useClick({ stickIfOpen })`.

--- a/cypress/e2e/NavigationMenu.cy.ts
+++ b/cypress/e2e/NavigationMenu.cy.ts
@@ -1,0 +1,44 @@
+describe('NavigationMenu — click-after-hover sticks open', () => {
+  beforeEach(() => {
+    cy.visitStory('navigationmenu--basic');
+  });
+
+  it('hover → click on same trigger keeps dropdown open', () => {
+    cy.findByText('Products').realHover();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+    cy.findByText('Products').realClick();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+  });
+
+  it('click on closed trigger opens it (regression)', () => {
+    cy.findByText('Products').should('have.attr', 'data-state', 'closed');
+    cy.findByText('Products').realClick();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+  });
+
+  it('click on click-opened trigger toggles closed (regression)', () => {
+    cy.findByText('Products').realClick();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+    cy.findByText('Products').realClick();
+    cy.findByText('Products').should('have.attr', 'data-state', 'closed');
+  });
+
+  it('hover A → hover B opens B and closes A (regression)', () => {
+    cy.findByText('Products').realHover();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+    cy.findByText('Company').realHover();
+    cy.findByText('Company').should('have.attr', 'data-state', 'open');
+    cy.findByText('Products').should('have.attr', 'data-state', 'closed');
+  });
+
+  it('hover → leave → re-hover → click sticks open (ref reset)', () => {
+    cy.findByText('Products').realHover();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+    cy.findByText('Link').realHover();
+    cy.findByText('Products').should('have.attr', 'data-state', 'closed');
+    cy.findByText('Products').realHover();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+    cy.findByText('Products').realClick();
+    cy.findByText('Products').should('have.attr', 'data-state', 'open');
+  });
+});

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -528,6 +528,10 @@ const NavigationMenuTrigger = React.forwardRef<
               }),
             )}
             onClick={composeEventHandlers(props.onClick, () => {
+              if (open && hasPointerMoveOpenedRef.current) {
+                hasPointerMoveOpenedRef.current = false;
+                return;
+              }
               context.onItemSelect(itemContext.value);
               wasClickCloseRef.current = open;
             })}


### PR DESCRIPTION
## Summary

Fixes a behavior bug in `NavigationMenu`: a trigger that the user has hovered (which opens the dropdown) gets closed if the user then clicks it. The click should be a no-op — leaving the dropdown open — which is what [Base UI's `NavigationMenuTrigger` does via Floating UI's `useClick({ stickIfOpen, toggle })`](https://github.com/mui/base-ui/blob/master/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx).

## Repro

In any `NavigationMenu` story (e.g. `NavigationMenu / Basic`):

1. Hover a trigger → dropdown opens (correct)
2. Click that same trigger → dropdown **closes** (wrong — should stay open)

## Root cause

`NavigationMenuTrigger` fires `onTriggerEnter` on `onPointerMove` (which sets `value = itemValue`) and fires `onItemSelect` on `onClick` (which toggles `value` based on `prevValue === itemValue`). So the sequence "hover → click" first opens via hover, then the toggle on click — having no notion of *how* the menu was opened — closes it.

## Fix

Reuse the existing `hasPointerMoveOpenedRef` (the per-trigger ref the component already keeps to suppress a different hover-vs-click race in `onPointerMove`). In `onClick`, if the trigger is currently open *and* `hasPointerMoveOpenedRef.current` is true, swallow the click and clear the ref. A subsequent click — without an intervening pointer-leave + re-hover — falls through to the normal toggle path. This mirrors Base UI's `stickIfOpen` semantics without touching the provider-level state machine or the public API.

The change is one `if` block in one handler in `packages/react/navigation-menu/src/navigation-menu.tsx`.

## Verified regressions

A new Cypress spec (`cypress/e2e/NavigationMenu.cy.ts`) locks the behavior. All five cases pass with the fix; the two "sticks open" cases fail without it (3 pass / 2 fail), confirming the test captures the bug:

- [x] hover → click on same trigger keeps dropdown open (the fix)
- [x] click on closed trigger opens it (regression check)
- [x] click on click-opened trigger toggles closed (toggle still works)
- [x] hover A → hover B opens B and closes A (cross-trigger hover still works)
- [x] hover → leave → re-hover → click sticks open (`hasPointerMoveOpenedRef` reset on `pointerLeave` is the right reset point)

Also verified:

- [x] `pnpm --filter @radix-ui/react-navigation-menu lint`
- [x] `pnpm --filter @radix-ui/react-navigation-menu typecheck`
- [x] `pnpm --filter @radix-ui/react-navigation-menu build`
- [x] `pnpm test` (vitest, 233 passing)