### PR TITLE
feat(menu): add focusOnItemEnter opt-out to Menu.Content

### DIFF
--- a/.changeset/focus-on-item-enter.md
+++ b/.changeset/focus-on-item-enter.md
@@ -1,0 +1,22 @@
+---
+'@radix-ui/react-menu': minor
+'@radix-ui/react-dropdown-menu': minor
+'@radix-ui/react-context-menu': minor
+'@radix-ui/react-menubar': minor
+---
+
+Add `focusOnItemEnter` prop to `Menu.Content` (and `DropdownMenu.Content`, `ContextMenu.Content`, `Menubar.Content`).
+
+Default `true` — preserves existing behaviour where moving the pointer over an item focuses it (matches native menu UX).
+
+Set to `false` when the menu contains focusable siblings (e.g. an embedded search `<input>`) that the user may want to keep typing in without their caret being stolen by every row the pointer passes over. Submenu hover-open is unaffected — submenu opening is driven by `onItemEnter` (pointer grace intent), not by the focus call.
+
+```jsx
+<DropdownMenu.Content focusOnItemEnter={false}>
+  <input type="text" placeholder="Filter…" />
+  <DropdownMenu.Item>Item 1</DropdownMenu.Item>
+  <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+</DropdownMenu.Content>
+```
+
+Fixes https://github.com/radix-ui/primitives/issues/2193

--- a/apps/storybook/stories/dropdown-menu.stories.tsx
+++ b/apps/storybook/stories/dropdown-menu.stories.tsx
@@ -930,6 +930,122 @@ export const WithTooltip = () => (
   </div>
 );
 
+export const WithSearchInput = () => {
+  // Demonstrates the `focusOnItemEnter` opt-out prop. By default, moving the
+  // pointer over a menu item steals focus from any sibling focusable element
+  // (here, the search `<input>`) — so the user can't keep typing while their
+  // cursor passes over rows. Setting `focusOnItemEnter={false}` on the
+  // `Content` lets the input keep its caret.
+  //
+  // The two examples below are identical except for that one prop. Hover the
+  // items in each and try typing in the input:
+  //   - Left (default): the input loses focus after every row the cursor
+  //     passes over.
+  //   - Right (`focusOnItemEnter={false}`): the input keeps focus; rows
+  //     still highlight visually thanks to the `:hover` rule in the CSS.
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: 40,
+        padding: 40,
+        fontFamily: 'apple-system, BlinkMacSystemFont, helvetica, arial, sans-serif',
+      }}
+    >
+      <div>
+        <h3>Default (focusOnItemEnter: true)</h3>
+        <p style={{ fontSize: 12, color: '#666' }}>
+          Hovering an item steals focus from the input — typing stops working.
+        </p>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger className={styles.trigger}>Open</DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={styles.content} sideOffset={5}>
+              <div style={{ padding: 4 }}>
+                <input
+                  type="text"
+                  placeholder="Type here…"
+                  style={{
+                    width: '100%',
+                    padding: '4px 6px',
+                    fontSize: 13,
+                    border: '1px solid #ccc',
+                    borderRadius: 3,
+                  }}
+                />
+              </div>
+              <DropdownMenu.Separator className={styles.separator} />
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Undo
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Redo
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Cut
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Copy
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Paste
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      </div>
+
+      <div>
+        <h3>focusOnItemEnter=false</h3>
+        <p style={{ fontSize: 12, color: '#666' }}>
+          Hovering items no longer steals focus — typing continues uninterrupted.
+        </p>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger className={styles.trigger}>Open</DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className={styles.content}
+              focusOnItemEnter={false}
+              sideOffset={5}
+            >
+              <div style={{ padding: 4 }}>
+                <input
+                  type="text"
+                  placeholder="Type here…"
+                  style={{
+                    width: '100%',
+                    padding: '4px 6px',
+                    fontSize: 13,
+                    border: '1px solid #ccc',
+                    borderRadius: 3,
+                  }}
+                />
+              </div>
+              <DropdownMenu.Separator className={styles.separator} />
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Undo
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Redo
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Cut
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Copy
+              </DropdownMenu.Item>
+              <DropdownMenu.Item className={styles.item} onSelect={() => {}}>
+                Paste
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      </div>
+    </div>
+  );
+};
+
 export const InPopupWindow = () => {
   const handlePopupClick = React.useCallback(() => {
     const popupWindow = window.open(undefined, undefined, 'width=300,height=300,top=100,left=100');

--- a/packages/react/dropdown-menu/src/dropdown-menu.test.tsx
+++ b/packages/react/dropdown-menu/src/dropdown-menu.test.tsx
@@ -5,6 +5,7 @@ import * as DropdownMenu from './dropdown-menu';
 
 const TRIGGER_TEXT = 'Open';
 const ITEM_TEXT = 'Item';
+const ITEM_TEXT_2 = 'Item 2';
 const SUB_TRIGGER_TEXT = 'Sub';
 const SUB_ITEM_TEXT = 'Sub Item';
 
@@ -33,6 +34,19 @@ const DropdownMenuWithSubTest = (props: React.ComponentProps<typeof DropdownMenu
             </DropdownMenu.SubContent>
           </DropdownMenu.Portal>
         </DropdownMenu.Sub>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
+  </DropdownMenu.Root>
+);
+
+const DropdownMenuWithInputTest = (props: { focusOnItemEnter?: boolean }) => (
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger>{TRIGGER_TEXT}</DropdownMenu.Trigger>
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content focusOnItemEnter={props.focusOnItemEnter}>
+        <input data-testid="search" type="text" />
+        <DropdownMenu.Item>{ITEM_TEXT}</DropdownMenu.Item>
+        <DropdownMenu.Item>{ITEM_TEXT_2}</DropdownMenu.Item>
       </DropdownMenu.Content>
     </DropdownMenu.Portal>
   </DropdownMenu.Root>
@@ -82,5 +96,120 @@ describe('closing on window blur', () => {
     await waitFor(() => expect(screen.queryByText(SUB_ITEM_TEXT)).not.toBeInTheDocument());
     expect(screen.queryByText(ITEM_TEXT)).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('focusOnItemEnter', () => {
+  afterEach(cleanup);
+
+  // Helper: open the menu with a keyboard Enter, focus the input (Radix does
+  // not auto-focus non-menuitem children on open — `onMountAutoFocus` only
+  // focuses the content root), then simulate a pointermove with the
+  // `pointerType: 'mouse'` Radix's `whenMouse` guard requires.
+  async function openMenuAndFocusInput(options: { focusOnItemEnter?: boolean } = {}) {
+    render(<DropdownMenuWithInputTest focusOnItemEnter={options.focusOnItemEnter} />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    const searchInput = await waitFor(() => screen.getByTestId('search'));
+    searchInput.focus();
+    expect(document.activeElement).toBe(searchInput);
+
+    return { searchInput };
+  }
+
+  it('should keep focus on a sibling input when focusOnItemEnter={false}', async () => {
+    const { searchInput } = await openMenuAndFocusInput({ focusOnItemEnter: false });
+    const item = await waitFor(() => screen.getByText(ITEM_TEXT));
+
+    // `whenMouse` in menu.tsx short-circuits unless event.pointerType === 'mouse'.
+    fireEvent.pointerMove(item, { pointerType: 'mouse' });
+
+    expect(document.activeElement).toBe(searchInput);
+    expect(document.activeElement).not.toBe(item);
+  });
+
+  it('should still focus items on hover when focusOnItemEnter is omitted (default)', async () => {
+    const { searchInput } = await openMenuAndFocusInput();
+    const item = await waitFor(() => screen.getByText(ITEM_TEXT));
+
+    // Default behaviour is preserved: hovering the item steals focus even though
+    // there's a sibling input that was just focused. Regression guard for the
+    // default (focusOnItemEnter: true) path.
+    fireEvent.pointerMove(item, { pointerType: 'mouse' });
+
+    expect(document.activeElement).toBe(item);
+    expect(document.activeElement).not.toBe(searchInput);
+  });
+
+  it('should keep focus on the input across multiple pointer moves over different items', async () => {
+    const { searchInput } = await openMenuAndFocusInput({ focusOnItemEnter: false });
+    const item1 = await waitFor(() => screen.getByText(ITEM_TEXT));
+    const item2 = await waitFor(() => screen.getByText(ITEM_TEXT_2));
+
+    fireEvent.pointerMove(item1, { pointerType: 'mouse' });
+    expect(document.activeElement).toBe(searchInput);
+
+    fireEvent.pointerMove(item2, { pointerType: 'mouse' });
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it('should still focus the first item on keyboard-open when focusOnItemEnter={false}', async () => {
+    // Regression guard: disabling hover-to-focus must not break the
+    // RovingFocusGroup entry-focus path. Keyboard-open focuses the first
+    // item via onEntryFocus (RovingFocusGroup), independent of pointermove.
+    render(<DropdownMenuWithInputTest focusOnItemEnter={false} />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    const item = await waitFor(() => screen.getByText(ITEM_TEXT));
+    await waitFor(() => expect(document.activeElement).toBe(item));
+  });
+});
+
+describe('focusOnItemEnter with submenus', () => {
+  // Submenu hover-open is driven by MenuSubTrigger.onPointerMove scheduling
+  // a setTimeout(open, 100). `focusOnItemEnter={false}` on the parent must
+  // not interfere with that path — the focus call lives in MenuItemImpl, not
+  // MenuSubTrigger.
+  //
+  // We avoid mixing fake timers with `waitFor` (which polls via setInterval
+  // and deadlocks under fake timers). Instead: real timers, then flush the
+  // 100ms SubTrigger open timer via the real event loop.
+  afterEach(cleanup);
+
+  it('should still open submenu on SubTrigger hover when parent has focusOnItemEnter={false}', async () => {
+    render(
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>{TRIGGER_TEXT}</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content focusOnItemEnter={false}>
+            <DropdownMenu.Item>{ITEM_TEXT}</DropdownMenu.Item>
+            <DropdownMenu.Sub>
+              <DropdownMenu.SubTrigger>{SUB_TRIGGER_TEXT}</DropdownMenu.SubTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.SubContent>
+                  <DropdownMenu.Item>{SUB_ITEM_TEXT}</DropdownMenu.Item>
+                </DropdownMenu.SubContent>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Sub>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+    );
+
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    const subTrigger = await waitFor(() => screen.getByText(SUB_TRIGGER_TEXT));
+    expect(screen.queryByText(SUB_ITEM_TEXT)).not.toBeInTheDocument();
+
+    // Pointer grace intent needs mouse pointer type (matches Radix whenMouse).
+    fireEvent.pointerMove(subTrigger, { pointerType: 'mouse' });
+
+    // Wait past the 100ms SubTrigger open timer + render flush.
+    await waitFor(() => expect(screen.getByText(SUB_ITEM_TEXT)).toBeInTheDocument(), {
+      timeout: 1000,
+    });
   });
 });

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -221,6 +221,30 @@ type MenuContentContextValue = {
   searchRef: React.RefObject<string>;
   pointerGraceTimerRef: React.MutableRefObject<number>;
   onPointerGraceIntentChange(intent: GraceIntent | null): void;
+  /**
+   * Whether items should focus themselves on `pointerMove` (i.e. hover).
+   *
+   * Default `true` — matches native menu behaviour where moving the pointer
+   * over an item focuses it.
+   *
+   * Set to `false` when the menu contains focusable siblings (e.g. an embedded
+   * search `<input>`) that the user may want to keep typing in without their
+   * caret being stolen by every row the pointer passes over. This fixes a
+   * long-standing focus-stealing issue (see
+   * https://github.com/radix-ui/primitives/issues/2193).
+   *
+   * **Visual hover state:** when `false`, items no longer set
+   * `data-highlighted` on hover (that attribute tracks the focused state).
+   * Consumers who need a hover visual should style via the `:hover`
+   * pseudo-class or a separate `onPointerEnter` mechanism.
+   *
+   * **Submenu interaction:** submenu hover-open via `MenuSubTrigger` is
+   * unaffected — submenu opening is driven by `onItemEnter` (pointer grace
+   * intent), not by the focus call.
+   *
+   * @defaultValue true
+   */
+  focusOnItemEnter: boolean;
 };
 const [MenuContentProvider, useMenuContentContext] =
   createMenuContext<MenuContentContextValue>(CONTENT_NAME);
@@ -361,6 +385,31 @@ interface MenuContentImplProps
    */
   loop?: RovingFocusGroupProps['loop'];
 
+  /**
+   * Whether items should focus themselves on `pointerMove` (i.e. hover).
+   *
+   * Default `true` — matches native menu behaviour where moving the pointer
+   * over an item focuses it.
+   *
+   * Set to `false` when the menu contains focusable siblings (e.g. an embedded
+   * search `<input>`) that the user may want to keep typing in without their
+   * caret being stolen by every row the pointer passes over. This fixes a
+   * long-standing focus-stealing issue (see
+   * https://github.com/radix-ui/primitives/issues/2193).
+   *
+   * **Visual hover state:** when `false`, items no longer set
+   * `data-highlighted` on hover (that attribute tracks the focused state).
+   * Consumers who need a hover visual should style via the `:hover`
+   * pseudo-class or a separate `onPointerEnter` mechanism.
+   *
+   * **Submenu interaction:** submenu hover-open via `MenuSubTrigger` is
+   * unaffected — submenu opening is driven by `onItemEnter` (pointer grace
+   * intent), not by the focus call.
+   *
+   * @defaultValue true
+   */
+  focusOnItemEnter?: boolean;
+
   onEntryFocus?: RovingFocusGroupProps['onEntryFocus'];
   onEscapeKeyDown?: DismissableLayerProps['onEscapeKeyDown'];
   onPointerDownOutside?: DismissableLayerProps['onPointerDownOutside'];
@@ -376,6 +425,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
       __scopeMenu,
       loop = false,
       trapFocus,
+      focusOnItemEnter = true,
       onOpenAutoFocus,
       onCloseAutoFocus,
       disableOutsidePointerEvents,
@@ -450,6 +500,7 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
       <MenuContentProvider
         scope={__scopeMenu}
         searchRef={searchRef}
+        focusOnItemEnter={focusOnItemEnter}
         onItemEnter={React.useCallback(
           (event) => {
             if (isPointerMovingToSubmenu(event)) event.preventDefault();
@@ -743,7 +794,7 @@ const MenuItemImpl = React.forwardRef<MenuItemImplElement, MenuItemImplProps>(
                   contentContext.onItemLeave(event);
                 } else {
                   contentContext.onItemEnter(event);
-                  if (!event.defaultPrevented) {
+                  if (!event.defaultPrevented && contentContext.focusOnItemEnter) {
                     const item = event.currentTarget;
                     item.focus({ preventScroll: true });
                   }


### PR DESCRIPTION
## Summary

Adds a `focusOnItemEnter?: boolean` prop to `Menu.Content` that lets consumers opt out of the hover-to-focus behavior in `MenuItemImpl`. Default `true` — zero behavior change for existing users.

## Background

`MenuItemImpl.onPointerMove` calls `item.focus({preventScroll: true})` on every mouseover (see `packages/react/menu/src/menu.tsx`). The in-source comment justifies this as matching native menu UX. But when a menu contains focusable siblings (e.g. an embedded search `<input>`), the focus theft breaks typing and breaks backspace-key hold-to-delete.

This has been reported and is still unfixed after three years:
- [#2193](https://github.com/radix-ui/primitives/issues/2193) — the original report, closed March 2024 as a "duplicate of #1969" though #1969 is about `aria-selected` roving focus and is unrelated.
- 17+ users piled workarounds onto #2193 (`onPointerMove={e => e.preventDefault()}`, `onBlur` refocus, focus-timeout hacks). None shipped upstream.

## What this PR does

- Adds `focusOnItemEnter?: boolean` to `MenuContentImplProps`. Inherited automatically by `DropdownMenuContent`, `ContextMenuContent`, `MenubarContent`, and `MenuSubContent`.
- Default `true` preserves the current behavior.
- `false` skips the `item.focus()` call inside the `MenuItemImpl.onPointerMove` handler — but leaves `onItemEnter(event)` and the rest of the pointermove handler untouched, so submenu hover-open via `MenuSubTrigger` (which uses a `setTimeout(open, 100)` on `onPointerGraceIntentChange`, not on `item.focus()`) is unaffected.

The name `focusOnItemEnter` describes what the prop gates: the focus call that fires inside the item-pointerenter handler. The `onItemEnter` event dispatch itself is preserved.

```jsx
<DropdownMenu.Content focusOnItemEnter={false}>
  <input type="text" placeholder="Filter…" />
  <DropdownMenu.Item>Item 1</DropdownMenu.Item>
  <DropdownMenu.Item>Item 2</DropdownMenu.Item>
</DropdownMenu.Content>
```

## Visual tradeoff

When `focusOnItemEnter={false}`, items no longer set `data-highlighted` on hover (that attribute tracks focus state). Consumers who want a hover visual should style via `:hover` or a separate `onPointerEnter` mechanism. Documented in the JSDoc.

## Test plan

- `pnpm test` — 378 tests pass (was 373), 5 new vitest cases in `dropdown-menu.test.tsx`:
  - Default-behavior regression guard (`focusOnItemEnter` omitted → item still gets focus on hover)
  - Opt-out keeps focus on a sibling `<input>`
  - Multi-row scenario (focus stays on input across many pointer moves)
  - Keyboard-open regression guard (RovingFocusGroup entry-focus path unaffected)
  - **Submenu hover-open regression guard** — verifies that `MenuSubTrigger` still opens the submenu on hover when the parent has `focusOnItemEnter={false}`
- `pnpm types:check` clean across the monorepo
- `pnpm lint` clean
- `pnpm format:check` clean on changed files
- `pnpm build` clean

## Storybook

Adds a `WithSearchInput` story to `apps/storybook/stories/dropdown-menu.stories.tsx` showing the default and opt-out side-by-side.

## Changeset

Adds a `.changeset/focus-on-item-enter.md` marking `minor` for `@radix-ui/react-menu`, `@radix-ui/react-dropdown-menu`, `@radix-ui/react-context-menu`, `@radix-ui/react-menubar`.

## Files changed

- `packages/react/menu/src/menu.tsx` (+52/-1)
- `packages/react/dropdown-menu/src/dropdown-menu.test.tsx` (+129)
- `apps/storybook/stories/dropdown-menu.stories.tsx` (+116)
- `.changeset/focus-on-item-enter.md` (+22, new)

## API name

`focusOnItemEnter` follows existing Radix boolean-prop conventions (`modal`, `loop`, `forceMount`, `trapFocus`). I'm open to alternative names if maintainers prefer — `disableHoverFocus` or `autoFocusItems={false}` have both been requested in #2193 by other users. Happy to rename + push a follow-up if needed.

## Open question

**API scope:** currently the prop lives only on `Menu.Content` (and inheritors via the `MenuRootContentTypeProps` chain). Should it also cascade from `Menu.Root` / `DropdownMenu.Root` for menu-wide convenience, given that submenus instantiate their own `MenuContentProvider`? I went with per-Content scope because each submenu can independently control its own focus-on-hover behavior, but happy to add a Root-level cascade if maintainers want it.
