### PR TITLE
fix(focus-guards): Eliminate per-mount reflow bottleneck

### DIFF
--- a/.changeset/lazy-guards-rest.md
+++ b/.changeset/lazy-guards-rest.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-focus-guards": patch
+"radix-ui": patch
+---
+
+Fixed a performance bottleneck where opening an overlay re-scanned the document and re-inserted the focus guards on every mount, forcing a synchronous reflow. The shared guard pair is now cached and only written to the DOM when their edge position actually changes.

--- a/packages/react/focus-guards/src/focus-guards.test.tsx
+++ b/packages/react/focus-guards/src/focus-guards.test.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { useFocusGuards, FocusGuards } from './focus-guards';
+
+function Guarded() {
+  useFocusGuards();
+  return null;
+}
+
+function getGuards() {
+  return document.querySelectorAll('[data-radix-focus-guard]');
+}
+
+// Regression tests for https://github.com/radix-ui/primitives/issues/2812
+describe('useFocusGuards', () => {
+  afterEach(cleanup);
+
+  it('injects a single pair of guards at the edges of <body>', () => {
+    render(<Guarded />);
+    const guards = getGuards();
+    expect(guards).toHaveLength(2);
+    expect(document.body.firstElementChild).toBe(guards[0]);
+    expect(document.body.lastElementChild).toBe(guards[1]);
+  });
+
+  it('does not duplicate guards when multiple consumers mount', () => {
+    render(
+      <>
+        <Guarded />
+        <Guarded />
+        <Guarded />
+      </>,
+    );
+    expect(getGuards()).toHaveLength(2);
+  });
+
+  it('removes the guards only after the last consumer unmounts', () => {
+    const { rerender } = render(
+      <>
+        <Guarded />
+        <Guarded />
+      </>,
+    );
+    expect(getGuards()).toHaveLength(2);
+
+    rerender(
+      <>
+        <Guarded />
+      </>,
+    );
+    expect(getGuards()).toHaveLength(2);
+
+    rerender(<></>);
+    expect(getGuards()).toHaveLength(0);
+  });
+
+  it('does not write to the DOM when an extra consumer mounts and the guards are already in place', () => {
+    const { rerender } = render(
+      <>
+        <Guarded />
+      </>,
+    );
+
+    const insertSpy = vi.spyOn(document.body, 'insertAdjacentElement');
+    rerender(
+      <>
+        <Guarded />
+        <Guarded />
+      </>,
+    );
+    expect(insertSpy).not.toHaveBeenCalled();
+    insertSpy.mockRestore();
+  });
+
+  it('re-asserts the trailing guard as the last child when a node is appended after it', () => {
+    const { rerender } = render(
+      <>
+        <Guarded />
+      </>,
+    );
+    const end = getGuards()[1];
+
+    // Simulate a portal appending content to the end of <body>.
+    const portal = document.createElement('div');
+    document.body.appendChild(portal);
+    expect(document.body.lastElementChild).toBe(portal);
+
+    rerender(
+      <>
+        <Guarded />
+        <Guarded />
+      </>,
+    );
+
+    // The same trailing guard instance is moved back to the end (not duplicated).
+    expect(getGuards()).toHaveLength(2);
+    expect(document.body.lastElementChild).toBe(end);
+    portal.remove();
+  });
+});
+
+describe('FocusGuards', () => {
+  afterEach(cleanup);
+
+  it('renders text children', () => {
+    render(<FocusGuards>Hello</FocusGuards>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders JSX children', () => {
+    render(
+      <FocusGuards>
+        <div data-testid="hello">Hello</div>
+      </FocusGuards>,
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByTestId('hello')).toBeInTheDocument();
+  });
+
+  it('injects a single pair of guards at the edges of <body>', () => {
+    render(<FocusGuards />);
+    const guards = getGuards();
+    expect(guards).toHaveLength(2);
+    expect(document.body.firstElementChild).toBe(guards[0]);
+    expect(document.body.lastElementChild).toBe(guards[1]);
+  });
+});

--- a/packages/react/focus-guards/src/focus-guards.tsx
+++ b/packages/react/focus-guards/src/focus-guards.tsx
@@ -3,6 +3,13 @@ import * as React from 'react';
 /** Number of components which have requested interest to have focus guards */
 let count = 0;
 
+/**
+ * Cached references to the single shared pair of edge guards. Keeping these at
+ * module scope lets us avoid scanning the whole document (`querySelectorAll`)
+ * and re-inserting the guards on every overlay mount.
+ */
+let guards: { start: HTMLSpanElement; end: HTMLSpanElement } | null = null;
+
 interface FocusGuardsProps {
   children?: React.ReactNode;
 }
@@ -18,16 +25,33 @@ function FocusGuards(props: FocusGuardsProps) {
  */
 function useFocusGuards() {
   React.useEffect(() => {
-    const edgeGuards = document.querySelectorAll('[data-radix-focus-guard]');
-    document.body.insertAdjacentElement('afterbegin', edgeGuards[0] ?? createFocusGuard());
-    document.body.insertAdjacentElement('beforeend', edgeGuards[1] ?? createFocusGuard());
+    if (!guards) {
+      guards = { start: createFocusGuard(), end: createFocusGuard() };
+    }
+    const { start, end } = guards;
+
+    // Only mutate the DOM when the edge invariant is actually broken. Writing
+    // to `document.body` dirties layout and forces a synchronous reflow once
+    // sibling effects read layout (Popper measuring, react-remove-scroll,
+    // aria-hidden, FocusScope), so skipping no-op moves avoids that cost on
+    // every mount. The trailing guard still gets re-asserted to last whenever a
+    // newly portaled node lands after it (portals append to the end of
+    // `document.body`). See https://github.com/radix-ui/primitives/issues/2812
+    if (document.body.firstElementChild !== start) {
+      document.body.insertAdjacentElement('afterbegin', start);
+    }
+    if (document.body.lastElementChild !== end) {
+      document.body.insertAdjacentElement('beforeend', end);
+    }
     count++;
 
     return () => {
       if (count === 1) {
-        document.querySelectorAll('[data-radix-focus-guard]').forEach((node) => node.remove());
+        guards?.start.remove();
+        guards?.end.remove();
+        guards = null;
       }
-      count--;
+      count = Math.max(0, count - 1);
     };
   }, []);
 }


### PR DESCRIPTION
The previous implementation re-scanned the whole document (`querySelectorAll`) and unconditionally called `insertAdjacentElement` twice on `document.body` each time the caller component's effect runs. When guards already existed, those calls removed existing nodes, dirtying layout and forcing a synchronous reflow once sibling effects read layout.

This caches the single shared guard pair at module scope and only writes to the DOM when a guard isn't already at its edge, so the common path does zero DOM mutation. 

Closes #2812