### PR TITLE
Select: Fix placeholder reset

### DIFF
--- a/.changeset/empty-walls-float.md
+++ b/.changeset/empty-walls-float.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-select": patch
+---
+
+Fix placeholder rendering when a controlled select is reset to an empty value.

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -898,12 +898,17 @@ export const ChromaticNoDefaultValue = () => (
 ChromaticNoDefaultValue.parameters = { chromatic: { disable: false } };
 
 export const Cypress = () => {
-  const [data, setData] = React.useState<{ size?: 'S' | 'M' | 'L' }>({});
+  const [data, setData] = React.useState<{ size?: string; model?: string }>({});
   const [model, setModel] = React.useState<string | undefined>('');
+  const [openColor, setOpenColor] = React.useState(false);
+  const [color, setColor] = React.useState<string | undefined>('green');
 
   function handleChange(event: React.FormEvent<HTMLFormElement>) {
     const formData = new FormData(event.currentTarget);
-    setData(Object.fromEntries((formData as any).entries()));
+    setData({
+      size: formData.get('size')?.toString(),
+      model: formData.get('model')?.toString(),
+    });
   }
 
   return (
@@ -957,7 +962,13 @@ export const Cypress = () => {
 
       <hr />
 
-      <div style={{ padding: 50 }}>
+      <form
+        style={{ padding: 50 }}
+        onSubmit={(event) => {
+          handleChange(event);
+          event.preventDefault();
+        }}
+      >
         <Label>
           choose a model
           <Select.Root name="model" value={model} onValueChange={setModel}>
@@ -1000,6 +1011,61 @@ export const Cypress = () => {
 
         <button type="button" style={{ width: 100, height: 50 }} onClick={() => setModel('')}>
           unset
+        </button>
+        <button type="submit" style={{ width: 100, height: 50 }}>
+          submit model
+        </button>
+        {data.model !== undefined ? (
+          <p>Submitted model: {data.model === '' ? 'empty' : data.model}</p>
+        ) : null}
+      </form>
+
+      <div style={{ padding: 50 }}>
+        <Label>
+          choose an open color
+          <Select.Root
+            open={openColor}
+            onOpenChange={setOpenColor}
+            value={color}
+            onValueChange={setColor}
+          >
+            <Select.Trigger className={styles.trigger}>
+              <Select.Value placeholder="Pick a color" />
+              <Select.Icon />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content className={styles.content}>
+                <Select.Viewport className={styles.viewport}>
+                  <Select.Item className={styles.item} value="red">
+                    <Select.ItemText>Red</Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={styles.item} value="green">
+                    <Select.ItemText>Green</Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                  <Select.Item className={styles.item} value="blue">
+                    <Select.ItemText>Blue</Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                </Select.Viewport>
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
+        </Label>
+
+        <button
+          type="button"
+          style={{ width: 160, height: 50 }}
+          onClick={() => setColor((value) => (value === '' ? 'green' : ''))}
+        >
+          toggle open color value
         </button>
       </div>
     </>

--- a/cypress/e2e/Select.cy.ts
+++ b/cypress/e2e/Select.cy.ts
@@ -22,12 +22,44 @@ describe('Select', () => {
     });
 
     it('can be reset to the placeholder', () => {
+      cy.findByLabelText(/choose a model/).as('modelTrigger');
+      cy.get('@modelTrigger').click();
+      cy.findByRole('option', { name: /model x/i }).click();
+      cy.findByRole('listbox').should('not.exist');
+      cy.get('@modelTrigger').should('include.text', 'Model X');
+      cy.findByText('unset').click();
+      cy.get('@modelTrigger').should('include.text', '…').and('not.include.text', 'Model X');
+    });
+
+    it('submits an empty value after being reset to the placeholder', () => {
       cy.findByLabelText(/choose a model/).click();
       cy.findByRole('option', { name: /model x/i }).click();
-      cy.findByText(/model y/i).should('not.exist');
-      cy.findByText(/model x/i).should('exist');
       cy.findByText('unset').click();
-      cy.findByText('…').should('exist');
+      cy.findByText('submit model').click();
+      cy.findByText('Submitted model: empty').should('exist');
+    });
+  });
+
+  describe('given an open select whose value changes externally', () => {
+    it('keeps the positioned content stable', () => {
+      cy.findByLabelText(/choose an open color/).as('colorTrigger');
+      cy.get('@colorTrigger').click();
+      cy.findByRole('listbox').then(($content) => {
+        const before = $content[0].parentElement!.getBoundingClientRect();
+
+        cy.findByText('toggle open color value').then(($button) => {
+          $button[0].click();
+        });
+
+        cy.findByRole('listbox').should('exist');
+        cy.get('@colorTrigger').should('include.text', 'Pick a color');
+        cy.findByRole('listbox').then(($updatedContent) => {
+          const after = $updatedContent[0].parentElement!.getBoundingClientRect();
+
+          expect(Math.abs(after.left - before.left)).to.be.lessThan(1);
+          expect(Math.abs(after.top - before.top)).to.be.lessThan(1);
+        });
+      });
     });
   });
 });

--- a/cypress/e2e/Toast.cy.ts
+++ b/cypress/e2e/Toast.cy.ts
@@ -142,7 +142,7 @@ describe('Toast', () => {
           .should('exist')
           .and('contain.text', 'Notification')
           .and('contain.text', 'Custom Container Toast')
-          .and('contain.text', 'This toast\'s announcements are rendered in a custom container');
+          .and('contain.text', "This toast's announcements are rendered in a custom container");
       });
 
       // Verify the announcement is NOT directly in the document body (default behavior)
@@ -166,7 +166,5 @@ describe('Toast', () => {
         cy.get('[role="status"]').should('not.exist');
       });
     });
-
   });
-
 });

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -229,7 +229,7 @@ const Select: React.FC<SelectProps> = (props: ScopedProps<SelectProps>) => {
             disabled={disabled}
             form={form}
           >
-            {value === undefined ? <option value="" /> : null}
+            {shouldShowPlaceholder(value) ? <option value="" /> : null}
             {Array.from(nativeOptionsSet)}
           </SelectBubbleInput>
         ) : null}
@@ -380,6 +380,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
 
     return (
       <Primitive.span
+        key={showPlaceholder ? 'placeholder' : 'value'}
         {...valueProps}
         asChild={showPlaceholder ? false : valueProps.asChild}
         ref={composedRefs}

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -380,7 +380,6 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
 
     return (
       <Primitive.span
-        key={showPlaceholder ? 'placeholder' : 'value'}
         {...valueProps}
         asChild={showPlaceholder ? false : valueProps.asChild}
         ref={composedRefs}
@@ -388,7 +387,9 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
         // through the item they came from
         style={{ pointerEvents: 'none' }}
       >
-        {showPlaceholder ? placeholder : children}
+        <React.Fragment key={showPlaceholder ? 'placeholder' : 'value'}>
+          {showPlaceholder ? placeholder : children}
+        </React.Fragment>
       </Primitive.span>
     );
   },


### PR DESCRIPTION
### Description

Fixes `Select.Value` after a controlled select is cleared back to the placeholder state:

- Render the hidden empty `<option>` for both `undefined` and `''` placeholder values.
- Key the `Select.Value` rendered contents when switching between selected value and placeholder so previously portaled selected item text is replaced without remounting the value node.
- Adds Cypress coverage for old selected text disappearing from the trigger, empty `FormData` submission after reset, and open-content positioning staying stable while the value changes externally.
- Adds a patch changeset for `@radix-ui/react-select`.
- Applies `oxfmt` to the existing Toast Cypress spec formatting issue.

Related issues: #2706, #3198, #3521

Verified while setting up the repo from scratch:

- `pnpm install`
- `pnpm build`
- `pnpm types:check`
- `pnpm lint`
- `pnpm format:check`
- `CI=1 pnpm test`
- `CI=1 pnpm test:ci`
- `CI=1 pnpm dev` and Storybook loaded on port 9009

Additional verification after reviewer feedback:

- `CI=1 pnpm cypress:run --spec cypress/e2e/Select.cy.ts`
- `pnpm lint`
- `pnpm types:check`
- `pnpm build`
- `CI=1 pnpm test`

Link to Devin session: https://app.devin.ai/sessions/ba1f9c54e06b4412930c879a440f5058
Requested by: @marktran