### PR TITLE
fix(toast): reset remaining time ref when duration changes after pause / resume

### DIFF
--- a/.changeset/violet-bees-shop.md
+++ b/.changeset/violet-bees-shop.md
@@ -1,5 +1,5 @@
 ---
-"@radix-ui/react-toast": major
+"@radix-ui/react-toast": patch
 ---
 
 Fix stale closeTimerRemainingTimeRef when duration prop changes after pause / resume

--- a/.changeset/violet-bees-shop.md
+++ b/.changeset/violet-bees-shop.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-toast": major
+---
+
+Fix stale closeTimerRemainingTimeRef when duration prop changes after pause / resume

--- a/apps/storybook/stories/toast.stories.tsx
+++ b/apps/storybook/stories/toast.stories.tsx
@@ -131,6 +131,85 @@ export const Promise = () => {
   );
 };
 
+export const DurationChangeAfterPause = () => {
+  const [phase, setPhase] = React.useState<'idle' | 'loading' | 'done'>('idle');
+  const [open, setOpen] = React.useState(false);
+  const [paused, setPaused] = React.useState(false);
+
+  const handleStart = () => {
+    setPhase('loading');
+    setOpen(true);
+    setPaused(false);
+    // Simulate async work completing after 3 seconds
+    window.setTimeout(() => setPhase('done'), 3000);
+  };
+
+  // Duration: Infinity while loading, 2000ms once done
+  const duration = phase === 'loading' ? Infinity : 2000;
+
+  return (
+    <Toast.Provider>
+      <div style={{ padding: 20 }}>
+        <p style={{ marginBottom: 12 }}>
+          Steps to reproduce the bug:
+          <br />1. Click "Start" to open the toast (duration = Infinity)
+          <br />2. Hover over the toast to pause the timer
+          <br />3. Move the mouse away to resume
+          <br />4. Wait 3 seconds, toast transitions to "Done!" (duration = 2000ms)
+          <br />5. Hover and un-hover again — toast should auto-close in ~2s
+          <br />   BUG: it never closes because the ref still holds Infinity
+        </p>
+        <button onClick={handleStart} disabled={phase !== 'idle'}>
+          Start
+        </button>
+      </div>
+
+      <Toast.Root
+        className={styles.root}
+        open={open}
+        onOpenChange={(o) => { setOpen(o); if (!o) { setPhase('idle'); setPaused(false); } }}
+        duration={duration}
+        onPause={() => setPaused(true)}
+        onResume={() => setPaused(false)}
+      >
+        <div className={styles.header}>
+          <Toast.Title className={styles.title}>
+            {phase === 'loading' ? 'Loading…' : 'Done! Will close in 2s'}
+          </Toast.Title>
+          {paused && (
+            <span style={{ marginLeft: 'auto', fontSize: 10, color: '#ffcc00', fontWeight: 'bold', letterSpacing: 1 }}>
+              ⏸ PAUSED
+            </span>
+          )}
+        </div>
+        <Toast.Description className={styles.description}>
+          {phase === 'loading'
+            ? 'Waiting for async work…'
+            : paused
+            ? 'Hovering — timer paused'
+            : 'Move mouse away to resume countdown'}
+        </Toast.Description>
+        {phase === 'done' && (
+          <div className={styles.progressBar}>
+            <div
+              key="done"
+              className={styles.progressBarInner}
+              style={{
+                animationDuration: `${duration - 100}ms`,
+                animationFillMode: 'forwards',
+                animationPlayState: paused ? 'paused' : 'running',
+                backgroundColor: paused ? 'orange' : undefined,
+              }}
+            />
+          </div>
+        )}
+      </Toast.Root>
+
+      <Toast.Viewport className={styles.viewport} />
+    </Toast.Provider>
+  );
+};
+
 export const KeyChange = () => {
   const [toastOneCount, setToastOneCount] = React.useState(0);
   const [toastTwoCount, setToastTwoCount] = React.useState(0);

--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -497,6 +497,20 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
     const closeTimerStartTimeRef = React.useRef(0);
     const closeTimerRemainingTimeRef = React.useRef(duration);
     const closeTimerRef = React.useRef(0);
+
+    // Sync remaining time when duration prop changes.
+    // When not paused: reset to new duration (timer restart is handled by the open/duration effect).
+    // When paused: clamp remaining to new duration so resume uses the correct value.
+    // Without this, a toast paused while duration=Infinity will hold Infinity in the ref
+    // forever and never close after duration changes to a finite value.
+    React.useEffect(() => {
+      if (!context.isClosePausedRef.current) {
+        closeTimerRemainingTimeRef.current = duration;
+      } else if (duration < closeTimerRemainingTimeRef.current) {
+        closeTimerRemainingTimeRef.current = duration;
+      }
+    }, [duration, context.isClosePausedRef])
+
     const { onToastAdd, onToastRemove } = context;
     const handleClose = useCallbackRef(() => {
       // focus viewport if focus is within toast to read the remaining toast


### PR DESCRIPTION

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->
Closes #2233 

### Description

`closeTimerRemainingTimeRef` is initialized once at mount with the `duration` value and never updated when the prop changes on re-renders.

This means a toast that was paused while `duration=Infinity` will hold `Infinity` in the ref permanently. So when `duration` later changes to a finite value, any subsequent pause/resume cycle calls `startTimer(Infinity)` and the toast never auto-closes.

**Root cause:**
```ts
// Initialized once at mount, never synced to prop changes
const closeTimerRemainingTimeRef = React.useRef(duration);
```

On resume, the timer is restarted using this ref:
```ts
startTimer(closeTimerRemainingTimeRef.current); // → startTimer(Infinity)
```
**Fix:**

Added a `useEffect` that syncs `closeTimerRemainingTimeRef` whenever `duration` changes:

- **Not paused:** reset to the new duration (the open/duration effect handles restarting the actual timer)
- **Paused:** clamp to the new duration if it's smaller, so resume uses the correct remaining time

### Manual Testing

A new Storybook story `DurationChangeAfterPause` has been added to reproduce this scenario.

1. Run `pnpm dev` and open **Components/Toast → DurationChangeAfterPause**
2. Click **Start** — toast opens with `duration=Infinity` (loading state)
3. Hover over the toast to pause it, then move away to resume
4. Wait 3 seconds — toast transitions to "Done! Will close in 2s"
5. Hover and un-hover again

**Before fix:** 
- Toast never closes — timer is stuck at `Infinity`  

**After fix:** 
- Toast closes ~2 seconds after un-hovering, with a progress bar reflecting the remaining time correctly. The `⏸ PAUSED` indicator also confirms pause/resume is working as expected.

### Video Demo

https://github.com/user-attachments/assets/8ca163c6-9768-4683-92b4-21f90551830b

