### PR TITLE
perf: reduce forced style recalculations during modal open

### DIFF
--- a/.changeset/sharp-cloths-dance.md
+++ b/.changeset/sharp-cloths-dance.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-focus-scope": patch
+"@radix-ui/react-presence": patch
+---
+
+Improved performance by reducing forced reflow in `FocusScope` and `Presence`

--- a/packages/react/focus-scope/src/focus-scope.test.tsx
+++ b/packages/react/focus-scope/src/focus-scope.test.tsx
@@ -130,6 +130,41 @@ describe('FocusScope', () => {
       ));
     });
   });
+
+  describe('given a FocusScope with hidden elements', () => {
+    let rendered: RenderResult;
+    let visibleFirst: HTMLInputElement;
+    let visibleLast: HTMLButtonElement;
+
+    beforeEach(() => {
+      rendered = render(
+        <div>
+          <FocusScope asChild loop trapped>
+            <form>
+              <TestField label={INNER_NAME_INPUT_LABEL} />
+              <TestField label="hidden-display" style={{ display: 'none' }} />
+              <TestField label="hidden-visibility" style={{ visibility: 'hidden' }} />
+              <button>{INNER_SUBMIT_LABEL}</button>
+            </form>
+          </FocusScope>
+        </div>,
+      );
+      visibleFirst = rendered.getByLabelText(INNER_NAME_INPUT_LABEL) as HTMLInputElement;
+      visibleLast = rendered.getByText(INNER_SUBMIT_LABEL) as HTMLButtonElement;
+    });
+
+    it('should skip elements with display: none when looping backward', async () => {
+      visibleFirst.focus();
+      await userEvent.tab({ shift: true });
+      await waitFor(() => expect(visibleLast).toHaveFocus());
+    });
+
+    it('should skip elements with visibility: hidden when looping forward', async () => {
+      visibleLast.focus();
+      await userEvent.tab();
+      await waitFor(() => expect(visibleFirst).toHaveFocus());
+    });
+  });
 });
 
 function TestField({ label, ...props }: { label: string } & React.ComponentProps<'input'>) {

--- a/packages/react/focus-scope/src/focus-scope.tsx
+++ b/packages/react/focus-scope/src/focus-scope.tsx
@@ -266,30 +266,27 @@ function getTabbableCandidates(container: HTMLElement) {
  * NOTE: Only checks visibility up to the `container`.
  */
 function findVisible(elements: HTMLElement[], container: HTMLElement) {
-  for (const element of elements) {
-    // we stop checking if it's hidden at the `container` level (excluding)
-    if (!isHidden(element, { upTo: container })) return element;
-  }
-}
-
-function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
   // `checkVisibility` performs a single native check for `visibility: hidden`
   // and `display: none` across the ancestor chain. This avoids the repeated
   // `getComputedStyle` calls per ancestor that the fallback path requires,
   // which reduces the cost of style resolution triggered by earlier DOM writes
   // (e.g. react-remove-scroll, DismissableLayer setting body styles).
-  //
-  // checkVisibility walks to the document root, but the original contract only
-  // checks ancestors strictly below `upTo`. When `upTo` itself is visible the
-  // two checks are equivalent — any hidden ancestor must be within scope. If
-  // `upTo` is hidden (rare: keyboard events don't fire on hidden containers)
-  // we fall back to the scoped loop to preserve the original contract.
-  if (typeof node.checkVisibility === 'function') {
-    if (!upTo || upTo.checkVisibility({ checkVisibilityCSS: true })) {
-      return !node.checkVisibility({ checkVisibilityCSS: true });
+  const canUseCheckVisibility =
+    typeof container.checkVisibility === 'function' &&
+    container.checkVisibility({ checkVisibilityCSS: true });
+
+  for (const element of elements) {
+    const hidden = canUseCheckVisibility
+      ? !element.checkVisibility({ checkVisibilityCSS: true })
+      : isHidden(element, { upTo: container });
+    // we stop checking if it's hidden at the `container` level (excluding)
+    if (!hidden) {
+      return element;
     }
   }
+}
 
+function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
   if (getComputedStyle(node).visibility === 'hidden') return true;
   while (node) {
     // we stop at `upTo` (excluding it)

--- a/packages/react/focus-scope/src/focus-scope.tsx
+++ b/packages/react/focus-scope/src/focus-scope.tsx
@@ -278,8 +278,16 @@ function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
   // `getComputedStyle` calls per ancestor that the fallback path requires,
   // which reduces the cost of style resolution triggered by earlier DOM writes
   // (e.g. react-remove-scroll, DismissableLayer setting body styles).
+  //
+  // checkVisibility walks to the document root, but the original contract only
+  // checks ancestors strictly below `upTo`. When `upTo` itself is visible the
+  // two checks are equivalent — any hidden ancestor must be within scope. If
+  // `upTo` is hidden (rare: keyboard events don't fire on hidden containers)
+  // we fall back to the scoped loop to preserve the original contract.
   if (typeof node.checkVisibility === 'function') {
-    return !node.checkVisibility({ checkVisibilityCSS: true });
+    if (!upTo || upTo.checkVisibility({ checkVisibilityCSS: true })) {
+      return !node.checkVisibility({ checkVisibilityCSS: true });
+    }
   }
 
   if (getComputedStyle(node).visibility === 'hidden') return true;

--- a/packages/react/focus-scope/src/focus-scope.tsx
+++ b/packages/react/focus-scope/src/focus-scope.tsx
@@ -273,6 +273,15 @@ function findVisible(elements: HTMLElement[], container: HTMLElement) {
 }
 
 function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
+  // `checkVisibility` performs a single native check for `visibility: hidden`
+  // and `display: none` across the ancestor chain. This avoids the repeated
+  // `getComputedStyle` calls per ancestor that the fallback path requires,
+  // which reduces the cost of style resolution triggered by earlier DOM writes
+  // (e.g. react-remove-scroll, DismissableLayer setting body styles).
+  if (typeof node.checkVisibility === 'function') {
+    return !node.checkVisibility({ checkVisibilityCSS: true });
+  }
+
   if (getComputedStyle(node).visibility === 'hidden') return true;
   while (node) {
     // we stop at `upTo` (excluding it)

--- a/packages/react/presence/src/presence.test.tsx
+++ b/packages/react/presence/src/presence.test.tsx
@@ -61,3 +61,85 @@ describe('ref stability', () => {
     expect(received).toBeInstanceOf(HTMLButtonElement);
   });
 });
+
+describe('mount/unmount behavior', () => {
+  afterEach(cleanup);
+
+  it('renders the child when present is true', () => {
+    const { queryByRole } = render(
+      <Presence present>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    expect(queryByRole('button')).not.toBeNull();
+  });
+
+  it('removes the child when present is false and no exit animation', () => {
+    const { queryByRole, rerender } = render(
+      <Presence present>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    rerender(
+      <Presence present={false}>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    expect(queryByRole('button')).toBeNull();
+  });
+
+  it('keeps the child mounted when toggling present back to true', () => {
+    const { queryByRole, rerender } = render(
+      <Presence present>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    rerender(
+      <Presence present={false}>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    rerender(
+      <Presence present>
+        <button type="button">Hello</button>
+      </Presence>,
+    );
+    expect(queryByRole('button')).not.toBeNull();
+  });
+});
+
+describe('render function children', () => {
+  afterEach(cleanup);
+
+  it('always renders the child when using a render function', () => {
+    const { queryByRole, rerender } = render(
+      <Presence present>
+        {({ present }) => <button type="button">{present ? 'visible' : 'hidden'}</button>}
+      </Presence>,
+    );
+    expect(queryByRole('button')).not.toBeNull();
+    expect(queryByRole('button')!.textContent).toBe('visible');
+
+    rerender(
+      <Presence present={false}>
+        {({ present }) => <button type="button">{present ? 'visible' : 'hidden'}</button>}
+      </Presence>,
+    );
+    // render function variant force-mounts: element stays in DOM
+    expect(queryByRole('button')).not.toBeNull();
+    expect(queryByRole('button')!.textContent).toBe('hidden');
+  });
+
+  it('passes present=true to the render function when present prop is true', () => {
+    let receivedPresent: boolean | undefined;
+    render(
+      <Presence present>
+        {({ present }) => {
+          receivedPresent = present;
+          return <div />;
+        }}
+      </Presence>,
+    );
+    expect(receivedPresent).toBe(true);
+  });
+});

--- a/packages/react/presence/src/presence.tsx
+++ b/packages/react/presence/src/presence.tsx
@@ -33,6 +33,7 @@ function usePresence(present: boolean) {
   const stylesRef = React.useRef<CSSStyleDeclaration | null>(null);
   const prevPresentRef = React.useRef(present);
   const prevAnimationNameRef = React.useRef<string>('none');
+  const mountAnimationNameRef = React.useRef<string | undefined>(undefined);
   const initialState = present ? 'mounted' : 'unmounted';
   const [state, send] = useStateMachine(initialState, {
     mounted: {
@@ -49,8 +50,19 @@ function usePresence(present: boolean) {
   });
 
   React.useEffect(() => {
-    const currentAnimationName = getAnimationName(stylesRef.current);
-    prevAnimationNameRef.current = state === 'mounted' ? currentAnimationName : 'none';
+    if (state === 'mounted') {
+      // Use the animation name captured during the layout phase (or the ref
+      // callback on first mount). By the time this passive effect runs,
+      // sibling effects like react-remove-scroll and DismissableLayer may have
+      // dirtied body styles, so re-reading from the live CSSStyleDeclaration
+      // here would force an expensive synchronous style recalculation.
+      // See: https://github.com/radix-ui/primitives/issues/1634
+      prevAnimationNameRef.current =
+        mountAnimationNameRef.current ?? getAnimationName(stylesRef.current);
+      mountAnimationNameRef.current = undefined;
+    } else {
+      prevAnimationNameRef.current = 'none';
+    }
   }, [state]);
 
   useLayoutEffect(() => {
@@ -63,6 +75,11 @@ function usePresence(present: boolean) {
       const currentAnimationName = getAnimationName(styles);
 
       if (present) {
+        // Capture the animation name now, while styles are still "clean"
+        // (before sibling passive effects dirty the body). The later passive
+        // effect will read from this ref instead of the live
+        // CSSStyleDeclaration, avoiding a forced style recalculation.
+        mountAnimationNameRef.current = currentAnimationName;
         send('MOUNT');
       } else if (currentAnimationName === 'none' || styles?.display === 'none') {
         // If there is no exit animation or the element is hidden, animations won't run
@@ -154,7 +171,18 @@ function usePresence(present: boolean) {
   return {
     isPresent: ['mounted', 'unmountSuspended'].includes(state),
     ref: React.useCallback((node: HTMLElement) => {
-      stylesRef.current = node ? getComputedStyle(node) : null;
+      if (node) {
+        const styles = getComputedStyle(node);
+        stylesRef.current = styles;
+        // Eagerly read the animation name while styles are clean. Ref
+        // callbacks fire during the commit phase, before any passive effects
+        // can dirty body styles. This cached value is consumed by the passive
+        // effect that records prevAnimationNameRef, letting it skip a
+        // redundant (and expensive) live-style read.
+        mountAnimationNameRef.current = getAnimationName(styles);
+      } else {
+        stylesRef.current = null;
+      }
       setNode(node);
     }, []),
   };


### PR DESCRIPTION
### Description

Reduces forced style recalculations triggered during modal/dialog open by optimizing two hot paths:

**1. `FocusScope.isHidden()` — use `Element.checkVisibility()`**

```diff
 function isHidden(node, { upTo }) {
+  if (typeof node.checkVisibility === 'function') {
+    return !node.checkVisibility({ checkVisibilityCSS: true });
+  }
+  // fallback: per-ancestor getComputedStyle loop
   ...
 }
```

The per-ancestor `getComputedStyle` loop is expensive when body styles have been dirtied by `react-remove-scroll` / `DismissableLayer`. `checkVisibility()` performs a single native check for both `visibility: hidden` and `display: none` across the ancestor chain.

**2. `Presence.usePresence()` — cache `animationName` from layout/ref phase**

```diff
+  const mountAnimationNameRef = React.useRef<string | undefined>(undefined);

   // ref callback (commit phase, before passive effects)
   ref: useCallback((node) => {
     stylesRef.current = getComputedStyle(node);
+    mountAnimationNameRef.current = getAnimationName(stylesRef.current);
   }, [])

   // passive effect (after sibling effects may have dirtied body)
   useEffect(() => {
-    prevAnimationNameRef.current = getAnimationName(stylesRef.current);
+    prevAnimationNameRef.current = mountAnimationNameRef.current ?? getAnimationName(stylesRef.current);
+    mountAnimationNameRef.current = undefined;
   }, [state]);
```

By the time the passive effect runs, sibling effects (`react-remove-scroll`, `DismissableLayer`) have written inherited styles to `<body>`, invalidating style caches. Reading from the live `CSSStyleDeclaration` at that point forces a synchronous style recalculation. The fix captures the value eagerly during the commit phase when styles are still clean.

**Tests added:**
- `FocusScope`: verify `display: none` and `visibility: hidden` elements are skipped during tab navigation
- `Presence`: verify mount/unmount behavior and render-function children pass correct `isPresent` value

**Remaining reflow sources (external):** `react-remove-scroll` writing inherited CSS vars on body, `aria-hidden` walking the DOM. A future improvement could replace both with the native `inert` attribute.

Ref: https://github.com/radix-ui/primitives/issues/1634

Link to Devin session: https://app.devin.ai/sessions/eab354d202a141f7b4d4ae5642eec8b7
Requested by: @chaance