### PR TITLE
Popper: Reduce risk for maximum update depth errors

### DIFF
--- a/.changeset/frank-places-sin.md
+++ b/.changeset/frank-places-sin.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-popper": patch
+"radix-ui": patch
+---
+
+Fixed Popper bug resulting in max-update depth exceeded error for pages with large number of popper instances

--- a/.changeset/popper-anchor-callback-ref.md
+++ b/.changeset/popper-anchor-callback-ref.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-popper': patch
+---
+
+Set the `PopperAnchor` DOM anchor from a callback ref instead of an effect so mounting many Popper-based components (Tooltip, Popover, DropdownMenu, HoverCard) at once no longer counts toward React's nested update depth limit and triggers "Maximum update depth exceeded". Virtual anchors continue to be read on every render so a swapped or late-assigned `virtualRef.current` is still picked up.

--- a/packages/react/popper/src/popper.test.tsx
+++ b/packages/react/popper/src/popper.test.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { cleanup, render, act } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import * as Popper from './popper';
+
+function makeVirtual() {
+  return {
+    getBoundingClientRect: vi.fn(() => DOMRect.fromRect({ x: 0, y: 0, width: 10, height: 10 })),
+  };
+}
+
+describe('PopperAnchor virtualRef', () => {
+  afterEach(cleanup);
+
+  it('updates the anchor when virtualRef.current is swapped on an unrelated re-render', async () => {
+    const first = makeVirtual();
+    const second = makeVirtual();
+
+    function Test() {
+      const virtualRef = React.useRef(first);
+      const [, force] = React.useReducer((c) => c + 1, 0);
+      return (
+        <Popper.Root>
+          <Popper.Anchor virtualRef={virtualRef as React.RefObject<typeof first>} />
+          <Popper.Content>content</Popper.Content>
+          <button
+            onClick={() => {
+              virtualRef.current = second;
+              force();
+            }}
+          >
+            swap
+          </button>
+        </Popper.Root>
+      );
+    }
+
+    const { getByText } = render(<Test />);
+    await act(async () => {});
+    second.getBoundingClientRect.mockClear();
+
+    await act(async () => {
+      getByText('swap').click();
+    });
+    await act(async () => {});
+
+    // After swapping the virtual anchor object and re-rendering, floating-ui
+    // should measure the NEW anchor object. If the anchor was never updated,
+    // `second` is never measured (stale anchor regression).
+    expect(second.getBoundingClientRect).toHaveBeenCalled();
+  });
+
+  it('registers a virtualRef whose current is set after mount', async () => {
+    const anchor = makeVirtual();
+
+    function Test() {
+      const virtualRef = React.useRef<typeof anchor | null>(null);
+      const [, force] = React.useReducer((c) => c + 1, 0);
+      return (
+        <Popper.Root>
+          <Popper.Anchor virtualRef={virtualRef as React.RefObject<typeof anchor>} />
+          <Popper.Content>content</Popper.Content>
+          <button
+            onClick={() => {
+              virtualRef.current = anchor;
+              force();
+            }}
+          >
+            attach
+          </button>
+        </Popper.Root>
+      );
+    }
+
+    const { getByText } = render(<Test />);
+    await act(async () => {});
+    anchor.getBoundingClientRect.mockClear();
+
+    await act(async () => {
+      getByText('attach').click();
+    });
+    await act(async () => {});
+
+    expect(anchor.getBoundingClientRect).toHaveBeenCalled();
+  });
+});

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -90,17 +90,35 @@ const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(
     const { __scopePopper, virtualRef, ...anchorProps } = props;
     const context = usePopperContext(ANCHOR_NAME, __scopePopper);
     const ref = React.useRef<PopperAnchorElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
+    const onAnchorChange = context.onAnchorChange;
+
+    // For DOM anchors, set the anchor from a callback ref rather than an
+    // effect. React invokes callback refs during the commit phase which does
+    // not count toward the nested update depth limit, so mounting many
+    // Popper-based components at once doesn't trigger "Maximum update depth
+    // exceeded"
+    // see https://github.com/radix-ui/primitives/issues/3858
+    const callbackRef = React.useCallback(
+      (node: PopperAnchorElement | null) => {
+        ref.current = node;
+        if (node) {
+          onAnchorChange(node);
+        }
+      },
+      [onAnchorChange],
+    );
+    const composedRefs = useComposedRefs(forwardedRef, callbackRef);
 
     const anchorRef = React.useRef<Measurable | null>(null);
     React.useEffect(() => {
+      if (!virtualRef) {
+        return;
+      }
+
       const previousAnchor = anchorRef.current;
-      anchorRef.current = virtualRef?.current || ref.current;
+      anchorRef.current = virtualRef.current;
       if (previousAnchor !== anchorRef.current) {
-        // Consumer can anchor the popper to something that isn't
-        // a DOM node e.g. pointer position, so we override the
-        // `anchorRef` with their virtual ref in this case.
-        context.onAnchorChange(anchorRef.current);
+        onAnchorChange(anchorRef.current);
       }
     });
 


### PR DESCRIPTION
Inspired largely by https://github.com/radix-ui/primitives/pull/3869, but we needed a small tweak. Virtual refs still may need to be updated in response to _any_ render since the ref is stable. 

Closes https://github.com/radix-ui/primitives/issues/3858