### PR TITLE
fix(navigation-menu): add missing data-state on forceMount viewport content

### DIFF
--- a/.changeset/nav-menu-data-state.md
+++ b/.changeset/nav-menu-data-state.md
@@ -1,0 +1,5 @@
+---
+"@radix-ui/react-navigation-menu": patch
+---
+
+Add missing `data-state` attribute on `NavigationMenuContent` when using `forceMount` with `NavigationMenuViewport`.

--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -373,3 +373,31 @@ describe('focus outside', () => {
     expect(onValueChange).toHaveBeenCalledWith('');
   });
 });
+
+// Reproduction for https://github.com/radix-ui/primitives/issues/3786
+describe('data-state on forceMount viewport content (repro)', () => {
+  afterEach(cleanup);
+
+  it('should have data-state on content element with forceMount + Viewport', async () => {
+    render(
+      <NavigationMenu.Root defaultValue="one">
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>{TRIGGER_TEXT}</NavigationMenu.Trigger>
+            <NavigationMenu.Content forceMount>
+              <NavigationMenu.Link href="#">{CONTENT_TEXT}</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+        <NavigationMenu.Viewport />
+      </NavigationMenu.Root>,
+    );
+    await waitFor(() => expect(screen.getByText(CONTENT_TEXT)).toBeInTheDocument());
+
+    // DismissableLayer (the content element) has data-orientation.
+    // Going up from the link, the first [data-orientation] ancestor is the
+    // content element itself — not the viewport wrapper further up.
+    const contentEl = screen.getByText(CONTENT_TEXT).closest('[data-orientation]');
+    expect(contentEl).toHaveAttribute('data-state', 'open');
+  });
+});

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -871,7 +871,7 @@ const NavigationMenuContent = /* @__PURE__ */ React.forwardRef<
       />
     </Presence>
   ) : (
-    <ViewportContentMounter forceMount={forceMount} {...commonProps} ref={composedRefs} />
+    <ViewportContentMounter forceMount={forceMount} data-state={getOpenState(open)} {...commonProps} ref={composedRefs} />
   );
 });
 


### PR DESCRIPTION
## Summary
- `NavigationMenuContent` with `forceMount` and `NavigationMenuViewport` was missing the `data-state` attribute on the content element (the `DismissableLayer` rendered by `NavigationMenuContentImpl`).
- The non-viewport path already set `data-state` correctly. The viewport path sends props through `ViewportContentMounter` → context → `NavigationMenuViewportItem` → `NavigationMenuContentImpl`, and `data-state` was not included in those props.
- Added a one-line fix to pass `data-state={getOpenState(open)}` to `ViewportContentMounter`, matching the non-viewport path.

## Test
- Added a regression test verifying the content element itself (not just the viewport wrapper) has the correct `data-state` attribute when using `forceMount` + `Viewport`.

Fixes https://github.com/radix-ui/primitives/issues/3786