### PR TITLE
Context Menu: Add support for controlled `open` state

### DIFF
--- a/.changeset/fuzzy-boxes-play.md
+++ b/.changeset/fuzzy-boxes-play.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-context-menu': minor
+'radix-ui': minor
+---
+
+Added support for a controlled `open` prop on `ContextMenu.Root`. This is intended for reading the open state and closing the menu programmatically, though we discourage opening the menu programmatically since opening the menu depends on user interaction to position the menu.

--- a/apps/storybook/stories/context-menu.stories.tsx
+++ b/apps/storybook/stories/context-menu.stories.tsx
@@ -42,6 +42,64 @@ export const Styled = () => (
   </div>
 );
 
+export const Controlled = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '150vh',
+        maxWidth: 400,
+        gap: 16,
+        justifySelf: 'center',
+      }}
+    >
+      <p>
+        The menu is currently <strong>{open ? 'open' : 'closed'}</strong>.
+      </p>
+      <p>
+        The <code>open</code> state is controllable so you can read the state and close the menu
+        programmatically. We advise only opening the menu in response to user interaction, which is
+        managed internally in Radix in response to right click / long press, so the menu can be
+        positioned at the pointer.
+      </p>
+      <ContextMenu.Root open={open} onOpenChange={setOpen}>
+        <ContextMenu.Trigger className={styles.trigger}>Right click here</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content className={styles.content} alignOffset={-5}>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button type="button">Noop</button>
+              <button type="button" onClick={() => setOpen(false)}>
+                Close
+              </button>
+            </div>
+            <ContextMenu.Item className={styles.item} onSelect={() => console.log('undo')}>
+              Undo
+            </ContextMenu.Item>
+            <ContextMenu.Item className={styles.item} onSelect={() => console.log('redo')}>
+              Redo
+            </ContextMenu.Item>
+            <ContextMenu.Separator className={styles.separator} />
+            <ContextMenu.Item className={styles.item} onSelect={() => console.log('cut')}>
+              Cut
+            </ContextMenu.Item>
+            <ContextMenu.Item className={styles.item} onSelect={() => console.log('copy')}>
+              Copy
+            </ContextMenu.Item>
+            <ContextMenu.Item className={styles.item} onSelect={() => console.log('paste')}>
+              Paste
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
+    </div>
+  );
+};
+
 export const Modality = () => (
   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '110vh' }}>
     <div style={{ display: 'grid', gap: 50 }}>

--- a/packages/react/context-menu/package.json
+++ b/packages/react/context-menu/package.json
@@ -39,7 +39,6 @@
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-menu": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*"
   },
   "devDependencies": {

--- a/packages/react/context-menu/src/context-menu.test.tsx
+++ b/packages/react/context-menu/src/context-menu.test.tsx
@@ -1,0 +1,468 @@
+import * as React from 'react';
+import { axe } from 'vitest-axe';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as ContextMenu from './context-menu';
+import type { MockInstance } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+const TRIGGER_TEXT = 'Right click here';
+const ITEM_TEXT = 'Item';
+
+function ContextMenuTest(props: React.ComponentProps<typeof ContextMenu.Root>) {
+  return (
+    <ContextMenu.Root {...props}>
+      <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content>
+          <ContextMenu.Item>{ITEM_TEXT}</ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}
+
+afterEach(cleanup);
+
+describe('rendering and opening', () => {
+  it('keeps the content closed by default', () => {
+    render(<ContextMenuTest />);
+    expect(screen.getByText(TRIGGER_TEXT)).toHaveAttribute('data-state', 'closed');
+    expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('opens the content on right click', async () => {
+    render(<ContextMenuTest />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+    expect(screen.getByText(ITEM_TEXT)).toBeVisible();
+    expect(screen.getByText(TRIGGER_TEXT)).toHaveAttribute('data-state', 'open');
+  });
+
+  it('closes the content when pressing escape', async () => {
+    render(<ContextMenuTest />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+    expect(screen.getByText(TRIGGER_TEXT)).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('has no accessibility violations when open', async () => {
+    const { container } = render(<ContextMenuTest />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('disabled trigger', () => {
+  it('does not open the menu on right click', () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger disabled>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Item>{ITEM_TEXT}</ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    expect(trigger).toHaveAttribute('data-disabled', '');
+    fireEvent.contextMenu(trigger);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});
+
+describe('items', () => {
+  it('calls `onSelect` and closes the menu when an item is selected', async () => {
+    const onSelect = vi.fn();
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Item onSelect={onSelect}>{ITEM_TEXT}</ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByText(ITEM_TEXT)).toBeVisible());
+
+    fireEvent.click(screen.getByText(ITEM_TEXT));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('does not select a disabled item', async () => {
+    const onSelect = vi.fn();
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Item disabled onSelect={onSelect}>
+              {ITEM_TEXT}
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const item = await screen.findByText(ITEM_TEXT);
+    expect(item).toHaveAttribute('data-disabled', '');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(item);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('keeps the menu open when `onSelect` prevents default', async () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Item onSelect={(event) => event.preventDefault()}>
+              Stay open
+            </ContextMenu.Item>
+            <ContextMenu.Item>Close me</ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Stay open'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Close me'));
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+});
+
+describe('groups and labels', () => {
+  it('renders grouped items with a label', async () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Group>
+              <ContextMenu.Label>Fruits</ContextMenu.Label>
+              <ContextMenu.Item>Apple</ContextMenu.Item>
+              <ContextMenu.Item>Banana</ContextMenu.Item>
+            </ContextMenu.Group>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+
+    const group = screen.getByRole('group');
+    expect(group).toBeInTheDocument();
+    expect(screen.getByText('Fruits')).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+});
+
+describe('checkbox items', () => {
+  it('toggles a checkbox item and reflects the checked state', async () => {
+    function CheckboxTest() {
+      const [checked, setChecked] = React.useState(false);
+      return (
+        <ContextMenu.Root>
+          <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Content>
+              <ContextMenu.CheckboxItem checked={checked} onCheckedChange={setChecked}>
+                Bold
+              </ContextMenu.CheckboxItem>
+            </ContextMenu.Content>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>
+      );
+    }
+
+    render(<CheckboxTest />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+
+    const checkbox = await screen.findByRole('menuitemcheckbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(checkbox);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const updated = await screen.findByRole('menuitemcheckbox');
+    expect(updated).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('marks a disabled checkbox item as disabled', async () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.CheckboxItem disabled>Strikethrough</ContextMenu.CheckboxItem>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const checkbox = await screen.findByRole('menuitemcheckbox');
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+  });
+});
+
+describe('radio items', () => {
+  it('selects a radio item and calls `onValueChange`', async () => {
+    const onValueChange = vi.fn();
+    function RadioTest() {
+      const [value, setValue] = React.useState('index.js');
+      return (
+        <ContextMenu.Root>
+          <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Content>
+              <ContextMenu.RadioGroup
+                value={value}
+                onValueChange={(next) => {
+                  onValueChange(next);
+                  setValue(next);
+                }}
+              >
+                <ContextMenu.RadioItem value="README.md">README.md</ContextMenu.RadioItem>
+                <ContextMenu.RadioItem value="index.js">index.js</ContextMenu.RadioItem>
+              </ContextMenu.RadioGroup>
+            </ContextMenu.Content>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>
+      );
+    }
+
+    render(<RadioTest />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+
+    const radios = await screen.findAllByRole('menuitemradio');
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+    expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(radios[0]!);
+    expect(onValueChange).toHaveBeenCalledWith('README.md');
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const updated = await screen.findAllByRole('menuitemradio');
+    expect(updated[0]).toHaveAttribute('aria-checked', 'true');
+    expect(updated[1]).toHaveAttribute('aria-checked', 'false');
+  });
+});
+
+describe('submenus', () => {
+  it('opens a submenu via keyboard', async () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger>Bookmarks</ContextMenu.SubTrigger>
+              <ContextMenu.Portal>
+                <ContextMenu.SubContent>
+                  <ContextMenu.Item>Inbox</ContextMenu.Item>
+                </ContextMenu.SubContent>
+              </ContextMenu.Portal>
+            </ContextMenu.Sub>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const subTrigger = await screen.findByText('Bookmarks');
+    expect(subTrigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(subTrigger, { key: 'ArrowRight' });
+    await waitFor(() => expect(screen.getByText('Inbox')).toBeVisible());
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('does not open a disabled submenu', async () => {
+    render(
+      <ContextMenu.Root>
+        <ContextMenu.Trigger>{TRIGGER_TEXT}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger disabled>History</ContextMenu.SubTrigger>
+              <ContextMenu.Portal>
+                <ContextMenu.SubContent>
+                  <ContextMenu.Item>Github</ContextMenu.Item>
+                </ContextMenu.SubContent>
+              </ContextMenu.Portal>
+            </ContextMenu.Sub>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    const subTrigger = await screen.findByText('History');
+    expect(subTrigger).toHaveAttribute('data-disabled', '');
+
+    fireEvent.keyDown(subTrigger, { key: 'ArrowRight' });
+    expect(screen.queryByText('Github')).not.toBeInTheDocument();
+  });
+});
+
+describe('modality', () => {
+  afterEach(() => {
+    document.body.style.pointerEvents = '';
+  });
+
+  it('disables pointer events on the body while a modal menu is open', async () => {
+    render(<ContextMenuTest />);
+    expect(document.body.style.pointerEvents).toBe('');
+
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(document.body.style.pointerEvents).toBe('none'));
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+    await waitFor(() => expect(document.body.style.pointerEvents).toBe(''));
+  });
+
+  it('does not disable pointer events on the body for a non-modal menu', async () => {
+    render(<ContextMenuTest modal={false} />);
+    fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+});
+
+describe('controlled `open` state', () => {
+  let consoleWarnMock: MockInstance;
+
+  beforeEach(() => {
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    consoleWarnMock.mockRestore();
+  });
+
+  it('opens on right click and reflects the open state via `onOpenChange`', async () => {
+    const onOpenChange = vi.fn();
+    render(<ContextMenuTest onOpenChange={onOpenChange} />);
+
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+    expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument();
+
+    fireEvent.contextMenu(trigger);
+
+    await waitFor(() => expect(screen.getByText(ITEM_TEXT)).toBeVisible());
+    expect(trigger).toHaveAttribute('data-state', 'open');
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('respects a controlled `open={false}` value and does not open on right click', async () => {
+    const onOpenChange = vi.fn();
+    render(<ContextMenuTest open={false} onOpenChange={onOpenChange} />);
+
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    fireEvent.contextMenu(trigger);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+    expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('can be closed programmatically while controlled', async () => {
+    function ControlledContextMenu() {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(false)}>close</button>
+          <ContextMenuTest open={open} onOpenChange={setOpen} />
+        </>
+      );
+    }
+
+    render(<ControlledContextMenu />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+
+    fireEvent.contextMenu(trigger);
+    await waitFor(() => expect(screen.getByText(ITEM_TEXT)).toBeVisible());
+
+    fireEvent.click(screen.getByText('close'));
+    await waitFor(() => expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument());
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('calls `onOpenChange` with `false` when dismissed via Escape', async () => {
+    const onOpenChange = vi.fn();
+    function ControlledContextMenu() {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <ContextMenuTest
+          open={open}
+          onOpenChange={(next) => {
+            onOpenChange(next);
+            setOpen(next);
+          }}
+        />
+      );
+    }
+
+    render(<ControlledContextMenu />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+
+    fireEvent.contextMenu(trigger);
+    await waitFor(() => expect(screen.getByText(ITEM_TEXT)).toBeVisible());
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument());
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  describe('dev warning when opened before interaction', () => {
+    it('warns when `open` is `true` before the user has interacted with the trigger', () => {
+      render(<ContextMenuTest open={true} />);
+      expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+      expect(consoleWarnMock.mock.calls[0]![0]).toEqual(
+        expect.stringContaining('The `open` prop has been set to `true`'),
+      );
+    });
+
+    it('does not warn for an uncontrolled menu', () => {
+      render(<ContextMenuTest />);
+      fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+      expect(consoleWarnMock).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the menu is opened through user interaction', async () => {
+      function ControlledContextMenu() {
+        const [open, setOpen] = React.useState(false);
+        return <ContextMenuTest open={open} onOpenChange={setOpen} />;
+      }
+
+      render(<ControlledContextMenu />);
+      fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));
+      await waitFor(() => expect(screen.getByText(ITEM_TEXT)).toBeVisible());
+      expect(consoleWarnMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/context-menu/src/context-menu.tsx
+++ b/packages/react/context-menu/src/context-menu.tsx
@@ -4,9 +4,7 @@ import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import * as MenuPrimitive from '@radix-ui/react-menu';
 import { createMenuScope } from '@radix-ui/react-menu';
-import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-
 import type { Scope } from '@radix-ui/react-context';
 
 type Direction = 'ltr' | 'rtl';
@@ -24,50 +22,68 @@ const [createContextMenuContext, createContextMenuScope] = createContextScope(CO
 ]);
 const useMenuScope = createMenuScope();
 
-type ContextMenuContextValue = {
+interface ContextMenuContextValue {
   open: boolean;
   onOpenChange(open: boolean): void;
   modal: boolean;
-};
+  hasInteractedRef: React.RefObject<boolean>;
+}
 
 const [ContextMenuProvider, useContextMenuContext] =
   createContextMenuContext<ContextMenuContextValue>(CONTEXT_MENU_NAME);
 
 interface ContextMenuProps {
   children?: React.ReactNode;
+  open?: boolean;
   onOpenChange?(open: boolean): void;
   dir?: Direction;
   modal?: boolean;
 }
 
 const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuProps>) => {
-  const { __scopeContextMenu, children, onOpenChange, dir, modal = true } = props;
-  const [open, setOpen] = React.useState(false);
-  const menuScope = useMenuScope(__scopeContextMenu);
-  const handleOpenChangeProp = useCallbackRef(onOpenChange);
+  const { __scopeContextMenu, children, onOpenChange, open: openProp, dir, modal = true } = props;
 
-  const handleOpenChange = React.useCallback(
-    (open: boolean) => {
-      setOpen(open);
-      handleOpenChangeProp(open);
-    },
-    [handleOpenChangeProp],
-  );
+  // OK to disable conditionally calling hooks here because they will always run
+  // consistently in the same environment. Bundlers should be able to remove the
+  // code block entirely in production.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const hasInteractedRef = React.useRef(false);
+  if (process.env.NODE_ENV !== 'production') {
+    const hasWarnedRef = React.useRef(false);
+    React.useEffect(() => {
+      if (openProp === true && !hasInteractedRef.current && !hasWarnedRef.current) {
+        hasWarnedRef.current = true;
+        // dev warning: open prop is controllable but its position has not been set
+        // because the user has not interacted with the trigger. The controllable
+        // state is only enabled so that the user can read or programatically close
+        // the menu. Programatically opening the menu will anchor it to the most
+        // recently interacted position.
+        console.warn(
+          'ContextMenu: The `open` prop has been set to `true` before the user has interacted with the trigger, so its position is indeterminate. This is likely unintended and will result in the menu being anchored to the top-left corner of the viewport.',
+        );
+      }
+    }, [openProp]);
+  }
+  /* eslint-enable react-hooks/rules-of-hooks */
+
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: false,
+    onChange: onOpenChange,
+    caller: CONTEXT_MENU_NAME,
+  });
+
+  const menuScope = useMenuScope(__scopeContextMenu);
 
   return (
     <ContextMenuProvider
       scope={__scopeContextMenu}
       open={open}
-      onOpenChange={handleOpenChange}
+      onOpenChange={setOpen}
       modal={modal}
+      hasInteractedRef={hasInteractedRef}
     >
-      <MenuPrimitive.Root
-        {...menuScope}
-        dir={dir}
-        open={open}
-        onOpenChange={handleOpenChange}
-        modal={modal}
-      >
+      <MenuPrimitive.Root {...menuScope} dir={dir} open={open} onOpenChange={setOpen} modal={modal}>
         {children}
       </MenuPrimitive.Root>
     </ContextMenuProvider>
@@ -103,6 +119,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
       [],
     );
     const handleOpen = (event: React.MouseEvent | React.PointerEvent) => {
+      context.hasInteractedRef.current = true;
       pointRef.current = { x: event.clientX, y: event.clientY };
       context.onOpenChange(true);
     };

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -188,7 +188,6 @@ describe('Tooltip', () => {
           skipDelayDuration: 0,
         });
 
-
         act(() => void fireEvent.pointerMove(triggerA));
         act(() => void vi.advanceTimersByTime(100));
         expect(triggerA).toHaveAttribute('data-state', 'delayed-open');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,9 +710,6 @@ importers:
       '@radix-ui/react-primitive':
         specifier: workspace:*
         version: link:../primitive
-      '@radix-ui/react-use-callback-ref':
-        specifier: workspace:*
-        version: link:../use-callback-ref
       '@radix-ui/react-use-controllable-state':
         specifier: workspace:*
         version: link:../use-controllable-state


### PR DESCRIPTION
This adds the ability for users to control the open state of the context menu.

Important to note that there is a footgun here. **Users should never open a context menu programmatically as it is positioned based on user interaction.**

We could consider programmatic positioning down the road, but this would add significant complexity and potentially enable bad UX patterns we'd like to avoid. The primary use cases here are 1. programmatically dismissing a context menu, and 2. having access to its state externally.

Closes:
- https://github.com/radix-ui/primitives/issues/1307
- https://github.com/radix-ui/primitives/issues/2795

