### PR TITLE
fix(select): pin hidden native select to containing block origin

### DIFF
--- a/.changeset/fix-select-bubble-input-scroll-3875.md
+++ b/.changeset/fix-select-bubble-input-scroll-3875.md
@@ -1,0 +1,5 @@
+---
+'@radix-ui/react-select': patch
+---
+
+Pin the visually hidden native select to the containing block origin so it no longer extends page scroll in constrained flex layouts.

--- a/packages/react/select/src/select.test.tsx
+++ b/packages/react/select/src/select.test.tsx
@@ -1529,6 +1529,31 @@ describe('Select.BubbleInput', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  // Regression test for https://github.com/radix-ui/primitives/issues/3875
+  it('pins the visually hidden native select to the containing block origin', () => {
+    const { container } = render(
+      <form>
+        <Select.Root name="fruit">
+          <Select.Trigger>
+            <Select.Value placeholder="Pick" />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content>
+              <Select.Viewport>
+                <Select.Item value="apple">
+                  <Select.ItemText>Apple</Select.ItemText>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </form>,
+    );
+
+    const bubbleInput = container.querySelector('select');
+    expect(bubbleInput).toHaveStyle({ position: 'absolute', top: '0px', left: '0px' });
+  });
+
   // TODO: Fix this
   it.todo('forwards props to the child element when `asChild` is set');
 });

--- a/packages/react/select/src/select.tsx
+++ b/packages/react/select/src/select.tsx
@@ -1833,7 +1833,10 @@ const SelectBubbleInput = /* @__PURE__ */ React.forwardRef<
         form={form}
         onChange={(event) => onValueChange(event.target.value)}
         {...props}
-        style={{ ...VISUALLY_HIDDEN_STYLES, ...props.style }}
+        // Pin to the containing block origin. Without `top`/`left`, absolutely
+        // positioned nodes keep their static position, which in constrained flex
+        // layouts can sit far below the trigger and extend page scroll (#3875).
+        style={{ ...VISUALLY_HIDDEN_STYLES, top: 0, left: 0, ...props.style }}
         ref={composedRefs}
         defaultValue={selectValue}
       >


### PR DESCRIPTION
## Summary

- Pins `SelectBubbleInput` with `top: 0` / `left: 0` so the visually hidden native `<select>` stays at the containing-block origin
- Adds a regression test for the constrained-layout scroll case
- Includes a changeset

Fixes #3875

## Problem

`VISUALLY_HIDDEN_STYLES` uses `position: absolute` without `top`/`left`, so the node keeps its static position. In nested flex layouts (`height: 100dvh` inside a `<form>`), that static position can sit far down the page and extend document scroll.

Prior attempt: #3876 (closed by author for lack of review). Broader `VisuallyHidden` change was declined in #3407; this keeps the fix scoped to Select’s bubble input.

## Test plan

- [x] `pnpm vitest run packages/react/select/src/select.test.tsx` — 49 passed
- [ ] CI passes on PR

Made with [Cursor](https://cursor.com)