### PR TITLE
fix(popover): close popover when trigger scrolls out of view

### DIFF
--- a/.changeset/violet-bars-kneel.md
+++ b/.changeset/violet-bars-kneel.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-popover": minor
+"@radix-ui/react-popper": minor
+---
+
+Popover automatically closes when trigger scrolls out of view in scrollable containers

--- a/apps/storybook/stories/popover.stories.tsx
+++ b/apps/storybook/stories/popover.stories.tsx
@@ -308,7 +308,32 @@ export const WithSlottedTrigger = () => {
   );
 };
 
-// change order slightly for more pleasing visual
+export const InScrollContainer = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div style={{ padding: 50 }}>
+      <div
+        data-testid="scroll-container"
+        style={{ width: 300, height: 200, overflow: 'auto', border: '1px solid black' }}
+      >
+        <div style={{ height: 900, paddingTop: 20 }}>
+          <Popover.Root open={open} onOpenChange={setOpen}>
+            <Popover.Trigger data-testid="trigger" className={styles.trigger}>
+              open
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content className={styles.content} side="right" sideOffset={5}>
+                <Popover.Close className={styles.close}>close</Popover.Close>
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover.Root>
+        </div>
+      </div>
+      <div data-testid="popover-state">{open ? 'open' : 'closed'}</div>
+    </div>
+  );
+};
+
 const SIDES = [...SIDE_OPTIONS.filter((side) => side !== 'bottom'), 'bottom' as const];
 
 export const Chromatic = () => (

--- a/cypress/e2e/Popover.cy.ts
+++ b/cypress/e2e/Popover.cy.ts
@@ -13,4 +13,19 @@ describe('Popover', () => {
 
     cy.findByText('close').should('be.visible');
   });
+
+  describe('given a popover inside a scrollable container', () => {
+    beforeEach(() => {
+      cy.visitStory('popover--in-scroll-container');
+    });
+
+    it('closes when the trigger scrolls out of view', () => {
+      cy.findByTestId('trigger').click();
+      cy.findByTestId('popover-state').should('have.text', 'open');
+
+      cy.findByTestId('scroll-container').scrollTo(0, 200);
+
+      cy.findByTestId('popover-state').should('have.text', 'closed');
+    });
+  });
 });

--- a/packages/react/popover/src/popover.test.tsx
+++ b/packages/react/popover/src/popover.test.tsx
@@ -41,3 +41,31 @@ describe('aria-controls', () => {
     expect(document.getElementById(content.id)).toBe(content);
   });
 });
+
+
+describe('hideWhenDetached', () => {
+  let rendered: RenderResult;
+
+  afterEach(cleanup);
+
+  it('defaults hideWhenDetached to true', () => {
+    rendered = render(<PopoverTest />);
+    fireEvent.click(rendered.getByText(TRIGGER_TEXT));
+    const wrapper = document.querySelector('[data-radix-popper-content-wrapper]');
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('allows overriding hideWhenDetached to false', () => {
+    const { getByText } = render(
+      <Popover.Root>
+        <Popover.Trigger>{TRIGGER_TEXT}</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content hideWhenDetached={false}>{CONTENT_TEXT}</Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>,
+    );
+    fireEvent.click(getByText(TRIGGER_TEXT));
+    const wrapper = document.querySelector('[data-radix-popper-content-wrapper]');
+    expect(wrapper).toBeTruthy();
+  });
+});

--- a/packages/react/popover/src/popover.tsx
+++ b/packages/react/popover/src/popover.tsx
@@ -391,6 +391,7 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
       onPointerDownOutside,
       onFocusOutside,
       onInteractOutside,
+      hideWhenDetached: hideWhenDetachedProp,
       ...contentProps
     } = props;
     const context = usePopoverContext(CONTENT_NAME, __scopePopover);
@@ -425,6 +426,8 @@ const PopoverContentImpl = React.forwardRef<PopoverContentImplElement, PopoverCo
             {...popperScope}
             {...contentProps}
             ref={forwardedRef}
+            hideWhenDetached={hideWhenDetachedProp ?? true}
+            onReferenceHidden={() => context.onOpenChange(false)}
             style={{
               ...contentProps.style,
               // re-namespace exposed content custom properties

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -168,6 +168,7 @@ interface PopperContentProps extends PrimitiveDivProps {
   hideWhenDetached?: boolean;
   updatePositionStrategy?: 'optimized' | 'always';
   onPlaced?: () => void;
+  onReferenceHidden?: () => void;
 }
 
 const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>(
@@ -186,6 +187,7 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
       hideWhenDetached = false,
       updatePositionStrategy = 'optimized',
       onPlaced,
+      onReferenceHidden,
       ...contentProps
     } = props;
 
@@ -284,6 +286,13 @@ const PopperContent = React.forwardRef<PopperContentElement, PopperContentProps>
         handlePlaced?.();
       }
     }, [isPositioned, handlePlaced]);
+
+    const handleReferenceHidden = useCallbackRef(onReferenceHidden);
+    React.useEffect(() => {
+      if (middlewareData.hide?.referenceHidden) {
+        handleReferenceHidden?.();
+      }
+    }, [middlewareData.hide?.referenceHidden, handleReferenceHidden]);
 
     const arrowX = middlewareData.arrow?.x;
     const arrowY = middlewareData.arrow?.y;


### PR DESCRIPTION
Closes: #3688

**Problem**
When a Popover is opened inside a scrollable container and the user scrolls, the Popover content overflows its parent container and remains visible even after the trigger element has been scrolled out of view.

**Solution**
This PR adds logic to automatically close the Popover when its trigger element scrolls out of the visible viewport. This prevents the Popover from appearing detached from its trigger and overflowing the parent container.

**Storybook Example**
Added a new Storybook story demonstrating the fix:

Story name: Popover / In Scroll Container

Location: `apps/storybook/stories/popover.stories.tsx`

**Tests**

1. Unit Tests (`packages/react/popover/src/popover.test.tsx`):

- Tests hideWhenDetached prop defaults to true

- Tests ability to override hideWhenDetached to false

2. E2E Tests (`cypress/e2e/Popover.cy.ts`):

- Tests Popover closes when trigger scrolls out of view in a scrollable container