### PR TITLE
Only open Tooltip on genuine user-initiated focus

### DIFF
--- a/.changeset/tooltip-focus-visible-open.md
+++ b/.changeset/tooltip-focus-visible-open.md
@@ -1,0 +1,6 @@
+---
+"radix-ui": patch
+"@radix-ui/react-tooltip": patch
+---
+
+Fixed `Tooltip` opening automatically when its trigger receives focus programmatically, e.g. when it is the first focusable element inside a `Popover` or `Dialog` that auto-focuses its content on open. The tooltip now only opens on focus that comes from a genuine user interaction (such as tabbing to the trigger), determined using `:focus-visible`. Hover-triggered opening is unaffected.

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -258,6 +258,98 @@ describe('Tooltip', () => {
     expect(commitCounts.c! - initial.c!).toBe(0);
   });
 
+  // Regression tests for https://github.com/radix-ui/primitives/issues/2248
+  // A trigger can receive focus without the user directly interacting with
+  // it, e.g. when a `Popover` or `Dialog` auto-focuses its content on open
+  // and the trigger happens to be the first focusable descendant. The
+  // tooltip should only open for focus that genuinely originates from the
+  // user (such as keyboard navigation), not from that kind of programmatic
+  // focus transfer.
+  describe('focus origin', () => {
+    it('does not open when the trigger is focused programmatically', async () => {
+      render(
+        <Tooltip.Provider>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger>Tooltip Trigger</Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content>Tooltip Content</Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>,
+      );
+
+      const trigger = screen.getByText('Tooltip Trigger');
+
+      // Simulates what a parent like `Popover.Content`'s auto-focus does: a
+      // plain, non-keyboard-driven `element.focus()` call.
+      act(() => trigger.focus());
+      expect(trigger).toHaveFocus();
+
+      // Give any (regressed) open timers a chance to run.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute('data-state', 'closed');
+
+      // Avoid leaking a focused-but-detached element into the next test's
+      // `:focus-visible` tracking once this tree unmounts.
+      act(() => trigger.blur());
+    });
+
+    it('still opens when the trigger is focused via keyboard navigation', async () => {
+      render(
+        <Tooltip.Provider>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger>Tooltip Trigger</Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content>Tooltip Content</Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>,
+      );
+
+      const user = userEvent.setup();
+      await user.tab();
+
+      const trigger = screen.getByText('Tooltip Trigger');
+      expect(trigger).toHaveFocus();
+
+      await waitFor(() => {
+        expect(screen.getByText('Tooltip Content')).toBeVisible();
+      });
+      expect(trigger).toHaveAttribute('data-state', 'instant-open');
+
+      // Avoid leaking a focused-but-detached element into the next test's
+      // `:focus-visible` tracking once this tree unmounts.
+      act(() => trigger.blur());
+    });
+
+    it('still closes on blur after a genuine keyboard focus', async () => {
+      render(
+        <Tooltip.Provider>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger>Tooltip Trigger</Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content>Tooltip Content</Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+          <button>Next</button>
+        </Tooltip.Provider>,
+      );
+
+      const user = userEvent.setup();
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.getByText('Tooltip Content')).toBeVisible();
+      });
+
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.queryByText('Tooltip Content')).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('skipDelayDuration', () => {
     function renderTwoTriggers(providerProps: Omit<Tooltip.TooltipProviderProps, 'children'>) {
       render(

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -314,8 +314,17 @@ const TooltipTrigger = /* @__PURE__ */ React.forwardRef<TooltipTriggerElement, T
             isPointerDownRef.current = true;
             document.addEventListener('pointerup', handlePointerUp, { once: true });
           })}
-          onFocus={composeEventHandlers(props.onFocus, () => {
-            if (!isPointerDownRef.current) context.onOpen();
+          onFocus={composeEventHandlers(props.onFocus, (event) => {
+            // A trigger can receive focus without any direct user interaction
+            // with it, e.g. when a `Popover` or `Dialog` auto-focuses its
+            // content on open and the trigger happens to be the first
+            // focusable descendant. `:focus-visible` reflects the browser's
+            // own judgement of whether this focus event stems from a real
+            // keyboard/user-driven interaction, so we use it to avoid
+            // opening the tooltip for that kind of programmatic focus while
+            // still opening it for genuine keyboard navigation.
+            const isFocusFromUserInteraction = event.currentTarget.matches(':focus-visible');
+            if (!isPointerDownRef.current && isFocusFromUserInteraction) context.onOpen();
           })}
           onBlur={composeEventHandlers(props.onBlur, context.onClose)}
           onClick={composeEventHandlers(props.onClick, context.onClose)}


### PR DESCRIPTION
Tooltip.Trigger opens the tooltip on any focus event, with no way to tell a real user interaction apart from focus it receives as a side effect of something else happening. The most common case: a Popover or Dialog auto-focuses its content on open, and if the tooltip trigger happens to be the first focusable element inside, the tooltip pops open immediately, before the user has hovered or tabbed to it themselves.

This fixes that by gating the open-on-focus behavior on `:focus-visible`. That pseudo-class already reflects the browser's own determination of whether a focus event came from a real keyboard/user interaction, as opposed to a plain scripted `.focus()` call, which is exactly what Popover's auto-focus (packages/react/focus-scope) does under the hood. Hover-triggered opening and the existing pointerdown guard are untouched.

I confirmed the bug with a Popover containing a Tooltip: before the fix, opening the popover left the tooltip in data-state="instant-open" the moment its content auto-focused. After the fix it stays closed until the user actually interacts with the trigger. I added three tests to Tooltip's suite covering: focus from a plain scripted .focus() call stays closed, real keyboard tab navigation still opens it, and tab-away still closes it. All pass, and the existing hover and click tests are untouched and still pass.

This only touches Tooltip's own trigger, not any shared focus-management code, so the blast radius should be limited to Tooltip itself. The one behavior change worth calling out: if anyone was relying on a scripted .focus() call to intentionally open a tooltip (outside of keyboard navigation), that will now no longer open it. That seems like exactly the behavior people have been asking for in this issue, but flagging it since Tooltip's focus handling is used everywhere.

Fixes #2248
