### PR TITLE
dialog: remove title/description warnings

### DIFF
--- a/.changeset/open-doodles-remain.md
+++ b/.changeset/open-doodles-remain.md
@@ -1,0 +1,7 @@
+---
+"@radix-ui/react-alert-dialog": patch
+"@radix-ui/react-dialog": patch
+"radix-ui": patch
+---
+
+Removed dev-only warnings for dialogs when title and/or description is not rendered.

--- a/packages/react/alert-dialog/package.json
+++ b/packages/react/alert-dialog/package.json
@@ -39,8 +39,7 @@
     "@radix-ui/react-compose-refs": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-dialog": "workspace:*",
-    "@radix-ui/react-primitive": "workspace:*",
-    "@radix-ui/react-slot": "workspace:*"
+    "@radix-ui/react-primitive": "workspace:*"
   },
   "devDependencies": {
     "@repo/builder": "workspace:*",

--- a/packages/react/alert-dialog/src/alert-dialog.tsx
+++ b/packages/react/alert-dialog/src/alert-dialog.tsx
@@ -120,37 +120,29 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
     const cancelRef = React.useRef<AlertDialogCancelElement | null>(null);
 
     return (
-      <DialogPrimitive.WarningProvider
-        contentName={CONTENT_NAME}
-        titleName={TITLE_NAME}
-        docsSlug="alert-dialog"
-      >
-        <AlertDialogContentProvider scope={__scopeAlertDialog} cancelRef={cancelRef}>
-          <DialogPrimitive.Content
-            role="alertdialog"
-            {...dialogScope}
-            {...contentProps}
-            ref={composedRefs}
-            onOpenAutoFocus={composeEventHandlers(contentProps.onOpenAutoFocus, (event) => {
-              event.preventDefault();
-              cancelRef.current?.focus({ preventScroll: true });
-            })}
-            onPointerDownOutside={(event) => event.preventDefault()}
-            onInteractOutside={(event) => event.preventDefault()}
-          >
-            {/**
-             * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
-             * around everything, otherwise the `DescriptionWarning` would be rendered straight away.
-             * This is because we want the accessibility checks to run only once the content is actually
-             * open and that behaviour is already encapsulated in `DialogContent`.
-             */}
-            <Slottable>{children}</Slottable>
-            {process.env.NODE_ENV === 'development' && (
-              <DescriptionWarning contentRef={contentRef} />
-            )}
-          </DialogPrimitive.Content>
-        </AlertDialogContentProvider>
-      </DialogPrimitive.WarningProvider>
+      <AlertDialogContentProvider scope={__scopeAlertDialog} cancelRef={cancelRef}>
+        <DialogPrimitive.Content
+          role="alertdialog"
+          {...dialogScope}
+          {...contentProps}
+          ref={composedRefs}
+          onOpenAutoFocus={composeEventHandlers(contentProps.onOpenAutoFocus, (event) => {
+            event.preventDefault();
+            cancelRef.current?.focus({ preventScroll: true });
+          })}
+          onPointerDownOutside={(event) => event.preventDefault()}
+          onInteractOutside={(event) => event.preventDefault()}
+        >
+          {/**
+           * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
+           * around everything, otherwise the `DescriptionWarning` would be rendered straight away.
+           * This is because we want the accessibility checks to run only once the content is actually
+           * open and that behaviour is already encapsulated in `DialogContent`.
+           */}
+          <Slottable>{children}</Slottable>
+          {process.env.NODE_ENV === 'development' && <DescriptionWarning contentRef={contentRef} />}
+        </DialogPrimitive.Content>
+      </AlertDialogContentProvider>
     );
   },
 );

--- a/packages/react/alert-dialog/src/alert-dialog.tsx
+++ b/packages/react/alert-dialog/src/alert-dialog.tsx
@@ -4,7 +4,6 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { createDialogScope } from '@radix-ui/react-dialog';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { createSlottable } from '@radix-ui/react-slot';
 
 import type { Scope } from '@radix-ui/react-context';
 
@@ -109,8 +108,6 @@ interface AlertDialogContentProps extends Omit<
   'onPointerDownOutside' | 'onInteractOutside'
 > {}
 
-const Slottable = createSlottable('AlertDialogContent');
-
 const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDialogContentProps>(
   (props: ScopedProps<AlertDialogContentProps>, forwardedRef) => {
     const { __scopeAlertDialog, children, ...contentProps } = props;
@@ -133,14 +130,7 @@ const AlertDialogContent = React.forwardRef<AlertDialogContentElement, AlertDial
           onPointerDownOutside={(event) => event.preventDefault()}
           onInteractOutside={(event) => event.preventDefault()}
         >
-          {/**
-           * We have to use `Slottable` here as we cannot wrap the `AlertDialogContentProvider`
-           * around everything, otherwise the `DescriptionWarning` would be rendered straight away.
-           * This is because we want the accessibility checks to run only once the content is actually
-           * open and that behaviour is already encapsulated in `DialogContent`.
-           */}
-          <Slottable>{children}</Slottable>
-          {process.env.NODE_ENV === 'development' && <DescriptionWarning contentRef={contentRef} />}
+          {children}
         </DialogPrimitive.Content>
       </AlertDialogContentProvider>
     );
@@ -232,29 +222,6 @@ const AlertDialogCancel = React.forwardRef<AlertDialogCancelElement, AlertDialog
 AlertDialogCancel.displayName = CANCEL_NAME;
 
 /* ---------------------------------------------------------------------------------------------- */
-
-type DescriptionWarningProps = {
-  contentRef: React.RefObject<AlertDialogContentElement | null>;
-};
-
-const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef }) => {
-  const MESSAGE = `\`${CONTENT_NAME}\` requires a description for the component to be accessible for screen reader users.
-
-You can add a description to the \`${CONTENT_NAME}\` by passing a \`${DESCRIPTION_NAME}\` component as a child, which also benefits sighted users by adding visible context to the dialog.
-
-Alternatively, you can use your own component as a description by assigning it an \`id\` and passing the same value to the \`aria-describedby\` prop in \`${CONTENT_NAME}\`. If the description is confusing or duplicative for sighted users, you can use the \`@radix-ui/react-visually-hidden\` primitive as a wrapper around your description component.
-
-For more information, see https://radix-ui.com/primitives/docs/components/alert-dialog`;
-
-  React.useEffect(() => {
-    const hasDescription = document.getElementById(
-      contentRef.current?.getAttribute('aria-describedby')!,
-    );
-    if (!hasDescription) console.warn(MESSAGE);
-  }, [MESSAGE, contentRef]);
-
-  return null;
-};
 
 const Root = AlertDialog;
 const Trigger = AlertDialogTrigger;

--- a/packages/react/dialog/src/dialog.test.tsx
+++ b/packages/react/dialog/src/dialog.test.tsx
@@ -10,27 +10,6 @@ const OPEN_TEXT = 'Open';
 const CLOSE_TEXT = 'Close';
 const TITLE_TEXT = 'Title';
 
-const NoLabelDialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
-  <Dialog.Root {...props}>
-    <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
-    <Dialog.Overlay />
-    <Dialog.Content>
-      <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
-    </Dialog.Content>
-  </Dialog.Root>
-);
-
-const UndefinedDescribedByDialog = (props: React.ComponentProps<typeof Dialog.Root>) => (
-  <Dialog.Root {...props}>
-    <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
-    <Dialog.Overlay />
-    <Dialog.Content aria-describedby={undefined}>
-      <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
-      <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
-    </Dialog.Content>
-  </Dialog.Root>
-);
-
 const DialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
   <Dialog.Root {...props}>
     <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
@@ -41,10 +20,6 @@ const DialogTest = (props: React.ComponentProps<typeof Dialog.Root>) => (
     </Dialog.Content>
   </Dialog.Root>
 );
-
-function renderAndClickDialogTrigger(Dialog: any) {
-  fireEvent.click(render(Dialog).getByText(OPEN_TEXT));
-}
 
 describe('given a default Dialog', () => {
   let rendered: RenderResult;
@@ -84,36 +59,6 @@ describe('given a default Dialog', () => {
     beforeEach(() => {
       fireEvent.click(trigger);
       closeButton = rendered.getByText(CLOSE_TEXT);
-    });
-
-    describe('when no description has been provided', () => {
-      it('should warn to the console', () => {
-        expect(consoleWarnMockFunction).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('when no title has been provided', () => {
-      beforeEach(() => {
-        cleanup();
-      });
-      it('should display an error in the console', () => {
-        consoleErrorMockFunction.mockClear();
-
-        renderAndClickDialogTrigger(<NoLabelDialogTest />);
-        expect(consoleErrorMockFunction).toHaveBeenCalled();
-      });
-    });
-
-    describe('when aria-describedby is set to undefined', () => {
-      beforeEach(() => {
-        cleanup();
-      });
-      it('should not warn to the console', () => {
-        consoleWarnMockFunction.mockClear();
-
-        renderAndClickDialogTrigger(<UndefinedDescribedByDialog />);
-        expect(consoleWarnMockFunction).not.toHaveBeenCalled();
-      });
     });
 
     it('should open the content', () => {

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { createContext, createContextScope } from '@radix-ui/react-context';
+import { createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -414,12 +414,6 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
             onDismiss={() => context.onOpenChange(false)}
           />
         </FocusScope>
-        {process.env.NODE_ENV !== 'production' && (
-          <>
-            <TitleWarning titleId={context.titleId} />
-            <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />
-          </>
-        )}
       </>
     );
   },
@@ -497,58 +491,6 @@ function getState(open: boolean) {
   return open ? 'open' : 'closed';
 }
 
-const TITLE_WARNING_NAME = 'DialogTitleWarning';
-
-const [WarningProvider, useWarningContext] = createContext(TITLE_WARNING_NAME, {
-  contentName: CONTENT_NAME,
-  titleName: TITLE_NAME,
-  docsSlug: 'dialog',
-});
-
-type TitleWarningProps = { titleId?: string };
-
-const TitleWarning: React.FC<TitleWarningProps> = ({ titleId }) => {
-  const titleWarningContext = useWarningContext(TITLE_WARNING_NAME);
-
-  const MESSAGE = `\`${titleWarningContext.contentName}\` requires a \`${titleWarningContext.titleName}\` for the component to be accessible for screen reader users.
-
-If you want to hide the \`${titleWarningContext.titleName}\`, you can wrap it with our VisuallyHidden component.
-
-For more information, see https://radix-ui.com/primitives/docs/components/${titleWarningContext.docsSlug}`;
-
-  React.useEffect(() => {
-    if (titleId) {
-      const hasTitle = document.getElementById(titleId);
-      if (!hasTitle) console.error(MESSAGE);
-    }
-  }, [MESSAGE, titleId]);
-
-  return null;
-};
-
-const DESCRIPTION_WARNING_NAME = 'DialogDescriptionWarning';
-
-type DescriptionWarningProps = {
-  contentRef: React.RefObject<DialogContentElement | null>;
-  descriptionId?: string;
-};
-
-const DescriptionWarning: React.FC<DescriptionWarningProps> = ({ contentRef, descriptionId }) => {
-  const descriptionWarningContext = useWarningContext(DESCRIPTION_WARNING_NAME);
-  const MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby={undefined}\` for {${descriptionWarningContext.contentName}}.`;
-
-  React.useEffect(() => {
-    const describedById = contentRef.current?.getAttribute('aria-describedby');
-    // if we have an id and the user hasn't set aria-describedby={undefined}
-    if (descriptionId && describedById) {
-      const hasDescription = document.getElementById(descriptionId);
-      if (!hasDescription) console.warn(MESSAGE);
-    }
-  }, [MESSAGE, contentRef, descriptionId]);
-
-  return null;
-};
-
 const Root = Dialog;
 const Trigger = DialogTrigger;
 const Portal = DialogPortal;
@@ -578,8 +520,6 @@ export {
   Title,
   Description,
   Close,
-  //
-  WarningProvider,
 };
 export type {
   DialogProps,

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -485,20 +485,23 @@ const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(
 
 DialogClose.displayName = CLOSE_NAME;
 
+/** @deprecated Noop component to avoid breaking changes. */
+export const WarningProvider: React.FC<
+  ScopedProps<{
+    children?: React.ReactNode;
+    contentName: string;
+    titleName: string;
+    docsSlug: 'dialog';
+  }>
+> = (props) => {
+  return props.children;
+};
+
 /* -----------------------------------------------------------------------------------------------*/
 
 function getState(open: boolean) {
   return open ? 'open' : 'closed';
 }
-
-const Root = Dialog;
-const Trigger = DialogTrigger;
-const Portal = DialogPortal;
-const Overlay = DialogOverlay;
-const Content = DialogContent;
-const Title = DialogTitle;
-const Description = DialogDescription;
-const Close = DialogClose;
 
 export {
   createDialogScope,
@@ -512,14 +515,14 @@ export {
   DialogDescription,
   DialogClose,
   //
-  Root,
-  Trigger,
-  Portal,
-  Overlay,
-  Content,
-  Title,
-  Description,
-  Close,
+  Dialog as Root,
+  DialogTrigger as Trigger,
+  DialogPortal as Portal,
+  DialogOverlay as Overlay,
+  DialogContent as Content,
+  DialogTitle as Title,
+  DialogDescription as Description,
+  DialogClose as Close,
 };
 export type {
   DialogProps,

--- a/packages/react/dialog/src/index.ts
+++ b/packages/react/dialog/src/index.ts
@@ -19,8 +19,6 @@ export {
   Title,
   Description,
   Close,
-  //
-  WarningProvider,
 } from './dialog';
 export type {
   DialogProps,

--- a/packages/react/dialog/src/index.ts
+++ b/packages/react/dialog/src/index.ts
@@ -19,6 +19,8 @@ export {
   Title,
   Description,
   Close,
+  /** @deprecated Noop component to avoid breaking changes. */
+  WarningProvider,
 } from './dialog';
 export type {
   DialogProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,9 +357,6 @@ importers:
       '@radix-ui/react-primitive':
         specifier: workspace:*
         version: link:../primitive
-      '@radix-ui/react-slot':
-        specifier: workspace:*
-        version: link:../slot
     devDependencies:
       '@repo/builder':
         specifier: workspace:*


### PR DESCRIPTION
While well-intentioned, the dev-warnings issues for missing title/description elements in dialogs has created more complexity than I think is merited, and we get a ton of issues where warnings are flagged unnecessarily. Missing description warnings can be particularly annoying since descriptions aren't explicitly required for dialogs to be perfectly usable or spec-compliant. Closes #3855.