### PR TITLE
dialog: fix `stopPropagation` on overlay blocking dismissal

### DIFF
--- a/apps/storybook/stories/dialog.stories.tsx
+++ b/apps/storybook/stories/dialog.stories.tsx
@@ -176,6 +176,53 @@ export const NoPointerDownOutsideDismiss = () => (
   </Dialog.Root>
 );
 
+export const EventPropagation = () => {
+  const count = React.useRef(0);
+  const [stopPropagation, setStopPropagation] = React.useState(true);
+  return (
+    <>
+      <div
+        style={{ padding: '2rem', border: '1px solid black' }}
+        onClick={() => {
+          count.current++;
+          console.log(`clicked the card ${count.current} time${count.current === 1 ? '' : 's'}!`);
+        }}
+      >
+        <Dialog.Root>
+          <Dialog.Trigger onClick={(event) => event.stopPropagation()}>open</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay
+              className={styles.overlay}
+              onClick={(event) => {
+                if (stopPropagation) {
+                  event.stopPropagation();
+                }
+                console.log('clicked the dialog overlay!');
+              }}
+            />
+            <Dialog.Content
+              className={styles.contentDefault}
+              onClick={(event) => {
+                if (stopPropagation) {
+                  event.stopPropagation();
+                }
+                console.log('clicked the dialog content!');
+              }}
+            >
+              <Dialog.Close>close</Dialog.Close>
+              <Dialog.Title>Title</Dialog.Title>
+              <Dialog.Description>You can close me now!</Dialog.Description>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      </div>
+      <button type="button" onClick={() => setStopPropagation(!stopPropagation)}>
+        Stop propagation: {stopPropagation ? 'on' : 'off'}
+      </button>
+    </>
+  );
+};
+
 export const WithPortalContainer = () => {
   const [portalContainer, setPortalContainer] = React.useState<HTMLDivElement | null>(null);
   return (

--- a/apps/storybook/stories/dialog.stories.tsx
+++ b/apps/storybook/stories/dialog.stories.tsx
@@ -209,7 +209,9 @@ export const EventPropagation = () => {
                 console.log('clicked the dialog content!');
               }}
             >
-              <Dialog.Close>close</Dialog.Close>
+              <ExternalOverlayTrigger />
+              <Dialog.Close className={styles.close}>close</Dialog.Close>
+              <InsideShadowSuggestion />
               <Dialog.Title>Title</Dialog.Title>
               <Dialog.Description>You can close me now!</Dialog.Description>
             </Dialog.Content>

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -4,7 +4,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useId } from '@radix-ui/react-id';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
+import { DismissableLayer, useDismissableLayerSurface } from '@radix-ui/react-dismissable-layer';
 import { FocusScope } from '@radix-ui/react-focus-scope';
 import { Portal as PortalPrimitive } from '@radix-ui/react-portal';
 import { Presence } from '@radix-ui/react-presence';
@@ -200,6 +200,13 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
   (props: ScopedProps<DialogOverlayImplProps>, forwardedRef) => {
     const { __scopeDialog, ...overlayProps } = props;
     const context = useDialogContext(OVERLAY_NAME, __scopeDialog);
+
+    // Register the overlay as a dismiss surface so a consumer calling
+    // `stopPropagation` on it (eg. to avoid triggering parent handlers) does not
+    // prevent the dialog from closing. See: https://github.com/radix-ui/primitives/issues/3346
+    const registerDismissableSurface = useDismissableLayerSurface();
+    const composedRefs = useComposedRefs(forwardedRef, registerDismissableSurface);
+
     return (
       // Make sure `Content` is scrollable even when it doesn't live inside `RemoveScroll`
       // ie. when `Overlay` and `Content` are siblings
@@ -207,7 +214,7 @@ const DialogOverlayImpl = React.forwardRef<DialogOverlayImplElement, DialogOverl
         <Primitive.div
           data-state={getState(context.open)}
           {...overlayProps}
-          ref={forwardedRef}
+          ref={composedRefs}
           // We re-enable pointer-events prevented by `Dialog.Content` to allow scrolling the overlay.
           style={{ pointerEvents: 'auto', ...overlayProps.style }}
         />

--- a/packages/react/dismissable-layer/src/dismissable-layer.test.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.test.tsx
@@ -281,6 +281,33 @@ describe('DismissableLayer', () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
+  it('dismisses when a registered dismiss surface stops propagation', async () => {
+    const onDismiss = vi.fn();
+
+    function Surface() {
+      const registerSurface = DismissableLayer.useDismissableLayerSurface();
+      return (
+        <div ref={registerSurface} onClick={(event) => event.stopPropagation()}>
+          surface
+        </div>
+      );
+    }
+
+    render(
+      <>
+        <DismissableLayer.Root deferPointerDownOutside onDismiss={onDismiss}>
+          <button type="button">inside</button>
+        </DismissableLayer.Root>
+        <Surface />
+      </>,
+    );
+    await waitForDocumentPointerDownListener();
+
+    firePointerMouseClick(screen.getByText('surface'));
+    await waitForDocumentPointerDownListener();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
   it('does not dismiss when focus moves outside during a deferred stopped interaction', async () => {
     const onDismiss = vi.fn();
 

--- a/packages/react/dismissable-layer/src/dismissable-layer.test.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.test.tsx
@@ -308,6 +308,73 @@ describe('DismissableLayer', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it('dismisses when a registered dismiss surface stops propagation without deferring', async () => {
+    const onDismiss = vi.fn();
+
+    function Surface() {
+      const registerSurface = DismissableLayer.useDismissableLayerSurface();
+      return (
+        <div ref={registerSurface} onClick={(event) => event.stopPropagation()}>
+          surface
+        </div>
+      );
+    }
+
+    render(
+      <>
+        <DismissableLayer.Root onDismiss={onDismiss}>
+          <button type="button">inside</button>
+        </DismissableLayer.Root>
+        <Surface />
+      </>,
+    );
+    await waitForDocumentPointerDownListener();
+
+    firePointerMouseClick(screen.getByText('surface'));
+    await waitForDocumentPointerDownListener();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('only exempts registered dismiss surfaces from stopped propagation', async () => {
+    const onDismiss = vi.fn();
+
+    function Surface() {
+      const registerSurface = DismissableLayer.useDismissableLayerSurface();
+      return (
+        <div ref={registerSurface} onClick={(event) => event.stopPropagation()}>
+          surface
+        </div>
+      );
+    }
+
+    render(
+      <>
+        <DismissableLayer.Root deferPointerDownOutside onDismiss={onDismiss}>
+          <button type="button">inside</button>
+        </DismissableLayer.Root>
+        <Surface />
+        <button type="button">outside</button>
+      </>,
+    );
+    await waitForDocumentPointerDownListener();
+
+    // A non-surface outside element that stops propagation should still block
+    // dismissal.
+    const outside = screen.getByText('outside');
+    const stopPropagation = (event: Event) => event.stopPropagation();
+    outside.addEventListener('mousedown', stopPropagation);
+    outside.addEventListener('mouseup', stopPropagation);
+    outside.addEventListener('click', stopPropagation);
+
+    firePointerMouseClick(outside);
+    await waitForDocumentPointerDownListener();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    firePointerMouseClick(screen.getByText('surface'));
+    await waitForDocumentPointerDownListener();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
   it('does not dismiss when focus moves outside during a deferred stopped interaction', async () => {
     const onDismiss = vi.fn();
 

--- a/packages/react/dismissable-layer/src/dismissable-layer.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.tsx
@@ -20,6 +20,13 @@ const DismissableLayerContext = React.createContext({
   layers: new Set<DismissableLayerElement>(),
   layersWithOutsidePointerEventsDisabled: new Set<DismissableLayerElement>(),
   branches: new Set<DismissableLayerBranchElement>(),
+
+  // Outside elements that belong to a layer's own dismiss affordance (eg, a
+  // dialog overlay). Pressing them should dismiss the layer regardless of
+  // whether or not they stop propagation.
+  //
+  // See https://github.com/radix-ui/primitives/issues/3346
+  dismissableSurfaces: new Set<DismissableLayerBranchElement>(),
 });
 
 type DismissableLayerElement = React.ComponentRef<typeof Primitive.div>;
@@ -108,6 +115,7 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
         ownerDocument,
         deferPointerDownOutside,
         isDeferredPointerDownOutsideRef,
+        dismissableSurfaces: context.dismissableSurfaces,
       },
     );
 
@@ -241,6 +249,26 @@ DismissableLayerBranch.displayName = BRANCH_NAME;
 
 /* -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Registers a node as a "dismiss surface" for the enclosing DismissableLayer
+ */
+function useDismissableLayerSurface(): React.RefCallback<DismissableLayerBranchElement> {
+  const context = React.useContext(DismissableLayerContext);
+  const [node, setNode] = React.useState<DismissableLayerBranchElement | null>(null);
+
+  React.useEffect(() => {
+    if (!node) {
+      return;
+    }
+    context.dismissableSurfaces.add(node);
+    return () => {
+      context.dismissableSurfaces.delete(node);
+    };
+  }, [node, context.dismissableSurfaces]);
+
+  return setNode;
+}
+
 type PointerDownOutsideEvent = CustomEvent<{ originalEvent: PointerEvent }>;
 type FocusOutsideEvent = CustomEvent<{ originalEvent: FocusEvent }>;
 
@@ -255,12 +283,14 @@ function usePointerDownOutside(
     ownerDocument: Document | undefined;
     deferPointerDownOutside: boolean;
     isDeferredPointerDownOutsideRef: React.RefObject<boolean>;
+    dismissableSurfaces: Set<DismissableLayerBranchElement>;
   },
 ) {
   const {
     ownerDocument = globalThis?.document,
     deferPointerDownOutside = false,
     isDeferredPointerDownOutsideRef,
+    dismissableSurfaces,
   } = args;
   const handlePointerDownOutside = useCallbackRef(onPointerDownOutside) as EventListener;
   const isPointerInsideReactTreeRef = React.useRef(false);
@@ -280,16 +310,25 @@ function usePointerDownOutside(
     }
 
     function handleInteractionCapture(event: Event) {
-      if (isPointerDownOutsideRef.current) {
-        interceptedOutsideInteractionEventsRef.current.set(event.type, true);
+      if (!isPointerDownOutsideRef.current) {
+        return;
+      }
 
-        if (event.type === 'click') {
-          window.setTimeout(() => {
-            if (isPointerDownOutsideRef.current) {
-              handleClickRef.current();
-            }
-          }, 0);
-        }
+      const target = event.target;
+      const isDismissableSurface =
+        target instanceof Node &&
+        [...dismissableSurfaces].some((surface) => surface.contains(target as Node));
+
+      if (!isDismissableSurface) {
+        interceptedOutsideInteractionEventsRef.current.set(event.type, true);
+      }
+
+      if (event.type === 'click') {
+        window.setTimeout(() => {
+          if (isPointerDownOutsideRef.current) {
+            handleClickRef.current();
+          }
+        }, 0);
       }
     }
 
@@ -407,6 +446,7 @@ function usePointerDownOutside(
     handlePointerDownOutside,
     deferPointerDownOutside,
     isDeferredPointerDownOutsideRef,
+    dismissableSurfaces,
   ]);
 
   return {
@@ -473,6 +513,7 @@ const Branch = DismissableLayerBranch;
 export {
   DismissableLayer,
   DismissableLayerBranch,
+  useDismissableLayerSurface,
   //
   Root,
   Branch,

--- a/packages/react/dismissable-layer/src/index.ts
+++ b/packages/react/dismissable-layer/src/index.ts
@@ -2,6 +2,7 @@
 export {
   DismissableLayer,
   DismissableLayerBranch,
+  useDismissableLayerSurface,
   //
   Root,
   Branch,

--- a/packages/react/dismissable-layer/src/index.ts
+++ b/packages/react/dismissable-layer/src/index.ts
@@ -2,9 +2,10 @@
 export {
   DismissableLayer,
   DismissableLayerBranch,
-  useDismissableLayerSurface,
   //
   Root,
   Branch,
+  /** @internal */
+  useDismissableLayerSurface,
 } from './dismissable-layer';
 export type { DismissableLayerProps } from './dismissable-layer';


### PR DESCRIPTION
Calling `event.stopPropagation()` on `Dialog.Overlay` preventes the dialog from closing currently prevents the dialog from closing. This is a regression caused by https://github.com/radix-ui/primitives/pull/3928, which is intended to stop clicks on _external_ elements that stop propagation from closing the dialog. This heuristic does not make sense for dialog overlays.

Since the two cases can't be told apart by event mechanics alone, I've added a `useDismissableLayerSurface` hook that registers certain elements as dismissable targets. This is not a public API, so we can change the implementation at any time if need be.

This behavior can be tested manually by running storybook, then navigating to the Dialog's "Event propagation" story. When propagation is stopped, clicks on elements inside the dialog content or the overlay itself should not call the outer div's click handler. Clicking the dialog's close button and the overlay should still close the dialog as expected, while interacting with elements inside the external overlay should not.

No changeset needed because this fixes a bug in unreleased code that already has a changeset.

Related: https://github.com/radix-ui/primitives/issues/3346