### PR TITLE
slot: Add customizable `mergeProps`

### DIFF
--- a/.changeset/slot-merge-props.md
+++ b/.changeset/slot-merge-props.md
@@ -1,0 +1,31 @@
+---
+"@radix-ui/react-slot": minor
+"radix-ui": minor
+---
+
+Added entrypoints to control how `Slot` merges props with its child. You can now:
+
+1. pass a `mergeProps` function to an individual `Slot` for one-off needs, or
+2. Use the new `Slot.Provider` to apply a custom merge strategy to all nested components that use `Slot` under the hood.
+
+```tsx
+import { Slot } from "radix-ui";
+
+const mergeProps: Slot.MergePropsFunction = (slotProps, childProps) => {
+  // your custom merge strategy, optionally delegating to the default
+  const merged = Slot.mergeProps(slotProps, childProps);
+  return {
+    ...merged,
+    className: classNameProcessor(slotProps, childProps),
+    'data-custom-merge': 'true',
+  };
+};
+
+// one-off
+<Slot.Root mergeProps={mergeProps}>{child}</Slot.Root>
+
+// applies to all nested `asChild` components
+<Slot.Provider mergeProps={mergeProps}>
+  <App />
+</Slot.Provider>
+```

--- a/.changeset/slot-merge-props.md
+++ b/.changeset/slot-merge-props.md
@@ -29,3 +29,26 @@ const mergeProps: Slot.MergePropsFunction = (slotProps, childProps) => {
   <App />
 </Slot.Provider>
 ```
+
+**IMPORTANT:** The `mergeProps` function should be stable across renders to avoid excessive rendering of Slot components. We recommend defining it outside of the component scope.
+
+```tsx
+// good, mergeProps is stable across renders
+const mergeProps = (slotProps, childProps) => {
+  // ...
+};
+function Good() {
+  return <Slot.Root mergeProps={mergeProps} />;
+}
+
+// not so good, mergeProps is recreated on every render
+function LessGood() {
+  return (
+    <Slot.Root
+      mergeProps={(slotProps, childProps) => {
+        // ...
+      }}
+    />
+  );
+}
+```

--- a/apps/storybook/stories/accordion.stories.tsx
+++ b/apps/storybook/stories/accordion.stories.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from 'react';
-import { Accordion } from 'radix-ui';
+import { Accordion, Slot } from 'radix-ui';
 import styles from './accordion.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Accordion' };
 
@@ -490,6 +491,23 @@ export const Horizontal = () => (
       </Accordion.Item>
     </Accordion.Root>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Accordion.Root type="single" className={styles.root}>
+      <Accordion.Item className={styles.item} value="one">
+        <Accordion.Header className={styles.header}>
+          <Accordion.Trigger className={styles.trigger} asChild>
+            <button>One (asChild)</button>
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Content className={styles.content}>
+          Trigger props are merged onto the consumer's element via a custom strategy.
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion.Root>
+  </Slot.Provider>
 );
 
 export const Chromatic = () => {

--- a/apps/storybook/stories/alert-dialog.stories.tsx
+++ b/apps/storybook/stories/alert-dialog.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { AlertDialog } from 'radix-ui';
+import { AlertDialog, Slot } from 'radix-ui';
 import styles from './alert-dialog.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/AlertDialog' };
 
@@ -61,6 +62,29 @@ export const Controlled = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <AlertDialog.Root>
+      <AlertDialog.Trigger className={styles.trigger} asChild>
+        <button>delete everything (asChild)</button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className={styles.overlay} />
+        <AlertDialog.Content className={styles.content}>
+          <AlertDialog.Title className={styles.title}>Are you sure?</AlertDialog.Title>
+          <AlertDialog.Description className={styles.description}>
+            This will do a very dangerous thing. Thar be dragons!
+          </AlertDialog.Description>
+          <AlertDialog.Action className={styles.action} asChild>
+            <button>yolo, do it</button>
+          </AlertDialog.Action>
+          <AlertDialog.Cancel className={styles.cancel}>maybe not</AlertDialog.Cancel>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <div

--- a/apps/storybook/stories/aspect-ratio.stories.tsx
+++ b/apps/storybook/stories/aspect-ratio.stories.tsx
@@ -1,5 +1,6 @@
-import { AspectRatio } from 'radix-ui';
+import { AspectRatio, Slot } from 'radix-ui';
 import styles from './aspect-ratio.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/AspectRatio' };
 
@@ -37,6 +38,16 @@ export const CustomRatios = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <div style={{ width: 300 }}>
+      <AspectRatio.Root className={styles.root} ratio={16 / 9} asChild>
+        <section>Custom merge (asChild)</section>
+      </AspectRatio.Root>
+    </div>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/avatar.stories.tsx
+++ b/apps/storybook/stories/avatar.stories.tsx
@@ -1,6 +1,7 @@
-import { Avatar } from 'radix-ui';
+import { Avatar, Slot } from 'radix-ui';
 import styles from './avatar.stories.module.css';
 import * as React from 'react';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Avatar' };
 
@@ -48,6 +49,16 @@ export const Styled = () => (
       )}
     </SourceChanger>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Avatar.Root className={styles.root}>
+      <Avatar.Fallback className={styles.fallback} asChild>
+        <span>JS</span>
+      </Avatar.Fallback>
+    </Avatar.Root>
+  </Slot.Provider>
 );
 
 export const Chromatic = () => (

--- a/apps/storybook/stories/checkbox.stories.tsx
+++ b/apps/storybook/stories/checkbox.stories.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
-import { Checkbox, Label as LabelPrimitive } from 'radix-ui';
+import { Checkbox, Label as LabelPrimitive, Slot } from 'radix-ui';
 import styles from './checkbox.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Checkbox' };
 
@@ -192,6 +193,18 @@ export const WithinForm = () => {
     </form>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Checkbox.unstable_Provider>
+      <Checkbox.unstable_Trigger className={styles.root} asChild>
+        <button data-custom-merge>
+          <Checkbox.Indicator className={styles.indicator} />
+        </button>
+      </Checkbox.unstable_Trigger>
+    </Checkbox.unstable_Provider>
+  </Slot.Provider>
+);
 
 export const LegacyStyled = () => (
   <>

--- a/apps/storybook/stories/collapsible.stories.tsx
+++ b/apps/storybook/stories/collapsible.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Collapsible } from 'radix-ui';
+import { Collapsible, Slot } from 'radix-ui';
 import styles from './collapsible.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Collapsible' };
 
@@ -57,6 +58,19 @@ export const AnimatedHorizontal = () => {
     </Collapsible.Root>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Collapsible.Root className={styles.root}>
+      <Collapsible.Trigger className={styles.trigger} asChild>
+        <button data-custom-merge>Trigger (asChild)</button>
+      </Collapsible.Trigger>
+      <Collapsible.Content className={styles.content} asChild>
+        <article data-custom-merge>Content merged via a custom strategy</article>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/context-menu.stories.tsx
+++ b/apps/storybook/stories/context-menu.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { ContextMenu, Dialog } from 'radix-ui';
+import { ContextMenu, Dialog, Slot } from 'radix-ui';
 import { foodGroups } from '@repo/test-data/foods';
 import styles from './context-menu.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/ContextMenu' };
 
@@ -877,6 +878,26 @@ export const Nested = () => (
       </ContextMenu.Portal>
     </ContextMenu.Root>
   </div>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <ContextMenu.Root>
+      <ContextMenu.Trigger className={styles.trigger} asChild>
+        <span data-custom-merge>Right click here (asChild)</span>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className={styles.content} alignOffset={-5}>
+          <ContextMenu.Item className={styles.item} asChild onSelect={() => console.log('undo')}>
+            <div>Undo (asChild)</div>
+          </ContextMenu.Item>
+          <ContextMenu.Item className={styles.item} onSelect={() => console.log('redo')}>
+            Redo
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  </Slot.Provider>
 );
 
 const TickIcon = () => (

--- a/apps/storybook/stories/custom-merge-props.tsx
+++ b/apps/storybook/stories/custom-merge-props.tsx
@@ -1,0 +1,22 @@
+import { Slot } from 'radix-ui';
+
+/**
+ * A demonstration `mergeProps` strategy shared by the "WithCustomMergeProps" stories across
+ * components. It delegates to the default merge behavior, then tags the merged element with a
+ * marker attribute and a visible dashed outline so it's obvious the custom function ran when
+ * merging `Slot` / `asChild` props onto the consumer's element.
+ *
+ * Drop it onto a single `Slot.Root` via the `mergeProps` prop for one-off needs, or onto a
+ * `Slot.Provider` to apply it to every nested Radix component that renders via `asChild`.
+ */
+export const customMergeProps: Slot.MergePropsFunction = (
+  slotProps: Record<string, any>,
+  childProps: Record<string, any>,
+) => {
+  const merged = Slot.mergeProps(slotProps, childProps);
+  return {
+    ...merged,
+    'data-custom-merge': 'true',
+    style: { outline: '2px dashed hotpink', outlineOffset: 2, ...merged.style },
+  };
+};

--- a/apps/storybook/stories/dialog.stories.tsx
+++ b/apps/storybook/stories/dialog.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Dialog, DropdownMenu } from 'radix-ui';
+import { Dialog, DropdownMenu, Slot } from 'radix-ui';
 import styles from './dialog.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Dialog' };
 
@@ -305,6 +306,26 @@ export const OuterScrollable = () => (
       </Dialog.Overlay>
     </Dialog.Portal>
   </Dialog.Root>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Dialog.Root>
+      <Dialog.Trigger className={styles.trigger} asChild>
+        <button data-custom-merge>open (asChild)</button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className={styles.overlay} />
+        <Dialog.Content className={styles.contentDefault}>
+          <Dialog.Title>Booking info</Dialog.Title>
+          <Dialog.Description>Please enter the info for your booking below.</Dialog.Description>
+          <Dialog.Close className={styles.close} asChild>
+            <button>close (asChild)</button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  </Slot.Provider>
 );
 
 export const Chromatic = () => (

--- a/apps/storybook/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/stories/dropdown-menu.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
-import { Dialog, DropdownMenu, Tooltip } from 'radix-ui';
+import { Dialog, DropdownMenu, Slot, Tooltip } from 'radix-ui';
 import { Popper } from 'radix-ui/internal';
 import { foodGroups } from '@repo/test-data/foods';
 import styles from './dropdown-menu.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 const { SIDE_OPTIONS, ALIGN_OPTIONS } = Popper;
 
@@ -1023,6 +1024,26 @@ export const InPopupWindow = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger className={styles.trigger} asChild>
+        <button data-custom-merge>Open (asChild)</button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={styles.content} sideOffset={5}>
+          <DropdownMenu.Item className={styles.item} asChild onSelect={() => console.log('undo')}>
+            <div data-custom-merge>Undo (asChild)</div>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className={styles.item} onSelect={() => console.log('redo')}>
+            Redo
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  </Slot.Provider>
+);
 
 // change order slightly for more pleasing visual
 const SIDES = [...SIDE_OPTIONS.filter((side) => side !== 'bottom'), 'bottom' as const];

--- a/apps/storybook/stories/form.stories.tsx
+++ b/apps/storybook/stories/form.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Form } from 'radix-ui';
+import { Form, Slot } from 'radix-ui';
 import styles from './form.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Form' };
 
@@ -73,6 +74,23 @@ export const Basic = () => {
     </>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Form.Root className={styles.form}>
+      <Form.Field name="email">
+        <Form.Label>Email</Form.Label>
+        <Form.Control type="email" required asChild>
+          <input data-custom-merge />
+        </Form.Control>
+        <Form.Message match="valueMissing">Email is required</Form.Message>
+      </Form.Field>
+      <Form.Submit asChild>
+        <button data-custom-merge>Submit (asChild)</button>
+      </Form.Submit>
+    </Form.Root>
+  </Slot.Provider>
+);
 
 export const Cypress = () => {
   const [data, setData] = React.useState({});

--- a/apps/storybook/stories/hover-card.stories.tsx
+++ b/apps/storybook/stories/hover-card.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Dialog, HoverCard } from 'radix-ui';
+import { Dialog, HoverCard, Slot } from 'radix-ui';
 import { Popper } from 'radix-ui/internal';
 import styles from './hover-card.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 const { SIDE_OPTIONS, ALIGN_OPTIONS } = Popper;
 
@@ -452,6 +453,25 @@ export const WithSlottedContent = () => (
       </HoverCard.Content>
     </HoverCard.Portal>
   </HoverCard.Root>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <div style={{ padding: 50, display: 'flex', justifyContent: 'center' }}>
+      <HoverCard.Root>
+        <HoverCard.Trigger className={styles.trigger} asChild>
+          <a href="/" data-custom-merge>
+            trigger (asChild)
+          </a>
+        </HoverCard.Trigger>
+        <HoverCard.Portal>
+          <HoverCard.Content className={styles.content} sideOffset={5}>
+            Hover card content
+          </HoverCard.Content>
+        </HoverCard.Portal>
+      </HoverCard.Root>
+    </div>
+  </Slot.Provider>
 );
 
 // change order slightly for more pleasing visual

--- a/apps/storybook/stories/label.stories.tsx
+++ b/apps/storybook/stories/label.stories.tsx
@@ -1,5 +1,6 @@
-import { Label as LabelPrimitive } from 'radix-ui';
+import { Label as LabelPrimitive, Slot } from 'radix-ui';
 import styles from './label.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 const Label = LabelPrimitive.Root;
 
@@ -38,3 +39,11 @@ const Control = (props: any) => {
     </button>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Label className={styles.root} asChild>
+      <span data-custom-merge>Label (asChild)</span>
+    </Label>
+  </Slot.Provider>
+);

--- a/apps/storybook/stories/menubar.stories.tsx
+++ b/apps/storybook/stories/menubar.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Dialog, Menubar } from 'radix-ui';
+import { Dialog, Menubar, Slot } from 'radix-ui';
 import { foodGroups } from '@repo/test-data/foods';
 import styles from './menubar.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 const subTriggerClass = [styles.item, styles.subTrigger].join(' ');
 
@@ -274,6 +275,25 @@ export const DismissesOnlyMenubarInsideDialog = () => {
     </div>
   );
 };
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Menubar.Root className={styles.root}>
+      <Menubar.Menu>
+        <Menubar.Trigger className={styles.trigger} asChild>
+          <button data-custom-merge>File (asChild)</button>
+        </Menubar.Trigger>
+        <Menubar.Portal>
+          <Menubar.Content className={styles.content} sideOffset={5}>
+            <Menubar.Item className={styles.item} asChild>
+              <div data-custom-merge>New Tab (asChild)</div>
+            </Menubar.Item>
+            <Menubar.Item className={styles.item}>New Window</Menubar.Item>
+          </Menubar.Content>
+        </Menubar.Portal>
+      </Menubar.Menu>
+    </Menubar.Root>
+  </Slot.Provider>
+);
 
 export const Cypress = () => {
   const [loop, setLoop] = React.useState(false);

--- a/apps/storybook/stories/navigation-menu.stories.tsx
+++ b/apps/storybook/stories/navigation-menu.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { NavigationMenu, Direction } from 'radix-ui';
+import { NavigationMenu, Direction, Slot } from 'radix-ui';
 import styles from './navigation-menu.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/NavigationMenu' };
 
@@ -367,6 +368,22 @@ export const Submenus = () => {
     </StoryFrame>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <NavigationMenu.Root>
+      <NavigationMenu.List className={styles.mainList}>
+        <NavigationMenu.Item>
+          <NavigationMenu.Link className={styles.link} asChild>
+            <a href="#example" data-custom-merge>
+              Link (asChild)
+            </a>
+          </NavigationMenu.Link>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+    </NavigationMenu.Root>
+  </Slot.Provider>
+);
 
 /* -----------------------------------------------------------------------------------------------*/
 

--- a/apps/storybook/stories/one-time-password-field.stories.tsx
+++ b/apps/storybook/stories/one-time-password-field.stories.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { unstable_OneTimePasswordField as OneTimePasswordField, Separator } from 'radix-ui';
+import { Slot, unstable_OneTimePasswordField as OneTimePasswordField, Separator } from 'radix-ui';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 import dialogStyles from './dialog.stories.module.css';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { userEvent, within, expect } from 'storybook/test';
 import styles from './one-time-password-field.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default {
   title: 'Components/OneTimePasswordField',
@@ -236,6 +237,24 @@ export const PastedAndDeletedUncontrolled: Story = {
     // if we keep deleting while the first input is focused, we eventually get ,2,3,1,2,3
   },
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <OneTimePasswordField.Root className={styles.otpRoot} asChild>
+      <div data-custom-merge>
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input />
+        <OneTimePasswordField.Input asChild>
+          <input data-custom-merge />
+        </OneTimePasswordField.Input>
+        <OneTimePasswordField.HiddenInput name="code" />
+      </div>
+    </OneTimePasswordField.Root>
+  </Slot.Provider>
+);
 
 function ErrorMessage({ children }: { children: string }) {
   return <div className={styles.errorMessage}>{children}</div>;

--- a/apps/storybook/stories/password-toggle-field.stories.tsx
+++ b/apps/storybook/stories/password-toggle-field.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { useArgs } from 'storybook/preview-api';
-import { unstable_PasswordToggleField as PasswordToggleField } from 'radix-ui';
+import { Slot, unstable_PasswordToggleField as PasswordToggleField } from 'radix-ui';
 import styles from './password-toggle-field.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default {
   title: 'Components/PasswordToggleField',
@@ -116,6 +117,29 @@ export const InsideForm = {
     );
   },
 } satisfies Story;
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <div className={styles.viewport}>
+      <PasswordToggleField.Root>
+        <div className={styles.field}>
+          <PasswordToggleField.Input className={styles.input} asChild>
+            <input data-custom-merge />
+          </PasswordToggleField.Input>
+          <PasswordToggleField.Toggle className={styles.toggle} asChild>
+            <button>
+              <PasswordToggleField.Icon
+                className={styles.toggleIcon}
+                visible={<EyeOpenIcon />}
+                hidden={<EyeClosedIcon />}
+              />
+            </button>
+          </PasswordToggleField.Toggle>
+        </div>
+      </PasswordToggleField.Root>
+    </div>
+  </Slot.Provider>
+);
 
 const EyeClosedIcon = () => (
   <svg

--- a/apps/storybook/stories/popover.stories.tsx
+++ b/apps/storybook/stories/popover.stories.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Dialog, Popover } from 'radix-ui';
+import { Dialog, Popover, Slot } from 'radix-ui';
 import { Popper } from 'radix-ui/internal';
 import styles from './popover.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 const { SIDE_OPTIONS, ALIGN_OPTIONS } = Popper;
 
@@ -376,6 +377,23 @@ export const WithSlottedTrigger = () => {
     </Popover.Root>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Popover.Root>
+      <Popover.Trigger className={styles.trigger} asChild>
+        <button data-custom-merge>open (asChild)</button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content className={styles.content} sideOffset={5}>
+          <Popover.Close className={styles.close} asChild>
+            <button data-custom-merge>close (asChild)</button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  </Slot.Provider>
+);
 
 // change order slightly for more pleasing visual
 const SIDES = [...SIDE_OPTIONS.filter((side) => side !== 'bottom'), 'bottom' as const];

--- a/apps/storybook/stories/progress.stories.tsx
+++ b/apps/storybook/stories/progress.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Progress } from 'radix-ui';
+import { Progress, Slot } from 'radix-ui';
 import styles from './progress.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default {
   title: 'Components/Progress',
@@ -24,6 +25,18 @@ export const Styled = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Progress.Root className={styles.root} value={50} max={100} asChild>
+      <div data-custom-merge>
+        <Progress.Indicator className={styles.indicator} style={{ width: '50%' }} asChild>
+          <span data-custom-merge />
+        </Progress.Indicator>
+      </div>
+    </Progress.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/radio-group.stories.tsx
+++ b/apps/storybook/stories/radio-group.stories.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
-import { Direction, Label as LabelPrimitive, RadioGroup } from 'radix-ui';
+import { Direction, Label as LabelPrimitive, RadioGroup, Slot } from 'radix-ui';
 import styles from './radio-group.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/RadioGroup' };
 
@@ -138,6 +139,20 @@ export const WithinFormReset = () => {
     </form>
   );
 };
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <RadioGroup.Root className={styles.root} defaultValue="1">
+      <RadioGroup.Item className={styles.item} value="1" asChild>
+        <button data-custom-merge>
+          <RadioGroup.Indicator className={styles.indicator} />
+        </button>
+      </RadioGroup.Item>
+      <RadioGroup.Item className={styles.item} value="2">
+        <RadioGroup.Indicator className={styles.indicator} />
+      </RadioGroup.Item>
+    </RadioGroup.Root>
+  </Slot.Provider>
+);
 
 export const LegacyStyled = () => (
   <Label>

--- a/apps/storybook/stories/scroll-area.stories.tsx
+++ b/apps/storybook/stories/scroll-area.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Direction, ScrollArea } from 'radix-ui';
+import { Direction, ScrollArea, Slot } from 'radix-ui';
 import styles from './scroll-area.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/ScrollArea' };
 
@@ -104,6 +105,22 @@ export const Animated = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <ScrollArea.Root style={{ width: 200, height: 100, overflow: 'hidden' }} asChild>
+      <div data-custom-merge>
+        <ScrollArea.Viewport style={{ width: '100%', height: '100%' }}>
+          <div style={{ width: 400 }}>Scrollable content via an asChild root</div>
+        </ScrollArea.Viewport>
+        <ScrollArea.Scrollbar orientation="horizontal">
+          <ScrollArea.Thumb />
+        </ScrollArea.Scrollbar>
+        <ScrollArea.Corner />
+      </div>
+    </ScrollArea.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <div className={styles.root}>

--- a/apps/storybook/stories/select.stories.tsx
+++ b/apps/storybook/stories/select.stories.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { Dialog, Popover, Select, Label as LabelPrimitive } from 'radix-ui';
+import { Dialog, Popover, Select, Slot, Label as LabelPrimitive } from 'radix-ui';
 import { foodGroups } from '@repo/test-data/foods';
 import styles from './select.stories.module.css';
 import { ExternalOverlayTrigger } from './external-overlay';
+import { customMergeProps } from './custom-merge-props';
 
 const Label = LabelPrimitive.Root;
 
@@ -1233,6 +1234,33 @@ export const WithVeryLongSelectItems = () => (
       </Select.Root>
     </Label>
   </div>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Select.Root defaultValue="two">
+      <Select.Trigger className={styles.trigger} asChild>
+        <button data-custom-merge>
+          <Select.Value />
+          <Select.Icon />
+        </button>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content className={styles.content} position="popper" sideOffset={5}>
+          <Select.Viewport className={styles.viewport}>
+            <Select.Item className={styles.item} value="one" asChild>
+              <div data-custom-merge>
+                <Select.ItemText>One (asChild)</Select.ItemText>
+              </div>
+            </Select.Item>
+            <Select.Item className={styles.item} value="two">
+              <Select.ItemText>Two</Select.ItemText>
+            </Select.Item>
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  </Slot.Provider>
 );
 
 export const ChromaticShortOptionsPaddedContent = () => (

--- a/apps/storybook/stories/separator.stories.tsx
+++ b/apps/storybook/stories/separator.stories.tsx
@@ -1,5 +1,6 @@
-import { Separator } from 'radix-ui';
+import { Separator, Slot } from 'radix-ui';
 import styles from './separator.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Separator' };
 
@@ -25,4 +26,12 @@ export const Styled = () => (
       <Separator.Root className={styles.root} orientation="vertical" decorative />
     </div>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Separator.Root className={styles.root} orientation="horizontal" decorative asChild>
+      <hr data-custom-merge />
+    </Separator.Root>
+  </Slot.Provider>
 );

--- a/apps/storybook/stories/slider.stories.tsx
+++ b/apps/storybook/stories/slider.stories.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
-import { Direction, Slider } from 'radix-ui';
+import { Direction, Slider, Slot } from 'radix-ui';
 import serialize from 'form-serialize';
 import styles from './slider.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Slider' };
 
@@ -504,6 +505,19 @@ export const InScrollableContext = () => {
     </div>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Slider.Root className={styles.root} defaultValue={[40]}>
+      <Slider.Track className={styles.track}>
+        <Slider.Range className={styles.range} />
+      </Slider.Track>
+      <Slider.Thumb className={styles.thumb} asChild>
+        <span data-custom-merge />
+      </Slider.Thumb>
+    </Slider.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/slot.stories.tsx
+++ b/apps/storybook/stories/slot.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Slot } from 'radix-ui';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Utilities/Slot' } satisfies Meta<typeof Slot.Root>;
 
@@ -101,6 +102,39 @@ export const WithLazyComponent = () => {
     </React.Suspense>
   );
 };
+
+export const WithCustomMergePropsProp = () => (
+  <Slot.Root
+    className="slot-class"
+    mergeProps={customMergeProps}
+    onClick={() => console.log('slot click')}
+  >
+    <button data-custom-merge className="child-class" onClick={() => console.log('child click')}>
+      Custom merge (prop)
+    </button>
+  </Slot.Root>
+);
+
+export const WithCustomMergePropsProvider = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <h1>Bare Slot under the provider</h1>
+    <Slot.Root className="slot-class">
+      <button className="child-class" data-custom-merge>
+        Custom merge via provider
+      </button>
+    </Slot.Root>
+    <h1>Component using Slot internally (asChild)</h1>
+    <Button
+      asChild
+      iconLeft={<MockIcon color="tomato" />}
+      iconRight={<MockIcon color="royalblue" />}
+    >
+      <a href="https://radix-ui.com" data-custom-merge>
+        Button <em>as link</em>
+      </a>
+    </Button>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/switch.stories.tsx
+++ b/apps/storybook/stories/switch.stories.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-pascal-case */
 import * as React from 'react';
-import { Label as LabelPrimitive, Switch } from 'radix-ui';
+import { Label as LabelPrimitive, Slot, Switch } from 'radix-ui';
 import styles from './switch.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Switch' };
 
@@ -226,6 +227,16 @@ export const PartsWithinForm = () => {
     </form>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Switch.Root className={styles.root} asChild>
+      <button data-custom-merge>
+        <Switch.Thumb className={styles.thumb} />
+      </button>
+    </Switch.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/tabs.stories.tsx
+++ b/apps/storybook/stories/tabs.stories.tsx
@@ -1,5 +1,6 @@
-import { Direction, Tabs } from 'radix-ui';
+import { Direction, Slot, Tabs } from 'radix-ui';
 import styles from './tabs.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Tabs' };
 
@@ -130,6 +131,27 @@ export const Animated = () => (
       </Tabs.Content>
     </Tabs.Root>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Tabs.Root defaultValue="tab1" className={styles.root}>
+      <Tabs.List aria-label="tabs example" className={styles.list}>
+        <Tabs.Trigger value="tab1" className={styles.trigger} asChild>
+          <button data-custom-merge>Tab 1 (asChild)</button>
+        </Tabs.Trigger>
+        <Tabs.Trigger value="tab2" className={styles.trigger}>
+          Tab 2
+        </Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="tab1" className={styles.content} asChild>
+        <div data-custom-merge>Tab 1 content (asChild)</div>
+      </Tabs.Content>
+      <Tabs.Content value="tab2" className={styles.content}>
+        Tab 2 content
+      </Tabs.Content>
+    </Tabs.Root>
+  </Slot.Provider>
 );
 
 export const Chromatic = () => (

--- a/apps/storybook/stories/toggle-group.stories.tsx
+++ b/apps/storybook/stories/toggle-group.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Direction, Dialog, ToggleGroup } from 'radix-ui';
+import { Direction, Dialog, Slot, ToggleGroup } from 'radix-ui';
 import styles from './toggle-group.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default {
   title: 'Components/ToggleGroup',
@@ -110,6 +111,19 @@ export const Multiple = () => {
     </>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <ToggleGroup.Root type="single" className={styles.root} aria-label="Options" defaultValue="1">
+      <ToggleGroup.Item value="1" className={styles.item} asChild>
+        <button data-custom-merge>Option 1 (asChild)</button>
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="2" className={styles.item}>
+        Option 2
+      </ToggleGroup.Item>
+    </ToggleGroup.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/toggle.stories.tsx
+++ b/apps/storybook/stories/toggle.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Toggle } from 'radix-ui';
+import { Slot, Toggle } from 'radix-ui';
 import styles from './toggle.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Toggle' };
 
@@ -15,6 +16,14 @@ export const Controlled = () => {
     </Toggle.Root>
   );
 };
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Toggle.Root className={styles.root} asChild>
+      <button data-custom-merge>Toggle (asChild)</button>
+    </Toggle.Root>
+  </Slot.Provider>
+);
 
 export const Chromatic = () => (
   <>

--- a/apps/storybook/stories/toolbar.stories.tsx
+++ b/apps/storybook/stories/toolbar.stories.tsx
@@ -1,5 +1,6 @@
-import { Direction, DropdownMenu, Toggle, Toolbar } from 'radix-ui';
+import { Direction, DropdownMenu, Slot, Toggle, Toolbar } from 'radix-ui';
 import styles from './toolbar.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 export default { title: 'Components/Toolbar' };
 
@@ -8,6 +9,21 @@ export const Styled = () => (
     <ToolbarExample title="Horizontal"></ToolbarExample>
     <ToolbarExample title="Vertical" orientation="vertical"></ToolbarExample>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Toolbar.Root className={styles.toolbar} aria-label="Custom merge toolbar">
+      <Toolbar.Button className={styles.toolbarItem} asChild>
+        <button data-custom-merge>Button (asChild)</button>
+      </Toolbar.Button>
+      <Toolbar.Link className={[styles.toolbarItem, styles.toolbarLink].join(' ')} asChild>
+        <a href="https://radix-ui.com" data-custom-merge>
+          Link (asChild)
+        </a>
+      </Toolbar.Link>
+    </Toolbar.Root>
+  </Slot.Provider>
 );
 
 export const Chromatic = () => (

--- a/apps/storybook/stories/tooltip.stories.tsx
+++ b/apps/storybook/stories/tooltip.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Popper } from 'radix-ui/internal';
-import { Dialog, Tooltip } from 'radix-ui';
+import { Dialog, Slot, Tooltip } from 'radix-ui';
 import styles from './tooltip.stories.module.css';
+import { customMergeProps } from './custom-merge-props';
 
 const { SIDE_OPTIONS, ALIGN_OPTIONS } = Popper;
 
@@ -787,6 +788,23 @@ export const DisableHoverableContent = () => (
       </Tooltip.Provider>
     </div>
   </>
+);
+
+export const WithCustomMergeProps = () => (
+  <Slot.Provider mergeProps={customMergeProps}>
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger className={styles.trigger} asChild>
+          <button data-custom-merge>Hover or Focus me (asChild)</button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={styles.content} sideOffset={5}>
+            Nicely done!
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  </Slot.Provider>
 );
 
 // change order slightly for more pleasing visual

--- a/packages/react/primitive/src/primitive.test.tsx
+++ b/packages/react/primitive/src/primitive.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { SlotProvider, mergeProps } from '@radix-ui/react-slot';
+import type { MergePropsFunction } from '@radix-ui/react-slot';
+import { Primitive } from './primitive';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+describe('Primitive `asChild` with a custom mergeProps from SlotProvider', () => {
+  afterEach(cleanup);
+
+  const joinWithUnderscore: MergePropsFunction = (
+    slotProps: Record<string, any>,
+    childProps: Record<string, any>,
+  ) => ({
+    ...mergeProps(slotProps, childProps),
+    className: [slotProps.className, childProps.className].filter(Boolean).join('__'),
+    'data-merge-strategy': 'underscore',
+  });
+
+  it('uses the provided mergeProps when merging Primitive props onto the `asChild` element', () => {
+    render(
+      <SlotProvider mergeProps={joinWithUnderscore}>
+        <Primitive.button className="primitive" asChild>
+          <a className="child" href="/">
+            link
+          </a>
+        </Primitive.button>
+      </SlotProvider>,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('class')).toBe('primitive__child');
+    expect(link.getAttribute('data-merge-strategy')).toBe('underscore');
+  });
+
+  it('applies to multiple, independently created Primitive slots in the same tree', () => {
+    render(
+      <SlotProvider mergeProps={joinWithUnderscore}>
+        <Primitive.div className="outer" asChild>
+          <section className="child-outer">
+            <Primitive.span className="inner" asChild>
+              <em className="child-inner">hi</em>
+            </Primitive.span>
+          </section>
+        </Primitive.div>
+      </SlotProvider>,
+    );
+
+    expect(document.querySelector('section')?.getAttribute('class')).toBe('outer__child-outer');
+    expect(document.querySelector('em')?.getAttribute('class')).toBe('inner__child-inner');
+  });
+
+  it('still composes handlers and refs through the custom strategy', () => {
+    const order: string[] = [];
+    const ref = vi.fn();
+    render(
+      <SlotProvider mergeProps={joinWithUnderscore}>
+        <Primitive.button asChild onClick={() => order.push('primitive')} ref={ref}>
+          <button onClick={() => order.push('child')} type="button">
+            hi
+          </button>
+        </Primitive.button>
+      </SlotProvider>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(ref).toHaveBeenCalledWith(button);
+    fireEvent.click(button);
+    expect(order).toEqual(['child', 'primitive']);
+  });
+
+  it('uses the default strategy when no provider is present', () => {
+    render(
+      <Primitive.button className="primitive" asChild>
+        <button className="child" type="button">
+          hi
+        </button>
+      </Primitive.button>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('class')).toBe('primitive child');
+    expect(button.getAttribute('data-merge-strategy')).toBeNull();
+  });
+});

--- a/packages/react/slot/package.json
+++ b/packages/react/slot/package.json
@@ -35,6 +35,7 @@
     "build": "radix-build"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-compose-refs": "workspace:*"
   },
   "devDependencies": {

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -1,8 +1,11 @@
 export {
   Slot,
   Slottable,
+  SlotProvider,
   //
   Root,
+  Provider,
+  //
   createSlot,
   createSlottable,
 } from './slot';

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -9,4 +9,4 @@ export {
   createSlot,
   createSlottable,
 } from './slot';
-export type { SlotProps } from './slot';
+export type { SlotProps, MergePropsFunction } from './slot';

--- a/packages/react/slot/src/index.ts
+++ b/packages/react/slot/src/index.ts
@@ -8,5 +8,7 @@ export {
   //
   createSlot,
   createSlottable,
+  //
+  mergeProps,
 } from './slot';
 export type { SlotProps, MergePropsFunction } from './slot';

--- a/packages/react/slot/src/merge-props.ts
+++ b/packages/react/slot/src/merge-props.ts
@@ -1,5 +1,3 @@
-import { composeRefs } from '@radix-ui/react-compose-refs';
-
 const mergeProps = (<
   SlotProps extends AnyProps = AnyProps,
   ChildProps extends AnyProps = SlotProps,
@@ -54,10 +52,6 @@ const mergeProps = (<
       (overrideProps as any)[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
     } else if (propName === 'aria-describedby') {
       (overrideProps as any)[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
-    } else if (propName === 'ref') {
-      (overrideProps as any)[propName] = slotPropValue
-        ? composeRefs(slotPropValue, childPropValue)
-        : childPropValue;
     }
   }
 

--- a/packages/react/slot/src/merge-props.ts
+++ b/packages/react/slot/src/merge-props.ts
@@ -1,3 +1,5 @@
+import { composeRefs } from '@radix-ui/react-compose-refs';
+
 const mergeProps = (<
   SlotProps extends AnyProps = AnyProps,
   ChildProps extends AnyProps = SlotProps,
@@ -52,6 +54,10 @@ const mergeProps = (<
       (overrideProps as any)[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
     } else if (propName === 'aria-describedby') {
       (overrideProps as any)[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
+    } else if (propName === 'ref') {
+      (overrideProps as any)[propName] = slotPropValue
+        ? composeRefs(slotPropValue, childPropValue)
+        : childPropValue;
     }
   }
 

--- a/packages/react/slot/src/merge-props.ts
+++ b/packages/react/slot/src/merge-props.ts
@@ -1,3 +1,5 @@
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
+
 const mergeProps = (<
   SlotProps extends AnyProps = AnyProps,
   ChildProps extends AnyProps = SlotProps,
@@ -17,7 +19,7 @@ const mergeProps = (<
       if (slotPropValue && childPropValue) {
         const slotIsFunction = typeof slotPropValue === 'function';
         const childIsFunction = typeof childPropValue === 'function';
-        if (process.env.NODE_ENV === 'development') {
+        if (IS_DEVELOPMENT) {
           if (!slotIsFunction || !childIsFunction) {
             console.warn(
               `Slot: Expected a function for ${propName}, but received ${[typeof slotPropValue, typeof childPropValue].filter((v) => v !== 'function').join(' and ')}.`,

--- a/packages/react/slot/src/merge-props.ts
+++ b/packages/react/slot/src/merge-props.ts
@@ -1,10 +1,12 @@
-const mergeProps: MergePropsFunction = function mergeProps(
-  slotProps: AnyProps,
-  childProps: AnyProps,
-) {
-  // all child props should override
+const mergeProps = (<
+  SlotProps extends AnyProps = AnyProps,
+  ChildProps extends AnyProps = SlotProps,
+  ReturnProps extends AnyProps = SlotProps & ChildProps,
+>(
+  slotProps: SlotProps,
+  childProps: ChildProps,
+): ReturnProps => {
   const overrideProps = { ...childProps };
-
   for (const propName in childProps) {
     const slotPropValue = slotProps[propName];
     const childPropValue = childProps[propName];
@@ -13,9 +15,24 @@ const mergeProps: MergePropsFunction = function mergeProps(
     if (isHandler) {
       // if the handler exists on both, we compose them
       if (slotPropValue && childPropValue) {
+        const slotIsFunction = typeof slotPropValue === 'function';
+        const childIsFunction = typeof childPropValue === 'function';
+        if (process.env.NODE_ENV === 'development') {
+          if (!slotIsFunction || !childIsFunction) {
+            console.warn(
+              `Slot: Expected a function for ${propName}, but received ${[typeof slotPropValue, typeof childPropValue].filter((v) => v !== 'function').join(' and ')}.`,
+            );
+          }
+        }
+
+        // @ts-expect-error - we don't know the type of the function. This
+        // technically makes the return signature a lie, not sure if it's worth
+        // handling.
         overrideProps[propName] = (...args: unknown[]) => {
-          const result = childPropValue(...args);
-          slotPropValue(...args);
+          const result = childIsFunction ? childPropValue(...args) : undefined;
+          if (slotIsFunction) {
+            slotPropValue(...args);
+          }
           return result;
         };
       }
@@ -24,18 +41,22 @@ const mergeProps: MergePropsFunction = function mergeProps(
         overrideProps[propName] = slotPropValue;
       }
     }
+
     // if it's `style`, we merge them
     else if (propName === 'style') {
-      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
+      (overrideProps as any)[propName] = {
+        ...(typeof slotPropValue === 'object' ? slotPropValue : null),
+        ...(typeof childPropValue === 'object' ? childPropValue : null),
+      };
     } else if (propName === 'className') {
-      overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+      (overrideProps as any)[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
     } else if (propName === 'aria-describedby') {
-      overrideProps[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
+      (overrideProps as any)[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
     }
   }
 
-  return { ...slotProps, ...overrideProps };
-};
+  return { ...slotProps, ...overrideProps } as ReturnProps;
+}) satisfies MergePropsFunction;
 
 // TODO: Move to primitive once that package exposed individual sub-modules
 function concatAriaDescribedby(...values: unknown[]): string | undefined {
@@ -50,21 +71,16 @@ function concatAriaDescribedby(...values: unknown[]): string | undefined {
   return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
 }
 
-// taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
-type TupleTypes<T> = { [P in keyof T]: T[P] } extends { [key: number]: infer V }
-  ? NullToObject<V>
-  : never;
-type NullToObject<T> = T extends null | undefined ? {} : T;
-
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
-  ? I
-  : never;
-
-interface MergePropsFunction {
-  <T extends AnyProps[] = AnyProps[]>(...args: T): UnionToIntersection<TupleTypes<T>>;
-  (...args: AnyProps[]): UnionToIntersection<TupleTypes<AnyProps[]>>;
+interface MergePropsFunction<
+  SlotProps extends AnyProps = UnknownProps,
+  ChildProps extends AnyProps = SlotProps,
+  ReturnProps extends AnyProps = SlotProps & ChildProps,
+> {
+  (slotProps: SlotProps, childProps: ChildProps): ReturnProps;
 }
 
 type AnyProps = Record<string, any>;
+type UnknownProps = Record<string, unknown>;
 
-export { mergeProps, type MergePropsFunction, type AnyProps };
+export { mergeProps };
+export type { MergePropsFunction, AnyProps, UnknownProps };

--- a/packages/react/slot/src/merge-props.ts
+++ b/packages/react/slot/src/merge-props.ts
@@ -1,0 +1,70 @@
+const mergeProps: MergePropsFunction = function mergeProps(
+  slotProps: AnyProps,
+  childProps: AnyProps,
+) {
+  // all child props should override
+  const overrideProps = { ...childProps };
+
+  for (const propName in childProps) {
+    const slotPropValue = slotProps[propName];
+    const childPropValue = childProps[propName];
+
+    const isHandler = /^on[A-Z]/.test(propName);
+    if (isHandler) {
+      // if the handler exists on both, we compose them
+      if (slotPropValue && childPropValue) {
+        overrideProps[propName] = (...args: unknown[]) => {
+          const result = childPropValue(...args);
+          slotPropValue(...args);
+          return result;
+        };
+      }
+      // but if it exists only on the slot, we use only this one
+      else if (slotPropValue) {
+        overrideProps[propName] = slotPropValue;
+      }
+    }
+    // if it's `style`, we merge them
+    else if (propName === 'style') {
+      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
+    } else if (propName === 'className') {
+      overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+    } else if (propName === 'aria-describedby') {
+      overrideProps[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
+    }
+  }
+
+  return { ...slotProps, ...overrideProps };
+};
+
+// TODO: Move to primitive once that package exposed individual sub-modules
+function concatAriaDescribedby(...values: unknown[]): string | undefined {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    for (const id of String(value).trim().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
+
+  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
+}
+
+// taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
+type TupleTypes<T> = { [P in keyof T]: T[P] } extends { [key: number]: infer V }
+  ? NullToObject<V>
+  : never;
+type NullToObject<T> = T extends null | undefined ? {} : T;
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
+  ? I
+  : never;
+
+interface MergePropsFunction {
+  <T extends AnyProps[] = AnyProps[]>(...args: T): UnionToIntersection<TupleTypes<T>>;
+  (...args: AnyProps[]): UnionToIntersection<TupleTypes<AnyProps[]>>;
+}
+
+type AnyProps = Record<string, any>;
+
+export { mergeProps, type MergePropsFunction, type AnyProps };

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -673,6 +673,122 @@ describe('Slot with a custom mergeProps', () => {
   });
 });
 
+describe('Slot ref composition', () => {
+  afterEach(cleanup);
+
+  it('composes the forwarded ref and the child ref by default (no custom merge)', () => {
+    const slotRef = vi.fn();
+    const childRef = vi.fn();
+    render(
+      <Slot ref={slotRef}>
+        <button ref={childRef} type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(slotRef).toHaveBeenCalledWith(button);
+    expect(childRef).toHaveBeenCalledWith(button);
+  });
+
+  it('exposes the composed ref on `slotProps` so a custom merge can pass it through', () => {
+    const slotRef = vi.fn();
+    const childRef = vi.fn();
+    // A custom strategy that never touches `ref` explicitly: it just spreads
+    // `slotProps`, which now carries the composed ref.
+    const passthrough: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => ({
+      ...childProps,
+      ...slotProps,
+      'data-custom': 'true',
+    });
+
+    render(
+      <Slot mergeProps={passthrough} ref={slotRef}>
+        <button ref={childRef} type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('data-custom')).toBe('true');
+    expect(slotRef).toHaveBeenCalledWith(button);
+    expect(childRef).toHaveBeenCalledWith(button);
+  });
+
+  it('drops the forwarded ref when a custom merge omits `ref` (child keeps its own)', () => {
+    const slotRef = vi.fn();
+    const childRef = vi.fn();
+    const dropRef: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => {
+      const { ref: _ref, ...rest } = mergeProps(slotProps, childProps);
+      return rest;
+    };
+
+    render(
+      <Slot mergeProps={dropRef} ref={slotRef}>
+        <button ref={childRef} type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    // The Slot's forwarded ref was dropped by the custom merge...
+    expect(slotRef).not.toHaveBeenCalled();
+    // ...but the child keeps its own ref, since `React.cloneElement` preserves
+    // props (including `ref`) that the merged props don't override.
+    expect(childRef).toHaveBeenCalledWith(button);
+  });
+
+  it('does not attach a ref (or any props) to a Fragment child', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const slotRef = vi.fn();
+
+    render(
+      <Slot ref={slotRef}>
+        <>
+          <span>a</span>
+          <span>b</span>
+        </>
+      </Slot>,
+    );
+
+    // React logs an error if a `ref` (or any non-`key`/`children` prop) is
+    // passed to a Fragment. A clean render proves nothing leaked onto it.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(slotRef).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps a stable composed ref across re-renders (no detach/reattach)', () => {
+    const childRef = vi.fn();
+
+    function Wrapper() {
+      const [, forceRender] = React.useState(0);
+      const slotRef = React.useRef<HTMLButtonElement>(null);
+      return (
+        <div>
+          <button data-testid="rerender" type="button" onClick={() => forceRender((n) => n + 1)}>
+            rerender
+          </button>
+          <Slot ref={slotRef}>
+            <span ref={childRef}>hi</span>
+          </Slot>
+        </div>
+      );
+    }
+
+    render(<Wrapper />);
+    expect(childRef).toHaveBeenCalledTimes(1);
+
+    // If the composed ref identity changed on re-render, React would call the
+    // child ref again (with `null`, then the node).
+    fireEvent.click(screen.getByTestId('rerender'));
+    expect(childRef).toHaveBeenCalledTimes(1);
+  });
+});
+
 type TriggerProps = React.ComponentProps<'button'> & { as: React.ElementType };
 
 const Trigger = ({ as: Comp = 'button', ...props }: TriggerProps) => <Comp {...props} />;

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Slot, Slottable } from './slot';
+import { Slot, Slottable, SlotProvider, mergeProps } from './slot';
+import type { AnyProps, MergePropsFunction } from './merge-props';
 import { afterEach, describe, it, beforeEach, vi, expect } from 'vitest';
 
 describe('given a slotted Trigger', () => {
@@ -547,6 +548,131 @@ describe('nested (render-prop) Slottable', () => {
   });
 });
 
+describe('Slot with a custom mergeProps', () => {
+  afterEach(cleanup);
+
+  // Observably different from the default: classNames are joined with `__` + a
+  // marker attribute is added so we can detect that it ran.
+  const joinWithUnderscore: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => ({
+    ...mergeProps(slotProps, childProps),
+    className: [slotProps.className, childProps.className].filter(Boolean).join('__'),
+    'data-merge-strategy': 'underscore',
+  });
+
+  it('uses a `mergeProps` function passed directly to the Slot', () => {
+    render(
+      <Slot className="slot" mergeProps={joinWithUnderscore}>
+        <button className="child" type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('class')).toBe('slot__child');
+    expect(button.getAttribute('data-merge-strategy')).toBe('underscore');
+  });
+
+  it('receives (slotProps, childProps) in that order', () => {
+    const spy = vi.fn((slotProps: Record<string, any>, childProps: Record<string, any>) =>
+      mergeProps(slotProps, childProps),
+    );
+    render(
+      <Slot data-from-slot="yes" mergeProps={spy}>
+        <button data-from-child="yes" type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [slotProps, childProps] = spy.mock.calls[0]!;
+    expect(slotProps).toMatchObject({ 'data-from-slot': 'yes' });
+    expect(childProps).toMatchObject({ 'data-from-child': 'yes' });
+  });
+
+  it('applies a `mergeProps` provided via SlotProvider to nested Slots', () => {
+    render(
+      <SlotProvider mergeProps={joinWithUnderscore}>
+        <Slot className="slot">
+          <button className="child" type="button">
+            hi
+          </button>
+        </Slot>
+      </SlotProvider>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('class')).toBe('slot__child');
+    expect(button.getAttribute('data-merge-strategy')).toBe('underscore');
+  });
+
+  it('prefers the Slot `mergeProps` prop over the one from SlotProvider', () => {
+    const joinWithHash: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => ({
+      ...mergeProps(slotProps, childProps),
+      className: [slotProps.className, childProps.className].filter(Boolean).join('##'),
+      'data-merge-strategy': 'hash',
+    });
+
+    render(
+      <SlotProvider mergeProps={joinWithUnderscore}>
+        <Slot className="slot" mergeProps={joinWithHash}>
+          <button className="child" type="button">
+            hi
+          </button>
+        </Slot>
+      </SlotProvider>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('class')).toBe('slot##child');
+    expect(button.getAttribute('data-merge-strategy')).toBe('hash');
+  });
+
+  it('falls back to the default merge (and logs) when a custom `mergeProps` throws', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const order: string[] = [];
+    const boom: MergePropsFunction = () => {
+      throw new Error('boom');
+    };
+
+    render(
+      <Slot className="slot" mergeProps={boom} onClick={() => order.push('slot')}>
+        <button className="child" onClick={() => order.push('child')} type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('class')).toBe('slot child');
+    fireEvent.click(button);
+    expect(order).toEqual(['child', 'slot']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mergeProps failed'),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('still composes the Slot ref and the child ref with a custom mergeProps', () => {
+    const slotRef = vi.fn();
+    const childRef = vi.fn();
+    render(
+      <Slot mergeProps={joinWithUnderscore} ref={slotRef}>
+        <button ref={childRef} type="button">
+          hi
+        </button>
+      </Slot>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(slotRef).toHaveBeenCalledWith(button);
+    expect(childRef).toHaveBeenCalledWith(button);
+  });
+});
+
 type TriggerProps = React.ComponentProps<'button'> & { as: React.ElementType };
 
 const Trigger = ({ as: Comp = 'button', ...props }: TriggerProps) => <Comp {...props} />;
@@ -599,7 +725,7 @@ const Input = React.forwardRef<
   return (
     <Comp
       {...props}
-      onChange={(event) => setValue(event.target.value)}
+      onChange={(event) => setValue((event.target as HTMLInputElement).value)}
       ref={forwardedRef}
       value={value}
     >

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -649,33 +649,6 @@ describe('Slot with a custom mergeProps', () => {
     expect(button.getAttribute('data-merge-strategy')).toBe('hash');
   });
 
-  it('falls back to the default merge (and logs) when a custom `mergeProps` throws', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const order: string[] = [];
-    const boom: MergePropsFunction = () => {
-      throw new Error('boom');
-    };
-
-    render(
-      <Slot className="slot" mergeProps={boom} onClick={() => order.push('slot')}>
-        <button className="child" onClick={() => order.push('child')} type="button">
-          hi
-        </button>
-      </Slot>,
-    );
-
-    const button = screen.getByRole('button');
-    expect(button.getAttribute('class')).toBe('slot child');
-    fireEvent.click(button);
-    expect(order).toEqual(['child', 'slot']);
-
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('mergeProps failed'),
-      expect.any(Error),
-    );
-    errorSpy.mockRestore();
-  });
-
   it('still composes the Slot ref and the child ref with a custom mergeProps', () => {
     const slotRef = vi.fn();
     const childRef = vi.fn();

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -358,6 +358,26 @@ describe('Slot prop and ref merging (single element child)', () => {
     expect(slotRef).toHaveBeenCalledWith(button);
     expect(childRef).toHaveBeenCalledWith(button);
   });
+
+  it('does not attach a ref (or any props) to a Fragment child', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const slotRef = vi.fn();
+
+    render(
+      <Slot ref={slotRef}>
+        <>
+          <span>a</span>
+          <span>b</span>
+        </>
+      </Slot>,
+    );
+
+    // React logs an error if a `ref` (or any non-`key`/`children` prop) is
+    // passed to a Fragment. A clean render proves nothing leaked onto it.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(slotRef).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
 });
 
 describe('Slot with non-mergeable children', () => {
@@ -670,122 +690,6 @@ describe('Slot with a custom mergeProps', () => {
     const button = screen.getByRole('button');
     expect(slotRef).toHaveBeenCalledWith(button);
     expect(childRef).toHaveBeenCalledWith(button);
-  });
-});
-
-describe('Slot ref composition', () => {
-  afterEach(cleanup);
-
-  it('composes the forwarded ref and the child ref by default (no custom merge)', () => {
-    const slotRef = vi.fn();
-    const childRef = vi.fn();
-    render(
-      <Slot ref={slotRef}>
-        <button ref={childRef} type="button">
-          hi
-        </button>
-      </Slot>,
-    );
-
-    const button = screen.getByRole('button');
-    expect(slotRef).toHaveBeenCalledWith(button);
-    expect(childRef).toHaveBeenCalledWith(button);
-  });
-
-  it('exposes the composed ref on `slotProps` so a custom merge can pass it through', () => {
-    const slotRef = vi.fn();
-    const childRef = vi.fn();
-    // A custom strategy that never touches `ref` explicitly: it just spreads
-    // `slotProps`, which now carries the composed ref.
-    const passthrough: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => ({
-      ...childProps,
-      ...slotProps,
-      'data-custom': 'true',
-    });
-
-    render(
-      <Slot mergeProps={passthrough} ref={slotRef}>
-        <button ref={childRef} type="button">
-          hi
-        </button>
-      </Slot>,
-    );
-
-    const button = screen.getByRole('button');
-    expect(button.getAttribute('data-custom')).toBe('true');
-    expect(slotRef).toHaveBeenCalledWith(button);
-    expect(childRef).toHaveBeenCalledWith(button);
-  });
-
-  it('drops the forwarded ref when a custom merge omits `ref` (child keeps its own)', () => {
-    const slotRef = vi.fn();
-    const childRef = vi.fn();
-    const dropRef: MergePropsFunction = (slotProps: AnyProps, childProps: AnyProps) => {
-      const { ref: _ref, ...rest } = mergeProps(slotProps, childProps);
-      return rest;
-    };
-
-    render(
-      <Slot mergeProps={dropRef} ref={slotRef}>
-        <button ref={childRef} type="button">
-          hi
-        </button>
-      </Slot>,
-    );
-
-    const button = screen.getByRole('button');
-    // The Slot's forwarded ref was dropped by the custom merge...
-    expect(slotRef).not.toHaveBeenCalled();
-    // ...but the child keeps its own ref, since `React.cloneElement` preserves
-    // props (including `ref`) that the merged props don't override.
-    expect(childRef).toHaveBeenCalledWith(button);
-  });
-
-  it('does not attach a ref (or any props) to a Fragment child', () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const slotRef = vi.fn();
-
-    render(
-      <Slot ref={slotRef}>
-        <>
-          <span>a</span>
-          <span>b</span>
-        </>
-      </Slot>,
-    );
-
-    // React logs an error if a `ref` (or any non-`key`/`children` prop) is
-    // passed to a Fragment. A clean render proves nothing leaked onto it.
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-    expect(slotRef).not.toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('keeps a stable composed ref across re-renders (no detach/reattach)', () => {
-    const childRef = vi.fn();
-
-    function Wrapper() {
-      const [, forceRender] = React.useState(0);
-      const slotRef = React.useRef<HTMLButtonElement>(null);
-      return (
-        <div>
-          <button data-testid="rerender" type="button" onClick={() => forceRender((n) => n + 1)}>
-            rerender
-          </button>
-          <Slot ref={slotRef}>
-            <span ref={childRef}>hi</span>
-          </Slot>
-        </div>
-      );
-    }
-
-    render(<Wrapper />);
-    expect(childRef).toHaveBeenCalledTimes(1);
-
-    // If the composed ref identity changed on re-render, React would call the
-    // child ref again (with `null`, then the node).
-    fireEvent.click(screen.getByTestId('rerender'));
-    expect(childRef).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import type { AnyProps, MergePropsFunction } from './merge-props';
+import { mergeProps } from './merge-props';
 
 declare module 'react' {
   interface ReactElement {
@@ -7,14 +9,39 @@ declare module 'react' {
   }
 }
 
+interface SlotContextValue {
+  mergeProps: MergePropsFunction;
+}
+
+const SlotContext = React.createContext<SlotContextValue>({ mergeProps });
+SlotContext.displayName = 'SlotContext';
+
+/* -------------------------------------------------------------------------------------------------
+ * SlotProvider
+ * -----------------------------------------------------------------------------------------------*/
+
+interface SlotProviderProps {
+  children: React.ReactNode;
+  mergeProps: MergePropsFunction;
+}
+
+const SlotProvider: React.FC<SlotProviderProps> = ({ children, mergeProps }) => {
+  return <SlotContext.Provider value={{ mergeProps }}>{children}</SlotContext.Provider>;
+};
+
 /* -------------------------------------------------------------------------------------------------
  * Slot
  * -----------------------------------------------------------------------------------------------*/
 
 export type Usable<T> = PromiseLike<T> | React.Context<T>;
 
+// taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
+// https://github.com/adobe/react-spectrum/blob/main@%7B2025-05-19T15:10:25.000Z%7D/packages/%40react-aria/utils/src/mergeProps.ts
+// double-taken from React Aria
+// Copyright 2019 Adobe, Apache License, Version 2.0
 type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<Elem>> = Props & {
   children?: React.ReactNode;
+  mergeProps?: MergePropsFunction;
 };
 
 /* @__NO_SIDE_EFFECTS__ */ export function createSlot<
@@ -22,7 +49,8 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
   Props = React.HTMLAttributes<Elem>,
 >(ownerName: string) {
   const Slot = React.forwardRef<Elem, SlotProps<Elem, Props>>((props, forwardedRef) => {
-    let { children, ...slotProps } = props;
+    const context = React.useContext(SlotContext);
+    let { children, mergeProps: mergePropsProp = context.mergeProps, ...slotProps } = props;
     let slottableElement: React.ReactElement | null = null;
     let hasSlottable = false;
     const newChildren: React.ReactNode[] = [];
@@ -77,14 +105,25 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
       return children;
     }
 
-    const mergedProps = mergeProps(slotProps, slottableElement.props ?? {});
+    const mergedProps = (() => {
+      try {
+        return mergePropsProp(slotProps, slottableElement.props ?? {});
+      } catch (error) {
+        console.error(
+          'Slot: mergeProps failed with the following error. Falling back to default behavior.',
+          error,
+        );
+
+        return mergeProps(slotProps, slottableElement.props ?? {});
+      }
+    })();
 
     // do not pass ref to React.Fragment for React 19 compatibility
     if (slottableElement.type !== React.Fragment) {
-      mergedProps.ref = forwardedRef ? composedRef : slottableElementRef;
+      (mergedProps as AnyProps).ref = forwardedRef ? composedRef : slottableElementRef;
     }
 
-    return React.cloneElement(slottableElement, mergedProps);
+    return React.cloneElement(slottableElement, mergedProps as AnyProps);
   });
 
   Slot.displayName = `${ownerName}.Slot`;
@@ -134,48 +173,6 @@ const getSlottableElementFromSlottable = (slottable: SlottableElement, child: Re
 
   return React.isValidElement(child) ? child : null;
 };
-
-/* -------------------------------------------------------------------------------------------------
- * mergeProps
- * -----------------------------------------------------------------------------------------------*/
-
-type AnyProps = Record<string, any>;
-
-function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
-  // all child props should override
-  const overrideProps = { ...childProps };
-
-  for (const propName in childProps) {
-    const slotPropValue = slotProps[propName];
-    const childPropValue = childProps[propName];
-
-    const isHandler = /^on[A-Z]/.test(propName);
-    if (isHandler) {
-      // if the handler exists on both, we compose them
-      if (slotPropValue && childPropValue) {
-        overrideProps[propName] = (...args: unknown[]) => {
-          const result = childPropValue(...args);
-          slotPropValue(...args);
-          return result;
-        };
-      }
-      // but if it exists only on the slot, we use only this one
-      else if (slotPropValue) {
-        overrideProps[propName] = slotPropValue;
-      }
-    }
-    // if it's `style`, we merge them
-    else if (propName === 'style') {
-      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
-    } else if (propName === 'className') {
-      overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
-    } else if (propName === 'aria-describedby') {
-      overrideProps[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
-    }
-  }
-
-  return { ...slotProps, ...overrideProps };
-}
 
 /* -------------------------------------------------------------------------------------------------
  * getElementRef
@@ -242,19 +239,6 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof value === 'object' && value !== null && 'then' in value;
 }
 
-// TODO: Move to primitive once that package exposed individual sub-modules
-function concatAriaDescribedby(...values: unknown[]): string | undefined {
-  const ids = new Set<string>();
-  for (const value of values) {
-    if (typeof value !== 'string') continue;
-    for (const id of String(value).trim().split(/\s+/)) {
-      if (id) ids.add(id);
-    }
-  }
-
-  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
-}
-
 const createSlotError = (ownerName: string) => {
   return `${ownerName} failed to slot onto its children. Expected a single React element child or \`Slottable\`.`;
 };
@@ -268,7 +252,11 @@ const use: typeof React.use | undefined = (React as any)[' use '.trim().toString
 export {
   Slot,
   Slottable,
+  SlotProvider,
   //
   Slot as Root,
+  SlotProvider as Provider,
+  //
+  mergeProps,
 };
 export type { SlotProps };

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -88,23 +88,6 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
     const slottableElementRef = slottableElement ? getElementRef(slottableElement) : undefined;
     const composedRef = useComposedRefs(forwardedRef, slottableElementRef);
 
-    // OK to conditionally call hooks here because they consistently run in the
-    // same environment. This should be written in a way that bundlers can
-    // easily remove the dead code in production.
-    let errorToLog: unknown,
-      setErrorToLog: (error: unknown) => void = () => void 0;
-    if (IS_DEVELOPMENT) {
-      [errorToLog, setErrorToLog] = React.useState<unknown>();
-      React.useEffect(() => {
-        if (errorToLog) {
-          console.error(
-            'Slot: mergeProps failed with the following error. Falling back to default behavior.',
-            errorToLog,
-          );
-        }
-      }, [errorToLog]);
-    }
-
     if (!slottableElement) {
       // Empty/falsy children (`null`, `undefined`, `false`, no children, etc.)
       // are valid and render nothing. Anything else is content we couldn't slot
@@ -118,36 +101,10 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
       return children;
     }
 
-    const mergedProps =
-      mergePropsProp === mergeProps
-        ? mergeProps(slotProps, (slottableElement.props ?? {}) as Record<string, unknown>)
-        : (() => {
-            try {
-              const result = mergePropsProp(
-                slotProps,
-                (slottableElement.props ?? {}) as Record<string, unknown>,
-              );
-
-              if (IS_DEVELOPMENT) {
-                if (errorToLog) {
-                  setErrorToLog(undefined);
-                }
-              }
-
-              return result;
-            } catch (error) {
-              if (IS_DEVELOPMENT) {
-                if (error && !errorToLog) {
-                  setErrorToLog(error);
-                }
-              }
-
-              return mergeProps(
-                slotProps,
-                (slottableElement.props ?? {}) as Record<string, unknown>,
-              );
-            }
-          })();
+    const mergedProps = mergePropsProp(
+      slotProps,
+      (slottableElement.props ?? {}) as Record<string, unknown>,
+    );
 
     // do not pass ref to React.Fragment for React 19 compatibility
     if (slottableElement.type !== React.Fragment) {

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -114,18 +114,21 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
         ? slotProps
         : { ...slotProps, ref: forwardedRef ? composedRef : slottableElementRef };
 
-    const mergedProps = (() => {
-      try {
-        return mergePropsProp(propsToMerge, childProps);
-      } catch (error) {
-        console.error(
-          'Slot: mergeProps failed with the following error. Falling back to default behavior.',
-          error,
-        );
+    const mergedProps =
+      mergePropsProp === mergeProps
+        ? mergeProps(propsToMerge, childProps)
+        : (() => {
+            try {
+              return mergePropsProp(propsToMerge, childProps);
+            } catch (error) {
+              console.error(
+                'Slot: mergeProps failed with the following error. Falling back to default behavior.',
+                error,
+              );
 
-        return mergeProps(propsToMerge, childProps);
-      }
-    })();
+              return mergeProps(propsToMerge, childProps);
+            }
+          })();
 
     return React.cloneElement(slottableElement, mergedProps);
   });

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import type { AnyProps, MergePropsFunction } from './merge-props';
 import { mergeProps } from './merge-props';
@@ -87,10 +88,28 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
     const slottableElementRef = slottableElement ? getElementRef(slottableElement) : undefined;
     const composedRef = useComposedRefs(forwardedRef, slottableElementRef);
 
+    // OK to conditionally call hooks here because they consistently run in the
+    // same environment. This should be written in a way that bundlers can
+    // easily remove the dead code in production.
+    let errorToLog: unknown,
+      setErrorToLog: (error: unknown) => void = () => void 0;
+    if (IS_DEVELOPMENT) {
+      [errorToLog, setErrorToLog] = React.useState<unknown>();
+      React.useEffect(() => {
+        if (errorToLog) {
+          console.error(
+            'Slot: mergeProps failed with the following error. Falling back to default behavior.',
+            errorToLog,
+          );
+        }
+      }, [errorToLog]);
+    }
+
     if (!slottableElement) {
-      // Empty/falsy children (`null`, `undefined`, `false`, no children, etc.) are valid and
-      // render nothing. Anything else is content we couldn't slot onto a single element, which
-      // is a usage error, so we fail loudly with a clear message.
+      // Empty/falsy children (`null`, `undefined`, `false`, no children, etc.)
+      // are valid and render nothing. Anything else is content we couldn't slot
+      // onto a single element, which is a usage error, so we fail loudly with a
+      // clear message.
       if (children || children === 0) {
         throw new Error(
           hasSlottable ? createSlottableError(ownerName) : createSlotError(ownerName),
@@ -104,15 +123,24 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
         ? mergeProps(slotProps, (slottableElement.props ?? {}) as Record<string, unknown>)
         : (() => {
             try {
-              return mergePropsProp(
+              const result = mergePropsProp(
                 slotProps,
                 (slottableElement.props ?? {}) as Record<string, unknown>,
               );
+
+              if (IS_DEVELOPMENT) {
+                if (errorToLog) {
+                  setErrorToLog(undefined);
+                }
+              }
+
+              return result;
             } catch (error) {
-              console.error(
-                'Slot: mergeProps failed with the following error. Falling back to default behavior.',
-                error,
-              );
+              if (IS_DEVELOPMENT) {
+                if (error && !errorToLog) {
+                  setErrorToLog(error);
+                }
+              }
 
               return mergeProps(
                 slotProps,

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -260,3 +260,4 @@ export {
   mergeProps,
 };
 export type { SlotProps };
+export type { MergePropsFunction } from './merge-props';

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -99,36 +99,32 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
       return children;
     }
 
-    // `ref` is treated as a normal prop when merging, but the composition
-    // itself stays memoized here: `mergeProps` may be a plain (or
-    // user-provided) function that can't call hooks, and composing on every
-    // render would detach/reattach the ref. We hand `mergeProps` the
-    // already-composed, stable ref via `slotProps` and strip the child's raw
-    // ref so it isn't applied twice.
-    const childProps: Record<string, unknown> = { ...(slottableElement.props ?? {}) };
-    delete childProps.ref;
-
-    const propsToMerge: Record<string, unknown> =
-      // do not pass ref to React.Fragment for React 19 compatibility
-      slottableElement.type === React.Fragment
-        ? slotProps
-        : { ...slotProps, ref: forwardedRef ? composedRef : slottableElementRef };
-
     const mergedProps =
       mergePropsProp === mergeProps
-        ? mergeProps(propsToMerge, childProps)
+        ? mergeProps(slotProps, (slottableElement.props ?? {}) as Record<string, unknown>)
         : (() => {
             try {
-              return mergePropsProp(propsToMerge, childProps);
+              return mergePropsProp(
+                slotProps,
+                (slottableElement.props ?? {}) as Record<string, unknown>,
+              );
             } catch (error) {
               console.error(
                 'Slot: mergeProps failed with the following error. Falling back to default behavior.',
                 error,
               );
 
-              return mergeProps(propsToMerge, childProps);
+              return mergeProps(
+                slotProps,
+                (slottableElement.props ?? {}) as Record<string, unknown>,
+              );
             }
           })();
+
+    // do not pass ref to React.Fragment for React 19 compatibility
+    if (slottableElement.type !== React.Fragment) {
+      mergedProps.ref = forwardedRef ? composedRef : slottableElementRef;
+    }
 
     return React.cloneElement(slottableElement, mergedProps);
   });

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -20,7 +20,7 @@ SlotContext.displayName = 'SlotContext';
 
 interface SlotProviderProps {
   children: React.ReactNode;
-  mergeProps: MergePropsFunction;
+  mergeProps: MergePropsFunction<AnyProps, AnyProps, AnyProps>;
 }
 
 const SlotProvider: React.FC<SlotProviderProps> = ({ children, mergeProps }) => {
@@ -105,7 +105,7 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
 
     const mergedProps = (() => {
       try {
-        return mergePropsProp(slotProps, slottableElement.props ?? {});
+        return mergePropsProp(slotProps, (slottableElement.props ?? {}) as Record<string, unknown>);
       } catch (error) {
         console.error(
           'Slot: mergeProps failed with the following error. Falling back to default behavior.',
@@ -118,10 +118,10 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
 
     // do not pass ref to React.Fragment for React 19 compatibility
     if (slottableElement.type !== React.Fragment) {
-      (mergedProps as AnyProps).ref = forwardedRef ? composedRef : slottableElementRef;
+      mergedProps.ref = forwardedRef ? composedRef : slottableElementRef;
     }
 
-    return React.cloneElement(slottableElement, mergedProps as AnyProps);
+    return React.cloneElement(slottableElement, mergedProps);
   });
 
   Slot.displayName = `${ownerName}.Slot`;

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import type { AnyProps, MergePropsFunction } from './merge-props';
 import { mergeProps } from './merge-props';

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -9,11 +9,9 @@ declare module 'react' {
   }
 }
 
-interface SlotContextValue {
-  mergeProps: MergePropsFunction;
-}
+type SlotContextValue = MergePropsFunction;
 
-const SlotContext = React.createContext<SlotContextValue>({ mergeProps });
+const SlotContext = React.createContext<SlotContextValue>(mergeProps);
 SlotContext.displayName = 'SlotContext';
 
 /* -------------------------------------------------------------------------------------------------
@@ -26,7 +24,7 @@ interface SlotProviderProps {
 }
 
 const SlotProvider: React.FC<SlotProviderProps> = ({ children, mergeProps }) => {
-  return <SlotContext.Provider value={{ mergeProps }}>{children}</SlotContext.Provider>;
+  return <SlotContext.Provider value={mergeProps}>{children}</SlotContext.Provider>;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -50,7 +48,7 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
 >(ownerName: string) {
   const Slot = React.forwardRef<Elem, SlotProps<Elem, Props>>((props, forwardedRef) => {
     const context = React.useContext(SlotContext);
-    let { children, mergeProps: mergePropsProp = context.mergeProps, ...slotProps } = props;
+    let { children, mergeProps: mergePropsProp = context, ...slotProps } = props;
     let slottableElement: React.ReactElement | null = null;
     let hasSlottable = false;
     const newChildren: React.ReactNode[] = [];

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -103,23 +103,33 @@ type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<
       return children;
     }
 
+    // `ref` is treated as a normal prop when merging, but the composition
+    // itself stays memoized here: `mergeProps` may be a plain (or
+    // user-provided) function that can't call hooks, and composing on every
+    // render would detach/reattach the ref. We hand `mergeProps` the
+    // already-composed, stable ref via `slotProps` and strip the child's raw
+    // ref so it isn't applied twice.
+    const childProps: Record<string, unknown> = { ...(slottableElement.props ?? {}) };
+    delete childProps.ref;
+
+    const propsToMerge: Record<string, unknown> =
+      // do not pass ref to React.Fragment for React 19 compatibility
+      slottableElement.type === React.Fragment
+        ? slotProps
+        : { ...slotProps, ref: forwardedRef ? composedRef : slottableElementRef };
+
     const mergedProps = (() => {
       try {
-        return mergePropsProp(slotProps, (slottableElement.props ?? {}) as Record<string, unknown>);
+        return mergePropsProp(propsToMerge, childProps);
       } catch (error) {
         console.error(
           'Slot: mergeProps failed with the following error. Falling back to default behavior.',
           error,
         );
 
-        return mergeProps(slotProps, slottableElement.props ?? {});
+        return mergeProps(propsToMerge, childProps);
       }
     })();
-
-    // do not pass ref to React.Fragment for React 19 compatibility
-    if (slottableElement.type !== React.Fragment) {
-      mergedProps.ref = forwardedRef ? composedRef : slottableElementRef;
-    }
 
     return React.cloneElement(slottableElement, mergedProps);
   });

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -33,10 +33,6 @@ const SlotProvider: React.FC<SlotProviderProps> = ({ children, mergeProps }) => 
 
 export type Usable<T> = PromiseLike<T> | React.Context<T>;
 
-// taken from: https://stackoverflow.com/questions/51603250/typescript-3-parameter-list-intersection-type/51604379#51604379
-// https://github.com/adobe/react-spectrum/blob/main@%7B2025-05-19T15:10:25.000Z%7D/packages/%40react-aria/utils/src/mergeProps.ts
-// double-taken from React Aria
-// Copyright 2019 Adobe, Apache License, Version 2.0
 type SlotProps<Elem extends Element = HTMLElement, Props = React.HTMLAttributes<Elem>> = Props & {
   children?: React.ReactNode;
   mergeProps?: MergePropsFunction;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2264,6 +2264,9 @@ importers:
 
   packages/react/slot:
     dependencies:
+      '@radix-ui/primitive':
+        specifier: workspace:*
+        version: link:../../core/primitive
       '@radix-ui/react-compose-refs':
         specifier: workspace:*
         version: link:../compose-refs


### PR DESCRIPTION
This PR adds entrypoints to control how `Slot` merges props with its child. You can now:

1. pass a `mergeProps` function to an individual `Slot` for one-off needs, or
2. Use the new `Slot.Provider` to apply a custom merge strategy to all nested components that use `Slot` under the hood.

```tsx
import { Slot } from "radix-ui";

const mergeProps: Slot.MergePropsFunction = (slotProps, childProps) => {
  // your custom merge strategy, optionally delegating to the default
  const merged = Slot.mergeProps(slotProps, childProps);
  return {
    ...merged,
    className: classNameProcessor(slotProps, childProps),
    'data-custom-merge': 'true',
  };
};

// one-off
<Slot.Root mergeProps={mergeProps}>{child}</Slot.Root>

// applies to all nested `asChild` components
<Slot.Provider mergeProps={mergeProps}>
  <App />
</Slot.Provider>
```

Closes #2631