### PR TITLE
Fixed `Toast` removing non-focused toasts when pressing `Escape`

### DIFF
--- a/.changeset/toast-escape-focused-removal.md
+++ b/.changeset/toast-escape-focused-removal.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-toast": patch
+---
+
+Fixed `Toast` removing non-focused toasts when pressing `Escape`.

--- a/packages/react/toast/src/toast.test.tsx
+++ b/packages/react/toast/src/toast.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
 import * as Toast from './toast';
 import { describe, it, afterEach, beforeEach, vi, expect, type Mock } from 'vitest';
 import { assertStableComposedRef } from '@repo/test-utils/ref-stability';
@@ -17,6 +17,52 @@ describe('ref stability', () => {
         <Toast.Viewport />
       </Toast.Provider>
     ));
+  });
+});
+
+// Regression test for https://github.com/radix-ui/primitives/issues/2906
+describe('escape key removal', () => {
+  afterEach(cleanup);
+
+  function renderToasts(onOpenChange: { first: Mock; second: Mock; third: Mock }) {
+    render(
+      <Toast.Provider>
+        <Toast.Root open duration={Infinity} onOpenChange={onOpenChange.first}>
+          <Toast.Title>Toast 1</Toast.Title>
+        </Toast.Root>
+        <Toast.Root open duration={Infinity} onOpenChange={onOpenChange.second}>
+          <Toast.Title>Toast 2</Toast.Title>
+        </Toast.Root>
+        <Toast.Root open duration={Infinity} onOpenChange={onOpenChange.third}>
+          <Toast.Title>Toast 3</Toast.Title>
+        </Toast.Root>
+        <Toast.Viewport />
+      </Toast.Provider>,
+    );
+  }
+
+  it('closes only the focused (non-topmost) toast on Escape', () => {
+    const onOpenChange = { first: vi.fn(), second: vi.fn(), third: vi.fn() };
+    renderToasts(onOpenChange);
+
+    const focusedToast = screen.getByText('Toast 2').closest('li')!;
+    focusedToast.focus();
+    fireEvent.keyDown(focusedToast, { key: 'Escape' });
+
+    expect(onOpenChange.second).toHaveBeenCalledWith(false);
+    expect(onOpenChange.first).not.toHaveBeenCalled();
+    expect(onOpenChange.third).not.toHaveBeenCalled();
+  });
+
+  it('closes the topmost toast on Escape when focus is outside any toast', () => {
+    const onOpenChange = { first: vi.fn(), second: vi.fn(), third: vi.fn() };
+    renderToasts(onOpenChange);
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+
+    expect(onOpenChange.third).toHaveBeenCalledWith(false);
+    expect(onOpenChange.first).not.toHaveBeenCalled();
+    expect(onOpenChange.second).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/react/toast/src/toast.tsx
+++ b/packages/react/toast/src/toast.tsx
@@ -34,7 +34,6 @@ type ToastProviderContextValue = {
   onViewportChange(viewport: ToastViewportElement): void;
   onToastAdd(): void;
   onToastRemove(): void;
-  isFocusedToastEscapeKeyDownRef: React.MutableRefObject<boolean>;
   isClosePausedRef: React.MutableRefObject<boolean>;
   announcerContainer?: Element | DocumentFragment;
 };
@@ -88,7 +87,6 @@ const ToastProvider: React.FC<ToastProviderProps> = (props: ScopedProps<ToastPro
   } = props;
   const [viewport, setViewport] = React.useState<ToastViewportElement | null>(null);
   const [toastCount, setToastCount] = React.useState(0);
-  const isFocusedToastEscapeKeyDownRef = React.useRef(false);
   const isClosePausedRef = React.useRef(false);
 
   if (!label.trim()) {
@@ -110,7 +108,6 @@ const ToastProvider: React.FC<ToastProviderProps> = (props: ScopedProps<ToastPro
         onViewportChange={setViewport}
         onToastAdd={React.useCallback(() => setToastCount((prevCount) => prevCount + 1), [])}
         onToastRemove={React.useCallback(() => setToastCount((prevCount) => prevCount - 1), [])}
-        isFocusedToastEscapeKeyDownRef={isFocusedToastEscapeKeyDownRef}
         isClosePausedRef={isClosePausedRef}
         announcerContainer={announcerContainer}
       >
@@ -489,6 +486,7 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
       ...toastProps
     } = props;
     const context = useToastProviderContext(TOAST_NAME, __scopeToast);
+    const getItems = useCollection(__scopeToast);
     const [node, setNode] = React.useState<ToastImplElement | null>(null);
     const composedRefs = useComposedRefs(forwardedRef, setNode);
     const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
@@ -581,9 +579,19 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
             <Collection.ItemSlot scope={__scopeToast}>
               <DismissableLayer.Root
                 asChild
-                onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, () => {
-                  if (!context.isFocusedToastEscapeKeyDownRef.current) handleClose();
-                  context.isFocusedToastEscapeKeyDownRef.current = false;
+                onEscapeKeyDown={composeEventHandlers(onEscapeKeyDown, (event) => {
+                  // Only the highest layer (most recent toast) registers the
+                  // escape listener, and it runs in the capture phase. If the
+                  // key press originated from within a focused toast, that
+                  // toast closes itself via `onKeyDown` below, so we must not
+                  // also close this (top-most) toast. Otherwise, close it.
+                  // See: https://github.com/radix-ui/primitives/issues/2906
+                  const isFocusInToast = getItems().some((item) =>
+                    item.ref.current?.contains(event.target as Node | null),
+                  );
+                  if (!isFocusInToast) {
+                    handleClose();
+                  }
                 })}
               >
                 <Primitive.li
@@ -597,7 +605,6 @@ const ToastImpl = React.forwardRef<ToastImplElement, ToastImplProps>(
                     if (event.key !== 'Escape') return;
                     onEscapeKeyDown?.(event.nativeEvent);
                     if (!event.nativeEvent.defaultPrevented) {
-                      context.isFocusedToastEscapeKeyDownRef.current = true;
                       handleClose();
                     }
                   })}


### PR DESCRIPTION
Closes #2906