### PR TITLE
Fix `ContextMenu` anchoring when re-triggered

### DIFF
--- a/.changeset/context-menu-reanchor.md
+++ b/.changeset/context-menu-reanchor.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-context-menu": patch
+---
+
+Fixed `ContextMenu` not re-anchoring to the latest pointer position when re-triggered while already open.

--- a/packages/react/context-menu/src/context-menu.test.tsx
+++ b/packages/react/context-menu/src/context-menu.test.tsx
@@ -39,6 +39,25 @@ describe('rendering and opening', () => {
     expect(screen.getByText(TRIGGER_TEXT)).toHaveAttribute('data-state', 'open');
   });
 
+  it('re-anchors the content when re-triggered in a new location while open', async () => {
+    render(<ContextMenuTest />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+
+    fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10 });
+    await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+
+    const wrapper = () =>
+      document.querySelector('[data-radix-popper-content-wrapper]') as HTMLElement;
+    await waitFor(() => expect(wrapper()).toBeTruthy());
+    const initialTransform = wrapper().style.transform;
+
+    // Right-click again in a different location while the menu is still open.
+    fireEvent.contextMenu(trigger, { clientX: 200, clientY: 150 });
+
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    await waitFor(() => expect(wrapper().style.transform).not.toEqual(initialTransform));
+  });
+
   it('closes the content when pressing escape', async () => {
     render(<ContextMenuTest />);
     fireEvent.contextMenu(screen.getByText(TRIGGER_TEXT));

--- a/packages/react/context-menu/src/context-menu.tsx
+++ b/packages/react/context-menu/src/context-menu.tsx
@@ -109,10 +109,19 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
     const { __scopeContextMenu, disabled = false, ...triggerProps } = props;
     const context = useContextMenuContext(TRIGGER_NAME, __scopeContextMenu);
     const menuScope = useMenuScope(__scopeContextMenu);
-    const pointRef = React.useRef<Point>({ x: 0, y: 0 });
-    const virtualRef = React.useRef({
-      getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, ...pointRef.current }),
-    });
+    const [point, setPoint] = React.useState<Point>({ x: 0, y: 0 });
+
+    // Re-create the virtual anchor whenever the pointer position changes so the
+    // content re-anchors to the latest point when the menu is re-triggered while
+    // already open (e.g. right-clicking in a new location, #2611).
+    const virtualRef = React.useMemo(
+      () => ({
+        current: {
+          getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, ...point }),
+        },
+      }),
+      [point],
+    );
     const longPressTimerRef = React.useRef(0);
     const clearLongPress = React.useCallback(
       () => window.clearTimeout(longPressTimerRef.current),
@@ -120,7 +129,7 @@ const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMe
     );
     const handleOpen = (event: React.MouseEvent | React.PointerEvent) => {
       context.hasInteractedRef.current = true;
-      pointRef.current = { x: event.clientX, y: event.clientY };
+      setPoint({ x: event.clientX, y: event.clientY });
       context.onOpenChange(true);
     };
 


### PR DESCRIPTION
Closes #2611