### PR TITLE
fix(dialog): only set aria-describedby when a Description is rendered

### DIFF
--- a/.changeset/dialog-conditional-aria-describedby.md
+++ b/.changeset/dialog-conditional-aria-describedby.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-dialog": patch
+---
+
+`Dialog.Content` no longer sets `aria-describedby` unless a `Dialog.Description` is rendered, fixing a dangling ARIA reference (WCAG 4.1.2) when no description is used.

--- a/packages/react/dialog/src/dialog.test.tsx
+++ b/packages/react/dialog/src/dialog.test.tsx
@@ -100,6 +100,53 @@ describe('aria-controls', () => {
   });
 });
 
+describe('aria-describedby', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should not be present when no `Dialog.Description` is rendered', () => {
+    const rendered = render(<DialogTest />);
+    fireEvent.click(rendered.getByText(OPEN_TEXT));
+    const content = rendered.getByRole('dialog');
+    expect(content).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('should reference the rendered `Dialog.Description`', () => {
+    const DESCRIPTION_TEXT = 'Description';
+    const rendered = render(
+      <Dialog.Root>
+        <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
+        <Dialog.Content>
+          <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
+          <Dialog.Description>{DESCRIPTION_TEXT}</Dialog.Description>
+          <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    fireEvent.click(rendered.getByText(OPEN_TEXT));
+    const content = rendered.getByRole('dialog');
+    const describedById = content.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(document.getElementById(describedById!)).toBe(rendered.getByText(DESCRIPTION_TEXT));
+  });
+
+  it('should respect an explicit `aria-describedby` override even without `Dialog.Description`', () => {
+    const rendered = render(
+      <Dialog.Root>
+        <Dialog.Trigger>{OPEN_TEXT}</Dialog.Trigger>
+        <Dialog.Content aria-describedby="custom-id">
+          <Dialog.Title>{TITLE_TEXT}</Dialog.Title>
+          <Dialog.Close>{CLOSE_TEXT}</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Root>,
+    );
+    fireEvent.click(rendered.getByText(OPEN_TEXT));
+    const content = rendered.getByRole('dialog');
+    expect(content).toHaveAttribute('aria-describedby', 'custom-id');
+  });
+});
+
 describe('given a modal Dialog', () => {
   afterEach(() => {
     cleanup();

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -31,6 +31,8 @@ type DialogContextValue = {
   contentId: string;
   titleId: string;
   descriptionId: string;
+  isDescriptionRendered: boolean;
+  setIsDescriptionRendered: React.Dispatch<React.SetStateAction<boolean>>;
   open: boolean;
   onOpenChange(open: boolean): void;
   onOpenToggle(): void;
@@ -64,6 +66,7 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
     onChange: onOpenChange,
     caller: DIALOG_NAME,
   });
+  const [isDescriptionRendered, setIsDescriptionRendered] = React.useState(false);
 
   return (
     <DialogProvider
@@ -73,6 +76,8 @@ const Dialog: React.FC<DialogProps> = (props: ScopedProps<DialogProps>) => {
       contentId={useId()}
       titleId={useId()}
       descriptionId={useId()}
+      isDescriptionRendered={isDescriptionRendered}
+      setIsDescriptionRendered={setIsDescriptionRendered}
       open={open}
       onOpenChange={setOpen}
       onOpenToggle={React.useCallback(() => setOpen((prevOpen) => !prevOpen), [setOpen])}
@@ -411,7 +416,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, DialogConte
           <DismissableLayer
             role="dialog"
             id={context.contentId}
-            aria-describedby={context.descriptionId}
+            aria-describedby={context.isDescriptionRendered ? context.descriptionId : undefined}
             aria-labelledby={context.titleId}
             data-state={getState(context.open)}
             {...contentProps}
@@ -459,6 +464,16 @@ const DialogDescription = React.forwardRef<DialogDescriptionElement, DialogDescr
   (props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
     const { __scopeDialog, ...descriptionProps } = props;
     const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog);
+    const { setIsDescriptionRendered } = context;
+
+    // Let `DialogContent` know a description is present so it only sets
+    // `aria-describedby` when there is an element for it to reference.
+    // https://github.com/radix-ui/primitives/issues/3007
+    React.useEffect(() => {
+      setIsDescriptionRendered(true);
+      return () => setIsDescriptionRendered(false);
+    }, [setIsDescriptionRendered]);
+
     return <Primitive.p id={context.descriptionId} {...descriptionProps} ref={forwardedRef} />;
   },
 );


### PR DESCRIPTION
`Dialog.Content` always sets `aria-describedby` to a generated id, even when no `Dialog.Description` is rendered, leaving a dangling ARIA reference (WCAG 4.1.2) (#3007).

`Dialog.Description` now registers its presence through context, and `DialogContentImpl` only sets `aria-describedby` when a Description is actually mounted. An explicit user-provided `aria-describedby` still works and the missing-description dev warning is unchanged. Alert Dialog inherits the fix since it delegates to `Dialog.Description`.

Added a `dialog.test.tsx` case asserting no `aria-describedby` without a Description. It fails without the fix and passes with it. All dialog and alert-dialog tests pass, typecheck and lint clean.

Closes #3007
