### PR TITLE
fix(navigation-menu): add missing data-state on forceMount viewport content

### DIFF
--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -373,3 +373,44 @@ describe('focus outside', () => {
     expect(onValueChange).toHaveBeenCalledWith('');
   });
 });
+
+// See: https://github.com/radix-ui/primitives/issues/3786
+describe('data-state on forceMount viewport content', () => {
+  afterEach(cleanup);
+
+  it('should have data-state="open" on active viewport content', async () => {
+    render(
+      <NavigationMenu.Root defaultValue="one">
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+            <NavigationMenu.Content forceMount>
+              <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+        <NavigationMenu.Viewport />
+      </NavigationMenu.Root>,
+    );
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+    expect(screen.getByText(CONTENT_TEXT).closest('[data-state]')).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should have data-state="closed" on inactive forceMount viewport content', async () => {
+    render(
+      <NavigationMenu.Root value="two">
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+            <NavigationMenu.Content forceMount>
+              <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+        <NavigationMenu.Viewport />
+      </NavigationMenu.Root>,
+    );
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+    expect(screen.getByText(CONTENT_TEXT).closest('[data-state]')).toHaveAttribute('data-state', 'closed');
+  });
+});

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -871,7 +871,7 @@ const NavigationMenuContent = /* @__PURE__ */ React.forwardRef<
       />
     </Presence>
   ) : (
-    <ViewportContentMounter forceMount={forceMount} {...commonProps} ref={composedRefs} />
+    <ViewportContentMounter forceMount={forceMount} data-state={getOpenState(open)} {...commonProps} ref={composedRefs} />
   );
 });
 


### PR DESCRIPTION
## Summary
- `NavigationMenuContent` with `forceMount` and `NavigationMenuViewport` was missing the `data-state` attribute
- The non-viewport path already set `data-state` correctly; this aligns the viewport path with the same behavior
- Added regression tests for both open and closed states

Fixes https://github.com/radix-ui/primitives/issues/3786