### PR TITLE
fix: context menu should clear submenu w/ long-press while open

### DIFF
--- a/.changeset/quick-bottles-show.md
+++ b/.changeset/quick-bottles-show.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-context-menu": patch
+"radix-ui": patch
+---
+
+Fixed bug in context menu where submenu's stayed expanded after re-opening on long-press touch events

--- a/cypress/e2e/ContextMenu.cy.ts
+++ b/cypress/e2e/ContextMenu.cy.ts
@@ -14,6 +14,23 @@ describe('ContextMenu', () => {
         cy.findByText('Inbox').should('not.exist');
       });
 
+      it('should open the root menu with a long touch interaction', () => {
+        cy.findByText('New Tab').click();
+        cy.findByText('New Tab').should('not.exist');
+
+        longTouch('Right Click Here');
+
+        cy.findByText('New Tab').should('be.visible');
+      });
+
+      it('should close open submenus and reopen the root menu when long touching trigger', () => {
+        pointerOver('Bookmarks →');
+        cy.findByText('Inbox').should('be.visible');
+        longTouch('Right Click Here');
+        cy.findByText('New Tab').should('be.visible');
+        cy.findByText('Inbox').should('not.exist');
+      });
+
       it('should open submenu and not focus first item when moving pointer over trigger', () => {
         pointerOver('Bookmarks →');
         cy.findByText('Inbox').should('not.be.focused');
@@ -257,5 +274,23 @@ describe('ContextMenu', () => {
 
   function pointerOver(elementText: string) {
     return cy.findByText(elementText).should('be.visible').realHover();
+  }
+
+  function longTouch(elementText: string) {
+    return cy
+      .findByText(elementText)
+      .should('be.visible')
+      .trigger('pointerdown', {
+        button: 0,
+        buttons: 1,
+        clientX: 100,
+        clientY: 100,
+        eventConstructor: 'PointerEvent',
+        force: true,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'touch',
+      })
+      .wait(750);
   }
 });

--- a/packages/react/context-menu/src/context-menu.tsx
+++ b/packages/react/context-menu/src/context-menu.tsx
@@ -157,6 +157,9 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
                   whenTouchOrPen((event) => {
                     // clear the long press here in case there's multiple touch points
                     clearLongPress();
+                    if (context.open) {
+                      context.onOpenChange(false);
+                    }
                     longPressTimerRef.current = window.setTimeout(() => handleOpen(event), 700);
                   }),
                 )


### PR DESCRIPTION
When a context menu is already open with a submenu expanded, then the user long-presses the trigger again with touch/pen, the root context menu reopens but the previous submenu remains mounted/open. This PR fixes that.