### PR TITLE
fix(tooltip): don't reopen on window/tab refocus (#1800)

### DIFF
--- a/.changeset/tooltip-window-refocus.md
+++ b/.changeset/tooltip-window-refocus.md
@@ -1,0 +1,6 @@
+---
+'@radix-ui/react-tooltip': patch
+'radix-ui': patch
+---
+
+Fixed a bug where the tooltip opened when switching back to the browser tab while its trigger was focused.

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -83,6 +83,41 @@ describe('Tooltip', () => {
     });
   });
 
+  // Regression test for https://github.com/radix-ui/primitives/issues/1800
+  // Switching away from and back to the browser tab refocuses the previously-focused
+  // trigger, firing a synthetic `focus` event that must not reopen the tooltip.
+  it('does not open on focus caused by the window regaining focus', () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger>Tooltip Trigger</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content>Tooltip Content</Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+
+    // A genuine focus opens the tooltip.
+    act(() => void fireEvent.focus(trigger));
+    expect(trigger).toHaveAttribute('data-state', 'instant-open');
+    act(() => void fireEvent.blur(trigger));
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    // Simulate the window losing focus, then the tab regaining focus and refocusing
+    // the trigger. The synthetic refocus must NOT reopen the tooltip.
+    act(() => void window.dispatchEvent(new FocusEvent('blur')));
+    act(() => void fireEvent.focus(trigger));
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+    expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+
+    // A subsequent genuine focus still opens it (the guard is consumed once).
+    act(() => void fireEvent.focus(trigger));
+    expect(trigger).toHaveAttribute('data-state', 'instant-open');
+  });
+
   // Regression test for https://github.com/radix-ui/primitives/issues/2375
   // Hovering a trigger inside a shared `TooltipProvider` must not re-render
   // sibling tooltips. The provider keeps its "open delayed" flag in a ref so

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -276,11 +276,21 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onTriggerChange);
     const isPointerDownRef = React.useRef(false);
     const hasPointerMoveOpenedRef = React.useRef(false);
+    const isWindowBlurredRef = React.useRef(false);
     const handlePointerUp = React.useCallback(() => (isPointerDownRef.current = false), []);
 
     React.useEffect(() => {
       return () => document.removeEventListener('pointerup', handlePointerUp);
     }, [handlePointerUp]);
+
+    // When the window/tab loses focus, the browser refocuses the previously active
+    // element once focus returns, firing a `focus` event that would otherwise reopen
+    // the tooltip. Track the blur so we can ignore that synthetic refocus. See #1800.
+    React.useEffect(() => {
+      const handleWindowBlur = () => (isWindowBlurredRef.current = true);
+      window.addEventListener('blur', handleWindowBlur);
+      return () => window.removeEventListener('blur', handleWindowBlur);
+    }, []);
 
     return (
       <PopperPrimitive.Anchor asChild {...popperScope}>
@@ -313,6 +323,12 @@ const TooltipTrigger = React.forwardRef<TooltipTriggerElement, TooltipTriggerPro
             document.addEventListener('pointerup', handlePointerUp, { once: true });
           })}
           onFocus={composeEventHandlers(props.onFocus, () => {
+            // Ignore focus caused by the tab/window regaining focus, which would
+            // otherwise reopen the tooltip on the previously-focused trigger. See #1800.
+            if (isWindowBlurredRef.current) {
+              isWindowBlurredRef.current = false;
+              return;
+            }
             if (!isPointerDownRef.current) context.onOpen();
           })}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}


### PR DESCRIPTION
## Summary

Fixes #1800. A `Tooltip` whose trigger is focused reopens itself when you switch away from and back to the browser tab (or minimize/restore the window).

## Root cause

Returning to the tab refocuses the previously-active element, firing a synthetic `focus` event on the trigger. `TooltipTrigger`'s `onFocus` opens on any non-pointer focus, so it can't distinguish that refocus from a genuine keyboard focus — and opens the tooltip.

## Fix

Track window blur via a ref (mirrors the recently-merged window-blur handling for menus, #3938). When the trigger is focused immediately after the window was blurred, treat it as the tab/window regaining focus and skip opening — consuming the flag so the next genuine focus opens normally.

## Test

Adds a regression test using `window.dispatchEvent(new FocusEvent('blur'))` then `fireEvent.focus(trigger)`, asserting `data-state` stays `closed`, and that a subsequent genuine focus still opens. Changeset included (`patch`: `@radix-ui/react-tooltip`, `radix-ui`).

## Tradeoff (open to feedback)

If the window is blurred and the user later keyboard-focuses a *different, never-focused* trigger, that trigger's first focus is suppressed once. Minor — happy to switch to a `requestAnimationFrame`-on-window-`focus` reset to eliminate it if preferred.
