### PR TITLE
Menu: Fix pointer transfer to collision-flipped submenus

### DIFF
--- a/.changeset/warm-menus-stay.md
+++ b/.changeset/warm-menus-stay.md
@@ -1,0 +1,9 @@
+---
+"@radix-ui/react-menu": patch
+"@radix-ui/react-dropdown-menu": patch
+"@radix-ui/react-context-menu": patch
+"@radix-ui/react-menubar": patch
+"radix-ui": patch
+---
+
+Fixed collision-flipped submenus closing before pointer clicks land in React 19.

--- a/e2e/dropdown-menu.spec.ts
+++ b/e2e/dropdown-menu.spec.ts
@@ -62,6 +62,19 @@ test.describe('DropdownMenu', () => {
           await pointerExitRightToLeft(page, 'WorkOS →');
           await expect(page.getByText('Radix', { exact: true })).toBeVisible();
         });
+
+        test('should select an item in a collision-flipped submenu after a single pointer move', async ({
+          page,
+        }) => {
+          await page.getByText('Bookmarks →', { exact: true }).click();
+          await page.getByText('WorkOS →', { exact: true }).click();
+
+          const submenu = page.getByRole('menu').filter({ hasText: 'Radix' });
+          await expect(submenu).toHaveAttribute('data-side', 'left');
+
+          await page.getByText('Radix', { exact: true }).click();
+          await expect(page.getByText('New Tab', { exact: true })).toHaveCount(0);
+        });
       });
 
       test('should close open submenu when moving pointer to any item in parent menu', async ({

--- a/packages/react/menu/src/menu.tsx
+++ b/packages/react/menu/src/menu.tsx
@@ -442,7 +442,13 @@ const MenuContentImpl = React.forwardRef<MenuContentImplElement, MenuContentImpl
     useFocusGuards();
 
     const isPointerMovingToSubmenu = React.useCallback((event: React.PointerEvent) => {
-      const isMovingTowards = pointerDirRef.current === pointerGraceIntentRef.current?.side;
+      // A pointerleave can be the first event after a coalesced move, so use its coordinates
+      // instead of relying on the direction recorded by the last pointermove.
+      let pointerDir = pointerDirRef.current;
+      if (event.type === 'pointerleave' && event.clientX !== lastPointerXRef.current) {
+        pointerDir = event.clientX > lastPointerXRef.current ? 'right' : 'left';
+      }
+      const isMovingTowards = pointerDir === pointerGraceIntentRef.current?.side;
       return isMovingTowards && isPointerInGraceArea(event, pointerGraceIntentRef.current?.area);
     }, []);
 


### PR DESCRIPTION
### Description

Closes #4036

When a submenu collision-flips, a coalesced pointer move can reach the submenu before another `pointermove` updates `pointerDirRef`. The stale direction makes the grace-area check fail and moves focus back to the parent menu, allowing React 19 to unmount the submenu before the queued click lands.

This change derives the direction from the latest `pointerleave` coordinate when it differs from the last recorded pointer position. Pointer-move and item-entry behavior continue using the existing recorded direction, preserving the current grace-area behavior.

A Playwright regression test uses the existing narrow-viewport nested submenu, verifies that it collision-flipped to the left, and clicks its item with a single pointer move.

### Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test --run` (37 files, 464 passed, 2 skipped)
- `pnpm types:check`
- `pnpm build` (62 packages)
- `pnpm exec playwright test e2e/dropdown-menu.spec.ts --project=chromium` (17 passed)