### PR TITLE
fix(Select): register content as ancestor FocusScope branch to prevent focus freeze inside Dialog

### DIFF
--- a/.changeset/slick-emus-show.md
+++ b/.changeset/slick-emus-show.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-select": patch
+---
+
+fix(Select): register content as ancestor FocusScope branch to prevent focus freeze inside Dialog

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -8,7 +8,7 @@ import { createContextScope } from '@radix-ui/react-context';
 import { useDirection } from '@radix-ui/react-direction';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { useFocusGuards } from '@radix-ui/react-focus-guards';
-import { FocusScope } from '@radix-ui/react-focus-scope';
+import { FocusScope, useFocusScopeBranch } from '@radix-ui/react-focus-scope';
 import { useId } from '@radix-ui/react-id';
 import * as PopperPrimitive from '@radix-ui/react-popper';
 import { createPopperScope } from '@radix-ui/react-popper';
@@ -667,6 +667,12 @@ const SelectContentImpl = /* @__PURE__ */ React.forwardRef<
     React.useEffect(() => {
       if (content) return hideOthers(content);
     }, [content]);
+
+    // Register this content as a branch of the nearest ancestor FocusScope
+    // (e.g. a Dialog). Without this, a trapped FocusScope above us (like
+    // Dialog's) would reclaim focus when the Select portal receives it,
+    // freezing focus. See https://github.com/radix-ui/primitives/issues/3701
+    useFocusScopeBranch(content);
 
     // Make sure the whole tree has focus guards as our `Select` may be
     // the last element in the DOM (because of the `Portal`)


### PR DESCRIPTION
When a Select is used inside a Dialog (React 19), the Dialog's FocusScope traps focus with `trapped={true}`. The Select opens its content in a portal (outside the Dialog's DOM subtree), so the Dialog's FocusScope reclaims focus whenever it moves to the Select's portal — freezing the user in the Dialog with no way to interact with the Select.

**Root cause:** the Select's `FocusScope` doesn't register its content as a branch of the nearest ancestor `FocusScopeBranchProvider` (set up by Dialog). The Dialog's FocusScope sees focus leave its container and pulls it back.

**The fix:** added `useFocusScopeBranch(content)` in `SelectContentImpl`. This registers the Select's portal content as a branch of the ancestor FocusScope, so the Dialog's FocusScope knows the Select's portal is part of its scope and allows focus to move freely between the two.

This is the same pattern already used by other portalled components (Popover, Tooltip) that work correctly inside Dialogs.

**Testing:** all existing tests pass — Select (17), Dialog (15), FocusScope (11).

Fixes #3701