### PR TITLE
fix(checkbox): restore value when externally associated form is reset

### DIFF
--- a/.changeset/checkbox-form-reset.md
+++ b/.changeset/checkbox-form-reset.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-checkbox": patch
+"radix-ui": patch
+---
+
+Fixed a bug where `Checkbox` did not restore its value when an externally associated form (via the `form` prop) was reset. This brings `Checkbox` in line with the fix already applied to `RadioGroup`, `Select`, `Slider`, and `Switch`.

--- a/apps/storybook/stories/checkbox.stories.tsx
+++ b/apps/storybook/stories/checkbox.stories.tsx
@@ -193,6 +193,100 @@ export const WithinForm = () => {
   );
 };
 
+export const WithinFormReset = () => {
+  const [controlled, setControlled] = React.useState<boolean | 'indeterminate'>(true);
+  const [externalControlled, setExternalControlled] = React.useState<boolean | 'indeterminate'>(
+    true,
+  );
+
+  return (
+    <>
+      <form onSubmit={(event) => event.preventDefault()}>
+        <p>
+          Check/uncheck the boxes, then press <strong>Reset</strong>. Each checkbox returns to its
+          initial value (the uncontrolled checkbox via its <code>defaultChecked</code>, the
+          controlled checkbox via its initial <code>checked</code> state).
+        </p>
+
+        <fieldset>
+          <legend>Uncontrolled (defaultChecked)</legend>
+          <label>
+            <Checkbox.Root className={styles.root} name="uncontrolled" defaultChecked>
+              <Checkbox.Indicator className={styles.indicator} />
+            </Checkbox.Root>{' '}
+            with label
+          </label>
+        </fieldset>
+
+        <br />
+
+        <fieldset>
+          <legend>Controlled checked: {String(controlled)}</legend>
+          <label>
+            <Checkbox.Root
+              className={styles.root}
+              name="controlled"
+              checked={controlled}
+              onCheckedChange={setControlled}
+            >
+              <Checkbox.Indicator className={styles.indicator} />
+            </Checkbox.Root>{' '}
+            with label
+          </label>
+        </fieldset>
+
+        <br />
+
+        <button type="reset">Reset</button>
+      </form>
+
+      <hr />
+
+      <p>
+        These checkboxes are associated with the form below via the <code>form</code> prop even
+        though they're rendered outside of it.
+      </p>
+
+      <form id="checkbox-reset-form" onSubmit={(event) => event.preventDefault()}>
+        <button type="reset">Reset external form</button>
+      </form>
+
+      <fieldset>
+        <legend>Uncontrolled (defaultChecked), external form</legend>
+        <label>
+          <Checkbox.Root
+            className={styles.root}
+            name="externalUncontrolled"
+            form="checkbox-reset-form"
+            defaultChecked
+          >
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.Root>{' '}
+          with label
+        </label>
+      </fieldset>
+
+      <br />
+
+      <fieldset>
+        <legend>Controlled checked: {String(externalControlled)}, external form</legend>
+        <label>
+          <Checkbox.Root
+            className={styles.root}
+            name="externalControlled"
+            form="checkbox-reset-form"
+            checked={externalControlled}
+            onCheckedChange={setExternalControlled}
+          >
+            <Checkbox.Indicator className={styles.indicator} />
+          </Checkbox.Root>{' '}
+          with label
+        </label>
+      </fieldset>
+    </>
+  );
+};
+
 export const LegacyStyled = () => (
   <>
     <p>This checkbox is nested inside a label. The state is uncontrolled.</p>

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -298,6 +298,121 @@ describe('Checkbox', () => {
   });
 });
 
+describe('given a Checkbox in a form', () => {
+  afterEach(cleanup);
+
+  describe('uncontrolled', () => {
+    it('should restore its `defaultChecked` value when the form is reset', () => {
+      render(
+        <form>
+          <Checkbox.Root name="agree" defaultChecked>
+            <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+          </Checkbox.Root>
+          <button type="reset">Reset</button>
+        </form>,
+      );
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      act(() => fireEvent.click(checkbox));
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      act(() => fireEvent.click(screen.getByText('Reset')));
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  describe('controlled', () => {
+    it('should restore its initial `checked` value when the form is reset', () => {
+      function ControlledCheckbox() {
+        const [checked, setChecked] = React.useState<boolean>(true);
+        return (
+          <form>
+            <Checkbox.Root name="agree" checked={checked} onCheckedChange={setChecked as any}>
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.Root>
+            <button type="reset">Reset</button>
+          </form>
+        );
+      }
+
+      render(<ControlledCheckbox />);
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      act(() => fireEvent.click(checkbox));
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      act(() => fireEvent.click(screen.getByText('Reset')));
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});
+
+describe('given a Checkbox with external form association', () => {
+  afterEach(cleanup);
+
+  describe('uncontrolled', () => {
+    it('should restore its `defaultChecked` value when the external form is reset', () => {
+      render(
+        <>
+          <form id="checkbox-reset-form">
+            <button type="reset">Reset</button>
+          </form>
+          <Checkbox.Root name="agree" form="checkbox-reset-form" defaultChecked>
+            <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+          </Checkbox.Root>
+        </>,
+      );
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      act(() => fireEvent.click(checkbox));
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      act(() => fireEvent.click(screen.getByRole('button', { name: 'Reset' })));
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  describe('controlled', () => {
+    it('should restore its initial `checked` value when the external form is reset', () => {
+      function ControlledCheckbox() {
+        const [checked, setChecked] = React.useState<boolean>(true);
+        return (
+          <>
+            <form id="checkbox-reset-form">
+              <button type="reset">Reset</button>
+            </form>
+            <Checkbox.Root
+              name="agree"
+              form="checkbox-reset-form"
+              checked={checked}
+              onCheckedChange={setChecked as any}
+            >
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.Root>
+          </>
+        );
+      }
+
+      render(<ControlledCheckbox />);
+
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      act(() => fireEvent.click(checkbox));
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      act(() => fireEvent.click(screen.getByRole('button', { name: 'Reset' })));
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});
+
 describe('Legacy Checkbox', () => {
   describe('given a default Checkbox', () => {
     let rendered: RenderResult;

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -136,6 +136,7 @@ const CheckboxTrigger = React.forwardRef<HTMLButtonElement, CheckboxTriggerProps
       disabled,
       checked,
       required,
+      form,
       setControl,
       setChecked,
       hasConsumerStoppedPropagationRef,
@@ -146,13 +147,13 @@ const CheckboxTrigger = React.forwardRef<HTMLButtonElement, CheckboxTriggerProps
 
     const initialCheckedStateRef = React.useRef(checked);
     React.useEffect(() => {
-      const form = control?.form;
-      if (form) {
+      const associatedForm = form ? control?.ownerDocument.getElementById(form) : control?.form;
+      if (associatedForm instanceof HTMLFormElement) {
         const reset = () => setChecked(initialCheckedStateRef.current);
-        form.addEventListener('reset', reset);
-        return () => form.removeEventListener('reset', reset);
+        associatedForm.addEventListener('reset', reset);
+        return () => associatedForm.removeEventListener('reset', reset);
       }
-    }, [control, setChecked]);
+    }, [control, form, setChecked]);
 
     return (
       <Primitive.button


### PR DESCRIPTION
### Description

`Checkbox` only listened for the form `reset` event via `control?.form` (i.e. an ancestor `<form>` element). Unlike `RadioGroup`, `Select`, `Slider`, and `Switch` (fixed in #3958), it never resolved the `form` prop by id via `ownerDocument.getElementById(form)`, so a `Checkbox` associated with an external form (`<Checkbox.Root form="my-form" />` rendered outside `<form id="my-form">`) did not restore its value when that form was reset.

This brings `Checkbox` in line with the fix already applied to the other form controls in #3958.

- `packages/react/checkbox/src/checkbox.tsx`: resolve the associated form the same way `Switch`/`RadioGroup` do.
- `packages/react/checkbox/src/checkbox.test.tsx`: added controlled/uncontrolled tests for both ancestor-form and external (`form` prop) reset, mirroring `switch.test.tsx`. Ran `pnpm test` — 30/30 passing (26 existing + 4 new). Confirmed the 2 new external-form tests fail without the fix and pass with it.
- `apps/storybook/stories/checkbox.stories.tsx`: added a `WithinFormReset` story (mirrors Switch's) covering both the ancestor-form and external-form cases.
- Added a changeset.