### PR TITLE
Add `ScrollArea.Content` part

### DIFF
--- a/.changeset/breezy-planes-shop.md
+++ b/.changeset/breezy-planes-shop.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-scroll-area": patch
+"radix-ui": patch
+---
+
+Fixed `asChild` being applied to the wrong element on `ScrollArea.Viewport`.

--- a/.changeset/tasty-parts-find.md
+++ b/.changeset/tasty-parts-find.md
@@ -1,0 +1,19 @@
+---
+"@radix-ui/react-scroll-area": minor
+"radix-ui": minor
+---
+
+Added a `ScrollArea.Content` part so consumers can own the wrapper element implicitly rendered by `ScrollArea.Viewport`. This must be used with the viewport's `disableImplicitContentElement` prop.
+
+```tsx
+<ScrollArea.Root>
+  <ScrollArea.Viewport disableImplicitContentElement>
+    <ScrollArea.Content>{children}</ScrollArea.Content>
+  </ScrollArea.Viewport>
+  <ScrollArea.Scrollbar>
+    <ScrollArea.Thumb />
+  </ScrollArea.Scrollbar>
+</ScrollArea.Root>
+```
+
+In the next major release, the content element will no longer be implicitly rendered by the viewport. We recommend migrating to this API today for a smooth upgrade path.

--- a/apps/storybook/stories/scroll-area.stories.tsx
+++ b/apps/storybook/stories/scroll-area.stories.tsx
@@ -384,14 +384,16 @@ export const Cypress = () => {
         className={styles.scrollArea}
         style={{ width: 200, height: 200 }}
       >
-        <ScrollArea.Viewport className={styles.scrollAreaViewport}>
-          <div style={{ width: horizontalOverflow ? 4000 : '100%' }}>
-            {Array.from({ length: 30 }).map((_, index) => (
-              <p key={index} style={{ margin: 0 }}>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              </p>
-            ))}
-          </div>
+        <ScrollArea.Viewport className={styles.scrollAreaViewport} disableImplicitContentElement>
+          <ScrollArea.Content>
+            <div style={{ width: horizontalOverflow ? 4000 : '100%' }}>
+              {Array.from({ length: 30 }).map((_, index) => (
+                <p key={index} style={{ margin: 0 }}>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </p>
+              ))}
+            </div>
+          </ScrollArea.Content>
         </ScrollArea.Viewport>
         <ScrollArea.Scrollbar className={styles.scrollbar} orientation="vertical">
           <ScrollArea.Thumb className={styles.thumb} />
@@ -418,7 +420,9 @@ const ScrollAreaStory = ({
     className={styles.scrollArea}
     style={{ width: 200, height: 200, ...props.style }}
   >
-    <ScrollArea.Viewport className={styles.scrollAreaViewport}>{children}</ScrollArea.Viewport>
+    <ScrollArea.Viewport className={styles.scrollAreaViewport} disableImplicitContentElement>
+      <ScrollArea.Content>{children}</ScrollArea.Content>
+    </ScrollArea.Viewport>
     {vertical && (
       <ScrollArea.Scrollbar className={styles.scrollbar} orientation="vertical">
         <ScrollArea.Thumb

--- a/packages/react/scroll-area/package.json
+++ b/packages/react/scroll-area/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-direction": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*"
   },

--- a/packages/react/scroll-area/src/index.ts
+++ b/packages/react/scroll-area/src/index.ts
@@ -4,12 +4,14 @@ export {
   //
   ScrollArea,
   ScrollAreaViewport,
+  ScrollAreaContent,
   ScrollAreaScrollbar,
   ScrollAreaThumb,
   ScrollAreaCorner,
   //
   Root,
   Viewport,
+  Content,
   Scrollbar,
   Thumb,
   Corner,
@@ -17,6 +19,7 @@ export {
 export type {
   ScrollAreaProps,
   ScrollAreaViewportProps,
+  ScrollAreaContentProps,
   ScrollAreaScrollbarProps,
   ScrollAreaThumbProps,
   ScrollAreaCornerProps,

--- a/packages/react/scroll-area/src/scroll-area.test.tsx
+++ b/packages/react/scroll-area/src/scroll-area.test.tsx
@@ -386,6 +386,36 @@ describe('ScrollArea.Viewport', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  // Regression for the Slottable fallback when `asChild` can't redirect onto a
+  // single element child. This avoids a breaking change for users who are
+  // misusing the asChild API. We should expect this test to fail when we remove
+  // the fallback branch ahead of the next major release.
+  it('falls back to the content wrapper when `asChild` children are not a single element', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const condition = false;
+
+    expect(() => {
+      render(
+        <ScrollArea.Root type="always">
+          <ScrollArea.Viewport asChild data-testid="viewport" className="custom-class">
+            {condition && <article />}
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>,
+      );
+    }).not.toThrow();
+
+    // Props land on the implicit content wrapper rather than throwing because
+    // there is no element for Slot to target
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport).toHaveClass('custom-class');
+    expect(viewport).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('`asChild` expects a single React element child'),
+    );
+
+    warn.mockRestore();
+  });
+
   it('renders an implicit content element around its children by default', () => {
     render(
       <ScrollArea.Root type="always">

--- a/packages/react/scroll-area/src/scroll-area.test.tsx
+++ b/packages/react/scroll-area/src/scroll-area.test.tsx
@@ -11,7 +11,9 @@ describe('ScrollArea ref stability', () => {
   it('keeps a stable composed ref on the root', () => {
     assertStableComposedRef((ref) => (
       <ScrollArea.Root ref={ref}>
-        <ScrollArea.Viewport>content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>content</ScrollArea.Content>
+        </ScrollArea.Viewport>
       </ScrollArea.Root>
     ));
   });
@@ -19,7 +21,9 @@ describe('ScrollArea ref stability', () => {
   it('keeps a stable composed ref on the scrollbar', () => {
     assertStableComposedRef((ref) => (
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar orientation="vertical" ref={ref}>
           <ScrollArea.Thumb />
         </ScrollArea.Scrollbar>
@@ -57,7 +61,9 @@ describe('ScrollArea.Root', () => {
         style={{ outlineColor: 'rgb(1, 2, 3)' }}
         onClick={onClick}
       >
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
       </ScrollArea.Root>,
     );
 
@@ -85,7 +91,9 @@ describe('ScrollArea.Root', () => {
         onClick={onClick}
       >
         <article>
-          <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+          <ScrollArea.Viewport disableImplicitContentElement>
+            <ScrollArea.Content>Content</ScrollArea.Content>
+          </ScrollArea.Viewport>
         </article>
       </ScrollArea.Root>,
     );
@@ -111,7 +119,9 @@ describe('ScrollArea.Scrollbar', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar
           orientation="vertical"
           ref={ref}
@@ -138,7 +148,9 @@ describe('ScrollArea.Scrollbar', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar
           orientation="vertical"
           asChild
@@ -175,7 +187,9 @@ describe('ScrollArea.Thumb', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar orientation="vertical">
           <ScrollArea.Thumb
             // `forceMount` because the thumb otherwise waits for a measured overflow
@@ -205,7 +219,9 @@ describe('ScrollArea.Thumb', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar orientation="vertical">
           <ScrollArea.Thumb
             forceMount
@@ -243,7 +259,9 @@ describe('ScrollArea.Corner', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar orientation="horizontal" />
         <ScrollArea.Scrollbar orientation="vertical" />
         <ScrollArea.Corner
@@ -272,7 +290,9 @@ describe('ScrollArea.Corner', () => {
 
     render(
       <ScrollArea.Root type="always">
-        <ScrollArea.Viewport>Content</ScrollArea.Viewport>
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content>Content</ScrollArea.Content>
+        </ScrollArea.Viewport>
         <ScrollArea.Scrollbar orientation="horizontal" />
         <ScrollArea.Scrollbar orientation="vertical" />
         <ScrollArea.Corner
@@ -332,6 +352,170 @@ describe('ScrollArea.Viewport', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  // TODO: Fix this
-  it.todo('forwards props to the child element when `asChild` is set');
+  it('forwards props to the child element when `asChild` is set', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport
+          asChild
+          ref={ref}
+          data-testid="viewport"
+          className="custom-class"
+          style={{ outlineColor: 'rgb(1, 2, 3)' }}
+          onClick={onClick}
+        >
+          <article>Content</article>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.tagName).toBe('ARTICLE');
+    expect(viewport).toHaveAttribute('data-radix-scroll-area-viewport', '');
+    expect(viewport.style.overflowX).toBe('hidden');
+    expect(viewport.style.overflowY).toBe('hidden');
+    expect(viewport).toHaveClass('custom-class');
+    expect(viewport.style.outlineColor).toBe('rgb(1, 2, 3)');
+    expect(ref.current).toBe(viewport);
+    expect(viewport.firstElementChild).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(viewport).toHaveTextContent('Content');
+
+    fireEvent.click(viewport);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders an implicit content element around its children by default', () => {
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport data-testid="viewport">Content</ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    const content = viewport.firstElementChild;
+    expect(content).toBeInstanceOf(HTMLDivElement);
+    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveTextContent('Content');
+  });
+
+  it('skips the implicit content element when `disableImplicitContentElement` is set', () => {
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport disableImplicitContentElement data-testid="viewport">
+          <span data-testid="child">Content</span>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    const child = screen.getByTestId('child');
+    expect(viewport.firstElementChild).toBe(child);
+    expect(child).not.toHaveStyle({ display: 'table' });
+  });
+
+  it('forwards props to the child when `asChild` is set with `disableImplicitContentElement`', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport
+          asChild
+          disableImplicitContentElement
+          ref={ref}
+          data-testid="viewport"
+          className="custom-class"
+          style={{ outlineColor: 'rgb(1, 2, 3)' }}
+          onClick={onClick}
+        >
+          <article>
+            <ScrollArea.Content>Content</ScrollArea.Content>
+          </article>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.tagName).toBe('ARTICLE');
+    expect(viewport).toHaveAttribute('data-radix-scroll-area-viewport', '');
+    expect(viewport.style.overflowX).toBe('hidden');
+    expect(viewport.style.overflowY).toBe('hidden');
+    expect(viewport).toHaveClass('custom-class');
+    expect(viewport.style.outlineColor).toBe('rgb(1, 2, 3)');
+    expect(ref.current).toBe(viewport);
+    expect(viewport.firstElementChild).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(viewport).toHaveTextContent('Content');
+
+    fireEvent.click(viewport);
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+
+describe('ScrollArea.Content', () => {
+  afterEach(cleanup);
+
+  it('spreads props it does not consume onto the element it renders', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content
+            ref={ref}
+            data-testid="content"
+            className="custom-class"
+            style={{ outlineColor: 'rgb(1, 2, 3)' }}
+            onClick={onClick}
+          >
+            Content
+          </ScrollArea.Content>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const content = screen.getByTestId('content');
+    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveClass('custom-class');
+    expect(content.style.outlineColor).toBe('rgb(1, 2, 3)');
+    expect(ref.current).toBe(content);
+
+    fireEvent.click(content);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('forwards props to the child element when `asChild` is set', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+
+    render(
+      <ScrollArea.Root type="always">
+        <ScrollArea.Viewport disableImplicitContentElement>
+          <ScrollArea.Content
+            asChild
+            ref={ref}
+            data-testid="content"
+            className="custom-class"
+            style={{ outlineColor: 'rgb(1, 2, 3)' }}
+            onClick={onClick}
+          >
+            <article>Content</article>
+          </ScrollArea.Content>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>,
+    );
+
+    const content = screen.getByTestId('content');
+    expect(content.tagName).toBe('ARTICLE');
+    expect(content).toHaveStyle({ display: 'table', minWidth: '100%' });
+    expect(content).toHaveClass('custom-class');
+    expect(content.style.outlineColor).toBe('rgb(1, 2, 3)');
+    expect(ref.current).toBe(content);
+    expect(content).toHaveTextContent('Content');
+
+    fireEvent.click(content);
+    expect(onClick).toHaveBeenCalled();
+  });
 });

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Presence } from '@radix-ui/react-presence';
+import { createSlottable } from '@radix-ui/react-slot';
 import { createContextScope } from '@radix-ui/react-context';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
@@ -149,10 +150,16 @@ const ScrollArea = /* @__PURE__ */ React.forwardRef<ScrollAreaElement, ScrollAre
  * -----------------------------------------------------------------------------------------------*/
 
 const VIEWPORT_NAME = 'ScrollAreaViewport';
+const Slottable = createSlottable(VIEWPORT_NAME);
 
 type ScrollAreaViewportElement = React.ComponentRef<typeof Primitive.div>;
 interface ScrollAreaViewportProps extends PrimitiveDivProps {
   nonce?: string;
+  /**
+   * @deprecated Implicit rendering of the content element will be removed in
+   * the next major release.
+   */
+  disableImplicitContentElement?: boolean;
 }
 
 const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
@@ -161,7 +168,8 @@ const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
 >(
   // blank line to reduce diff noise
   function ScrollAreaViewport(props: ScopedProps<ScrollAreaViewportProps>, forwardedRef) {
-    const { __scopeScrollArea, children, nonce, ...viewportProps } = props;
+    const { __scopeScrollArea, children, nonce, disableImplicitContentElement, ...viewportProps } =
+      props;
     const context = useScrollAreaContext(VIEWPORT_NAME, __scopeScrollArea);
     const ref = React.useRef<ScrollAreaViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
@@ -189,16 +197,27 @@ const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
             ...props.style,
           }}
         >
-          {/**
-           * `display: table` ensures our content div will match the size of its children in both
-           * horizontal and vertical axis so we can determine if scroll width/height changed and
-           * recalculate thumb sizes. This doesn't account for children with *percentage*
-           * widths that change. We'll wait to see what use-cases consumers come up with there
-           * before trying to resolve it.
+          {/*
+           * Nested `Slottable` keeps the content-measuring wrapper inside the
+           * slotted element when `asChild` is set. Without it, `Slot` would
+           * target that wrapper and drop every prop on the consumer's element.
+           *
+           * See: https://github.com/radix-ui/primitives/issues/1666.
            */}
-          <div ref={context.onContentChange} style={{ minWidth: '100%', display: 'table' }}>
-            {children}
-          </div>
+          {disableImplicitContentElement ? (
+            children
+          ) : (
+            <Slottable child={children}>
+              {(slottable) => (
+                <ScrollAreaContent
+                  // @ts-expect-error
+                  __scopeScrollArea={__scopeScrollArea}
+                >
+                  {slottable}
+                </ScrollAreaContent>
+              )}
+            </Slottable>
+          )}
         </Primitive.div>
       </>
     );
@@ -219,6 +238,39 @@ const ScrollAreaViewportStyle = /* @__PURE__ */ React.memo(
   },
   (prevProps, nextProps) => prevProps.nonce === nextProps.nonce,
 );
+
+/* -------------------------------------------------------------------------------------------------
+ * ScrollAreaContent
+ * -----------------------------------------------------------------------------------------------*/
+
+const CONTENT_NAME = 'ScrollAreaContent';
+
+type ScrollAreaContentElement = React.ComponentRef<typeof Primitive.div>;
+interface ScrollAreaContentProps extends PrimitiveDivProps {}
+
+const ScrollAreaContent = /* @__PURE__ */ React.forwardRef<
+  ScrollAreaContentElement,
+  ScrollAreaContentProps
+>(function ScrollAreaContent(props: ScopedProps<ScrollAreaContentProps>, forwardedRef) {
+  const { __scopeScrollArea, children, ...contentProps } = props;
+  const context = useScrollAreaContext(CONTENT_NAME, __scopeScrollArea);
+  const composedRefs = useComposedRefs(forwardedRef, context.onContentChange);
+  return (
+    // `display: table` ensures our content div will match the size of its
+    // children in both horizontal and vertical axis so we can determine if
+    // scroll width/height changed and recalculate thumb sizes. This doesn't
+    // account for children with *percentage* widths that change. We'll wait to
+    // see what use-cases consumers come up with there before trying to resolve
+    // it.
+    <Primitive.div
+      {...contentProps}
+      ref={composedRefs}
+      style={{ minWidth: '100%', display: 'table', ...props.style }}
+    >
+      {children}
+    </Primitive.div>
+  );
+});
 
 /* -------------------------------------------------------------------------------------------------
  * ScrollAreaScrollbar
@@ -1076,12 +1128,14 @@ export {
   //
   ScrollArea,
   ScrollAreaViewport,
+  ScrollAreaContent,
   ScrollAreaScrollbar,
   ScrollAreaThumb,
   ScrollAreaCorner,
   //
   ScrollArea as Root,
   ScrollAreaViewport as Viewport,
+  ScrollAreaContent as Content,
   ScrollAreaScrollbar as Scrollbar,
   ScrollAreaThumb as Thumb,
   ScrollAreaCorner as Corner,
@@ -1089,6 +1143,7 @@ export {
 export type {
   ScrollAreaProps,
   ScrollAreaViewportProps,
+  ScrollAreaContentProps,
   ScrollAreaScrollbarProps,
   ScrollAreaThumbProps,
   ScrollAreaCornerProps,

--- a/packages/react/scroll-area/src/scroll-area.tsx
+++ b/packages/react/scroll-area/src/scroll-area.tsx
@@ -9,6 +9,7 @@ import { useDirection } from '@radix-ui/react-direction';
 import { useLayoutEffect } from '@radix-ui/react-use-layout-effect';
 import { clamp } from '@radix-ui/number';
 import { composeEventHandlers } from '@radix-ui/primitive';
+import { IS_DEVELOPMENT } from '@radix-ui/primitive/is-development';
 import { useStateMachine } from './use-state-machine';
 
 import type { Scope } from '@radix-ui/react-context';
@@ -156,8 +157,12 @@ type ScrollAreaViewportElement = React.ComponentRef<typeof Primitive.div>;
 interface ScrollAreaViewportProps extends PrimitiveDivProps {
   nonce?: string;
   /**
-   * @deprecated Implicit rendering of the content element will be removed in
-   * the next major release.
+   * Disables implicit rendering of an additional wrapper element that measures
+   * the content size. When `true`, a child `<ScrollArea.Content>` must be
+   * rendered as a direct child of the viewport.
+   *
+   * Implicit rendering of the content element will be removed in the next major
+   * release.
    */
   disableImplicitContentElement?: boolean;
 }
@@ -173,6 +178,27 @@ const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
     const context = useScrollAreaContext(VIEWPORT_NAME, __scopeScrollArea);
     const ref = React.useRef<ScrollAreaViewportElement>(null);
     const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange);
+
+    // `Slot` can only redirect props onto a single element, so `asChild` can
+    // only reach the consumer's element when `children` is one.
+    const canSlotOntoChildren = React.isValidElement(children);
+
+    // oxlint-disable react-hooks/rules-of-hooks
+    if (IS_DEVELOPMENT) {
+      const hasWarnedRef = React.useRef(false);
+      const shouldWarn =
+        props.asChild === true && !disableImplicitContentElement && !canSlotOntoChildren;
+      React.useEffect(() => {
+        if (shouldWarn && !hasWarnedRef.current) {
+          hasWarnedRef.current = true;
+          console.warn(
+            `${VIEWPORT_NAME}: \`asChild\` expects a single React element child, so its props have been applied to the implicitly rendered content element instead. Wrap the children in a single element, or opt into \`disableImplicitContentElement\` and render a \`ScrollArea.Content\` inside the viewport.`,
+          );
+        }
+      }, [shouldWarn]);
+    }
+    // oxlint-enable react-hooks/rules-of-hooks
+
     return (
       <>
         <ScrollAreaViewportStyle nonce={nonce} />
@@ -206,7 +232,7 @@ const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
            */}
           {disableImplicitContentElement ? (
             children
-          ) : (
+          ) : canSlotOntoChildren ? (
             <Slottable child={children}>
               {(slottable) => (
                 <ScrollAreaContent
@@ -216,6 +242,19 @@ const ScrollAreaViewport = /* @__PURE__ */ React.forwardRef<
                   {slottable}
                 </ScrollAreaContent>
               )}
+            </Slottable>
+          ) : (
+            // When `children` isn't a single element there is nothing for
+            // `Slot` to redirect onto, so target the wrapper. This mirrors the
+            // old [incorrect] behavior, but it's better than throwing on a
+            // patch update.
+            <Slottable>
+              <ScrollAreaContent
+                // @ts-expect-error
+                __scopeScrollArea={__scopeScrollArea}
+              >
+                {children}
+              </ScrollAreaContent>
             </Slottable>
           )}
         </Primitive.div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2054,6 +2054,9 @@ importers:
       '@radix-ui/react-primitive':
         specifier: workspace:*
         version: link:../primitive
+      '@radix-ui/react-slot':
+        specifier: workspace:*
+        version: link:../slot
       '@radix-ui/react-use-callback-ref':
         specifier: workspace:*
         version: link:../use-callback-ref


### PR DESCRIPTION
This PR does two things:

- Fixes `asChild` misdirection in `ScrollArea.Viewport` (Closes #1666)
- Adds a new `ScrollArea.Content` component that exposes the wrapper element that is implicitly rendered by the Viewport (this will be removed in the next major release)