### PR TITLE
Fix dev-only code paths using conditional exports

### DIFF
--- a/.changeset/sour-lemons-join.md
+++ b/.changeset/sour-lemons-join.md
@@ -1,0 +1,10 @@
+---
+"@radix-ui/react-use-controllable-state": patch
+"@radix-ui/react-password-toggle-field": patch
+"@radix-ui/react-context-menu": patch
+"@radix-ui/primitive": patch
+"@radix-ui/react-avatar": patch
+"@repo/builder": patch
+---
+
+Fix dev-only checks with conditional exports to drop dev-warnings from production builds.

--- a/.changeset/sour-lemons-join.md
+++ b/.changeset/sour-lemons-join.md
@@ -1,4 +1,5 @@
 ---
+"radix-ui": patch
 "@radix-ui/react-use-controllable-state": patch
 "@radix-ui/react-password-toggle-field": patch
 "@radix-ui/react-context-menu": patch

--- a/internal/builder/builder.js
+++ b/internal/builder/builder.js
@@ -32,19 +32,26 @@ export async function build(relativePath) {
 
   const tasks = [];
   const pkg = packageJson.name;
-  const UNBUNDLED_PACKAGES = new Set(['radix-ui', '@radix-ui/primitive']);
+  const files = ['index.ts'];
 
-  const files = [];
-  if (UNBUNDLED_PACKAGES.has(pkg)) {
+  if (pkg === 'radix-ui') {
+    // The `radix-ui` package exposes every module in `src` as its own subpath
+    // entry point (eg. `radix-ui/accordion`, `radix-ui/unstable/dismissable-layer`),
+    // so build all of them. `recursive` is used to pick up nested modules such as
+    // those under `src/unstable`.
     const sourceDirectory = path.resolve(relativePath || '.', 'src');
     const additionalEntryFiles = fs
       .readdirSync(sourceDirectory, { recursive: true })
       .map((entry) => entry.toString().split(path.sep).join('/'))
-      .filter((file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !file.endsWith('.d.ts'))
+      .filter((file) => file.endsWith('.ts') && !file.endsWith('.d.ts') && file !== 'index.ts')
       .sort();
     files.push(...additionalEntryFiles);
-  } else {
-    files.push('index.ts');
+  } else if (pkg === '@radix-ui/primitive') {
+    // Additional files exposed to consumers
+    files.push(
+      'internal/is-development.false.ts',
+      'internal/is-development.true.ts',
+    );
   }
 
   const entryPoints = files.map((file) => `${relativePath || '.'}/src/${file}`);
@@ -53,9 +60,9 @@ export async function build(relativePath) {
   /** @type {esbuild.BuildOptions} */
   const esbuildConfig = {
     entryPoints: entryPoints,
-    external: !UNBUNDLED_PACKAGES.has(pkg) ? ['@radix-ui/*'] : undefined,
+    external:  ['@radix-ui/*'] ,
     packages: 'external',
-    bundle: !UNBUNDLED_PACKAGES.has(pkg),
+    bundle: true,
     sourcemap: true,
     format: 'cjs',
     target: 'es2022',

--- a/internal/builder/builder.js
+++ b/internal/builder/builder.js
@@ -32,19 +32,19 @@ export async function build(relativePath) {
 
   const tasks = [];
   const pkg = packageJson.name;
-  const files = ['index.ts'];
-  if (pkg === 'radix-ui') {
-    // The `radix-ui` package exposes every module in `src` as its own subpath
-    // entry point (eg. `radix-ui/accordion`, `radix-ui/unstable/dismissable-layer`),
-    // so build all of them. `recursive` is used to pick up nested modules such as
-    // those under `src/unstable`.
+  const UNBUNDLED_PACKAGES = new Set(['radix-ui', '@radix-ui/primitive']);
+
+  const files = [];
+  if (UNBUNDLED_PACKAGES.has(pkg)) {
     const sourceDirectory = path.resolve(relativePath || '.', 'src');
     const additionalEntryFiles = fs
       .readdirSync(sourceDirectory, { recursive: true })
       .map((entry) => entry.toString().split(path.sep).join('/'))
-      .filter((file) => file.endsWith('.ts') && !file.endsWith('.d.ts') && file !== 'index.ts')
+      .filter((file) => (file.endsWith('.ts') || file.endsWith('.tsx')) && !file.endsWith('.d.ts'))
       .sort();
     files.push(...additionalEntryFiles);
+  } else {
+    files.push('index.ts');
   }
 
   const entryPoints = files.map((file) => `${relativePath || '.'}/src/${file}`);
@@ -53,9 +53,9 @@ export async function build(relativePath) {
   /** @type {esbuild.BuildOptions} */
   const esbuildConfig = {
     entryPoints: entryPoints,
-    external: ['@radix-ui/*'],
+    external: !UNBUNDLED_PACKAGES.has(pkg) ? ['@radix-ui/*'] : undefined,
     packages: 'external',
-    bundle: true,
+    bundle: !UNBUNDLED_PACKAGES.has(pkg),
     sourcemap: true,
     format: 'cjs',
     target: 'es2022',

--- a/internal/builder/builder.js
+++ b/internal/builder/builder.js
@@ -49,6 +49,7 @@ export async function build(relativePath) {
   } else if (pkg === '@radix-ui/primitive') {
     // Additional files exposed to consumers
     files.push(
+      //
       'internal/is-development.false.ts',
       'internal/is-development.true.ts',
     );
@@ -60,7 +61,7 @@ export async function build(relativePath) {
   /** @type {esbuild.BuildOptions} */
   const esbuildConfig = {
     entryPoints: entryPoints,
-    external:  ['@radix-ui/*'] ,
+    external: ['@radix-ui/*'],
     packages: 'external',
     bundle: true,
     sourcemap: true,

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -5,6 +5,15 @@
   "source": "./src/index.ts",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./is-development": "./src/internal/is-development.true.ts",
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
   "publishConfig": {
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
@@ -18,6 +27,48 @@
         "require": {
           "types": "./dist/index.d.ts",
           "default": "./dist/index.js"
+        }
+      },
+      "./is-development": {
+        "development": {
+          "import": {
+            "types": "./dist/internal/is-development.true.d.mts",
+            "default": "./dist/internal/is-development.true.mjs"
+          },
+          "require": {
+            "types": "./dist/internal/is-development.true.d.ts",
+            "default": "./dist/internal/is-development.true.js"
+          }
+        },
+        "production": {
+          "import": {
+            "types": "./dist/internal/is-development.false.d.mts",
+            "default": "./dist/internal/is-development.false.mjs"
+          },
+          "require": {
+            "types": "./dist/internal/is-development.false.d.ts",
+            "default": "./dist/internal/is-development.false.js"
+          }
+        },
+        "default": {
+          "import": {
+            "types": "./dist/internal/is-development.false.d.mts",
+            "default": "./dist/internal/is-development.false.mjs"
+          },
+          "require": {
+            "types": "./dist/internal/is-development.false.d.ts",
+            "default": "./dist/internal/is-development.false.js"
+          }
+        }
+      },
+      "./*": {
+        "import": {
+          "types": "./dist/*.d.mts",
+          "default": "./dist/*.mjs"
+        },
+        "require": {
+          "types": "./dist/*.d.ts",
+          "default": "./dist/*.js"
         }
       }
     }

--- a/packages/core/primitive/package.json
+++ b/packages/core/primitive/package.json
@@ -6,13 +6,8 @@
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "exports": {
-    ".": {
-      "default": "./src/index.ts"
-    },
-    "./is-development": "./src/internal/is-development.true.ts",
-    "./*": {
-      "default": "./src/*.ts"
-    }
+    ".": "./src/index.ts",
+    "./is-development": "./src/internal/is-development.true.ts"
   },
   "publishConfig": {
     "main": "./dist/index.js",
@@ -59,16 +54,6 @@
             "types": "./dist/internal/is-development.false.d.ts",
             "default": "./dist/internal/is-development.false.js"
           }
-        }
-      },
-      "./*": {
-        "import": {
-          "types": "./dist/*.d.mts",
-          "default": "./dist/*.mjs"
-        },
-        "require": {
-          "types": "./dist/*.d.ts",
-          "default": "./dist/*.js"
         }
       }
     }

--- a/packages/core/primitive/src/internal/is-development.false.ts
+++ b/packages/core/primitive/src/internal/is-development.false.ts
@@ -1,0 +1,1 @@
+export const IS_DEVELOPMENT = false;

--- a/packages/core/primitive/src/internal/is-development.true.ts
+++ b/packages/core/primitive/src/internal/is-development.true.ts
@@ -1,0 +1,1 @@
+export const IS_DEVELOPMENT = true;

--- a/packages/react/avatar/package.json
+++ b/packages/react/avatar/package.json
@@ -35,6 +35,7 @@
     "build": "radix-build"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-context": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",

--- a/packages/react/avatar/src/avatar.tsx
+++ b/packages/react/avatar/src/avatar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { createContextScope } from '@radix-ui/react-context';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
@@ -189,7 +190,7 @@ function getImageLoadingStatus(image: HTMLImageElement) {
 // oxlint-disable react-hooks/rules-of-hooks
 function useImageCount() {
   let state = STATIC_IMAGE_COUNT_STATE;
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     state = React.useState(0);
     const [imageCount] = state;
     const hasWarnedRef = React.useRef(false);
@@ -207,7 +208,7 @@ function useImageCount() {
 }
 
 function useUpdateImageCount(setImageCount: React.Dispatch<React.SetStateAction<number>>) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     React.useEffect(() => {
       setImageCount((imageCount) => imageCount + 1);
       return () => {

--- a/packages/react/context-menu/src/context-menu.tsx
+++ b/packages/react/context-menu/src/context-menu.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
@@ -48,7 +49,7 @@ const ContextMenu: React.FC<ContextMenuProps> = (props: ScopedProps<ContextMenuP
   // code block entirely in production.
   /* eslint-disable react-hooks/rules-of-hooks */
   const hasInteractedRef = React.useRef(false);
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     const hasWarnedRef = React.useRef(false);
     React.useEffect(() => {
       if (openProp === true && !hasInteractedRef.current && !hasWarnedRef.current) {

--- a/packages/react/password-toggle-field/src/password-toggle-field.tsx
+++ b/packages/react/password-toggle-field/src/password-toggle-field.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { flushSync } from 'react-dom';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Primitive, type PrimitivePropsWithRef } from '@radix-ui/react-primitive';
@@ -84,7 +85,7 @@ const PasswordToggleField: React.FC<PasswordToggleFieldProps> = ({
     onVisibilityChange = props.onVisibilityChange;
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     // oxlint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       if (shouldWarn) {

--- a/packages/react/use-controllable-state/package.json
+++ b/packages/react/use-controllable-state/package.json
@@ -35,6 +35,7 @@
     "build": "radix-build"
   },
   "dependencies": {
+    "@radix-ui/primitive": "workspace:*",
     "@radix-ui/react-use-effect-event": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },

--- a/packages/react/use-controllable-state/src/use-controllable-state-reducer.tsx
+++ b/packages/react/use-controllable-state/src/use-controllable-state-reducer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { useEffectEvent } from '@radix-ui/react-use-effect-event';
 
 type ChangeHandler<T> = (state: T) => void;
@@ -49,7 +50,7 @@ export function useControllableStateReducer<T, S extends {}, A extends AnyAction
   // consistently in the same environment. Bundlers should be able to remove the
   // code block entirely in production.
   /* eslint-disable react-hooks/rules-of-hooks */
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     const isControlledRef = React.useRef(controlledState !== undefined);
     React.useEffect(() => {
       const wasControlled = isControlledRef.current;

--- a/packages/react/use-controllable-state/src/use-controllable-state.tsx
+++ b/packages/react/use-controllable-state/src/use-controllable-state.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 
 // Prevent bundlers from trying to optimize the import
@@ -32,7 +33,7 @@ export function useControllableState<T>({
   // consistently in the same environment. Bundlers should be able to remove the
   // code block entirely in production.
   /* eslint-disable react-hooks/rules-of-hooks */
-  if (process.env.NODE_ENV !== 'production') {
+  if (IS_DEVELOPMENT) {
     const isControlledRef = React.useRef(prop !== undefined);
     React.useEffect(() => {
       const wasControlled = isControlledRef.current;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,9 @@ importers:
 
   packages/react/avatar:
     dependencies:
+      '@radix-ui/primitive':
+        specifier: workspace:*
+        version: link:../../core/primitive
       '@radix-ui/react-context':
         specifier: workspace:*
         version: link:../context
@@ -2659,6 +2662,9 @@ importers:
 
   packages/react/use-controllable-state:
     dependencies:
+      '@radix-ui/primitive':
+        specifier: workspace:*
+        version: link:../../core/primitive
       '@radix-ui/react-use-effect-event':
         specifier: workspace:*
         version: link:../use-effect-event


### PR DESCRIPTION
### Description

Dev-only code paths (typically used for warnings) are currently broken because our build output hard-codes process.env checks at build time, meaning `process.env.NODE_ENV !== "production"` gets replaced with `true`, so those code paths are always shipped to production code. This PR address that by adding conditional exports for `development` and `production`, which most modern bundlers and tools resolve by default.

Important to note: **esbuild does not enable the development condition automatically**, so warnings remain disabled unless consumers explicitly configure it. I consider this a reasonable trade-off. esbuild is a low-level compiler by design. Folk who use it directly to bundle their apps should expect the need for manual configuration. Getting a smaller prod bundle makes the potential loss of development warnings is still a net positive, IMO. Nothing is actually broken by this change.