### PR TITLE
Fix `asChild` bug in Navigation Menu

### DIFF
--- a/.changeset/tidy-cows-repeat.md
+++ b/.changeset/tidy-cows-repeat.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-navigation-menu": patch
+"radix-ui": patch
+---
+
+Fixed a bug with `asChild` on `NavigationMenu.Viewport` where the viewport discarded its children and rendered the active content in their place. The active content is now rendered inside the consumer's element alongside any children it already had.

--- a/.changeset/tidy-cows-repeat.md
+++ b/.changeset/tidy-cows-repeat.md
@@ -3,4 +3,4 @@
 "radix-ui": patch
 ---
 
-Fixed a bug with `asChild` on `NavigationMenu.Viewport` where the viewport discarded its children and rendered the active content in their place. The active content is now rendered inside the consumer's element alongside any children it already had.
+Fixed a bug on `NavigationMenu.Viewport` where the viewport discarded its children and rendered the active content in their place. The active content is now rendered inside the consumer's element alongside any children it already had.

--- a/packages/react/navigation-menu/package.json
+++ b/packages/react/navigation-menu/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-id": "workspace:*",
     "@radix-ui/react-presence": "workspace:*",
     "@radix-ui/react-primitive": "workspace:*",
+    "@radix-ui/react-slot": "workspace:*",
     "@radix-ui/react-use-callback-ref": "workspace:*",
     "@radix-ui/react-use-controllable-state": "workspace:*",
     "@radix-ui/react-use-layout-effect": "workspace:*",

--- a/packages/react/navigation-menu/src/navigation-menu.test.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.test.tsx
@@ -965,6 +965,65 @@ describe('NavigationMenu.Viewport', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  // TODO: Fix bug so this test passes.
-  it.todo('forwards props to the child element when `asChild` is set');
+  it('forwards props to the child element when `asChild` is set', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const onClick = vi.fn();
+
+    render(
+      <NavigationMenu.Root defaultValue="one">
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>Trigger</NavigationMenu.Trigger>
+            <NavigationMenu.Content>
+              <NavigationMenu.Link href="/">Link</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+        <NavigationMenu.Viewport asChild>
+          <section
+            ref={ref}
+            data-testid="viewport"
+            className="custom-class"
+            style={{ outlineColor: 'rgb(1, 2, 3)' }}
+            onClick={onClick}
+          />
+        </NavigationMenu.Viewport>
+      </NavigationMenu.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.tagName).toBe('SECTION');
+    expect(viewport).toHaveAttribute('data-state', 'open');
+    expect(viewport).toHaveAttribute('data-orientation', 'horizontal');
+    expect(viewport).toHaveClass('custom-class');
+    expect(viewport.style.outlineColor).toBe('rgb(1, 2, 3)');
+    expect(ref.current).toBe(viewport);
+
+    fireEvent.click(viewport);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders the active content inside the child element when `asChild` is set', () => {
+    render(
+      <NavigationMenu.Root defaultValue="one">
+        <NavigationMenu.List>
+          <NavigationMenu.Item value="one">
+            <NavigationMenu.Trigger>Trigger</NavigationMenu.Trigger>
+            <NavigationMenu.Content>
+              <NavigationMenu.Link href="/">Link</NavigationMenu.Link>
+            </NavigationMenu.Content>
+          </NavigationMenu.Item>
+        </NavigationMenu.List>
+        <NavigationMenu.Viewport asChild>
+          <section data-testid="viewport">
+            <span data-testid="decoration" />
+          </section>
+        </NavigationMenu.Viewport>
+      </NavigationMenu.Root>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport).toContainElement(screen.getByTestId('decoration'));
+    expect(viewport).toContainElement(screen.getByRole('link', { name: 'Link' }));
+  });
 });

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -7,6 +7,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useDirection } from '@radix-ui/react-direction';
 import { Presence } from '@radix-ui/react-presence';
+import { createSlottable } from '@radix-ui/react-slot';
 import { useId } from '@radix-ui/react-id';
 import { createCollection } from '@radix-ui/react-collection';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
@@ -1077,6 +1078,7 @@ const NavigationMenuContentImpl = /* @__PURE__ */ React.forwardRef<
  * -----------------------------------------------------------------------------------------------*/
 
 const VIEWPORT_NAME = 'NavigationMenuViewport';
+const Slottable = createSlottable(VIEWPORT_NAME);
 
 type NavigationMenuViewportElement = NavigationMenuViewportImplElement;
 interface NavigationMenuViewportProps extends Omit<
@@ -1160,19 +1162,33 @@ const NavigationMenuViewportImpl = /* @__PURE__ */ React.forwardRef<
       onPointerEnter={composeEventHandlers(props.onPointerEnter, context.onContentEnter)}
       onPointerLeave={composeEventHandlers(props.onPointerLeave, whenMouse(context.onContentLeave))}
     >
-      {Array.from(viewportContentContext.items).map(([value, { ref, forceMount, ...props }]) => {
-        const isActive = activeContentValue === value;
-        return (
-          <Presence key={value} present={forceMount || isActive}>
-            <NavigationMenuViewportItem
-              {...props}
-              contentRef={ref}
-              isActive={isActive}
-              onActiveContentChange={setContent}
-            />
-          </Presence>
-        );
-      })}
+      {/*
+       * Nested `Slottable` keeps the proxied content inside the slotted element
+       * when `asChild` is set. Without it, `Slot` would target that content and
+       * drop every prop on the consumer's element.
+       */}
+      <Slottable child={children}>
+        {(slottable) => (
+          <>
+            {slottable}
+            {Array.from(viewportContentContext.items).map(
+              ([value, { ref, forceMount, ...props }]) => {
+                const isActive = activeContentValue === value;
+                return (
+                  <Presence key={value} present={forceMount || isActive}>
+                    <NavigationMenuViewportItem
+                      {...props}
+                      contentRef={ref}
+                      isActive={isActive}
+                      onActiveContentChange={setContent}
+                    />
+                  </Presence>
+                );
+              },
+            )}
+          </>
+        )}
+      </Slottable>
     </Primitive.div>
   );
 });

--- a/packages/react/navigation-menu/src/navigation-menu.tsx
+++ b/packages/react/navigation-menu/src/navigation-menu.tsx
@@ -1163,32 +1163,24 @@ const NavigationMenuViewportImpl = /* @__PURE__ */ React.forwardRef<
       onPointerLeave={composeEventHandlers(props.onPointerLeave, whenMouse(context.onContentLeave))}
     >
       {/*
-       * Nested `Slottable` keeps the proxied content inside the slotted element
-       * when `asChild` is set. Without it, `Slot` would target that content and
-       * drop every prop on the consumer's element.
+       * `Slottable` keeps the proxied content inside the slotted element when
+       * `asChild` is set. Without it, `Slot` would target that content and drop
+       * every prop on the consumer's element.
        */}
-      <Slottable child={children}>
-        {(slottable) => (
-          <>
-            {slottable}
-            {Array.from(viewportContentContext.items).map(
-              ([value, { ref, forceMount, ...props }]) => {
-                const isActive = activeContentValue === value;
-                return (
-                  <Presence key={value} present={forceMount || isActive}>
-                    <NavigationMenuViewportItem
-                      {...props}
-                      contentRef={ref}
-                      isActive={isActive}
-                      onActiveContentChange={setContent}
-                    />
-                  </Presence>
-                );
-              },
-            )}
-          </>
-        )}
-      </Slottable>
+      <Slottable>{children}</Slottable>
+      {Array.from(viewportContentContext.items).map(([value, { ref, forceMount, ...props }]) => {
+        const isActive = activeContentValue === value;
+        return (
+          <Presence key={value} present={forceMount || isActive}>
+            <NavigationMenuViewportItem
+              {...props}
+              contentRef={ref}
+              isActive={isActive}
+              onActiveContentChange={setContent}
+            />
+          </Presence>
+        );
+      })}
     </Primitive.div>
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,6 +1331,9 @@ importers:
       '@radix-ui/react-primitive':
         specifier: workspace:*
         version: link:../primitive
+      '@radix-ui/react-slot':
+        specifier: workspace:*
+        version: link:../slot
       '@radix-ui/react-use-callback-ref':
         specifier: workspace:*
         version: link:../use-callback-ref


### PR DESCRIPTION
This PR fixes a bug with `asChild` on `NavigationMenu.Viewport` where the viewport discarded its children and rendered the active content in their place. The active content is now rendered inside the consumer's element alongside any children it already had.