### PR TITLE
fix(scroll-area): use block display on viewport content wrapper

### DIFF
--- a/.changeset/fix-scroll-area-display-table-3646.md
+++ b/.changeset/fix-scroll-area-display-table-3646.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-scroll-area': patch
+---
+
+Use `display: block` instead of `display: table` on the viewport content wrapper to prevent layout breakage in flex and resizable containers.

--- a/packages/react/scroll-area/src/scroll-area.test.tsx
+++ b/packages/react/scroll-area/src/scroll-area.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import * as ScrollArea from './scroll-area';
+
+describe('ScrollArea', () => {
+  afterEach(cleanup);
+
+  // Regression test for https://github.com/radix-ui/primitives/issues/3646
+  it('should use block display on the viewport content wrapper', () => {
+    const { container } = render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport>
+          <div>content</div>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const contentWrapper = container.querySelector('[data-radix-scroll-area-viewport] > div');
+    expect(contentWrapper).toHaveStyle({ display: 'block' });
+  });
+});

--- a/packages/react/scroll-area/src/scroll-area.test.tsx
+++ b/packages/react/scroll-area/src/scroll-area.test.tsx
@@ -379,7 +379,7 @@ describe('ScrollArea.Viewport', () => {
     expect(viewport).toHaveClass('custom-class');
     expect(viewport.style.outlineColor).toBe('rgb(1, 2, 3)');
     expect(ref.current).toBe(viewport);
-    expect(viewport.firstElementChild).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(viewport.firstElementChild).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(viewport).toHaveTextContent('Content');
 
     fireEvent.click(viewport);
@@ -408,7 +408,7 @@ describe('ScrollArea.Viewport', () => {
     // there is no element for Slot to target
     const viewport = screen.getByTestId('viewport');
     expect(viewport).toHaveClass('custom-class');
-    expect(viewport).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(viewport).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('`asChild` expects a single React element child'),
     );
@@ -426,7 +426,7 @@ describe('ScrollArea.Viewport', () => {
     const viewport = screen.getByTestId('viewport');
     const content = viewport.firstElementChild;
     expect(content).toBeInstanceOf(HTMLDivElement);
-    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(content).toHaveTextContent('Content');
   });
 
@@ -442,7 +442,7 @@ describe('ScrollArea.Viewport', () => {
     const viewport = screen.getByTestId('viewport');
     const child = screen.getByTestId('child');
     expect(viewport.firstElementChild).toBe(child);
-    expect(child).not.toHaveStyle({ display: 'table' });
+    expect(child).not.toHaveStyle({ display: 'block' });
   });
 
   it('forwards props to the child when `asChild` is set with `disableImplicitContentElement`', () => {
@@ -475,7 +475,7 @@ describe('ScrollArea.Viewport', () => {
     expect(viewport).toHaveClass('custom-class');
     expect(viewport.style.outlineColor).toBe('rgb(1, 2, 3)');
     expect(ref.current).toBe(viewport);
-    expect(viewport.firstElementChild).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(viewport.firstElementChild).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(viewport).toHaveTextContent('Content');
 
     fireEvent.click(viewport);
@@ -485,6 +485,21 @@ describe('ScrollArea.Viewport', () => {
 
 describe('ScrollArea.Content', () => {
   afterEach(cleanup);
+
+  // Regression test for https://github.com/radix-ui/primitives/issues/3646
+  it('uses block display so flex/resizable layouts are not broken by display:table', () => {
+    render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport data-testid="viewport">
+          <div>content</div>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const contentWrapper = screen.getByTestId('viewport').firstElementChild;
+    expect(contentWrapper).toHaveStyle({ display: 'block', minWidth: '100%' });
+  });
+
 
   it('spreads props it does not consume onto the element it renders', () => {
     const ref = React.createRef<HTMLDivElement>();
@@ -507,7 +522,7 @@ describe('ScrollArea.Content', () => {
     );
 
     const content = screen.getByTestId('content');
-    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(content).toHaveClass('custom-class');
     expect(content.style.outlineColor).toBe('rgb(1, 2, 3)');
     expect(ref.current).toBe(content);
@@ -539,7 +554,7 @@ describe('ScrollArea.Content', () => {
 
     const content = screen.getByTestId('content');
     expect(content.tagName).toBe('ARTICLE');
-    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveStyle({ display: 'block', minWidth: '100%' });
     expect(content).toHaveClass('custom-class');
     expect(content.style.outlineColor).toBe('rgb(1, 2, 3)');
     expect(ref.current).toBe(content);

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -168,13 +168,11 @@ const ScrollAreaViewport = React.forwardRef<ScrollAreaViewportElement, ScrollAre
           }}
         >
           {/**
-           * `display: table` ensures our content div will match the size of its children in both
-           * horizontal and vertical axis so we can determine if scroll width/height changed and
-           * recalculate thumb sizes. This doesn't account for children with *percentage*
-           * widths that change. We'll wait to see what use-cases consumers come up with there
-           * before trying to resolve it.
+           * `display: block` avoids layout issues caused by `display: table` in
+           * flex and resizable layouts while still allowing the viewport to
+           * measure scrollable content via `minWidth: 100%`.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
+          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'block' }}>
             {children}
           </div>
         </Primitive.div>

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -295,16 +295,14 @@ const ScrollAreaContent = /* @__PURE__ */ React.forwardRef<
   const context = useScrollAreaContext(CONTENT_NAME, __scopeScrollArea);
   const composedRefs = useComposedRefs(forwardedRef, context.onContentChange);
   return (
-    // `display: table` ensures our content div will match the size of its
-    // children in both horizontal and vertical axis so we can determine if
-    // scroll width/height changed and recalculate thumb sizes. This doesn't
-    // account for children with *percentage* widths that change. We'll wait to
-    // see what use-cases consumers come up with there before trying to resolve
-    // it.
+    // `display: block` avoids layout issues caused by `display: table` in flex
+    // and resizable layouts while still allowing the viewport to measure
+    // scrollable content via `minWidth: 100%`.
+    // See: https://github.com/radix-ui/primitives/issues/3646
     <Primitive.div
       {...contentProps}
       ref={composedRefs}
-      style={{ minWidth: '100%', display: 'table', ...props.style }}
+      style={{ minWidth: '100%', display: 'block', ...props.style }}
     >
       {children}
     </Primitive.div>


### PR DESCRIPTION
## Summary

- Changes the ScrollArea viewport content wrapper from `display: table` to `display: block`
- Adds a regression test for the layout behavior

Fixes #3646

## Problem

`display: table` on the viewport content wrapper causes layout issues in flex and resizable containers.

## Test plan

- [x] `pnpm vitest run packages/react/scroll-area/src/scroll-area.test.tsx`
- [x] Storybook **Basic** — content scrolls and layout renders correctly
- [ ] CI passes on PR

Made with [Cursor](https://cursor.com)