### PR TITLE
fix(select): prevent text selection on items

### DIFF
--- a/.changeset/fix-select-item-user-select-1488.md
+++ b/.changeset/fix-select-item-user-select-1488.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+Prevent text selection on Select items to avoid Firefox leaving selection mode active after closing inside a Dialog.

--- a/packages/react/select/src/select.test.tsx
+++ b/packages/react/select/src/select.test.tsx
@@ -140,3 +140,14 @@ describe('clearing an optional value (#2706)', () => {
     expect(emptyOptions).toHaveLength(1);
   });
 });
+
+// Regression test for https://github.com/radix-ui/primitives/issues/1488
+describe('given a select item', () => {
+  afterEach(cleanup);
+
+  it('should not allow text selection', async () => {
+    render(<SelectTest defaultOpen />);
+    const option = await waitFor(() => screen.getByRole('option', { name: 'Apple', hidden: true }));
+    expect(option).toHaveStyle({ userSelect: 'none' });
+  });
+});

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1408,6 +1408,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
             data-disabled={disabled ? '' : undefined}
             tabIndex={disabled ? undefined : -1}
             {...itemProps}
+            style={{ userSelect: 'none', ...itemProps.style }}
             ref={composedRefs}
             onFocus={composeEventHandlers(itemProps.onFocus, () => setIsFocused(true))}
             onBlur={composeEventHandlers(itemProps.onBlur, () => setIsFocused(false))}


### PR DESCRIPTION
## Summary

- Sets `userSelect: 'none'` on Select items to prevent accidental text selection when interacting with the dropdown

Fixes #1488

## Problem

In Firefox (especially inside dialogs), dragging over Select options can highlight item text instead of selecting the option.

## Test plan

- [x] `pnpm vitest run packages/react/select/src/select.test.tsx`
- [x] Storybook **Within Dialog** — options have `user-select: none`
- [ ] CI passes on PR

Made with [Cursor](https://cursor.com)