### PR TITLE
Concatenate `aria-describedby` attributes

### DIFF
--- a/.changeset/slimy-mammals-marry.md
+++ b/.changeset/slimy-mammals-marry.md
@@ -1,0 +1,9 @@
+---
+"@radix-ui/react-tooltip": minor
+"@radix-ui/react-dialog": minor
+"@radix-ui/react-form": minor
+"@radix-ui/react-slot": minor
+"radix-ui": minor
+---
+
+Added support for multiple `aria-describedby` attributes.

--- a/packages/react/dialog/src/dialog.test.tsx
+++ b/packages/react/dialog/src/dialog.test.tsx
@@ -127,6 +127,31 @@ describe('aria-labelledby / aria-describedby references', () => {
     expect(document.getElementById(describedBy!)).toHaveTextContent('Description');
   });
 
+  // Regression test for https://github.com/radix-ui/primitives/issues/2598
+  it('should normalize existing aria-describedby ids and append the Description id', () => {
+    const rendered = render(
+      <>
+        <span id="existing-description">Existing description</span>
+        <span id="shared-description">Shared description</span>
+        <Dialog.Root defaultOpen>
+          <Dialog.Content
+            aria-describedby={' existing-description\texisting-description shared-description '}
+          >
+            <Dialog.Title>Title</Dialog.Title>
+            <Dialog.Description>Description</Dialog.Description>
+          </Dialog.Content>
+        </Dialog.Root>
+      </>,
+    );
+
+    const content = rendered.getByRole('dialog');
+    const description = rendered.getByText('Description');
+    expect(content).toHaveAttribute(
+      'aria-describedby',
+      `existing-description shared-description ${description.id}`,
+    );
+  });
+
   it('should not set `aria-labelledby` when no `Title` is rendered', () => {
     const rendered = render(
       <Dialog.Root defaultOpen>

--- a/packages/react/dialog/src/dialog.tsx
+++ b/packages/react/dialog/src/dialog.tsx
@@ -410,7 +410,14 @@ const DialogContentImpl = /* @__PURE__ */ React.forwardRef<
 >(
   // blank line to reduce diff noise
   function DialogContentImpl(props: ScopedProps<DialogContentImplProps>, forwardedRef) {
-    const { __scopeDialog, trapFocus, onOpenAutoFocus, onCloseAutoFocus, ...contentProps } = props;
+    const {
+      __scopeDialog,
+      trapFocus,
+      onOpenAutoFocus,
+      onCloseAutoFocus,
+      'aria-describedby': ariaDescribedby,
+      ...contentProps
+    } = props;
     const context = useDialogContext(CONTENT_NAME, __scopeDialog);
 
     // Make sure the whole tree has focus guards as our `Dialog` will be
@@ -429,8 +436,12 @@ const DialogContentImpl = /* @__PURE__ */ React.forwardRef<
           <DismissableLayer
             role="dialog"
             id={context.contentId}
-            aria-describedby={context.descriptionPresent ? context.descriptionId : undefined}
             aria-labelledby={context.titlePresent ? context.titleId : undefined}
+            aria-describedby={
+              context.descriptionPresent
+                ? concatAriaDescribedby(ariaDescribedby, context.descriptionId)
+                : ariaDescribedby
+            }
             data-state={getState(context.open)}
             {...contentProps}
             ref={forwardedRef}
@@ -530,6 +541,19 @@ export const WarningProvider: React.FC<
 };
 
 /* -----------------------------------------------------------------------------------------------*/
+
+// TODO: Move to primitive once that package exposed individual sub-modules
+function concatAriaDescribedby(...values: unknown[]): string | undefined {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    for (const id of String(value).trim().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
+
+  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
+}
 
 function getState(open: boolean) {
   return open ? 'open' : 'closed';

--- a/packages/react/form/src/form.test.tsx
+++ b/packages/react/form/src/form.test.tsx
@@ -120,6 +120,42 @@ describe('Form', () => {
       expect(control.getAttribute('aria-describedby')).toContain(message.id);
     });
 
+    // Regression test for https://github.com/radix-ui/primitives/issues/2598
+    it('should normalize existing aria-describedby ids and append a matching message id', async () => {
+      render(
+        <Form.Root>
+          <Form.Control
+            aria-describedby={' existing-description\texisting-description shared-description '}
+            name="email"
+            id="email"
+            type="email"
+            required
+          />
+          <Form.Message match="valueMissing" name="email">
+            Please enter your email address.
+          </Form.Message>
+          <span id="existing-description">Existing description</span>
+          <span id="shared-description">Shared description</span>
+        </Form.Root>,
+      );
+
+      const control = screen.getByRole('textbox');
+      expect(control).toHaveAttribute(
+        'aria-describedby',
+        'existing-description shared-description',
+      );
+
+      await act(async () => {
+        fireEvent.invalid(control);
+      });
+
+      const message = screen.getByText('Please enter your email address.');
+      expect(control).toHaveAttribute(
+        'aria-describedby',
+        `existing-description shared-description ${message.id}`,
+      );
+    });
+
     it('should expose validity through `Form.ValidityState` via `name`', async () => {
       render(
         <Form.Root>

--- a/packages/react/form/src/form.tsx
+++ b/packages/react/form/src/form.tsx
@@ -284,7 +284,13 @@ interface FormControlProps extends PrimitiveInputProps {}
 
 const FormControl = /* @__PURE__ */ React.forwardRef<FormControlElement, FormControlProps>(
   function FormControl(props: ScopedProps<FormControlProps>, forwardedRef) {
-    const { __scopeForm, name: nameProp, id: idProp, ...controlProps } = props;
+    const {
+      __scopeForm,
+      name: nameProp,
+      id: idProp,
+      'aria-describedby': ariaDescribedby,
+      ...controlProps
+    } = props;
 
     const validationContext = useValidationContext(CONTROL_NAME, __scopeForm);
     const fieldContext = useFormFieldContext(CONTROL_NAME, __scopeForm, { optional: true });
@@ -425,7 +431,10 @@ const FormControl = /* @__PURE__ */ React.forwardRef<FormControlElement, FormCon
         data-valid={getValidAttribute(validity, serverInvalid)}
         data-invalid={getInvalidAttribute(validity, serverInvalid)}
         aria-invalid={serverInvalid || undefined}
-        aria-describedby={ariaDescriptionContext.getFieldDescription(name)}
+        aria-describedby={concatAriaDescribedby(
+          ariaDescribedby,
+          ariaDescriptionContext.getFieldDescription(name),
+        )}
         // disable default browser behaviour of showing built-in error message on hover
         title=""
         {...controlProps}
@@ -724,20 +733,26 @@ function getValidAttribute(validity: ValidityState | undefined, serverInvalid: b
   if (validity?.valid === true && !serverInvalid) return true;
   return undefined;
 }
+
 function getInvalidAttribute(validity: ValidityState | undefined, serverInvalid: boolean) {
   if (validity?.valid === false || serverInvalid) return true;
   return undefined;
 }
 
-/* -----------------------------------------------------------------------------------------------*/
+// TODO: Move to primitive once that package exposed individual sub-modules
+function concatAriaDescribedby(...values: unknown[]): string | undefined {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    for (const id of String(value).trim().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
 
-const Root = Form;
-const Field = FormField;
-const Label = FormLabel;
-const Control = FormControl;
-const Message = FormMessage;
-const ValidityState = FormValidityState;
-const Submit = FormSubmit;
+  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
+}
+
+/* -----------------------------------------------------------------------------------------------*/
 
 export {
   createFormScope,
@@ -750,13 +765,13 @@ export {
   FormValidityState,
   FormSubmit,
   //
-  Root,
-  Field,
-  Label,
-  Control,
-  Message,
-  ValidityState,
-  Submit,
+  Form as Root,
+  FormField as Field,
+  FormLabel as Label,
+  FormControl as Control,
+  FormMessage as Message,
+  FormValidityState as ValidityState,
+  FormSubmit as Submit,
 };
 
 export type {

--- a/packages/react/slot/src/slot.test.tsx
+++ b/packages/react/slot/src/slot.test.tsx
@@ -324,6 +324,24 @@ describe('Slot prop and ref merging (single element child)', () => {
     expect(order).toEqual(['child', 'slot']);
   });
 
+  it('merges, normalizes, and deduplicates aria-describedby with the child ids first', () => {
+    render(
+      <Slot aria-describedby={' shared-description  slot-description '}>
+        <button
+          aria-describedby={' child-description\tshared-description child-description '}
+          type="button"
+        >
+          hi
+        </button>
+      </Slot>,
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-describedby',
+      'child-description shared-description slot-description',
+    );
+  });
+
   it('composes the Slot ref and the child ref onto the same node', () => {
     const slotRef = vi.fn();
     const childRef = vi.fn();

--- a/packages/react/slot/src/slot.tsx
+++ b/packages/react/slot/src/slot.tsx
@@ -169,6 +169,8 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
       overrideProps[propName] = { ...slotPropValue, ...childPropValue };
     } else if (propName === 'className') {
       overrideProps[propName] = [slotPropValue, childPropValue].filter(Boolean).join(' ');
+    } else if (propName === 'aria-describedby') {
+      overrideProps[propName] = concatAriaDescribedby(childPropValue, slotPropValue);
     }
   }
 
@@ -238,6 +240,19 @@ function isLazyComponent(element: React.ReactNode): element is LazyReactElement 
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof value === 'object' && value !== null && 'then' in value;
+}
+
+// TODO: Move to primitive once that package exposed individual sub-modules
+function concatAriaDescribedby(...values: unknown[]): string | undefined {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    for (const id of String(value).trim().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
+
+  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
 }
 
 const createSlotError = (ownerName: string) => {

--- a/packages/react/tooltip/src/tooltip.test.tsx
+++ b/packages/react/tooltip/src/tooltip.test.tsx
@@ -50,6 +50,96 @@ describe('Tooltip', () => {
     });
   });
 
+  // Regression test for https://github.com/radix-ui/primitives/issues/2598
+  it('appends the tooltip id to an existing aria-describedby', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger aria-describedby="existing-description">Tooltip Trigger</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content id="tooltip-description">Tooltip Content</Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+        <span id="existing-description">Existing description</span>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    expect(trigger).toHaveAttribute('aria-describedby', 'existing-description');
+
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute(
+        'aria-describedby',
+        'existing-description tooltip-description',
+      );
+    });
+
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-describedby', 'existing-description');
+    });
+  });
+
+  it('normalizes and deduplicates aria-describedby ids when the tooltip opens', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger
+            aria-describedby={' existing-description\texisting-description tooltip-description '}
+          >
+            Tooltip Trigger
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content id="tooltip-description">Tooltip Content</Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute(
+        'aria-describedby',
+        'existing-description tooltip-description',
+      );
+    });
+  });
+
+  // Regression test for https://github.com/radix-ui/primitives/issues/2598
+  it('appends the tooltip id to aria-describedby on an asChild trigger', async () => {
+    render(
+      <Tooltip.Provider>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger asChild>
+            <button aria-describedby="existing-description">Tooltip Trigger</button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content id="tooltip-description">Tooltip Content</Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+        <span id="existing-description">Existing description</span>
+      </Tooltip.Provider>,
+    );
+
+    const trigger = screen.getByText('Tooltip Trigger');
+    expect(trigger).toHaveAttribute('aria-describedby', 'existing-description');
+
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute(
+        'aria-describedby',
+        'existing-description tooltip-description',
+      );
+    });
+
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-describedby', 'existing-description');
+    });
+  });
+
   // Regression test for https://github.com/radix-ui/primitives/issues/3034
   // Content children must be mounted to the DOM a single time so that their
   // effects (analytics, fetches, etc.) do not run twice.

--- a/packages/react/tooltip/src/tooltip.tsx
+++ b/packages/react/tooltip/src/tooltip.tsx
@@ -270,7 +270,7 @@ interface TooltipTriggerProps extends PrimitiveButtonProps {}
 
 const TooltipTrigger = /* @__PURE__ */ React.forwardRef<TooltipTriggerElement, TooltipTriggerProps>(
   function TooltipTrigger(props: ScopedProps<TooltipTriggerProps>, forwardedRef) {
-    const { __scopeTooltip, ...triggerProps } = props;
+    const { __scopeTooltip, 'aria-describedby': ariaDescribedby, ...triggerProps } = props;
     const context = useTooltipContext(TRIGGER_NAME, __scopeTooltip);
     const providerContext = useTooltipProviderContext(TRIGGER_NAME, __scopeTooltip);
     const popperScope = usePopperScope(__scopeTooltip);
@@ -289,7 +289,11 @@ const TooltipTrigger = /* @__PURE__ */ React.forwardRef<TooltipTriggerElement, T
         <Primitive.button
           // We purposefully avoid adding `type=button` here because tooltip triggers are also
           // commonly anchors and the anchor `type` attribute signifies MIME type.
-          aria-describedby={context.open ? context.contentId : undefined}
+          aria-describedby={
+            context.open
+              ? concatAriaDescribedby(ariaDescribedby, context.contentId)
+              : ariaDescribedby
+          }
           data-state={context.stateAttribute}
           {...triggerProps}
           ref={composedRefs}
@@ -750,12 +754,18 @@ function getHullPresorted<P extends Point>(points: Readonly<Array<P>>): Array<P>
   }
 }
 
-const Provider = TooltipProvider;
-const Root = Tooltip;
-const Trigger = TooltipTrigger;
-const Portal = TooltipPortal;
-const Content = TooltipContent;
-const Arrow = TooltipArrow;
+// TODO: Move to primitive once that package exposed individual sub-modules
+function concatAriaDescribedby(...values: unknown[]): string | undefined {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    for (const id of String(value).trim().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
+
+  return ids.size > 0 ? Array.from(ids).join(' ') : undefined;
+}
 
 export {
   createTooltipScope,
@@ -767,12 +777,12 @@ export {
   TooltipContent,
   TooltipArrow,
   //
-  Provider,
-  Root,
-  Trigger,
-  Portal,
-  Content,
-  Arrow,
+  TooltipProvider as Provider,
+  Tooltip as Root,
+  TooltipTrigger as Trigger,
+  TooltipPortal as Portal,
+  TooltipContent as Content,
+  TooltipArrow as Arrow,
 };
 export type {
   TooltipProviderProps,


### PR DESCRIPTION
Fixes #2598.

Preserves consumer-provided `aria-describedby` IDs when Radix adds its own descriptions in Tooltip, Dialog, and Form. Additionally, this updates Slot prop merging so `asChild` elements compose descriptions correctly. ID lists are normalized, deduplicated, and retain consumer-first ordering.