### PR TITLE
Navigation Menu: Add `activationMode` and `disableToggle` props

### DIFF
--- a/.changeset/eighty-baboons-go.md
+++ b/.changeset/eighty-baboons-go.md
@@ -1,0 +1,9 @@
+---
+"@radix-ui/react-navigation-menu": minor
+"radix-ui": minor 
+---
+
+Added a `disableToggle` prop to `NavigationMenu.Sub`.
+
+- `true`: Clicking the trigger of an already-open submenu item keeps it open. This is the default and matches existing behavior.
+- `false`: Clicking the trigger of a submenu item toggles it open or closed.

--- a/.changeset/floppy-cloths-lay.md
+++ b/.changeset/floppy-cloths-lay.md
@@ -1,11 +1,11 @@
 ---
-"radix-ui": minor
 "@radix-ui/react-navigation-menu": minor
+"radix-ui": minor
 ---
 
 Added an `activationMode` prop to `NavigationMenu.Root` and `NavigationMenu.Sub`.
 
-- `"automatic"`: hovering or focusing a trigger opens its item, and moving away from the trigger closes it after a short delay. This is the default and matches the existing behavior.
-- `"manual"`: pointer entry and focus never open an item; the user toggles items by clicking their trigger. An open item stays open until its trigger is clicked again, another trigger is clicked, the user clicks outside, or `Escape` is pressed.
+- `"automatic"`: Hovering or focusing a trigger opens its item, and moving away from the trigger closes it after a short delay. This is the default and matches existing behavior.
+- `"manual"`: Pointer entry and focus never open an item; the item is opened by clicking its trigger.
 
 When `activationMode` is omitted on `NavigationMenu.Sub`, it inherits the value from the parent `NavigationMenu.Root`, so setting `"manual"` on the root also applies to submenus unless a submenu opts back in to `"automatic"`.

--- a/.changeset/floppy-cloths-lay.md
+++ b/.changeset/floppy-cloths-lay.md
@@ -1,0 +1,11 @@
+---
+"radix-ui": minor
+"@radix-ui/react-navigation-menu": minor
+---
+
+Added an `activationMode` prop to `NavigationMenu.Root` and `NavigationMenu.Sub`.
+
+- `"automatic"`: hovering or focusing a trigger opens its item, and moving away from the trigger closes it after a short delay. This is the default and matches the existing behavior.
+- `"manual"`: pointer entry and focus never open an item; the user toggles items by clicking their trigger. An open item stays open until its trigger is clicked again, another trigger is clicked, the user clicks outside, or `Escape` is pressed.
+
+When `activationMode` is omitted on `NavigationMenu.Sub`, it inherits the value from the parent `NavigationMenu.Root`, so setting `"manual"` on the root also applies to submenus unless a submenu opts back in to `"automatic"`.

--- a/.changeset/navigation-menu-sub-trigger-behavior.md
+++ b/.changeset/navigation-menu-sub-trigger-behavior.md
@@ -1,7 +1,0 @@
----
-"@radix-ui/react-navigation-menu": minor
----
-
-Added a `triggerBehavior` prop to `NavigationMenu.Sub`.
-- `"open"`: default, current behavior where clicking a trigger only opens its item
-- `"toggle"`: clicking the trigger of an already open item closes it, matching the root `NavigationMenu`)

--- a/.changeset/navigation-menu-sub-trigger-behavior.md
+++ b/.changeset/navigation-menu-sub-trigger-behavior.md
@@ -1,0 +1,7 @@
+---
+"@radix-ui/react-navigation-menu": minor
+---
+
+Added a `triggerBehavior` prop to `NavigationMenu.Sub`.
+- `"open"`: default, current behavior where clicking a trigger only opens its item
+- `"toggle"`: clicking the trigger of an already open item closes it, matching the root `NavigationMenu`)

--- a/apps/storybook/stories/navigation-menu.stories.tsx
+++ b/apps/storybook/stories/navigation-menu.stories.tsx
@@ -190,6 +190,7 @@ export const Viewport = () => {
 type SubmenusStory = StoryObj<{
   activationMode?: NavigationMenu.ActivationMode;
   submenuActivationMode?: NavigationMenu.ActivationMode;
+  submenuDisableToggle?: boolean;
 }>;
 
 export const Submenus = {
@@ -202,10 +203,13 @@ export const Submenus = {
       control: 'select',
       options: ['automatic', 'manual'],
     },
+    submenuDisableToggle: {
+      control: 'boolean',
+    },
   },
   render: (args) => (
     <StoryFrame>
-      <NavigationMenu.Root activationMode={args.activationMode || undefined}>
+      <NavigationMenu.Root activationMode={args.activationMode}>
         <NavigationMenu.List className={styles.mainList}>
           <NavigationMenu.Item>
             <TriggerWithIndicator>Products</TriggerWithIndicator>
@@ -213,7 +217,8 @@ export const Submenus = {
               <NavigationMenu.Sub
                 className={styles.submenusRoot}
                 defaultValue="extensibility"
-                activationMode={args.submenuActivationMode || undefined}
+                activationMode={args.submenuActivationMode}
+                disableToggle={args.submenuDisableToggle}
               >
                 <NavigationMenu.List className={styles.mainList}>
                   <NavigationMenu.Item value="extensibility">

--- a/apps/storybook/stories/navigation-menu.stories.tsx
+++ b/apps/storybook/stories/navigation-menu.stories.tsx
@@ -3,8 +3,11 @@ import { customMergeProps } from './custom-merge-props';
 import { Dialog, NavigationMenu, Direction, Slot } from 'radix-ui';
 import styles from './navigation-menu.stories.module.css';
 import dialogStyles from './dialog.stories.module.css';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
-export default { title: 'Components/NavigationMenu' };
+export default {
+  title: 'Components/NavigationMenu',
+} satisfies Meta<typeof NavigationMenu.Root>;
 
 export const Basic = () => {
   return (
@@ -184,15 +187,34 @@ export const Viewport = () => {
   );
 };
 
-export const Submenus = () => {
-  return (
+type SubmenusStory = StoryObj<{
+  activationMode?: NavigationMenu.ActivationMode;
+  submenuActivationMode?: NavigationMenu.ActivationMode;
+}>;
+
+export const Submenus = {
+  argTypes: {
+    activationMode: {
+      control: 'select',
+      options: ['automatic', 'manual'],
+    },
+    submenuActivationMode: {
+      control: 'select',
+      options: ['automatic', 'manual'],
+    },
+  },
+  render: (args) => (
     <StoryFrame>
-      <NavigationMenu.Root>
+      <NavigationMenu.Root activationMode={args.activationMode || undefined}>
         <NavigationMenu.List className={styles.mainList}>
           <NavigationMenu.Item>
             <TriggerWithIndicator>Products</TriggerWithIndicator>
             <NavigationMenu.Content className={styles.submenusContent}>
-              <NavigationMenu.Sub className={styles.submenusRoot} defaultValue="extensibility">
+              <NavigationMenu.Sub
+                className={styles.submenusRoot}
+                defaultValue="extensibility"
+                activationMode={args.submenuActivationMode || undefined}
+              >
                 <NavigationMenu.List className={styles.mainList}>
                   <NavigationMenu.Item value="extensibility">
                     <NavigationMenu.Trigger className={styles.submenusSubTrigger}>
@@ -367,8 +389,8 @@ export const Submenus = () => {
         <NavigationMenu.Viewport className={styles.submenusViewport} />
       </NavigationMenu.Root>
     </StoryFrame>
-  );
-};
+  ),
+} satisfies SubmenusStory;
 
 export const WithCustomMergeProps = () => (
   <Slot.Provider mergeProps={customMergeProps}>
@@ -584,12 +606,22 @@ export const InsideDialog = () => {
 
 /* -----------------------------------------------------------------------------------------------*/
 
-const StoryFrame: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const StoryFrame: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
   const [rtl, setRtl] = React.useState(false);
 
   return (
     <div style={{ height: '100vh', backgroundColor: '#e5e8eb' }}>
-      <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 20, paddingBottom: 30 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          paddingTop: 20,
+          paddingBottom: 30,
+          gap: 16,
+        }}
+      >
         <label>
           <input
             type="checkbox"
@@ -685,132 +717,6 @@ const DurationNavigation = (props: React.ComponentProps<typeof NavigationMenu.Ro
           </NavigationMenu.Content>
         </NavigationMenu.Item>
       </NavigationMenu.List>
-    </NavigationMenu.Root>
-  );
-};
-
-export const ActivationMode = () => {
-  return (
-    <div
-      style={{
-        minHeight: '100vh',
-        backgroundColor: '#e5e8eb',
-        paddingBottom: 150,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}
-    >
-      <h1>Root activation mode</h1>
-      <h2>Default (&quot;automatic&quot;): hovering or focusing a trigger opens its item</h2>
-      <ActivationModeNavigation />
-
-      <h2>&quot;manual&quot;: hover does nothing; click a trigger to toggle its item</h2>
-      <ActivationModeNavigation activationMode="manual" />
-
-      <h1 style={{ marginTop: 50 }}>Submenu activation mode</h1>
-      <h2>Submenu inherits &quot;manual&quot; from the root (click to toggle)</h2>
-      <SubActivationModeNavigation rootActivationMode="manual" />
-
-      <h2>Submenu overrides the root&apos;s &quot;manual&quot; back to &quot;automatic&quot;</h2>
-      <SubActivationModeNavigation rootActivationMode="manual" subActivationMode="automatic" />
-    </div>
-  );
-};
-
-const ActivationModeNavigation = (props: React.ComponentProps<typeof NavigationMenu.Root>) => {
-  return (
-    <NavigationMenu.Root
-      {...props}
-      style={{ backgroundColor: 'white', borderRadius: 500, padding: '2px 12px', ...props.style }}
-    >
-      <NavigationMenu.List className={styles.mainList}>
-        <NavigationMenu.Item className={styles.expandableItem}>
-          <TriggerWithIndicator>Products</TriggerWithIndicator>
-          <NavigationMenu.Content className={styles.basicContent}>
-            <LinkGroup
-              bordered={false}
-              items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
-            />
-          </NavigationMenu.Content>
-        </NavigationMenu.Item>
-
-        <NavigationMenu.Item className={styles.expandableItem}>
-          <TriggerWithIndicator>Company</TriggerWithIndicator>
-          <NavigationMenu.Content className={styles.basicContent}>
-            <LinkGroup
-              bordered={false}
-              items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
-            />
-          </NavigationMenu.Content>
-        </NavigationMenu.Item>
-      </NavigationMenu.List>
-    </NavigationMenu.Root>
-  );
-};
-
-const SubActivationModeNavigation = ({
-  rootActivationMode,
-  subActivationMode,
-}: {
-  rootActivationMode?: React.ComponentProps<typeof NavigationMenu.Root>['activationMode'];
-  subActivationMode?: React.ComponentProps<typeof NavigationMenu.Sub>['activationMode'];
-}) => {
-  return (
-    <NavigationMenu.Root
-      activationMode={rootActivationMode}
-      style={{ backgroundColor: 'white', borderRadius: 500, padding: '2px 12px' }}
-    >
-      <NavigationMenu.List className={styles.mainList}>
-        <NavigationMenu.Item>
-          <TriggerWithIndicator>Products</TriggerWithIndicator>
-          <NavigationMenu.Content className={styles.submenusContent}>
-            <NavigationMenu.Sub
-              className={styles.submenusRoot}
-              defaultValue="extensibility"
-              activationMode={subActivationMode}
-            >
-              <NavigationMenu.List className={styles.mainList}>
-                <NavigationMenu.Item value="extensibility">
-                  <NavigationMenu.Trigger className={styles.submenusSubTrigger}>
-                    Extensibility
-                  </NavigationMenu.Trigger>
-                  <NavigationMenu.Content
-                    className={styles.submenusSubContent}
-                    style={{ gridTemplateColumns: '1fr 1fr' }}
-                  >
-                    <LinkGroup items={['Donec quis dui', 'Vestibulum', 'Nunc dignissim']} />
-                    <LinkGroup
-                      items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
-                    />
-                  </NavigationMenu.Content>
-                </NavigationMenu.Item>
-
-                <NavigationMenu.Item value="security">
-                  <NavigationMenu.Trigger className={styles.submenusSubTrigger}>
-                    Security
-                  </NavigationMenu.Trigger>
-                  <NavigationMenu.Content
-                    className={styles.submenusSubContent}
-                    style={{ gridTemplateColumns: '1fr 1fr' }}
-                  >
-                    <LinkGroup
-                      items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
-                    />
-                    <LinkGroup items={['Fusce pellentesque', 'Aliquam porttitor']} />
-                  </NavigationMenu.Content>
-                </NavigationMenu.Item>
-
-                <NavigationMenu.Indicator className={styles.submenusSubIndicator} />
-              </NavigationMenu.List>
-
-              <NavigationMenu.Viewport className={styles.submenusSubViewport} />
-            </NavigationMenu.Sub>
-          </NavigationMenu.Content>
-        </NavigationMenu.Item>
-      </NavigationMenu.List>
-
-      <NavigationMenu.Viewport className={styles.submenusViewport} />
     </NavigationMenu.Root>
   );
 };

--- a/apps/storybook/stories/navigation-menu.stories.tsx
+++ b/apps/storybook/stories/navigation-menu.stories.tsx
@@ -689,6 +689,132 @@ const DurationNavigation = (props: React.ComponentProps<typeof NavigationMenu.Ro
   );
 };
 
+export const ActivationMode = () => {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        backgroundColor: '#e5e8eb',
+        paddingBottom: 150,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+    >
+      <h1>Root activation mode</h1>
+      <h2>Default (&quot;automatic&quot;): hovering or focusing a trigger opens its item</h2>
+      <ActivationModeNavigation />
+
+      <h2>&quot;manual&quot;: hover does nothing; click a trigger to toggle its item</h2>
+      <ActivationModeNavigation activationMode="manual" />
+
+      <h1 style={{ marginTop: 50 }}>Submenu activation mode</h1>
+      <h2>Submenu inherits &quot;manual&quot; from the root (click to toggle)</h2>
+      <SubActivationModeNavigation rootActivationMode="manual" />
+
+      <h2>Submenu overrides the root&apos;s &quot;manual&quot; back to &quot;automatic&quot;</h2>
+      <SubActivationModeNavigation rootActivationMode="manual" subActivationMode="automatic" />
+    </div>
+  );
+};
+
+const ActivationModeNavigation = (props: React.ComponentProps<typeof NavigationMenu.Root>) => {
+  return (
+    <NavigationMenu.Root
+      {...props}
+      style={{ backgroundColor: 'white', borderRadius: 500, padding: '2px 12px', ...props.style }}
+    >
+      <NavigationMenu.List className={styles.mainList}>
+        <NavigationMenu.Item className={styles.expandableItem}>
+          <TriggerWithIndicator>Products</TriggerWithIndicator>
+          <NavigationMenu.Content className={styles.basicContent}>
+            <LinkGroup
+              bordered={false}
+              items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
+            />
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+
+        <NavigationMenu.Item className={styles.expandableItem}>
+          <TriggerWithIndicator>Company</TriggerWithIndicator>
+          <NavigationMenu.Content className={styles.basicContent}>
+            <LinkGroup
+              bordered={false}
+              items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
+            />
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+    </NavigationMenu.Root>
+  );
+};
+
+const SubActivationModeNavigation = ({
+  rootActivationMode,
+  subActivationMode,
+}: {
+  rootActivationMode?: React.ComponentProps<typeof NavigationMenu.Root>['activationMode'];
+  subActivationMode?: React.ComponentProps<typeof NavigationMenu.Sub>['activationMode'];
+}) => {
+  return (
+    <NavigationMenu.Root
+      activationMode={rootActivationMode}
+      style={{ backgroundColor: 'white', borderRadius: 500, padding: '2px 12px' }}
+    >
+      <NavigationMenu.List className={styles.mainList}>
+        <NavigationMenu.Item>
+          <TriggerWithIndicator>Products</TriggerWithIndicator>
+          <NavigationMenu.Content className={styles.submenusContent}>
+            <NavigationMenu.Sub
+              className={styles.submenusRoot}
+              defaultValue="extensibility"
+              activationMode={subActivationMode}
+            >
+              <NavigationMenu.List className={styles.mainList}>
+                <NavigationMenu.Item value="extensibility">
+                  <NavigationMenu.Trigger className={styles.submenusSubTrigger}>
+                    Extensibility
+                  </NavigationMenu.Trigger>
+                  <NavigationMenu.Content
+                    className={styles.submenusSubContent}
+                    style={{ gridTemplateColumns: '1fr 1fr' }}
+                  >
+                    <LinkGroup items={['Donec quis dui', 'Vestibulum', 'Nunc dignissim']} />
+                    <LinkGroup
+                      items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
+                    />
+                  </NavigationMenu.Content>
+                </NavigationMenu.Item>
+
+                <NavigationMenu.Item value="security">
+                  <NavigationMenu.Trigger className={styles.submenusSubTrigger}>
+                    Security
+                  </NavigationMenu.Trigger>
+                  <NavigationMenu.Content
+                    className={styles.submenusSubContent}
+                    style={{ gridTemplateColumns: '1fr 1fr' }}
+                  >
+                    <LinkGroup
+                      items={['Fusce pellentesque', 'Aliquam porttitor', 'Pellentesque']}
+                    />
+                    <LinkGroup items={['Fusce pellentesque', 'Aliquam porttitor']} />
+                  </NavigationMenu.Content>
+                </NavigationMenu.Item>
+
+                <NavigationMenu.Indicator className={styles.submenusSubIndicator} />
+              </NavigationMenu.List>
+
+              <NavigationMenu.Viewport className={styles.submenusSubViewport} />
+            </NavigationMenu.Sub>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+
+      <NavigationMenu.Viewport className={styles.submenusViewport} />
+    </NavigationMenu.Root>
+  );
+};
+
 const TriggerWithIndicator: React.FC<{ children?: React.ReactNode; disabled?: boolean }> = ({
   children,
   disabled,

--- a/packages/react/navigation-menu/src/index.ts
+++ b/packages/react/navigation-menu/src/index.ts
@@ -32,4 +32,8 @@ export type {
   NavigationMenuIndicatorProps,
   NavigationMenuContentProps,
   NavigationMenuViewportProps,
+  //
+  ActivationMode,
+  Direction,
+  Orientation,
 } from './navigation-menu';

--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -100,27 +100,27 @@ describe('NavigationMenu activationMode', () => {
   });
 });
 
+const NavigationMenuSubTest = (props: React.ComponentProps<typeof NavigationMenu.Sub>) => (
+  <NavigationMenu.Sub defaultValue="one" {...props}>
+    <NavigationMenu.List>
+      <NavigationMenu.Item value="one">
+        <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+        <NavigationMenu.Content>
+          <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+        </NavigationMenu.Content>
+      </NavigationMenu.Item>
+    </NavigationMenu.List>
+  </NavigationMenu.Sub>
+);
+
 describe('NavigationMenuSub activationMode', () => {
   afterEach(cleanup);
-
-  const NavigationMenuSubTest = (props: React.ComponentProps<typeof NavigationMenu.Sub>) => (
-    <NavigationMenu.Sub defaultValue="one" {...props}>
-      <NavigationMenu.List>
-        <NavigationMenu.Item value="one">
-          <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
-          <NavigationMenu.Content>
-            <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
-          </NavigationMenu.Content>
-        </NavigationMenu.Item>
-      </NavigationMenu.List>
-    </NavigationMenu.Sub>
-  );
 
   describe('"automatic" activationMode', () => {
     it('opens the item on pointer enter', async () => {
       render(
         <NavigationMenu.Root>
-          <NavigationMenuSubTest defaultValue="" />
+          <NavigationMenuSubTest activationMode="automatic" defaultValue="" />
         </NavigationMenu.Root>,
       );
       const trigger = screen.getByText(TRIGGER_TEXT);
@@ -128,20 +128,6 @@ describe('NavigationMenuSub activationMode', () => {
 
       fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
       await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
-      expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    });
-
-    it('keeps the open item open on click', async () => {
-      render(
-        <NavigationMenu.Root>
-          <NavigationMenuSubTest />
-        </NavigationMenu.Root>,
-      );
-      const trigger = screen.getByText(TRIGGER_TEXT);
-      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
-
-      fireEvent.click(trigger);
-      expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
@@ -164,25 +150,121 @@ describe('NavigationMenuSub activationMode', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
     });
 
-    it('closes the open item on click', async () => {
+    it('opens the item on click', async () => {
       render(
         <NavigationMenu.Root>
-          <NavigationMenuSubTest activationMode="manual" />
+          <NavigationMenuSubTest activationMode="manual" defaultValue="" />
         </NavigationMenu.Root>,
       );
       const trigger = screen.getByText(TRIGGER_TEXT);
-      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
 
       fireEvent.click(trigger);
-      await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
-      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
 
-  it('inherits "manual" from the parent NavigationMenu', async () => {
+  // `activationMode` governs pointer/focus activation, so inheritance is asserted
+  // via hover behavior (open on pointer enter) rather than click.
+  describe('inheritance', () => {
+    it('inherits "manual" from the parent NavigationMenu', async () => {
+      render(
+        <NavigationMenu.Root activationMode="manual">
+          <NavigationMenuSubTest defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('inherits "automatic" from the parent NavigationMenu', async () => {
+      render(
+        <NavigationMenu.Root activationMode="automatic">
+          <NavigationMenuSubTest defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('overrides inherited "manual" with activationMode="automatic"', async () => {
+      render(
+        <NavigationMenu.Root activationMode="manual">
+          <NavigationMenuSubTest activationMode="automatic" defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('overrides inherited "automatic" with activationMode="manual"', async () => {
+      render(
+        <NavigationMenu.Root activationMode="automatic">
+          <NavigationMenuSubTest activationMode="manual" defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+});
+
+describe('NavigationMenuSub disableToggle', () => {
+  afterEach(cleanup);
+
+  it('does not close an open item when clicking its trigger by default', async () => {
+    render(
+      <NavigationMenu.Root>
+        <NavigationMenuSubTest defaultValue="one" />
+      </NavigationMenu.Root>,
+    );
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('keeps an open item open on click in manual mode by default', async () => {
     render(
       <NavigationMenu.Root activationMode="manual">
-        <NavigationMenuSubTest />
+        <NavigationMenuSubTest defaultValue="one" />
+      </NavigationMenu.Root>,
+    );
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('closes an open item when clicking its trigger with disableToggle={false}', async () => {
+    render(
+      <NavigationMenu.Root>
+        <NavigationMenuSubTest defaultValue="one" disableToggle={false} />
       </NavigationMenu.Root>,
     );
     const trigger = screen.getByText(TRIGGER_TEXT);
@@ -193,38 +275,10 @@ describe('NavigationMenuSub activationMode', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('inherits "automatic" from the parent NavigationMenu', async () => {
-    render(
-      <NavigationMenu.Root activationMode="automatic">
-        <NavigationMenuSubTest />
-      </NavigationMenu.Root>,
-    );
-    const trigger = screen.getByText(TRIGGER_TEXT);
-    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
-
-    fireEvent.click(trigger);
-    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('overrides inherited "manual" with activationMode="automatic"', async () => {
+  it('closes an open item on click with disableToggle={false} in manual mode', async () => {
     render(
       <NavigationMenu.Root activationMode="manual">
-        <NavigationMenuSubTest activationMode="automatic" />
-      </NavigationMenu.Root>,
-    );
-    const trigger = screen.getByText(TRIGGER_TEXT);
-    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
-
-    fireEvent.click(trigger);
-    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('overrides inherited "automatic" with activationMode="manual"', async () => {
-    render(
-      <NavigationMenu.Root activationMode="automatic">
-        <NavigationMenuSubTest activationMode="manual" />
+        <NavigationMenuSubTest defaultValue="one" disableToggle={false} />
       </NavigationMenu.Root>,
     );
     const trigger = screen.getByText(TRIGGER_TEXT);

--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { cleanup, render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { assertStableComposedRef } from '@repo/test-utils/ref-stability';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
+import { assertStableComposedRef } from '@repo/test-utils/ref-stability';
 import * as NavigationMenu from './navigation-menu';
 
 const TRIGGER_TEXT = 'Item One';
@@ -43,6 +43,45 @@ describe('aria-controls', () => {
     const content = document.getElementById(contentId!);
     expect(content).not.toBeNull();
     expect(content).toContainElement(screen.getByText(CONTENT_TEXT));
+  });
+});
+
+describe('NavigationMenuSub triggerBehavior', () => {
+  afterEach(cleanup);
+
+  const NavigationMenuSubTest = (props: React.ComponentProps<typeof NavigationMenu.Sub>) => (
+    <NavigationMenu.Root>
+      <NavigationMenu.Sub defaultValue="one" {...props}>
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+            <NavigationMenu.Content>
+              <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+      </NavigationMenu.Sub>
+    </NavigationMenu.Root>
+  );
+
+  it('keeps the open item open when clicking its trigger by default ("open")', async () => {
+    render(<NavigationMenuSubTest />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('closes the open item when clicking its trigger with triggerBehavior="toggle"', async () => {
+    render(<NavigationMenuSubTest triggerBehavior="toggle" />);
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });
 

--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -46,26 +46,159 @@ describe('aria-controls', () => {
   });
 });
 
-describe('NavigationMenuSub triggerBehavior', () => {
+describe('NavigationMenu activationMode', () => {
+  afterEach(cleanup);
+
+  describe('"automatic" activationMode', () => {
+    it('opens the item on pointer enter', async () => {
+      render(<NavigationMenuTest activationMode="automatic" />);
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('toggles item on click', async () => {
+      render(<NavigationMenuTest defaultValue="one" />);
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+      fireEvent.click(trigger);
+      await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('"manual" activationMode', () => {
+    it('does not open on pointer enter', async () => {
+      render(<NavigationMenuTest activationMode="manual" />);
+      const trigger = screen.getByText(TRIGGER_TEXT);
+
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+
+      // Wait past the default open delay to catch a hover-open regression.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('toggles item on click', async () => {
+      render(<NavigationMenuTest activationMode="manual" />);
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+      fireEvent.click(trigger);
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.click(trigger);
+      await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+});
+
+describe('NavigationMenuSub activationMode', () => {
   afterEach(cleanup);
 
   const NavigationMenuSubTest = (props: React.ComponentProps<typeof NavigationMenu.Sub>) => (
-    <NavigationMenu.Root>
-      <NavigationMenu.Sub defaultValue="one" {...props}>
-        <NavigationMenu.List>
-          <NavigationMenu.Item value="one">
-            <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
-            <NavigationMenu.Content>
-              <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
-            </NavigationMenu.Content>
-          </NavigationMenu.Item>
-        </NavigationMenu.List>
-      </NavigationMenu.Sub>
-    </NavigationMenu.Root>
+    <NavigationMenu.Sub defaultValue="one" {...props}>
+      <NavigationMenu.List>
+        <NavigationMenu.Item value="one">
+          <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+          <NavigationMenu.Content>
+            <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+          </NavigationMenu.Content>
+        </NavigationMenu.Item>
+      </NavigationMenu.List>
+    </NavigationMenu.Sub>
   );
 
-  it('keeps the open item open when clicking its trigger by default ("open")', async () => {
-    render(<NavigationMenuSubTest />);
+  describe('"automatic" activationMode', () => {
+    it('opens the item on pointer enter', async () => {
+      render(
+        <NavigationMenu.Root>
+          <NavigationMenuSubTest defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('keeps the open item open on click', async () => {
+      render(
+        <NavigationMenu.Root>
+          <NavigationMenuSubTest />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+      fireEvent.click(trigger);
+      expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('"manual" activationMode', () => {
+    it('does not open on pointer enter', async () => {
+      render(
+        <NavigationMenu.Root>
+          <NavigationMenuSubTest activationMode="manual" defaultValue="" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+      fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('closes the open item on click', async () => {
+      render(
+        <NavigationMenu.Root>
+          <NavigationMenuSubTest activationMode="manual" />
+        </NavigationMenu.Root>,
+      );
+      const trigger = screen.getByText(TRIGGER_TEXT);
+      await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+      fireEvent.click(trigger);
+      await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  it('inherits "manual" from the parent NavigationMenu', async () => {
+    render(
+      <NavigationMenu.Root activationMode="manual">
+        <NavigationMenuSubTest />
+      </NavigationMenu.Root>,
+    );
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    await waitFor(() => expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('inherits "automatic" from the parent NavigationMenu', async () => {
+    render(
+      <NavigationMenu.Root activationMode="automatic">
+        <NavigationMenuSubTest />
+      </NavigationMenu.Root>,
+    );
     const trigger = screen.getByText(TRIGGER_TEXT);
     await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
 
@@ -74,8 +207,26 @@ describe('NavigationMenuSub triggerBehavior', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('closes the open item when clicking its trigger with triggerBehavior="toggle"', async () => {
-    render(<NavigationMenuSubTest triggerBehavior="toggle" />);
+  it('overrides inherited "manual" with activationMode="automatic"', async () => {
+    render(
+      <NavigationMenu.Root activationMode="manual">
+        <NavigationMenuSubTest activationMode="automatic" />
+      </NavigationMenu.Root>,
+    );
+    const trigger = screen.getByText(TRIGGER_TEXT);
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    fireEvent.click(trigger);
+    expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('overrides inherited "automatic" with activationMode="manual"', async () => {
+    render(
+      <NavigationMenu.Root activationMode="automatic">
+        <NavigationMenuSubTest activationMode="manual" />
+      </NavigationMenu.Root>,
+    );
     const trigger = screen.getByText(TRIGGER_TEXT);
     await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
 

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -1392,4 +1392,8 @@ export type {
   NavigationMenuIndicatorProps,
   NavigationMenuContentProps,
   NavigationMenuViewportProps,
+  //
+  ActivationMode,
+  Direction,
+  Orientation,
 };

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -102,13 +102,17 @@ interface NavigationMenuProps
   dir?: Direction;
   orientation?: Orientation;
   /**
-   * The duration from when the pointer enters the trigger until the tooltip gets opened.
-   * @defaultValue 200
+   * The duration from when the pointer enters the trigger until the tooltip
+   * gets opened. When `activationMode` is `manual`, this prop is ignored.
+   *
+   * @default 200
    */
   delayDuration?: number;
   /**
-   * How much time a user has to enter another trigger without incurring a delay again.
-   * @defaultValue 300
+   * How much time a user has to enter another trigger without incurring a delay
+   * again. When `activationMode` is `manual`, this prop is ignored.
+   *
+   * @default 300
    */
   skipDelayDuration?: number;
   /**
@@ -117,7 +121,7 @@ interface NavigationMenuProps
    *   away closes it after a short delay.
    * - `"manual"`: clicking a trigger toggles the item; hover and focus are ignored
    *
-   * @defaultValue automatic
+   * @default "automatic"
    */
   activationMode?: ActivationMode;
 }
@@ -284,6 +288,12 @@ interface NavigationMenuSubProps
    * `"automatic"`.
    */
   activationMode?: ActivationMode;
+  /**
+   * When true, clicking a sub-menu item's trigger once it's active will not deactivate it.
+   *
+   * @default true
+   */
+  disableToggle?: boolean;
 }
 
 const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
@@ -299,6 +309,7 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
       defaultValue,
       orientation = Orientation.Horizontal,
       activationMode: activationModeProp,
+      disableToggle = true,
       ...subProps
     } = props;
     const context = useNavigationMenuContext(SUB_NAME, __scopeNavigationMenu);
@@ -325,10 +336,7 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
           }
         }}
         onItemSelect={(itemValue) => {
-          // In manual mode, clicking an open item's trigger toggles it closed
-          setValue((prevValue) =>
-            activationMode === ActivationMode.Manual && prevValue === itemValue ? '' : itemValue,
-          );
+          setValue((prevValue) => (disableToggle || prevValue !== itemValue ? itemValue : ''));
         }}
         onItemDismiss={() => setValue('')}
       >

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -229,6 +229,16 @@ interface NavigationMenuSubProps
   defaultValue?: string;
   onValueChange?: (value: string) => void;
   orientation?: Orientation;
+  /**
+   * Controls how clicking a trigger affects its item.
+   * - `"open"`: clicking a trigger only ever opens its item, leaving the
+   *   currently open item unchanged.
+   * - `"toggle"`: clicking the trigger of an already open item closes it,
+   *   matching the toggle behavior of the root `NavigationMenu`.
+   *
+   * @defaultValue "open"
+   */
+  triggerBehavior?: 'open' | 'toggle';
 }
 
 const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
@@ -243,6 +253,7 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
       onValueChange,
       defaultValue,
       orientation = 'horizontal',
+      triggerBehavior = 'open',
       ...subProps
     } = props;
     const context = useNavigationMenuContext(SUB_NAME, __scopeNavigationMenu);
@@ -262,7 +273,11 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
         orientation={orientation}
         rootNavigationMenu={context.rootNavigationMenu}
         onTriggerEnter={(itemValue) => setValue(itemValue)}
-        onItemSelect={(itemValue) => setValue(itemValue)}
+        onItemSelect={(itemValue) => {
+          setValue((prevValue) =>
+            triggerBehavior === 'toggle' && prevValue === itemValue ? '' : itemValue,
+          );
+        }}
         onItemDismiss={() => setValue('')}
       >
         <Primitive.div data-orientation={orientation} {...subProps} ref={forwardedRef} />

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -17,8 +17,24 @@ import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
 
 import type { Scope } from '@radix-ui/react-context';
 
-type Orientation = 'vertical' | 'horizontal';
-type Direction = 'ltr' | 'rtl';
+const ActivationMode = {
+  Automatic: 'automatic',
+  Manual: 'manual',
+} as const;
+
+const Orientation = {
+  Vertical: 'vertical',
+  Horizontal: 'horizontal',
+} as const;
+
+const Direction = {
+  LTR: 'ltr',
+  RTL: 'rtl',
+} as const;
+
+type Orientation = (typeof Orientation)[keyof typeof Orientation];
+type Direction = (typeof Direction)[keyof typeof Direction];
+type ActivationMode = (typeof ActivationMode)[keyof typeof ActivationMode];
 
 /* -------------------------------------------------------------------------------------------------
  * NavigationMenu
@@ -44,13 +60,14 @@ type ContentData = {
   ref?: React.Ref<ViewportContentMounterElement>;
 } & ViewportContentMounterProps;
 
-type NavigationMenuContextValue = {
+interface NavigationMenuContextValue {
   isRootMenu: boolean;
   value: string;
   previousValue: string;
   baseId: string;
   dir: Direction;
   orientation: Orientation;
+  activationMode: ActivationMode;
   rootNavigationMenu: NavigationMenuElement | null;
   indicatorTrack: HTMLDivElement | null;
   onIndicatorTrackChange(indicatorTrack: HTMLDivElement | null): void;
@@ -64,7 +81,7 @@ type NavigationMenuContextValue = {
   onContentLeave(): void;
   onItemSelect(itemValue: string): void;
   onItemDismiss(): void;
-};
+}
 
 const [NavigationMenuProviderImpl, useNavigationMenuContext] =
   createNavigationMenuContext<NavigationMenuContextValue>(NAVIGATION_MENU_NAME);
@@ -94,6 +111,15 @@ interface NavigationMenuProps
    * @defaultValue 300
    */
   skipDelayDuration?: number;
+  /**
+   * Whether an item is activated automatically or manually.
+   * - `"automatic"`: hovering or focusing a trigger opens its item, and moving
+   *   away closes it after a short delay.
+   * - `"manual"`: clicking a trigger toggles the item; hover and focus are ignored
+   *
+   * @defaultValue automatic
+   */
+  activationMode?: ActivationMode;
 }
 
 const NavigationMenu = /* @__PURE__ */ React.forwardRef<NavigationMenuElement, NavigationMenuProps>(
@@ -105,8 +131,9 @@ const NavigationMenu = /* @__PURE__ */ React.forwardRef<NavigationMenuElement, N
       defaultValue,
       delayDuration = 200,
       skipDelayDuration = 300,
-      orientation = 'horizontal',
+      orientation = Orientation.Horizontal,
       dir,
+      activationMode = ActivationMode.Automatic,
       ...NavigationMenuProps
     } = props;
     const [navigationMenu, setNavigationMenu] = React.useState<NavigationMenuElement | null>(null);
@@ -184,18 +211,34 @@ const NavigationMenu = /* @__PURE__ */ React.forwardRef<NavigationMenuElement, N
         value={value}
         dir={direction}
         orientation={orientation}
+        activationMode={activationMode}
         rootNavigationMenu={navigationMenu}
         onTriggerEnter={(itemValue) => {
-          window.clearTimeout(openTimerRef.current);
-          if (isOpenDelayed) handleDelayedOpen(itemValue);
-          else handleOpen(itemValue);
+          if (activationMode === ActivationMode.Automatic) {
+            window.clearTimeout(openTimerRef.current);
+            if (isOpenDelayed) {
+              handleDelayedOpen(itemValue);
+            } else {
+              handleOpen(itemValue);
+            }
+          }
         }}
         onTriggerLeave={() => {
-          window.clearTimeout(openTimerRef.current);
-          startCloseTimer();
+          if (activationMode === ActivationMode.Automatic) {
+            window.clearTimeout(openTimerRef.current);
+            startCloseTimer();
+          }
         }}
-        onContentEnter={() => window.clearTimeout(closeTimerRef.current)}
-        onContentLeave={startCloseTimer}
+        onContentEnter={() => {
+          if (activationMode === ActivationMode.Automatic) {
+            window.clearTimeout(closeTimerRef.current);
+          }
+        }}
+        onContentLeave={() => {
+          if (activationMode === ActivationMode.Automatic) {
+            startCloseTimer();
+          }
+        }}
         onItemSelect={(itemValue) => {
           setValue((prevValue) => (prevValue === itemValue ? '' : itemValue));
         }}
@@ -230,15 +273,17 @@ interface NavigationMenuSubProps
   onValueChange?: (value: string) => void;
   orientation?: Orientation;
   /**
-   * Controls how clicking a trigger affects its item.
-   * - `"open"`: clicking a trigger only ever opens its item, leaving the
-   *   currently open item unchanged.
-   * - `"toggle"`: clicking the trigger of an already open item closes it,
-   *   matching the toggle behavior of the root `NavigationMenu`.
+   * Whether an item is activated automatically or manually.
+   * - `"automatic"`: hovering or focusing a trigger opens its item, and moving
+   *   away closes it after a short delay.
+   * - `"manual"`: clicking a trigger toggles the item; hover and focus are
+   *   ignored
    *
-   * @defaultValue "open"
+   * The default value is inherited from the parent Navigation Menu root
+   * component. If no value is provided to the parent, the default value is
+   * `"automatic"`.
    */
-  triggerBehavior?: 'open' | 'toggle';
+  activationMode?: ActivationMode;
 }
 
 const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
@@ -252,11 +297,12 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
       value: valueProp,
       onValueChange,
       defaultValue,
-      orientation = 'horizontal',
-      triggerBehavior = 'open',
+      orientation = Orientation.Horizontal,
+      activationMode: activationModeProp,
       ...subProps
     } = props;
     const context = useNavigationMenuContext(SUB_NAME, __scopeNavigationMenu);
+    const activationMode = activationModeProp ?? context.activationMode;
     const [value, setValue] = useControllableState({
       prop: valueProp,
       onChange: onValueChange,
@@ -271,11 +317,17 @@ const NavigationMenuSub = /* @__PURE__ */ React.forwardRef<
         value={value}
         dir={context.dir}
         orientation={orientation}
+        activationMode={activationMode}
         rootNavigationMenu={context.rootNavigationMenu}
-        onTriggerEnter={(itemValue) => setValue(itemValue)}
+        onTriggerEnter={(itemValue) => {
+          if (activationMode === ActivationMode.Automatic) {
+            setValue(itemValue);
+          }
+        }}
         onItemSelect={(itemValue) => {
+          // In manual mode, clicking an open item's trigger toggles it closed
           setValue((prevValue) =>
-            triggerBehavior === 'toggle' && prevValue === itemValue ? '' : itemValue,
+            activationMode === ActivationMode.Manual && prevValue === itemValue ? '' : itemValue,
           );
         }}
         onItemDismiss={() => setValue('')}
@@ -294,6 +346,7 @@ interface NavigationMenuProviderPrivateProps {
   children: React.ReactNode;
   orientation: Orientation;
   dir: Direction;
+  activationMode: ActivationMode;
   rootNavigationMenu: NavigationMenuElement | null;
   value: string;
   onTriggerEnter(itemValue: string): void;
@@ -315,6 +368,7 @@ const NavigationMenuProvider: React.FC<NavigationMenuProviderProps> = (
     rootNavigationMenu,
     dir,
     orientation,
+    activationMode,
     children,
     value,
     onItemSelect,
@@ -338,6 +392,7 @@ const NavigationMenuProvider: React.FC<NavigationMenuProviderProps> = (
       baseId={useId()}
       dir={dir}
       orientation={orientation}
+      activationMode={activationMode}
       viewport={viewport}
       onViewportChange={setViewport}
       indicatorTrack={indicatorTrack}
@@ -553,7 +608,7 @@ const NavigationMenuTrigger = /* @__PURE__ */ React.forwardRef<
               wasClickCloseRef.current = open;
             })}
             onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
-              const verticalEntryKey = context.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight';
+              const verticalEntryKey = context.dir === Direction.RTL ? 'ArrowLeft' : 'ArrowRight';
               const entryKey = { horizontal: 'ArrowDown', vertical: verticalEntryKey }[
                 context.orientation
               ];
@@ -698,7 +753,7 @@ const NavigationMenuIndicatorImpl = /* @__PURE__ */ React.forwardRef<
     null,
   );
   const [position, setPosition] = React.useState<{ size: number; offset: number } | null>(null);
-  const isHorizontal = context.orientation === 'horizontal';
+  const isHorizontal = context.orientation === Orientation.Horizontal;
   const isVisible = Boolean(context.value);
 
   React.useEffect(() => {
@@ -911,7 +966,7 @@ const NavigationMenuContentImpl = /* @__PURE__ */ React.forwardRef<
   const motionAttribute = React.useMemo(() => {
     const items = getItems();
     const values = items.map((item) => item.value);
-    if (context.dir === 'rtl') values.reverse();
+    if (context.dir === Direction.RTL) values.reverse();
     const index = values.indexOf(context.value);
     const prevIndex = values.indexOf(context.previousValue);
     const isSelected = value === context.value;
@@ -1187,7 +1242,7 @@ const FocusGroupItem = /* @__PURE__ */ React.forwardRef<FocusGroupItemElement, F
             const isFocusNavigationKey = ['Home', 'End', ...ARROW_KEYS].includes(event.key);
             if (isFocusNavigationKey) {
               let candidateNodes = getItems().map((item) => item.ref.current!);
-              const prevItemKey = context.dir === 'rtl' ? 'ArrowRight' : 'ArrowLeft';
+              const prevItemKey = context.dir === Direction.RTL ? 'ArrowRight' : 'ArrowLeft';
               const prevKeys = [prevItemKey, 'ArrowUp', 'End'];
               if (prevKeys.includes(event.key)) candidateNodes.reverse();
               if (ARROW_KEYS.includes(event.key)) {


### PR DESCRIPTION
Closes https://github.com/radix-ui/primitives/issues/2089

This PR adds two new features to Navigation Menu.

- `activationMode`
  - `"automatic"`: Hovering or focusing a trigger opens its item, and moving away from the trigger closes it after a short delay. This is the default and matches existing behavior.
  - `"manual"`: Pointer entry and focus never open an item; the item is opened by clicking its trigger.
  - Applies to both the root menu and submenu.
  - When `activationMode` is omitted on `NavigationMenu.Sub`, it inherits the value from the parent `NavigationMenu.Root`, so setting `"manual"` on the root also applies to submenus unless a submenu opts back in to `"automatic"`.
- `disableToggle`
  - `true`: Clicking the trigger of an already-open menu item keeps it open. This is the default and matches existing behavior.
  - `false`: Clicking the trigger of a menu item toggles it open or closed.
  - Only applies to submenus; I don't see a good use case for changing this behavior on root menus, but if a user truly wants it for some reason they can always control state and/or use `preventDefault` on the root items' click. 