### PR TITLE
[Checkbox] Fix visual state not updating when `defaultChecked` changes in a form

### DIFF
--- a/.changeset/quick-cheetahs-check.md
+++ b/.changeset/quick-cheetahs-check.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-checkbox": patch
+"radix-ui": patch
+---
+
+Fixed an issue where an uncontrolled `Checkbox.Root` inside a form would not visually reflect a change to its `defaultChecked` prop after a form reset (e.g. when a server action re-renders with a new value).

--- a/packages/react/checkbox/src/checkbox.test.tsx
+++ b/packages/react/checkbox/src/checkbox.test.tsx
@@ -239,6 +239,37 @@ describe('Checkbox', () => {
     });
   });
 
+  describe('given an uncontrolled Checkbox in a form', () => {
+    afterEach(cleanup);
+
+    // regression test for https://github.com/radix-ui/primitives/issues/4087
+    it('should restore the visual state to the latest `defaultChecked` prop when the form is reset', () => {
+      function App({ defaultChecked }: { defaultChecked: boolean }) {
+        return (
+          <form>
+            <Checkbox.Root defaultChecked={defaultChecked} aria-label="basic checkbox">
+              <Checkbox.Indicator data-testid={INDICATOR_TEST_ID} />
+            </Checkbox.Root>
+          </form>
+        );
+      }
+
+      const { rerender } = render(<App defaultChecked={false} />);
+      const checkbox = screen.getByRole(CHECKBOX_ROLE);
+      const form = checkbox.closest('form')!;
+
+      act(() => fireEvent.click(checkbox));
+      expect(screen.getByTestId(INDICATOR_TEST_ID)).toBeVisible();
+
+      // simulate a server action (e.g. `useActionState`) re-rendering with a new
+      // `defaultChecked` and then resetting the form
+      act(() => rerender(<App defaultChecked />));
+      act(() => fireEvent.reset(form));
+
+      expect(screen.getByTestId(INDICATOR_TEST_ID)).toBeVisible();
+    });
+  });
+
   describe('given a controlled Checkbox in form with bubble input', () => {
     const onChange = vi.fn();
 

--- a/packages/react/checkbox/src/checkbox.tsx
+++ b/packages/react/checkbox/src/checkbox.tsx
@@ -156,18 +156,18 @@ const CheckboxTrigger = /* @__PURE__ */ React.forwardRef<HTMLButtonElement, Chec
       onUserInteraction,
       isFormControl,
       bubbleInput,
+      defaultChecked,
     } = useCheckboxContext(TRIGGER_NAME, __scopeCheckbox);
     const composedRefs = useComposedRefs(forwardedRef, setControl);
 
-    const initialCheckedStateRef = React.useRef(checked);
     React.useEffect(() => {
       const form = control?.form;
       if (form) {
-        const reset = () => setChecked(initialCheckedStateRef.current);
+        const reset = () => setChecked(defaultChecked ?? false);
         form.addEventListener('reset', reset);
         return () => form.removeEventListener('reset', reset);
       }
-    }, [control, setChecked]);
+    }, [control, setChecked, defaultChecked]);
 
     return (
       <Primitive.button


### PR DESCRIPTION
### Description

Fixes #4087.

When an uncontrolled `Checkbox.Root` lives inside a form and the `defaultChecked`
prop changes (e.g. a server action via `useActionState` re-renders it from
`false` to `true`), the form reset left the visual checkbox unchecked even though
the hidden `input[type="checkbox"]` was checked.

The form `reset` handler in `CheckboxTrigger` restored the checked state captured
at mount (`initialCheckedStateRef`), ignoring the updated `defaultChecked` prop.
It now restores to the current `defaultChecked` prop (`defaultChecked ?? false`),
matching native `<input defaultChecked>` semantics where a reset restores the
latest default value.

#### Changes
- `packages/react/checkbox/src/checkbox.tsx` — the form reset handler now uses
  the current `defaultChecked` prop instead of a mount-time snapshot.
- `packages/react/checkbox/src/checkbox.test.tsx` — regression test covering an
  uncontrolled checkbox in a form whose `defaultChecked` goes `false` → `true`
  followed by a form reset.
- `.changeset/quick-cheetahs-check.md` — patch changeset for
  `@radix-ui/react-checkbox` and `radix-ui`.