### PR TITLE
fix(toast): clear close timer on unmount to prevent stale callbacks

### DIFF
--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -545,6 +545,14 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       if (open && !context.isClosePausedRef.current) startTimer(duration);
     }, [open, duration, context.isClosePausedRef, startTimer]);
 
+    // clear timer on unmount to prevent calling handleClose (which accesses
+    // document.activeElement) after the component tree has been torn down,
+    // which causes ReferenceError in test environments and potential stale
+    // closure issues in production
+    React.useEffect(() => {
+      return () => window.clearTimeout(closeTimerRef.current);
+    }, []);
+
     React.useEffect(() => {
       onToastAdd();
       return () => onToastRemove();


### PR DESCRIPTION
## Problem

`ToastImpl` starts a `window.setTimeout` via `startTimer` that calls `handleClose` after the toast duration. This timer is only cleared when the viewport fires a `VIEWPORT_PAUSE` event — but if the toast is **unmounted before the timer fires** (e.g. programmatically removed from the tree), the timer is never cleared.

`handleClose` accesses `document.activeElement`:

```ts
const handleClose = useCallbackRef(() => {
  const isFocusInToast = node?.contains(document.activeElement);
  // ...
});
```

When this fires after unmount in a test environment (JSDOM teardown), `document` is no longer defined, causing:

```
ReferenceError: document is not defined
```

This is a common source of flaky tests for apps that have a global toast system that removes toasts by unmounting them.

## Fix

Add a cleanup `useEffect` that clears `closeTimerRef.current` on unmount — a standard React pattern for timer cleanup:

```ts
React.useEffect(() => {
  return () => window.clearTimeout(closeTimerRef.current);
}, []);
```

This is safe: `clearTimeout` with an already-elapsed or invalid timer ID is a no-op.

Fixes #3703