### PR TITLE
fix(checkbox): hide bubble input with native hidden attribute

### DIFF
--- a/.changeset/fix-checkbox-bubble-input-a11y-3167.md
+++ b/.changeset/fix-checkbox-bubble-input-a11y-3167.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-checkbox': patch
+---
+
+Fix bubble input accessibility by using the native `hidden` attribute instead of `aria-hidden`, and mirror label association from the control to the hidden input.

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -296,6 +296,27 @@ describe('Checkbox', () => {
       expect(onChange).toHaveBeenCalledWith(false);
     });
   });
+
+  // Regression test for https://github.com/radix-ui/primitives/issues/3167
+  describe('given a Checkbox with label association in a form', () => {
+    it('should hide the bubble input with the native hidden attribute', async () => {
+      const rendered = render(
+        <form>
+          <label htmlFor="pikachu">
+            Pikachu
+            <Checkbox.Root id="pikachu" name="Pikachu" value="Pikachu">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.Root>
+          </label>
+        </form>,
+      );
+
+      const input = rendered.container.querySelector('input[type="checkbox"]');
+      expect(input).toHaveAttribute('hidden');
+      expect(input).not.toHaveAttribute('aria-hidden');
+      expect(await axe(rendered.container)).toHaveNoViolations();
+    });
+  });
 });
 
 describe('Legacy Checkbox', () => {
@@ -478,21 +499,9 @@ describe('Legacy Checkbox', () => {
 });
 
 function LegacyCheckbox(props: React.ComponentProps<typeof Checkbox.Root>) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => {
-    // We use the `hidden` attribute to hide the nested input from both sighted users and the
-    // accessibility tree. This is perfectly valid so long as users don't override the display of
-    // `hidden` in CSS. Unfortunately axe doesn't recognize this, so we get a violation because the
-    // input doesn't have a label. This adds an additional `aria-hidden` attribute to the input to
-    // get around that.
-    // https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/
-    containerRef.current?.querySelector('input')?.setAttribute('aria-hidden', 'true');
-  }, []);
   return (
-    <div ref={containerRef}>
-      <Checkbox.Root aria-label="basic checkbox" {...props}>
-        <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
-      </Checkbox.Root>
-    </div>
+    <Checkbox.Root aria-label="basic checkbox" {...props}>
+      <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+    </Checkbox.Root>
   );
 }

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -297,7 +297,7 @@ describe('Checkbox', () => {
     });
   });
 
-  describe('given a Checkbox with a clickable ancestor inside a form', () => {
+describe('given a Checkbox with a clickable ancestor inside a form', () => {
     const onParentClick = vi.fn();
     const onFormChange = vi.fn();
 
@@ -373,6 +373,27 @@ describe('Checkbox', () => {
 
       // the form should still be notified of the change
       expect(onFormChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  // Regression test for https://github.com/radix-ui/primitives/issues/3167
+  describe('given a Checkbox with label association in a form', () => {
+    it('should hide the bubble input with the native hidden attribute', async () => {
+      const rendered = render(
+        <form>
+          <label htmlFor="pikachu">
+            Pikachu
+            <Checkbox.Root id="pikachu" name="Pikachu" value="Pikachu">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.Root>
+          </label>
+        </form>,
+      );
+
+      const input = rendered.container.querySelector('input[type="checkbox"]');
+      expect(input).toHaveAttribute('hidden');
+      expect(input).not.toHaveAttribute('aria-hidden');
+      expect(await axe(rendered.container)).toHaveNoViolations();
     });
   });
 });
@@ -557,22 +578,10 @@ describe('Legacy Checkbox', () => {
 });
 
 function LegacyCheckbox(props: React.ComponentProps<typeof Checkbox.Root>) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => {
-    // We use the `hidden` attribute to hide the nested input from both sighted users and the
-    // accessibility tree. This is perfectly valid so long as users don't override the display of
-    // `hidden` in CSS. Unfortunately axe doesn't recognize this, so we get a violation because the
-    // input doesn't have a label. This adds an additional `aria-hidden` attribute to the input to
-    // get around that.
-    // https://developer.paciellogroup.com/blog/2012/05/html5-accessibility-chops-hidden-and-aria-hidden/
-    containerRef.current?.querySelector('input')?.setAttribute('aria-hidden', 'true');
-  }, []);
   return (
-    <div ref={containerRef}>
-      <Checkbox.Root aria-label="basic checkbox" {...props}>
-        <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
-      </Checkbox.Root>
-    </div>
+    <Checkbox.Root aria-label="basic checkbox" {...props}>
+      <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+    </Checkbox.Root>
   );
 }
 
@@ -818,7 +827,8 @@ describe('Checkbox.unstable_BubbleInput', () => {
     const input = screen.getByTestId('bubble-input');
     expect(input.tagName).toBe('INPUT');
     expect(input).toHaveAttribute('type', 'checkbox');
-    expect(input).toHaveAttribute('aria-hidden', 'true');
+    expect(input).toHaveAttribute('hidden');
+    expect(input).not.toHaveAttribute('aria-hidden');
     expect(input).toHaveClass('custom-class');
     expect(input.style.outlineColor).toBe('rgb(1, 2, 3)');
     expect(ref.current).toBe(input);

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -341,16 +341,21 @@ const CheckboxBubbleInput = React.forwardRef<HTMLInputElement, CheckboxBubbleInp
     }, [bubbleInput, prevChecked, checked, hasConsumerStoppedPropagationRef]);
 
     const defaultCheckedRef = React.useRef(isIndeterminate(checked) ? false : checked);
+    const controlAriaLabel = control?.getAttribute('aria-label') ?? undefined;
+    const controlAriaLabelledBy = control?.getAttribute('aria-labelledby') ?? undefined;
+
     return (
       <Primitive.input
         type="checkbox"
-        aria-hidden
+        hidden
         defaultChecked={defaultChecked ?? defaultCheckedRef.current}
         required={required}
         disabled={disabled}
         name={name}
         value={value}
         form={form}
+        aria-label={controlAriaLabel}
+        aria-labelledby={controlAriaLabelledBy}
         {...props}
         tabIndex={-1}
         ref={composedRefs}

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -384,16 +384,21 @@ const CheckboxBubbleInput = /* @__PURE__ */ React.forwardRef<
     }, [bubbleInput, checked, hasConsumerStoppedPropagationRef, userInteractionCount]);
 
     const defaultCheckedRef = React.useRef(isIndeterminate(checked) ? false : checked);
+    const controlAriaLabel = control?.getAttribute('aria-label') ?? undefined;
+    const controlAriaLabelledBy = control?.getAttribute('aria-labelledby') ?? undefined;
+
     return (
       <Primitive.input
         type="checkbox"
-        aria-hidden
+        hidden
         defaultChecked={defaultChecked ?? defaultCheckedRef.current}
         required={required}
         disabled={disabled}
         name={name}
         value={value}
         form={form}
+        aria-label={controlAriaLabel}
+        aria-labelledby={controlAriaLabelledBy}
         {...props}
         tabIndex={-1}
         ref={composedRefs}


### PR DESCRIPTION
## Summary

- Replaces `aria-hidden` on the Checkbox form bubble `<input>` with the native `hidden` attribute
- Mirrors `aria-label` and `aria-labelledby` from the visible control button onto the bubble input
- Adds a regression test for the label + `htmlFor` scenario reported in #3167

Fixes #3167

## Problem

Wave flags "Missing form label" on the auto-generated bubble `<input>` used for native form integration. The input was hidden with `aria-hidden="true"` while still being focusable (`tabIndex={-1}`), which confuses accessibility scanners even when the visible checkbox button is correctly labelled.

## Solution

Use the native `hidden` attribute instead, which removes the bubble input from the accessibility tree without the `aria-hidden` + focusable conflict. Label association is mirrored from the control for scanners that still inspect hidden inputs.

## Test plan

- [x] `pnpm vitest run packages/react/checkbox/src/checkbox.test.tsx` — 27/27 pass
- [x] `@radix-ui/react-checkbox` typecheck passes
- [x] Storybook **Legacy Within Form** — bubble inputs have `hidden: true`, form toggle works
- [ ] CI passes on PR


Made with [Cursor](https://cursor.com)