### PR TITLE
fix(select): use overflowX/overflowY instead of overflow shorthand in Viewport

### DIFF
--- a/.changeset/five-zoos-smash.md
+++ b/.changeset/five-zoos-smash.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-select": patch
+---
+
+Fix React warning when composing ScrollArea inside Select by replacing overflow shorthand with overflowX/overflowY longhand properties in Select.Viewport

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { Dialog, Select, Label as LabelPrimitive } from 'radix-ui';
+import { Dialog, Select, ScrollArea, Label as LabelPrimitive } from 'radix-ui';
 import { foodGroups } from '@repo/test-data/foods';
 import styles from './select.stories.module.css';
 
@@ -863,6 +863,48 @@ export const WithVeryLongSelectItems = () => (
     </Label>
   </div>
 );
+
+export const WithScrollArea = () => {
+  <div  style={{ padding: 50 }}>
+    <p style={{ marginBottom: 16, fontSize: 13, color: '#666', maxWidth: 400 }}>
+      Open the browser console. Before the fix, opening this select logs a React
+      style conflict warning: <em>"Updating a style property during rerender
+      (overflowY) when a conflicting property is set (overflow)"</em>.
+      After the fix, no warning should appear.
+    </p>
+    <Select.Root>
+      <Select.Trigger className={styles.trigger}>
+        <Select.Value placeholder="Pick a fruit…" />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content className={styles.content} position="popper" sideOffset={5}>
+          <ScrollArea.Root style={{ height: 200 }} type="auto">
+            <Select.Viewport asChild>
+              <ScrollArea.Viewport className={styles.viewport}>
+                {[
+                  'Apple', 'Banana', 'Blueberry', 'Grapes', 'Pineapple',
+                  'Mango', 'Strawberry', 'Watermelon', 'Peach', 'Plum',
+                  'Cherry', 'Kiwi',
+                ].map((fruit) => (
+                  <Select.Item key={fruit} className={styles.item} value={fruit.toLowerCase()}>
+                    <Select.ItemText>{fruit}</Select.ItemText>
+                    <Select.ItemIndicator className={styles.indicator}>
+                      <TickIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                ))}
+              </ScrollArea.Viewport>
+            </Select.Viewport>
+            <ScrollArea.Scrollbar orientation="vertical" style={{ width: 6 }}>
+              <ScrollArea.Thumb style={{ background: 'rgba(0,0,0,0.3)', borderRadius: 3 }} />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  </div>
+}
 
 export const ChromaticShortOptionsPaddedContent = () => (
   <ChromaticStoryShortOptions paddedElement="content" />

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1242,7 +1242,8 @@ const SelectViewport = React.forwardRef<SelectViewportElement, SelectViewportPro
               // This won't work in vertical writing modes, so we'll need to
               // revisit this if/when that is supported
               // https://developer.chrome.com/blog/vertical-form-controls
-              overflow: 'hidden auto',
+              overflowX: 'hidden',
+              overflowY: 'auto',
               ...viewportProps.style,
             }}
             onScroll={composeEventHandlers(viewportProps.onScroll, (event) => {


### PR DESCRIPTION


<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change (run `pnpm test`).
- 🔍 Add or edit Storybook examples to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

Closes #2059 

### Description

`Select.Viewport` was setting `overflow: 'hidden auto'` as a CSS shorthand. 

When a `ScrollArea` is composed inside `Select.Content` (as shown in the Radix docs), `ScrollArea.Viewport` sets `overflowX` and `overflowY` as separate longhand properties. 

React detects this as a conflict between a shorthand and longhands on the same element during re-render and logs a warning:

> Warning: Updating a style property during rerender (overflowY) when a conflicting property is set (overflow). To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.

### Fix

- Replace the `overflow` shorthand in `Select.Viewport` with explicit `overflowX: 'hidden'` and `overflowY: 'auto'` longhand properties. 

- This matches how `ScrollArea.Viewport` already sets its own overflow styles and eliminates the conflict.

### Manual Testing

A new Storybook story `WithScrollArea` has been added to reproduce this scenario. To verify:

1. Run `pnpm dev` and open **Components/Select → WithScrollArea**
2. Switch your DevTools console context to `storybook-preview-iframe`
3. **Before fix**: open the Select dropdown — the console shows a React style conflict warning
4. **After fix**: open the Select dropdown — no warning appears in the console

### Screenshot of Fix
<img width="1918" height="952" alt="no-console-warning" src="https://github.com/user-attachments/assets/3b4b0517-a1ca-49da-a387-38425c0da71f" />

