### PR TITLE
password-toggle-field: rename misspelled prop

### DIFF
--- a/.changeset/big-candles-poke.md
+++ b/.changeset/big-candles-poke.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-password-toggle-field": minor
+"radix-ui": minor
+---
+
+Renamed misspelled `onVisiblityChange` prop to `onVisibilityChange`

--- a/apps/storybook/stories/password-toggle-field.stories.tsx
+++ b/apps/storybook/stories/password-toggle-field.stories.tsx
@@ -54,7 +54,7 @@ export const Controlled = {
         <PasswordToggleField.Root
           {...args}
           visible={visible}
-          onVisiblityChange={(visible) => updateArgs({ visible })}
+          onVisibilityChange={(visible) => updateArgs({ visible })}
         >
           <div className={styles.field}>
             <PasswordToggleField.Input className={styles.input} />
@@ -96,7 +96,7 @@ export const InsideForm = {
         >
           <PasswordToggleField.Root
             visible={visible}
-            onVisiblityChange={(visible) => updateArgs({ visible })}
+            onVisibilityChange={(visible) => updateArgs({ visible })}
             {...args}
           >
             <div className={styles.field}>

--- a/packages/react/password-toggle-field/src/password-toggle-field.tsx
+++ b/packages/react/password-toggle-field/src/password-toggle-field.tsx
@@ -45,7 +45,7 @@ interface PasswordToggleFieldProps {
   id?: string;
   visible?: boolean;
   defaultVisible?: boolean;
-  onVisiblityChange?: (visible: boolean) => void;
+  onVisibilityChange?: (visible: boolean) => void;
   children?: React.ReactNode;
 }
 
@@ -69,12 +69,12 @@ const PasswordToggleField: React.FC<PasswordToggleFieldProps> = ({
     [],
   );
 
-  const { visible: visibleProp, defaultVisible, onVisiblityChange, children } = props;
+  const { visible: visibleProp, defaultVisible, onVisibilityChange, children } = props;
   const [visible = false, setVisible] = useControllableState({
     caller: PASSWORD_TOGGLE_FIELD_NAME,
     prop: visibleProp,
     defaultProp: defaultVisible ?? false,
-    onChange: onVisiblityChange,
+    onChange: onVisibilityChange,
   });
 
   const inputRef = React.useRef<HTMLInputElement | null>(null);


### PR DESCRIPTION
Closes #3606. This is a breaking change, but since the API is still prefiexed with `unstable_` I'm marking this as a minor release change.