### PR TITLE
fix(popper): allow virtualRef to accept RefObject<Measurable | null> for React 19

### DIFF
--- a/.changeset/popper-virtualref-null.md
+++ b/.changeset/popper-virtualref-null.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-popper": patch
+---
+
+Allow `PopperAnchor`'s `virtualRef` to accept a `RefObject<Measurable | null>`, matching the type that `useRef<Measurable>(null)` returns in React 19.

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -76,7 +76,7 @@ const ANCHOR_NAME = 'PopperAnchor';
 type PopperAnchorElement = React.ComponentRef<typeof Primitive.div>;
 type PrimitiveDivProps = React.ComponentPropsWithoutRef<typeof Primitive.div>;
 interface PopperAnchorProps extends PrimitiveDivProps {
-  virtualRef?: React.RefObject<Measurable>;
+  virtualRef?: React.RefObject<Measurable | null>;
 }
 
 const PopperAnchor = React.forwardRef<PopperAnchorElement, PopperAnchorProps>(


### PR DESCRIPTION
## Description

`PopperAnchor`'s `virtualRef` prop is typed as `React.RefObject<Measurable>`, but in React 19 `useRef<Measurable>(null)` returns `RefObject<Measurable | null>`. As a result, passing a virtual ref (the documented anchoring pattern) fails to type-check under React 19.

This widens the prop type to `React.RefObject<Measurable | null>`. The change is type-only and internally safe:

- `anchorRef` is already `Measurable | null` (`useRef<Measurable | null>(null)`).
- `virtualRef.current` is read into that slot, and rendering only branches on `virtualRef` truthiness.

No runtime behavior changes, and existing callers passing a non-null ref remain assignable.

Closes #3635
