### PR TITLE
fix(select): announce option position and total for screen readers

### DIFF
--- a/.changeset/soft-tigers-glow.md
+++ b/.changeset/soft-tigers-glow.md
@@ -1,0 +1,6 @@
+---
+"@radix-ui/react-select": patch
+"radix-ui": patch
+---
+
+Fix `Select.Item` so screen readers announce the option's position and total (`aria-posinset` / `aria-setsize`). VoiceOver + Chrome previously announced an incorrect count (based on the options visible in the scrollable viewport) or omitted the count entirely when no value was preselected; the option now declares its own position within its list, including grouped selects.

--- a/packages/react/select/src/select.test.tsx
+++ b/packages/react/select/src/select.test.tsx
@@ -1602,6 +1602,124 @@ describe('Select.ItemText', () => {
   it.todo("applies the consumer's `className` and `style`");
 });
 
+describe('Select.Item aria-posinset/aria-setsize', () => {
+  afterEach(cleanupModal);
+
+  it('declares each ungrouped option position within the full list', () => {
+    render(
+      <Select.Root defaultOpen>
+        <Select.Trigger>
+          <Select.Value placeholder="Pick one" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Item value="apple">
+                <Select.ItemText>Apple</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="banana">
+                <Select.ItemText>Banana</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="cherry">
+                <Select.ItemText>Cherry</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="date">
+                <Select.ItemText>Date</Select.ItemText>
+              </Select.Item>
+              <Select.Item value="elderberry">
+                <Select.ItemText>Elderberry</Select.ItemText>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const listbox = screen.getByRole('listbox');
+    const apple = within(listbox).getByRole('option', { name: 'Apple' });
+    const banana = within(listbox).getByRole('option', { name: 'Banana' });
+    const elderberry = within(listbox).getByRole('option', { name: 'Elderberry' });
+
+    expect(apple).toHaveAttribute('aria-posinset', '1');
+    expect(apple).toHaveAttribute('aria-setsize', '5');
+    expect(banana).toHaveAttribute('aria-posinset', '2');
+    expect(banana).toHaveAttribute('aria-setsize', '5');
+    expect(elderberry).toHaveAttribute('aria-posinset', '5');
+    expect(elderberry).toHaveAttribute('aria-setsize', '5');
+  });
+
+  it('counts position within each group, not across the whole list', () => {
+    render(
+      <Select.Root defaultOpen>
+        <Select.Trigger>
+          <Select.Value placeholder="Pick one" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Group>
+                <Select.Label>Fruits</Select.Label>
+                <Select.Item value="apple">
+                  <Select.ItemText>Apple</Select.ItemText>
+                </Select.Item>
+                <Select.Item value="banana">
+                  <Select.ItemText>Banana</Select.ItemText>
+                </Select.Item>
+              </Select.Group>
+              <Select.Group>
+                <Select.Label>Vegetables</Select.Label>
+                <Select.Item value="carrot">
+                  <Select.ItemText>Carrot</Select.ItemText>
+                </Select.Item>
+              </Select.Group>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    const listbox = screen.getByRole('listbox');
+    const banana = within(listbox).getByRole('option', { name: 'Banana' });
+    const carrot = within(listbox).getByRole('option', { name: 'Carrot' });
+
+    // Second item of the first group: position within that group.
+    expect(banana).toHaveAttribute('aria-posinset', '2');
+    expect(banana).toHaveAttribute('aria-setsize', '2');
+    // Only item of the second group: restarts the count.
+    expect(carrot).toHaveAttribute('aria-posinset', '1');
+    expect(carrot).toHaveAttribute('aria-setsize', '1');
+  });
+
+  it('leaves the attributes unset until the option is mounted', () => {
+    render(
+      <Select.Root>
+        <Select.Trigger>
+          <Select.Value placeholder="Pick one" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Item value="apple">
+                <Select.ItemText>Apple</Select.ItemText>
+              </Select.Item>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    // Content is not rendered until the Select opens, so no listbox exists yet.
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+    // Open it, then the option declares its position.
+    fireEvent.click(screen.getByRole('combobox'));
+    const listbox = screen.getByRole('listbox');
+    const apple = within(listbox).getByRole('option', { name: 'Apple' });
+    expect(apple).toHaveAttribute('aria-posinset', '1');
+    expect(apple).toHaveAttribute('aria-setsize', '1');
+  });
+});
+
 function cleanupModal() {
   cleanup();
   // Open content is a modal layer, which sets this on the `body` and only

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1365,7 +1365,42 @@ const SelectItem = /* @__PURE__ */ React.forwardRef<SelectItemElement, SelectIte
     const handleItemRefCallback = useCallbackRef((node: SelectItemElement | null) =>
       contentContext.itemRefCallback?.(node, value, disabled),
     );
-    const composedRefs = useComposedRefs(forwardedRef, handleItemRefCallback);
+
+    // VoiceOver + Chrome fails to derive "position of total" (e.g. "Banana, 2
+    // of 5") from a scrollable listbox with real focus on each option: it
+    // announces an incorrect count based on the options currently visible in
+    // the viewport, or omits the count entirely when no value is preselected.
+    // Other combos (Safari+VoiceOver, NVDA+Chrome) happen to work, but the
+    // announced position is only reliable when the option declares it
+    // explicitly. We compute aria-posinset/aria-setsize from the DOM: each
+    // option counts itself within its own list container - the enclosing
+    // [role="group"] when the item sits in a Select.Group, otherwise the
+    // [role="listbox"] - so the totals stay correct for grouped selects too.
+    const [ariaPosinset, setAriaPosinset] = React.useState<number | undefined>(undefined);
+    const [ariaSetsize, setAriaSetsize] = React.useState<number | undefined>(undefined);
+    const itemRef = React.useRef<SelectItemElement | null>(null);
+    const composedRefs = useComposedRefs(forwardedRef, handleItemRefCallback, itemRef);
+
+    React.useLayoutEffect(() => {
+      const option = itemRef.current;
+      if (!option) return;
+      // The list container is the option's immediate parent: the [role="group"]
+      // when the item sits in a Select.Group, otherwise the viewport inside the
+      // [role="listbox"]. Counting direct option children of that container
+      // yields the position within the correct list (grouped selects count
+      // per-group, ungrouped selects count all options).
+      const list = option.parentElement;
+      if (!list) return;
+      const options = Array.from(list.querySelectorAll(':scope > [role="option"]'));
+      const index = options.indexOf(option);
+      if (index === -1) return;
+      setAriaPosinset(index + 1);
+      setAriaSetsize(options.length);
+      // The select content mounts all its options in the same commit, so the
+      // DOM-derived positions are stable for the lifetime of the opened list;
+      // an empty dependency list (compute once on mount) is intentional.
+      // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     const textId = useId();
     const pointerTypeRef = React.useRef<React.PointerEvent['pointerType']>('touch');
 
@@ -1394,6 +1429,8 @@ const SelectItem = /* @__PURE__ */ React.forwardRef<SelectItemElement, SelectIte
           <Primitive.div
             role="option"
             aria-labelledby={textId}
+            aria-posinset={ariaPosinset}
+            aria-setsize={ariaSetsize}
             data-highlighted={isFocused ? '' : undefined}
             // `isFocused` caveat fixes stuttering in VoiceOver
             aria-selected={isSelected && isFocused}


### PR DESCRIPTION
## Summary

Fixes #3962 - `Select` options don't declare their position/total, so VoiceOver + Chrome announces an incorrect item count (based on the options visible in the scrollable viewport) or omits the count entirely when no value is preselected.

Example: a list of 5 fruits with `"Banana"` preselected announces `"Banana, 1 of 3"` instead of `"Banana, 2 of 5"`; with no preselection it announces just `"Banana"` with no position or count.

## Root cause

`Select.Item` renders `role="option"` but never sets `aria-posinset` / `aria-setsize`. Radix uses roving focus (real focus moves to each option) inside a scrollable `role="listbox"`, so the browser is left to derive the position from the DOM. Safari+VoiceOver and NVDA+Chrome happen to work, but VoiceOver+Chrome counts only the options currently visible in the viewport, giving a wrong total.

## Change

Each `Select.Item` now computes and declares its own position:

- `aria-setsize` - the number of options in its list container
- `aria-posinset` - its 1-based index within that container

The list container is the option's immediate parent: the enclosing `role="group"` when the item sits in a `Select.Group`, otherwise the viewport inside the `role="listbox"`. This keeps the count correct for grouped selects too (each group counts independently, per the [APG grouped listbox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/)).

The values are computed once on mount via `useLayoutEffect` from the DOM, so they're available before the first paint of the opened list.

## Verification

- New unit tests: ungrouped options get `aria-posinset`/`aria-setsize` for the full list; grouped options count within each group (count restarts per group).
- All existing Select tests pass.
- `lint`, `typecheck`, format check, and build (ESM/CJS/types) all pass.

Manual validation with VoiceOver + Chrome is still needed to confirm the announcement, but the attributes are now correct in the DOM.
