### PR TITLE
fix(react): stabilize composed ref identities to end React 19 render loop (#3963)

### DIFF
--- a/packages/react/dismissable-layer/src/dismissable-layer.tsx
+++ b/packages/react/dismissable-layer/src/dismissable-layer.tsx
@@ -87,7 +87,7 @@ const DismissableLayer = React.forwardRef<DismissableLayerElement, DismissableLa
     const [node, setNode] = React.useState<DismissableLayerElement | null>(null);
     const ownerDocument = node?.ownerDocument ?? globalThis?.document;
     const [, force] = React.useState({});
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setNode(node));
+    const composedRefs = useComposedRefs(forwardedRef, setNode);
     const layers = Array.from(context.layers);
     const [highestLayerWithOutsidePointerEventsDisabled] = [...context.layersWithOutsidePointerEventsDisabled].slice(-1); // prettier-ignore
     const highestLayerWithOutsidePointerEventsDisabledIndex = layers.indexOf(highestLayerWithOutsidePointerEventsDisabled!); // prettier-ignore

--- a/packages/react/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { composeRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive } from '@radix-ui/react-primitive';
@@ -101,6 +101,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
     const { __scopeDropdownMenu, disabled = false, ...triggerProps } = props;
     const context = useDropdownMenuContext(TRIGGER_NAME, __scopeDropdownMenu);
     const menuScope = useMenuScope(__scopeDropdownMenu);
+    const composedRefs = useComposedRefs(forwardedRef, context.triggerRef);
     return (
       <MenuPrimitive.Anchor asChild {...menuScope}>
         <Primitive.button
@@ -113,7 +114,7 @@ const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, Dropdow
           data-disabled={disabled ? '' : undefined}
           disabled={disabled}
           {...triggerProps}
-          ref={composeRefs(forwardedRef, context.triggerRef)}
+          ref={composedRefs}
           onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)

--- a/packages/react/focus-scope/src/focus-scope.tsx
+++ b/packages/react/focus-scope/src/focus-scope.tsx
@@ -57,7 +57,7 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
   const onMountAutoFocus = useCallbackRef(onMountAutoFocusProp);
   const onUnmountAutoFocus = useCallbackRef(onUnmountAutoFocusProp);
   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null);
-  const composedRefs = useComposedRefs(forwardedRef, (node) => setContainer(node));
+  const composedRefs = useComposedRefs(forwardedRef, setContainer);
 
   const focusScope = React.useRef({
     paused: false,

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createCollection } from '@radix-ui/react-collection';
-import { useComposedRefs, composeRefs } from '@radix-ui/react-compose-refs';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { useDirection } from '@radix-ui/react-direction';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -1057,6 +1057,8 @@ const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, MenuSubTriggerPro
       };
     }, [pointerGraceTimerRef, onPointerGraceIntentChange]);
 
+    const composedRefs = useComposedRefs(forwardedRef, subContext.onTriggerChange);
+
     return (
       <MenuAnchor asChild {...scope}>
         <MenuItemImpl
@@ -1066,7 +1068,7 @@ const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, MenuSubTriggerPro
           aria-controls={context.open ? subContext.contentId : undefined}
           data-state={getOpenState(context.open)}
           {...props}
-          ref={composeRefs(forwardedRef, subContext.onTriggerChange)}
+          ref={composedRefs}
           // This is redundant for mouse users but we cannot determine pointer type from
           // click event and we cannot use pointerup event (see git history for reasons why)
           onClick={(event) => {

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -192,7 +192,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
     const context = usePopperContext(CONTENT_NAME, __scopePopper);
 
     const [content, setContent] = React.useState<HTMLDivElement | null>(null);
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
+    const composedRefs = useComposedRefs(forwardedRef, setContent);
 
     const [arrow, setArrow] = React.useState<HTMLSpanElement | null>(null);
     const arrowSize = useSize(arrow);

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -82,7 +82,7 @@ const ScrollArea = React.forwardRef<ScrollAreaElement, ScrollAreaProps>(
     const [cornerHeight, setCornerHeight] = React.useState(0);
     const [scrollbarXEnabled, setScrollbarXEnabled] = React.useState(false);
     const [scrollbarYEnabled, setScrollbarYEnabled] = React.useState(false);
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setScrollArea(node));
+    const composedRefs = useComposedRefs(forwardedRef, setScrollArea);
     const direction = useDirection(dir);
 
     return (
@@ -665,7 +665,7 @@ const ScrollAreaScrollbarImpl = React.forwardRef<
   } = props;
   const context = useScrollAreaContext(SCROLLBAR_NAME, __scopeScrollArea);
   const [scrollbar, setScrollbar] = React.useState<ScrollAreaScrollbarElement | null>(null);
-  const composeRefs = useComposedRefs(forwardedRef, (node) => setScrollbar(node));
+  const composeRefs = useComposedRefs(forwardedRef, setScrollbar);
   const rectRef = React.useRef<DOMRect | null>(null);
   const prevWebkitUserSelectRef = React.useRef<string>('');
   const viewport = context.viewport;
@@ -783,9 +783,7 @@ const ScrollAreaThumbImpl = React.forwardRef<ScrollAreaThumbImplElement, ScrollA
     const scrollAreaContext = useScrollAreaContext(THUMB_NAME, __scopeScrollArea);
     const scrollbarContext = useScrollbarContext(THUMB_NAME, __scopeScrollArea);
     const { onThumbPositionChange } = scrollbarContext;
-    const composedRef = useComposedRefs(forwardedRef, (node) =>
-      scrollbarContext.onThumbChange(node),
-    );
+    const composedRef = useComposedRefs(forwardedRef, scrollbarContext.onThumbChange);
     const removeUnlinkedScrollListenerRef = React.useRef<() => void>(undefined);
     const debounceScrollEnd = useDebounceCallback(() => {
       if (removeUnlinkedScrollListenerRef.current) {

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -662,7 +662,7 @@ const SelectContentImpl = React.forwardRef<SelectContentImplElement, SelectConte
     const context = useSelectContext(CONTENT_NAME, __scopeSelect);
     const [content, setContent] = React.useState<SelectContentImplElement | null>(null);
     const [viewport, setViewport] = React.useState<SelectViewportElement | null>(null);
-    const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
+    const composedRefs = useComposedRefs(forwardedRef, setContent);
     const [selectedItem, setSelectedItem] = React.useState<SelectItemElement | null>(null);
     const [selectedItemText, setSelectedItemText] = React.useState<SelectItemTextElement | null>(
       null,
@@ -938,7 +938,7 @@ const SelectItemAlignedPosition = React.forwardRef<
   const contentContext = useSelectContentContext(CONTENT_NAME, __scopeSelect);
   const [contentWrapper, setContentWrapper] = React.useState<HTMLDivElement | null>(null);
   const [content, setContent] = React.useState<SelectItemAlignedPositionElement | null>(null);
-  const composedRefs = useComposedRefs(forwardedRef, (node) => setContent(node));
+  const composedRefs = useComposedRefs(forwardedRef, setContent);
   const getItems = useCollection(__scopeSelect);
   const shouldExpandOnScrollRef = React.useRef(false);
   const shouldRepositionRef = React.useRef(true);
@@ -1366,9 +1366,10 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
     const isSelected = context.value === value;
     const [textValue, setTextValue] = React.useState(textValueProp ?? '');
     const [isFocused, setIsFocused] = React.useState(false);
-    const composedRefs = useComposedRefs(forwardedRef, (node) =>
-      contentContext.itemRefCallback?.(node, value, disabled),
+    const handleItemRefCallback = useCallbackRef((node: SelectItemElement | null) =>
+      contentContext.itemRefCallback?.(node, value, disabled)
     );
+    const composedRefs = useComposedRefs(forwardedRef, handleItemRefCallback);
     const textId = useId();
     const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
@@ -1472,11 +1473,14 @@ const SelectItemText = React.forwardRef<SelectItemTextElement, SelectItemTextPro
     const itemContext = useSelectItemContext(ITEM_TEXT_NAME, __scopeSelect);
     const nativeOptionsContext = useSelectNativeOptionsContext(ITEM_TEXT_NAME, __scopeSelect);
     const [itemTextNode, setItemTextNode] = React.useState<SelectItemTextElement | null>(null);
+    const handleItemTextRefCallback = useCallbackRef((node: SelectItemTextElement | null) =>
+      contentContext.itemTextRefCallback?.(node, itemContext.value, itemContext.disabled)
+    );
     const composedRefs = useComposedRefs(
       forwardedRef,
-      (node) => setItemTextNode(node),
+      setItemTextNode,
       itemContext.onItemTextChange,
-      (node) => contentContext.itemTextRefCallback?.(node, itemContext.value, itemContext.disabled),
+      handleItemTextRefCallback,
     );
 
     const textContent = itemTextNode?.textContent;


### PR DESCRIPTION
## Summary

Follows up on #3899, which stabilized Slot's composed ref to fix the React 19 infinite re-render loop. The same unstable-identity pattern still exists in several other packages' own code, and under React 19's ref-cleanup semantics each reproduces the same `Maximum update depth exceeded` crash.

`useComposedRefs` is `React.useCallback(composeRefs(...refs), refs)`. When a member of `refs` is an inline arrow (or the composition is a bare `composeRefs(...)` in render), the composed callback gets a new identity every render. React 19 detaches/re-attaches the ref on every commit; any composed state-setter ref toggles `null -> node` each cycle, scheduling another render — an infinite loop.

## Changes

Same principle as #3899 — give the composed refs a stable identity:

- **Pass state setters directly** (`useComposedRefs(forwardedRef, setX)`), matching existing usage like `select.tsx` `onTriggerChange`:
  - `react-dismissable-layer`: `DismissableLayer` → `setNode`
  - `react-focus-scope`: `FocusScope` → `setContainer`
  - `react-popper`: `PopperContent` → `setContent`
  - `react-scroll-area`: `ScrollArea` → `setScrollArea`, `Scrollbar` → `setScrollbar`, `Thumb` → `scrollbarContext.onThumbChange` (already stabilized via `useCallbackRef`)
  - `react-select`: `SelectContentImpl` / `SelectItemAlignedPosition` → `setContent`, `SelectItemText` → `setItemTextNode`
- **Hoist render-inline `composeRefs(...)` into `useComposedRefs`** above the JSX:
  - `react-dropdown-menu`: `DropdownMenuTrigger`
  - `react-menu`: `MenuSubTrigger` (composed directly with the `onTriggerChange` state setter)
- **Wrap closures that capture per-render values in `useCallbackRef`** before composing (they take extra args, so can't be passed directly):
  - `react-select`: `SelectItem` (`value`, `disabled`) and `SelectItemText` (`value`, `disabled`)

## Notes

- Changes are mechanical and behavior-preserving; identities are now stable across renders.
- `react-dismissable-layer` is emphasized in #3963 as the residual loop driver, since it wraps every menu/popover/dialog content stack.

Closes #3963.
