### PR TITLE
radio-group: Add unstable `ItemProvider`, `ItemTrigger` and `ItemBubbleInput`

### DIFF
--- a/.changeset/young-bikes-read.md
+++ b/.changeset/young-bikes-read.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-radio-group': minor
+'radix-ui': minor
+---
+
+Add unstable `RadioGroupItemProvider`, `RadioGroupItemTrigger` and `RadioGroupItemBubbleInput` parts. These expose the previously internal composition of a radio item (context provider, the interactive control, and the hidden form input) so consumers can directly access and recompose them. The `RadioGroupItem` component continues to render them by default.

--- a/apps/storybook/stories/radio-group.stories.tsx
+++ b/apps/storybook/stories/radio-group.stories.tsx
@@ -1,8 +1,94 @@
+/* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
 import { Direction, Label as LabelPrimitive, RadioGroup } from 'radix-ui';
 import styles from './radio-group.stories.module.css';
 
 export default { title: 'Components/RadioGroup' };
+
+export const Parts = () => (
+  <Label>
+    Favourite pet
+    <RadioGroup.Root className={styles.root} defaultValue="1">
+      <Label>
+        <RadioGroup.unstable_ItemProvider value="1">
+          <RadioGroup.unstable_ItemTrigger className={styles.item}>
+            <RadioGroup.Indicator className={styles.indicator} />
+          </RadioGroup.unstable_ItemTrigger>
+        </RadioGroup.unstable_ItemProvider>
+        Cat
+      </Label>{' '}
+      <Label>
+        <RadioGroup.unstable_ItemProvider value="2">
+          <RadioGroup.unstable_ItemTrigger className={styles.item}>
+            <RadioGroup.Indicator className={styles.indicator} />
+          </RadioGroup.unstable_ItemTrigger>
+        </RadioGroup.unstable_ItemProvider>
+        Dog
+      </Label>{' '}
+      <Label>
+        <RadioGroup.unstable_ItemProvider value="3">
+          <RadioGroup.unstable_ItemTrigger className={styles.item}>
+            <RadioGroup.Indicator className={styles.indicator} />
+          </RadioGroup.unstable_ItemTrigger>
+        </RadioGroup.unstable_ItemProvider>
+        Rabbit
+      </Label>
+    </RadioGroup.Root>
+  </Label>
+);
+
+export const PartsWithinForm = () => {
+  const [data, setData] = React.useState({ required: '', stopprop: '' });
+
+  return (
+    <form
+      onSubmit={(event) => event.preventDefault()}
+      onChange={(event) => {
+        const radio = event.target as unknown as HTMLInputElement;
+        setData((prevData) => ({ ...prevData, [radio.name]: radio.value }));
+      }}
+    >
+      <fieldset>
+        <legend>required value: {data.required}</legend>
+        <RadioGroup.Root className={styles.root} name="required" required>
+          {['1', '2', '3'].map((value) => (
+            <RadioGroup.unstable_ItemProvider key={value} value={value}>
+              <RadioGroup.unstable_ItemTrigger className={styles.item}>
+                <RadioGroup.Indicator className={styles.indicator} />
+              </RadioGroup.unstable_ItemTrigger>
+              <RadioGroup.unstable_ItemBubbleInput />
+            </RadioGroup.unstable_ItemProvider>
+          ))}
+        </RadioGroup.Root>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <fieldset>
+        <legend>stop propagation value: {data.stopprop}</legend>
+        <RadioGroup.Root className={styles.root} name="stopprop">
+          {['1', '2', '3'].map((value) => (
+            <RadioGroup.unstable_ItemProvider key={value} value={value}>
+              <RadioGroup.unstable_ItemTrigger
+                className={styles.item}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <RadioGroup.Indicator className={styles.indicator} />
+              </RadioGroup.unstable_ItemTrigger>
+              <RadioGroup.unstable_ItemBubbleInput />
+            </RadioGroup.unstable_ItemProvider>
+          ))}
+        </RadioGroup.Root>
+      </fieldset>
+
+      <br />
+      <br />
+
+      <button>Submit</button>
+    </form>
+  );
+};
 
 export const LegacyStyled = () => (
   <Label>

--- a/packages/react/radio-group/src/index.ts
+++ b/packages/react/radio-group/src/index.ts
@@ -4,10 +4,23 @@ export {
   //
   RadioGroup,
   RadioGroupItem,
+  RadioGroupItemProvider as unstable_RadioGroupItemProvider,
+  RadioGroupItemTrigger as unstable_RadioGroupItemTrigger,
+  RadioGroupItemBubbleInput as unstable_RadioGroupItemBubbleInput,
   RadioGroupIndicator,
   //
   Root,
   Item,
+  ItemProvider as unstable_ItemProvider,
+  ItemTrigger as unstable_ItemTrigger,
+  ItemBubbleInput as unstable_ItemBubbleInput,
   Indicator,
 } from './radio-group';
-export type { RadioGroupProps, RadioGroupItemProps, RadioGroupIndicatorProps } from './radio-group';
+export type {
+  RadioGroupProps,
+  RadioGroupItemProps,
+  RadioGroupItemProviderProps as unstable_RadioGroupItemProviderProps,
+  RadioGroupItemTriggerProps as unstable_RadioGroupItemTriggerProps,
+  RadioGroupItemBubbleInputProps as unstable_RadioGroupItemBubbleInputProps,
+  RadioGroupIndicatorProps,
+} from './radio-group';

--- a/packages/react/radio-group/src/radio-group.test.tsx
+++ b/packages/react/radio-group/src/radio-group.test.tsx
@@ -1,0 +1,346 @@
+import * as React from 'react';
+import { axe } from 'vitest-axe';
+import type { RenderResult } from '@testing-library/react';
+import { cleanup, render, fireEvent, screen, act } from '@testing-library/react';
+import * as RadioGroup from '.';
+import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
+
+const RADIO_ROLE = 'radio';
+const INDICATOR_TEST_ID = 'radio-indicator';
+
+global.ResizeObserver = class ResizeObserver {
+  cb: any;
+  constructor(cb: any) {
+    this.cb = cb;
+  }
+  observe() {
+    this.cb([{ borderBoxSize: { inlineSize: 0, blockSize: 0 } }]);
+  }
+  unobserve() {}
+  disconnect() {}
+};
+
+const VALUES = ['1', '2', '3'];
+const LABELS: Record<string, string> = { '1': 'cat', '2': 'dog', '3': 'rabbit' };
+
+function ClassicRadioGroup(props: React.ComponentProps<typeof RadioGroup.Root>) {
+  return (
+    <RadioGroup.Root aria-label="pets" {...props}>
+      {VALUES.map((value) => (
+        <RadioGroup.Item key={value} value={value} aria-label={LABELS[value]}>
+          <RadioGroup.Indicator data-testid={`${INDICATOR_TEST_ID}-${value}`} />
+        </RadioGroup.Item>
+      ))}
+    </RadioGroup.Root>
+  );
+}
+
+function ComposableRadioGroup(props: React.ComponentProps<typeof RadioGroup.Root>) {
+  return (
+    <RadioGroup.Root aria-label="pets" {...props}>
+      {VALUES.map((value) => (
+        <RadioGroup.unstable_ItemProvider key={value} value={value}>
+          <RadioGroup.unstable_ItemTrigger aria-label={LABELS[value]}>
+            <RadioGroup.Indicator data-testid={`${INDICATOR_TEST_ID}-${value}`} />
+          </RadioGroup.unstable_ItemTrigger>
+          <RadioGroup.unstable_ItemBubbleInput />
+        </RadioGroup.unstable_ItemProvider>
+      ))}
+    </RadioGroup.Root>
+  );
+}
+
+describe('RadioGroup', () => {
+  afterEach(cleanup);
+
+  describe('given a default RadioGroup', () => {
+    let rendered: RenderResult;
+    beforeEach(() => {
+      rendered = render(<ClassicRadioGroup />);
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should render all items unchecked', () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      expect(radios).toHaveLength(3);
+      radios.forEach((radio) => expect(radio).toHaveAttribute('aria-checked', 'false'));
+    });
+
+    it('should check an item and show its indicator when clicked', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+
+      expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-1`)).toBeVisible();
+    });
+
+    it('should move selection to another item', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+      await act(async () => fireEvent.click(radios[1]!));
+
+      expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+      expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-1`)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-2`)).toBeVisible();
+    });
+
+    it('should not uncheck an item when clicked again', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+      await act(async () => fireEvent.click(radios[0]!));
+
+      expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-1`)).toBeVisible();
+    });
+  });
+
+  describe('given a RadioGroup with `defaultValue`', () => {
+    it('should render the matching item checked', () => {
+      render(<ClassicRadioGroup defaultValue="2" />);
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-2`)).toBeVisible();
+    });
+  });
+
+  describe('given a disabled RadioGroup', () => {
+    let rendered: RenderResult;
+    const onValueChange = vi.fn();
+    beforeEach(() => {
+      onValueChange.mockReset();
+      rendered = render(<ClassicRadioGroup disabled onValueChange={onValueChange} />);
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should not check an item when clicked', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+      expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a RadioGroup with a disabled item', () => {
+    const onValueChange = vi.fn();
+    beforeEach(() => {
+      onValueChange.mockReset();
+      render(
+        <RadioGroup.Root aria-label="pets" onValueChange={onValueChange}>
+          <RadioGroup.Item value="1" aria-label="cat">
+            <RadioGroup.Indicator data-testid={`${INDICATOR_TEST_ID}-1`} />
+          </RadioGroup.Item>
+          <RadioGroup.Item value="2" aria-label="dog" disabled>
+            <RadioGroup.Indicator data-testid={`${INDICATOR_TEST_ID}-2`} />
+          </RadioGroup.Item>
+        </RadioGroup.Root>,
+      );
+    });
+
+    it('should not check the disabled item when clicked', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[1]!));
+      expect(radios[1]).toHaveAttribute('aria-checked', 'false');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('should still allow checking an enabled item', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+      expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+      expect(onValueChange).toHaveBeenCalledWith('1');
+    });
+  });
+
+  describe('given a controlled RadioGroup', () => {
+    const onValueChange = vi.fn();
+
+    function ControlledRadioGroup() {
+      const [value, setValue] = React.useState<string | null>(null);
+      const [blockChange, setBlockChange] = React.useState(false);
+      return (
+        <div>
+          <RadioGroup.Root
+            aria-label="pets"
+            value={value}
+            onValueChange={(next) => {
+              onValueChange(next);
+              if (!blockChange) setValue(next);
+            }}
+          >
+            {VALUES.map((v) => (
+              <RadioGroup.Item key={v} value={v} aria-label={LABELS[v]}>
+                <RadioGroup.Indicator data-testid={`${INDICATOR_TEST_ID}-${v}`} />
+              </RadioGroup.Item>
+            ))}
+          </RadioGroup.Root>
+          <button type="button" onClick={() => setBlockChange((prev) => !prev)}>
+            {blockChange ? 'Unblock' : 'Block'}
+          </button>
+        </div>
+      );
+    }
+
+    beforeEach(() => {
+      onValueChange.mockReset();
+      render(<ControlledRadioGroup />);
+    });
+
+    it('should call `onValueChange` with the clicked value', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[2]!));
+      expect(onValueChange).toHaveBeenCalledWith('3');
+      expect(radios[2]).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should not change selection unless controlled state updates', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(screen.getByText('Block')));
+      await act(async () => fireEvent.click(radios[0]!));
+      expect(onValueChange).toHaveBeenCalledWith('1');
+      expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-1`)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should check an item that receives focus while an arrow key is pressed', async () => {
+      render(<ClassicRadioGroup />);
+      const radios = screen.getAllByRole(RADIO_ROLE);
+
+      await act(async () => radios[0]!.focus());
+      // `RovingFocusGroup` moves focus to the next item on arrow keys; once an
+      // item is focused during arrow navigation it should also become checked.
+      await act(async () => {
+        fireEvent.keyDown(radios[0]!, { key: 'ArrowDown' });
+        radios[1]!.focus();
+      });
+
+      expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-2`)).toBeVisible();
+    });
+
+    it('should not check an item that receives focus without arrow navigation', async () => {
+      render(<ClassicRadioGroup />);
+      const radios = screen.getAllByRole(RADIO_ROLE);
+
+      await act(async () => radios[1]!.focus());
+
+      expect(radios[1]).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should not check an item on Enter key', async () => {
+      render(<ClassicRadioGroup />);
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => radios[0]!.focus());
+      await act(async () => fireEvent.keyDown(radios[0]!, { key: 'Enter' }));
+      expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  describe('given an uncontrolled RadioGroup in a form', () => {
+    it('should bubble a change event with the selected value', () => {
+      const onChange = vi.fn();
+      render(
+        <form onChange={(event) => onChange((event.target as unknown as HTMLInputElement).value)}>
+          <ClassicRadioGroup name="pet" />
+        </form>,
+      );
+
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      act(() => fireEvent.click(radios[1]!));
+      expect(onChange).toHaveBeenCalledWith('2');
+    });
+
+    it('should expose the group as required for native validation', () => {
+      const { container } = render(
+        <form>
+          <ClassicRadioGroup name="pet" required />
+        </form>,
+      );
+      const form = container.querySelector('form')!;
+      expect(form.checkValidity()).toBe(false);
+
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      act(() => fireEvent.click(radios[0]!));
+      expect(form.checkValidity()).toBe(true);
+    });
+  });
+});
+
+describe('Composable RadioGroup', () => {
+  afterEach(cleanup);
+
+  describe('given a default composable RadioGroup', () => {
+    let rendered: RenderResult;
+    beforeEach(() => {
+      rendered = render(<ComposableRadioGroup />);
+    });
+
+    it('should have no accessibility violations', async () => {
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+
+    it('should render all items unchecked', () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      expect(radios).toHaveLength(3);
+      radios.forEach((radio) => expect(radio).toHaveAttribute('aria-checked', 'false'));
+    });
+
+    it('should check an item and show its indicator when clicked', async () => {
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      await act(async () => fireEvent.click(radios[0]!));
+      expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+      expect(screen.queryByTestId(`${INDICATOR_TEST_ID}-1`)).toBeVisible();
+    });
+  });
+
+  describe('given a composable RadioGroup in a form', () => {
+    it('should bubble a change event with the selected value', () => {
+      const onChange = vi.fn();
+      render(
+        <form onChange={(event) => onChange((event.target as unknown as HTMLInputElement).value)}>
+          <ComposableRadioGroup name="pet" />
+        </form>,
+      );
+
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      act(() => fireEvent.click(radios[2]!));
+      expect(onChange).toHaveBeenCalledWith('3');
+    });
+
+    it('should not bubble to the form when propagation is stopped on the trigger', () => {
+      const onChange = vi.fn();
+      render(
+        <form onChange={(event) => onChange((event.target as unknown as HTMLInputElement).value)}>
+          <RadioGroup.Root aria-label="pets" name="pet">
+            {VALUES.map((value) => (
+              <RadioGroup.unstable_ItemProvider key={value} value={value}>
+                <RadioGroup.unstable_ItemTrigger
+                  aria-label={LABELS[value]}
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <RadioGroup.Indicator />
+                </RadioGroup.unstable_ItemTrigger>
+                <RadioGroup.unstable_ItemBubbleInput />
+              </RadioGroup.unstable_ItemProvider>
+            ))}
+          </RadioGroup.Root>
+        </form>,
+      );
+
+      const radios = screen.getAllByRole(RADIO_ROLE);
+      act(() => fireEvent.click(radios[0]!));
+      // selection still happens locally
+      expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+      // but the change does not reach the form
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/radio-group/src/radio-group.tsx
+++ b/packages/react/radio-group/src/radio-group.tsx
@@ -7,7 +7,15 @@ import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { createRovingFocusGroupScope } from '@radix-ui/react-roving-focus';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useDirection } from '@radix-ui/react-direction';
-import { Radio, RadioIndicator, createRadioScope } from './radio';
+import {
+  type Radio,
+  RadioProvider,
+  RadioTrigger,
+  RadioBubbleInput,
+  RadioIndicator,
+  createRadioScope,
+  useRadioContext,
+} from './radio';
 
 import type { Scope } from '@radix-ui/react-context';
 
@@ -110,10 +118,121 @@ const RadioGroup = React.forwardRef<RadioGroupElement, RadioGroupProps>(
 RadioGroup.displayName = RADIO_GROUP_NAME;
 
 /* -------------------------------------------------------------------------------------------------
- * RadioGroupItem
+ * RadioGroupItemProvider
  * -----------------------------------------------------------------------------------------------*/
 
 const ITEM_NAME = 'RadioGroupItem';
+const ITEM_PROVIDER_NAME = 'RadioGroupItemProvider';
+const ITEM_TRIGGER_NAME = 'RadioGroupItemTrigger';
+const ITEM_BUBBLE_INPUT_NAME = 'RadioGroupItemBubbleInput';
+
+interface RadioGroupItemProviderProps {
+  value: string;
+  disabled?: boolean;
+  children?: React.ReactNode;
+}
+
+function RadioGroupItemProvider(props: ScopedProps<RadioGroupItemProviderProps>) {
+  const {
+    __scopeRadioGroup,
+    value,
+    disabled,
+    children,
+    // @ts-expect-error
+    internal_do_not_use_render,
+  } = props;
+  const context = useRadioGroupContext(ITEM_PROVIDER_NAME, __scopeRadioGroup);
+  const radioScope = useRadioScope(__scopeRadioGroup);
+  const isDisabled = context.disabled || disabled;
+
+  return (
+    <RadioProvider
+      {...radioScope}
+      checked={context.value === value}
+      disabled={isDisabled}
+      required={context.required}
+      name={context.name}
+      value={value}
+      onCheck={() => context.onValueChange(value)}
+      // @ts-expect-error
+      internal_do_not_use_render={internal_do_not_use_render}
+    >
+      {children}
+    </RadioProvider>
+  );
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * RadioGroupItemTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+type RadioGroupItemTriggerElement = React.ComponentRef<typeof RadioTrigger>;
+interface RadioGroupItemTriggerProps extends React.ComponentPropsWithoutRef<typeof RadioTrigger> {}
+
+const RadioGroupItemTrigger = React.forwardRef<
+  RadioGroupItemTriggerElement,
+  RadioGroupItemTriggerProps
+>((props: ScopedProps<RadioGroupItemTriggerProps>, forwardedRef) => {
+  const { __scopeRadioGroup, ...triggerProps } = props;
+  const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeRadioGroup);
+  const radioScope = useRadioScope(__scopeRadioGroup);
+  const { checked, disabled } = useRadioContext(ITEM_TRIGGER_NAME, radioScope.__scopeRadio);
+  const ref = React.useRef<RadioGroupItemTriggerElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+  const isArrowKeyPressedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (ARROW_KEYS.includes(event.key)) {
+        isArrowKeyPressedRef.current = true;
+      }
+    };
+    const handleKeyUp = () => (isArrowKeyPressedRef.current = false);
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  return (
+    <RovingFocusGroup.Item
+      asChild
+      {...rovingFocusGroupScope}
+      focusable={!disabled}
+      active={checked}
+    >
+      <RadioTrigger
+        {...radioScope}
+        {...triggerProps}
+        ref={composedRefs}
+        onKeyDown={composeEventHandlers(triggerProps.onKeyDown, (event) => {
+          // According to WAI ARIA, radio groups don't activate items on enter
+          // keypress
+          if (event.key === 'Enter') event.preventDefault();
+        })}
+        onFocus={composeEventHandlers(triggerProps.onFocus, () => {
+          /**
+           * Our `RovingFocusGroup` will focus the radio when navigating with
+           * arrow keys and we need to "check" it in that case. We click it to
+           * "check" it (instead of updating `context.value`) so that the radio
+           * change event fires.
+           */
+          if (isArrowKeyPressedRef.current) {
+            ref.current?.click();
+          }
+        })}
+      />
+    </RovingFocusGroup.Item>
+  );
+});
+
+RadioGroupItemTrigger.displayName = ITEM_TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * RadioGroupItem
+ * -----------------------------------------------------------------------------------------------*/
 
 type RadioGroupItemElement = React.ComponentRef<typeof Radio>;
 type RadioProps = React.ComponentPropsWithoutRef<typeof Radio>;
@@ -123,66 +242,56 @@ interface RadioGroupItemProps extends Omit<RadioProps, 'onCheck' | 'name'> {
 
 const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
   (props: ScopedProps<RadioGroupItemProps>, forwardedRef) => {
-    const { __scopeRadioGroup, disabled, ...itemProps } = props;
-    const context = useRadioGroupContext(ITEM_NAME, __scopeRadioGroup);
-    const isDisabled = context.disabled || disabled;
-    const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeRadioGroup);
-    const radioScope = useRadioScope(__scopeRadioGroup);
-    const ref = React.useRef<React.ComponentRef<typeof Radio>>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
-    const checked = context.value === itemProps.value;
-    const isArrowKeyPressedRef = React.useRef(false);
-
-    React.useEffect(() => {
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (ARROW_KEYS.includes(event.key)) {
-          isArrowKeyPressedRef.current = true;
-        }
-      };
-      const handleKeyUp = () => (isArrowKeyPressedRef.current = false);
-      document.addEventListener('keydown', handleKeyDown);
-      document.addEventListener('keyup', handleKeyUp);
-      return () => {
-        document.removeEventListener('keydown', handleKeyDown);
-        document.removeEventListener('keyup', handleKeyUp);
-      };
-    }, []);
+    const { __scopeRadioGroup, value, disabled, ...itemProps } = props;
 
     return (
-      <RovingFocusGroup.Item
-        asChild
-        {...rovingFocusGroupScope}
-        focusable={!isDisabled}
-        active={checked}
-      >
-        <Radio
-          disabled={isDisabled}
-          required={context.required}
-          checked={checked}
-          {...radioScope}
-          {...itemProps}
-          name={context.name}
-          ref={composedRefs}
-          onCheck={() => context.onValueChange(itemProps.value)}
-          onKeyDown={composeEventHandlers((event) => {
-            // According to WAI ARIA, radio groups don't activate items on enter keypress
-            if (event.key === 'Enter') event.preventDefault();
-          })}
-          onFocus={composeEventHandlers(itemProps.onFocus, () => {
-            /**
-             * Our `RovingFocusGroup` will focus the radio when navigating with arrow keys
-             * and we need to "check" it in that case. We click it to "check" it (instead
-             * of updating `context.value`) so that the radio change event fires.
-             */
-            if (isArrowKeyPressedRef.current) ref.current?.click();
-          })}
-        />
-      </RovingFocusGroup.Item>
+      <RadioGroupItemProvider
+        __scopeRadioGroup={__scopeRadioGroup}
+        value={value}
+        disabled={disabled}
+        // @ts-expect-error
+        internal_do_not_use_render={({ isFormControl }: { isFormControl: boolean }) => (
+          <>
+            <RadioGroupItemTrigger
+              {...itemProps}
+              ref={forwardedRef}
+              // @ts-expect-error
+              __scopeRadioGroup={__scopeRadioGroup}
+            />
+            {isFormControl && (
+              <RadioGroupItemBubbleInput
+                // @ts-expect-error
+                __scopeRadioGroup={__scopeRadioGroup}
+              />
+            )}
+          </>
+        )}
+      />
     );
   },
 );
 
 RadioGroupItem.displayName = ITEM_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * RadioGroupItemBubbleInput
+ * -----------------------------------------------------------------------------------------------*/
+
+type RadioGroupItemBubbleInputElement = React.ComponentRef<typeof RadioBubbleInput>;
+interface RadioGroupItemBubbleInputProps extends React.ComponentPropsWithoutRef<
+  typeof RadioBubbleInput
+> {}
+
+const RadioGroupItemBubbleInput = React.forwardRef<
+  RadioGroupItemBubbleInputElement,
+  RadioGroupItemBubbleInputProps
+>((props: ScopedProps<RadioGroupItemBubbleInputProps>, forwardedRef) => {
+  const { __scopeRadioGroup, ...bubbleProps } = props;
+  const radioScope = useRadioScope(__scopeRadioGroup);
+  return <RadioBubbleInput {...radioScope} {...bubbleProps} ref={forwardedRef} />;
+});
+
+RadioGroupItemBubbleInput.displayName = ITEM_BUBBLE_INPUT_NAME;
 
 /* -------------------------------------------------------------------------------------------------
  * RadioGroupIndicator
@@ -206,19 +315,28 @@ RadioGroupIndicator.displayName = INDICATOR_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
-const Root = RadioGroup;
-const Item = RadioGroupItem;
-const Indicator = RadioGroupIndicator;
-
 export {
   createRadioGroupScope,
   //
   RadioGroup,
   RadioGroupItem,
+  RadioGroupItemProvider,
+  RadioGroupItemTrigger,
+  RadioGroupItemBubbleInput,
   RadioGroupIndicator,
   //
-  Root,
-  Item,
-  Indicator,
+  RadioGroup as Root,
+  RadioGroupItem as Item,
+  RadioGroupItemProvider as ItemProvider,
+  RadioGroupItemTrigger as ItemTrigger,
+  RadioGroupItemBubbleInput as ItemBubbleInput,
+  RadioGroupIndicator as Indicator,
 };
-export type { RadioGroupProps, RadioGroupItemProps, RadioGroupIndicatorProps };
+export type {
+  RadioGroupProps,
+  RadioGroupItemProps,
+  RadioGroupItemProviderProps,
+  RadioGroupItemTriggerProps,
+  RadioGroupItemBubbleInputProps,
+  RadioGroupIndicatorProps,
+};

--- a/packages/react/radio-group/src/radio.tsx
+++ b/packages/react/radio-group/src/radio.tsx
@@ -9,21 +9,154 @@ import { Primitive } from '@radix-ui/react-primitive';
 
 import type { Scope } from '@radix-ui/react-context';
 
-/* -------------------------------------------------------------------------------------------------
- * Radio
- * -----------------------------------------------------------------------------------------------*/
-
 const RADIO_NAME = 'Radio';
 
 type ScopedProps<P> = P & { __scopeRadio?: Scope };
 const [createRadioContext, createRadioScope] = createContextScope(RADIO_NAME);
 
-type RadioContextValue = { checked: boolean; disabled?: boolean };
-const [RadioProvider, useRadioContext] = createRadioContext<RadioContextValue>(RADIO_NAME);
+type RadioContextValue = {
+  checked: boolean;
+  disabled: boolean | undefined;
+  required: boolean | undefined;
+  name: string | undefined;
+  form: string | undefined;
+  value: string | number | readonly string[];
+  control: HTMLButtonElement | null;
+  setControl: React.Dispatch<React.SetStateAction<HTMLButtonElement | null>>;
+  hasConsumerStoppedPropagationRef: React.RefObject<boolean>;
+  isFormControl: boolean;
+  bubbleInput: HTMLInputElement | null;
+  setBubbleInput: React.Dispatch<React.SetStateAction<HTMLInputElement | null>>;
+  onCheck(): void;
+};
+
+const [RadioProviderImpl, useRadioContext] = createRadioContext<RadioContextValue>(RADIO_NAME);
+
+/* -------------------------------------------------------------------------------------------------
+ * RadioProvider
+ * -----------------------------------------------------------------------------------------------*/
+
+interface RadioProviderProps {
+  checked?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  name?: string;
+  form?: string;
+  value?: string | number | readonly string[];
+  onCheck?(): void;
+  children?: React.ReactNode;
+}
+
+function RadioProvider(props: ScopedProps<RadioProviderProps>) {
+  const {
+    __scopeRadio,
+    checked = false,
+    children,
+    disabled,
+    form,
+    name,
+    onCheck,
+    required,
+    value = 'on',
+    // @ts-expect-error
+    internal_do_not_use_render,
+  } = props;
+
+  const [control, setControl] = React.useState<HTMLButtonElement | null>(null);
+  const [bubbleInput, setBubbleInput] = React.useState<HTMLInputElement | null>(null);
+  const hasConsumerStoppedPropagationRef = React.useRef(false);
+  const isFormControl = control
+    ? !!form || !!control.closest('form')
+    : // We set this to true by default so that events bubble to forms without JS (SSR)
+      true;
+
+  const context: RadioContextValue = {
+    checked,
+    disabled,
+    required,
+    name,
+    form,
+    value,
+    control,
+    setControl,
+    hasConsumerStoppedPropagationRef,
+    isFormControl,
+    bubbleInput,
+    setBubbleInput,
+    onCheck: () => onCheck?.(),
+  };
+
+  return (
+    <RadioProviderImpl scope={__scopeRadio} {...context}>
+      {isFunction(internal_do_not_use_render) ? internal_do_not_use_render(context) : children}
+    </RadioProviderImpl>
+  );
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * RadioTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_NAME = 'RadioTrigger';
+
+interface RadioTriggerProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof Primitive.button>,
+  keyof RadioProviderProps
+> {
+  children?: React.ReactNode;
+}
+
+const RadioTrigger = React.forwardRef<HTMLButtonElement, RadioTriggerProps>(
+  ({ __scopeRadio, onClick, ...radioProps }: ScopedProps<RadioTriggerProps>, forwardedRef) => {
+    const {
+      checked,
+      disabled,
+      value,
+      setControl,
+      onCheck,
+      hasConsumerStoppedPropagationRef,
+      isFormControl,
+      bubbleInput,
+    } = useRadioContext(TRIGGER_NAME, __scopeRadio);
+    const composedRefs = useComposedRefs(forwardedRef, setControl);
+
+    return (
+      <Primitive.button
+        type="button"
+        role="radio"
+        aria-checked={checked}
+        data-state={getState(checked)}
+        data-disabled={disabled ? '' : undefined}
+        disabled={disabled}
+        value={value}
+        {...radioProps}
+        ref={composedRefs}
+        onClick={composeEventHandlers(onClick, (event) => {
+          // radios cannot be unchecked so we only communicate a checked state
+          if (!checked) onCheck();
+          if (bubbleInput && isFormControl) {
+            hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
+            // if radio has a bubble input and is a form control, stop propagation
+            // from the button so that we only propagate one click event (from the
+            // input). We propagate changes from an input so that native form
+            // validation works and form events reflect radio updates.
+            if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
+          }
+        })}
+      />
+    );
+  },
+);
+
+RadioTrigger.displayName = TRIGGER_NAME;
+
+/* -------------------------------------------------------------------------------------------------
+ * Radio
+ * -----------------------------------------------------------------------------------------------*/
 
 type RadioElement = React.ComponentRef<typeof Primitive.button>;
 type PrimitiveButtonProps = React.ComponentPropsWithoutRef<typeof Primitive.button>;
-interface RadioProps extends PrimitiveButtonProps {
+interface RadioProps extends Omit<PrimitiveButtonProps, 'checked'> {
   checked?: boolean;
   required?: boolean;
   onCheck?(): void;
@@ -31,64 +164,37 @@ interface RadioProps extends PrimitiveButtonProps {
 
 const Radio = React.forwardRef<RadioElement, RadioProps>(
   (props: ScopedProps<RadioProps>, forwardedRef) => {
-    const {
-      __scopeRadio,
-      name,
-      checked = false,
-      required,
-      disabled,
-      value = 'on',
-      onCheck,
-      form,
-      ...radioProps
-    } = props;
-    const [button, setButton] = React.useState<HTMLButtonElement | null>(null);
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node));
-    const hasConsumerStoppedPropagationRef = React.useRef(false);
-    // We set this to true by default so that events bubble to forms without JS (SSR)
-    const isFormControl = button ? form || !!button.closest('form') : true;
+    const { __scopeRadio, name, checked, required, disabled, value, onCheck, form, ...radioProps } =
+      props;
 
     return (
-      <RadioProvider scope={__scopeRadio} checked={checked} disabled={disabled}>
-        <Primitive.button
-          type="button"
-          role="radio"
-          aria-checked={checked}
-          data-state={getState(checked)}
-          data-disabled={disabled ? '' : undefined}
-          disabled={disabled}
-          value={value}
-          {...radioProps}
-          ref={composedRefs}
-          onClick={composeEventHandlers(props.onClick, (event) => {
-            // radios cannot be unchecked so we only communicate a checked state
-            if (!checked) onCheck?.();
-            if (isFormControl) {
-              hasConsumerStoppedPropagationRef.current = event.isPropagationStopped();
-              // if radio is in a form, stop propagation from the button so that we only propagate
-              // one click event (from the input). We propagate changes from an input so that native
-              // form validation works and form events reflect radio updates.
-              if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation();
-            }
-          })}
-        />
-        {isFormControl && (
-          <RadioBubbleInput
-            control={button}
-            bubbles={!hasConsumerStoppedPropagationRef.current}
-            name={name}
-            value={value}
-            checked={checked}
-            required={required}
-            disabled={disabled}
-            form={form}
-            // We transform because the input is absolutely positioned but we have
-            // rendered it **after** the button. This pulls it back to sit on top
-            // of the button.
-            style={{ transform: 'translateX(-100%)' }}
-          />
+      <RadioProvider
+        __scopeRadio={__scopeRadio}
+        checked={checked}
+        disabled={disabled}
+        required={required}
+        onCheck={onCheck}
+        name={name}
+        form={form}
+        value={value}
+        // @ts-expect-error
+        internal_do_not_use_render={({ isFormControl }: RadioContextValue) => (
+          <>
+            <RadioTrigger
+              {...radioProps}
+              ref={forwardedRef}
+              // @ts-expect-error
+              __scopeRadio={__scopeRadio}
+            />
+            {isFormControl && (
+              <RadioBubbleInput
+                // @ts-expect-error
+                __scopeRadio={__scopeRadio}
+              />
+            )}
+          </>
         )}
-      </RadioProvider>
+      />
     );
   },
 );
@@ -137,31 +243,30 @@ RadioIndicator.displayName = INDICATOR_NAME;
 const BUBBLE_INPUT_NAME = 'RadioBubbleInput';
 
 type InputProps = React.ComponentPropsWithoutRef<typeof Primitive.input>;
-interface RadioBubbleInputProps extends Omit<InputProps, 'checked'> {
-  checked: boolean;
-  control: HTMLElement | null;
-  bubbles: boolean;
-}
+interface RadioBubbleInputProps extends Omit<InputProps, 'checked'> {}
 
 const RadioBubbleInput = React.forwardRef<HTMLInputElement, RadioBubbleInputProps>(
-  (
-    {
-      __scopeRadio,
+  ({ __scopeRadio, ...props }: ScopedProps<RadioBubbleInputProps>, forwardedRef) => {
+    const {
       control,
       checked,
-      bubbles = true,
-      ...props
-    }: ScopedProps<RadioBubbleInputProps>,
-    forwardedRef,
-  ) => {
-    const ref = React.useRef<HTMLInputElement>(null);
-    const composedRefs = useComposedRefs(ref, forwardedRef);
+      required,
+      disabled,
+      name,
+      value,
+      form,
+      bubbleInput,
+      setBubbleInput,
+      hasConsumerStoppedPropagationRef,
+    } = useRadioContext(BUBBLE_INPUT_NAME, __scopeRadio);
+
+    const composedRefs = useComposedRefs(forwardedRef, setBubbleInput);
     const prevChecked = usePrevious(checked);
     const controlSize = useSize(control);
 
     // Bubble checked change to parents (e.g form change event)
     React.useEffect(() => {
-      const input = ref.current;
+      const input = bubbleInput;
       if (!input) return;
 
       const inputProto = window.HTMLInputElement.prototype;
@@ -170,18 +275,26 @@ const RadioBubbleInput = React.forwardRef<HTMLInputElement, RadioBubbleInputProp
         'checked',
       ) as PropertyDescriptor;
       const setChecked = descriptor.set;
+
+      const bubbles = !hasConsumerStoppedPropagationRef.current;
       if (prevChecked !== checked && setChecked) {
         const event = new Event('click', { bubbles });
         setChecked.call(input, checked);
         input.dispatchEvent(event);
       }
-    }, [prevChecked, checked, bubbles]);
+    }, [bubbleInput, prevChecked, checked, hasConsumerStoppedPropagationRef]);
 
+    const defaultCheckedRef = React.useRef(checked);
     return (
       <Primitive.input
         type="radio"
         aria-hidden
-        defaultChecked={checked}
+        defaultChecked={defaultCheckedRef.current}
+        required={required}
+        disabled={disabled}
+        name={name}
+        value={value}
+        form={form}
         {...props}
         tabIndex={-1}
         ref={composedRefs}
@@ -192,6 +305,10 @@ const RadioBubbleInput = React.forwardRef<HTMLInputElement, RadioBubbleInputProp
           pointerEvents: 'none',
           opacity: 0,
           margin: 0,
+          // We transform because the input is absolutely positioned but we have
+          // rendered it **after** the button. This pulls it back to sit on top
+          // of the button.
+          transform: 'translateX(-100%)',
         }}
       />
     );
@@ -202,14 +319,22 @@ RadioBubbleInput.displayName = BUBBLE_INPUT_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
 
+function isFunction(value: unknown): value is (...args: any[]) => any {
+  return typeof value === 'function';
+}
+
 function getState(checked: boolean) {
   return checked ? 'checked' : 'unchecked';
 }
 
 export {
   createRadioScope,
+  useRadioContext,
   //
   Radio,
+  RadioProvider,
+  RadioTrigger,
   RadioIndicator,
+  RadioBubbleInput,
 };
-export type { RadioProps };
+export type { RadioProps, RadioProviderProps, RadioTriggerProps, RadioBubbleInputProps };


### PR DESCRIPTION
Mirrors the design and intent behind https://github.com/radix-ui/primitives/pull/3459. See that issue for background and ratoinale.

```tsx
// before
<RadioGroup.Root>
  <RadioGroup.Item value={value}>
    <RadioGroup.Indicator />
  </RadioGroup.Item>
</RadioGroup.Root>

// after
<RadioGroup.Root>
  <RadioGroup.ItemProvider value={value}>
    <RadioGroup.ItemTrigger>
      <RadioGroup.Indicator />
    </RadioGroup.ItemTrigger>
    <RadioGroup.ItemBubbleInput />
  </RadioGroup.ItemProvider>
</RadioGroup.Root>
```