### PR TITLE
fix(navigation-menu): pass data-state to ViewportContentMounter

### DIFF
--- a/.changeset/humble-jars-prove.md
+++ b/.changeset/humble-jars-prove.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-navigation-menu": major
+---
+
+Fix missing data-state attribute on NavigationMenuContent when used with forceMount and NavigationMenuViewport

--- a/apps/storybook/stories/navigation-menu.stories.tsx
+++ b/apps/storybook/stories/navigation-menu.stories.tsx
@@ -4,6 +4,42 @@ import styles from './navigation-menu.stories.module.css';
 
 export default { title: 'Components/NavigationMenu' };
 
+export const ForceMountWithViewport = () => {
+  return (
+    <StoryFrame>
+      <NavigationMenu.Root>
+        <NavigationMenu.List className={styles.mainList}>
+          <NavigationMenu.Item>
+            <TriggerWithIndicator>Products</TriggerWithIndicator>
+            {/* forceMount keeps content mounted; Viewport routes it via ViewportContentMounter */}
+            <NavigationMenu.Content
+              forceMount
+              className={styles.viewportContent}
+              style={{ width: 400 }}
+            >
+              <LinkGroup items={['Item One', 'Item Two', 'Item Three']} />
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+
+          <NavigationMenu.Item>
+            <TriggerWithIndicator>Company</TriggerWithIndicator>
+            <NavigationMenu.Content
+              forceMount
+              className={styles.viewportContent}
+              style={{ width: 300 }}
+            >
+              <LinkGroup items={['About', 'Careers']} />
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+
+        {/* Viewport is the key — this triggers the ViewportContentMounter path */}
+        <NavigationMenu.Viewport />
+      </NavigationMenu.Root>
+    </StoryFrame>
+  );
+};
+
 export const Basic = () => {
   return (
     <StoryFrame>

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -764,6 +764,7 @@ const NavigationMenuContent = React.forwardRef<
   const itemContext = useNavigationMenuItemContext(CONTENT_NAME, props.__scopeNavigationMenu);
   const composedRefs = useComposedRefs(itemContext.contentRef, forwardedRef);
   const open = itemContext.value === context.value;
+  const openState = getOpenState(open);
 
   const commonProps = {
     value: itemContext.value,
@@ -794,7 +795,12 @@ const NavigationMenuContent = React.forwardRef<
       />
     </Presence>
   ) : (
-    <ViewportContentMounter forceMount={forceMount} {...commonProps} ref={composedRefs} />
+    <ViewportContentMounter
+      data-state={openState}
+      forceMount={forceMount}
+      {...commonProps}
+      ref={composedRefs}
+    />
   );
 });
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->
Closes #3786 

### Description

<!-- Describe the change you are introducing -->

`NavigationMenuContent` has two rendering paths depending on whether a
`NavigationMenuViewport` is present:

- **Without viewport** — renders `NavigationMenuContentImpl` directly,
  with `data-state` passed explicitly. ✅
- **With viewport** — hands off to `ViewportContentMounter`, which stores
  props in a shared `Map` that the viewport renders from. `data-state` was
  never included in this handoff. ❌

This meant that when using `forceMount` with a `NavigationMenuViewport`,
the rendered content elements had no `data-state` attribute at all, making it 
impossible to target open/closed states in CSS or animations.

### Fix

Extract `openState` from `getOpenState(open)` into a shared variable and
pass it as `data-state` to `ViewportContentMounter`, mirroring what was
already done for the non-viewport path.

### Manual Testing

A new Storybook story `ForceMountWithViewport` has been added to reproduce
this scenario. To verify:

1. Run `pnpm dev` and open **Components/NavigationMenu → ForceMountWithViewport**
2. Hover  over a trigger — the attribute should toggle between `"open"` and `"closed"` on the corresponding content element

### Video Demo of Fix

https://github.com/user-attachments/assets/8a4d2eb7-6607-4753-914d-3a87ea1e52d3

