### PR TITLE
Fixed overriding inline animation style in `Popper.Content`

### DIFF
--- a/.changeset/dirty-rooms-shine.md
+++ b/.changeset/dirty-rooms-shine.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-popper": patch
+"radix-ui": patch
+---
+
+Fixed overriding inline animation style in `Popper.Content`.

--- a/packages/react/popper/src/popper.tsx
+++ b/packages/react/popper/src/popper.tsx
@@ -333,9 +333,10 @@ const PopperContent = /* @__PURE__ */ React.forwardRef<PopperContentElement, Pop
             ref={composedRefs}
             style={{
               ...contentProps.style,
-              // if the PopperContent hasn't been placed yet (not all measurements done)
-              // we prevent animations so that users's animation don't kick in too early referring wrong sides
-              animation: !isPositioned ? 'none' : undefined,
+              // if the PopperContent hasn't been placed yet (not all
+              // measurements done) we prevent animations so that users'
+              // animations don't kick in too early from the wrong sides.
+              animation: !isPositioned ? 'none' : contentProps.style?.animation,
             }}
           />
         </PopperContentProvider>


### PR DESCRIPTION
Closes https://github.com/radix-ui/primitives/issues/2780